### PR TITLE
Staging 20181009

### DIFF
--- a/jenkins/build-trigger.jpl
+++ b/jenkins/build-trigger.jpl
@@ -67,6 +67,9 @@ def addDefconfigs(configs, kdir, arch) {
             for (String config: found.tokenize(' \n'))
                 configs.add(config)
         }
+        if (arch == "mips") {
+            configs.remove("generic_defconfig")
+        }
     } else {
         echo("WARNING: No configs directory: ${configs_dir}")
     }

--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -685,7 +685,7 @@ device_types:
 
   sun8i_h3_libretech_all_h3_cc:
     name: 'sun8i-h3-libretech-all-h3-cc'
-    mach: alliwinnder
+    mach: allwinner
     class: arm-dtb
     boot_method: uboot
 


### PR DESCRIPTION
Summary: 
* Fix a typo in the test-configs.yaml
* Remove the generic_defconfig from MIPS builds as it is not a config that is expected to be buildable, and some builds are hanging until timing out due to an unset CONFIG_HZ

Note: The patch to build with the all_abi config fragment from Anders' work-in-progress branch is being kept on staging until this has been accepted in upstream Linux kernel.