### PR TITLE
Staging 20181009

### DIFF
--- a/jenkins/build-trigger.jpl
+++ b/jenkins/build-trigger.jpl
@@ -67,6 +67,9 @@ def addDefconfigs(configs, kdir, arch) {
             for (String config: found.tokenize(' \n'))
                 configs.add(config)
         }
+        if (arch == "mips") {
+            configs.remove("generic_defconfig")
+        }
     } else {
         echo("WARNING: No configs directory: ${configs_dir}")
     }

--- a/jenkins/build-trigger.jpl
+++ b/jenkins/build-trigger.jpl
@@ -122,7 +122,7 @@ def addExtraConfigs(configs, kdir, arch) {
         addExtraIfExists(extra, kdir, "arch/x86/configs/kvm_guest.config")
     }
 
-    for (String frag: ["debug", "kselftest"])
+    for (String frag: ["debug", "kselftest", "all_abi"])
         addExtraIfExists(extra, kdir, "kernel/configs/${frag}.config")
 
     if (params.TREE_NAME == "lsk" || params.TREE_NAME == "anders") {

--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -685,7 +685,7 @@ device_types:
 
   sun8i_h3_libretech_all_h3_cc:
     name: 'sun8i-h3-libretech-all-h3-cc'
-    mach: alliwinnder
+    mach: allwinner
     class: arm-dtb
     boot_method: uboot
 


### PR DESCRIPTION
Summary:
* test-configs: Fix typo in `allwinner`
* MIPS: do not build `generic_defconfig`
* add extra `all_abi` config fragment if it's present in the source tarball