### PR TITLE
Staging 20181026

### DIFF
--- a/jenkins/build.jpl
+++ b/jenkins/build.jpl
@@ -92,7 +92,7 @@ ${kci_core}/build.py \
     sh(script: """rm -rf ${kdir}""")
 }
 
-node("docker-builder") {
+node("docker") {
     def docker_image = "${params.DOCKERBASE}${params.COMPILER}_${params.ARCH}"
 
     echo("""\

--- a/jenkins/build.jpl
+++ b/jenkins/build.jpl
@@ -92,7 +92,7 @@ ${kci_core}/build.py \
     sh(script: """rm -rf ${kdir}""")
 }
 
-node("docker") {
+node("docker && builder") {
     def docker_image = "${params.DOCKERBASE}${params.COMPILER}_${params.ARCH}"
 
     echo("""\

--- a/jenkins/debian/debos/overlays/tests/usr/bin/v4l2-parser.sh
+++ b/jenkins/debian/debos/overlays/tests/usr/bin/v4l2-parser.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+set -e
+
+driver_name=$(basename $(readlink -f /sys/class/video4linux/video2/device/driver)) && echo "[kernelci-meta-data] v4l2 driver: $driver_name" || echo "Failed to get v4l2 driver name"
+
+device_name=$(cat /sys/class/video4linux/video2/name) && echo "[kernelci-meta-data] v4l2 device: $device_name" || echo "Failed to get v4l2 device name"
+
+IFS=''
+
+v4l2-compliance -s | while read line; do
+    echo "$line" # to keep regular output
+    echo "$line" | grep -qe "test .*: [OK|FAIL]" && {
+        id=$(echo $line | sed s/'\ttest \(.*\): \(.*\)'/'\1'/ | sed s/' '/'-'/g | sed s/"[\(\)']"//g)
+        res=$(echo $line | sed s/'\(.*\): \([OK|FAIL].*\)'/'\2'/ | sed s/'OK (Not Supported)'/skip/ | sed s/OK/pass/ | sed s/FAIL/fail/)
+        lava-test-case "$id" --result "$res"
+    }
+done
+
+exit 0

--- a/jenkins/debian/debos/rootfs.yaml
+++ b/jenkins/debian/debos/rootfs.yaml
@@ -3,6 +3,7 @@
 {{- $extra_packages := or .extra_packages "" -}}
 {{- $suite := or .suite "stretch" -}}
 {{- $script := or .script "scripts/nothing.sh" -}}
+{{- $test_overlay := .test_overlay -}}
 
 architecture: {{ $architecture }}
 
@@ -81,6 +82,12 @@ actions:
     description: Add /var/tmp
     source: overlays/minimal
 
+{{ if $test_overlay }}
+  - action: overlay
+    description: Add test overlay {{ $test_overlay }}
+    source: {{ $test_overlay }}
+{{ end }}
+
   - action: run
     description: Drop legacy /var/lib/dbus/machine-id generation
     chroot: true
@@ -146,4 +153,3 @@ actions:
     description: Create cpio archive
     chroot: false
     command: cd ${ROOTDIR} ; find -H  |  cpio -H newc -v -o | gzip -c - > ${ARTIFACTDIR}/{{ $basename -}}/rootfs.cpio.gz
-

--- a/jenkins/stretchtests.jpl
+++ b/jenkins/stretchtests.jpl
@@ -10,6 +10,8 @@ def config = ['name':"stretchtests",
               'extra_packages':"libpciaccess0 libkmod2 libprocps6 libcairo2 \
                                 libssl1.1 libunwind8 libudev1 libglib2.0-0 \
                                 libdw1 liblzma5",
-              'script':"scripts/stretchtests.sh"]
+              'script':"scripts/stretchtests.sh",
+              'test_overlay': "overlays/tests",
+             ]
 
 r.buildImage(config)

--- a/src/org/kernelci/debian/RootFS.groovy
+++ b/src/org/kernelci/debian/RootFS.groovy
@@ -74,7 +74,13 @@ def buildImage(config) {
 }
 
 
-def makeImageStep(String pipeline_version, String arch, String debianRelease, String debosFile, String extraPackages, String name, String script) {
+def makeImageStep(String pipeline_version,
+                  String arch,
+                  String debianRelease,
+                  String debosFile,
+                  String extraPackages,
+                  String name,
+                  String script) {
     return {
         node('builder' && 'docker') {
             stage("Checkout") {
@@ -85,7 +91,13 @@ def makeImageStep(String pipeline_version, String arch, String debianRelease, St
                 stage("Build base image for ${arch}") {
                     sh """
                         mkdir -p ${pipeline_version}/${arch}
-                        debos -t architecture:${arch} -t suite:${debianRelease} -t basename:${pipeline_version}/${arch} -t extra_packages:'${extraPackages}' -t script:${script} ${debosFile}
+                        debos \
+                            -t architecture:${arch} \
+                            -t suite:${debianRelease} \
+                            -t basename:${pipeline_version}/${arch} \
+                            -t extra_packages:'${extraPackages}' \
+                            -t script:${script} \
+                            ${debosFile}
                     """
                 archiveArtifacts artifacts: "${pipeline_version}/${arch}/initrd.cpio.gz", fingerprint: true
                 archiveArtifacts artifacts: "${pipeline_version}/${arch}/rootfs.cpio.gz", fingerprint: true
@@ -122,5 +134,3 @@ def getDockerArgs() {
 
   return "--group-add " + "${GROUP}"
 }
-
-

--- a/src/org/kernelci/debian/RootFS.groovy
+++ b/src/org/kernelci/debian/RootFS.groovy
@@ -57,6 +57,8 @@ def buildImage(config) {
         script = config.script
     }
 
+    def test_overlay = config.test_overlay ?: ""
+
     def stepsForParallel = [:]
     for (int i = 0; i < archList.size(); i++) {
         def arch = archList[i]
@@ -67,7 +69,8 @@ def buildImage(config) {
                                                     debosFile,
                                                     extraPackages,
                                                     name,
-                                                    script)
+                                                    script,
+                                                    test_overlay)
     }
 
     parallel stepsForParallel
@@ -80,7 +83,8 @@ def makeImageStep(String pipeline_version,
                   String debosFile,
                   String extraPackages,
                   String name,
-                  String script) {
+                  String script,
+                  String test_overlay) {
     return {
         node('builder' && 'docker') {
             stage("Checkout") {
@@ -97,6 +101,7 @@ def makeImageStep(String pipeline_version,
                             -t basename:${pipeline_version}/${arch} \
                             -t extra_packages:'${extraPackages}' \
                             -t script:${script} \
+                            -t test_overlay:'${test_overlay}' \
                             ${debosFile}
                     """
                 archiveArtifacts artifacts: "${pipeline_version}/${arch}/initrd.cpio.gz", fingerprint: true

--- a/src/org/kernelci/debian/RootFS.groovy
+++ b/src/org/kernelci/debian/RootFS.groovy
@@ -86,7 +86,7 @@ def makeImageStep(String pipeline_version,
                   String script,
                   String test_overlay) {
     return {
-        node('builder' && 'docker') {
+        node("docker && debos") {
             stage("Checkout") {
                 checkout scm
             }

--- a/templates/v4l2/v4l2.jinja2
+++ b/templates/v4l2/v4l2.jinja2
@@ -13,13 +13,7 @@
           - functional
         run:
           steps:
-          - v4l2-compliance | sed "s/test /test $test/g"
-        parse:
-          pattern: 'test (?P<test_case_id>\S*):\s+(?P<result>(OK|FAIL|SKIP))'
-          fixupdict:
-            OK: pass
-            FAIL: fail
-            SKIP: skip
+          - /usr/bin/v4l2-parser.sh
       lava-signal: kmsg
       from: inline
       name: v4l2

--- a/templates/v4l2/v4l2.jinja2
+++ b/templates/v4l2/v4l2.jinja2
@@ -20,6 +20,7 @@
             OK: pass
             FAIL: fail
             SKIP: skip
+      lava-signal: kmsg
       from: inline
       name: v4l2
       path: inline/v4l2.yaml

--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -964,7 +964,7 @@ test_configs:
     test_plans: [boot]
 
   - device_type: rk3399_gru_kevin
-    test_plans: [boot]
+    test_plans: [boot, v4l2]
 
   - device_type: rk3399_puma_haikou
     test_plans: [boot, kselftest]

--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -12,12 +12,12 @@ file_system_types:
       armel:   {arch: arm}
 
   debian_stretch:
-    url: 'http://storage.kernelci.org/images/rootfs/debian/stretch/20180627.0'
+    url: 'http://storage.kernelci.org/images/rootfs/debian/stretch/20181022.0'
     arch_map:
       armhf: {arch: arm}
 
   debian_stretchtests:
-    url: 'http://storage.kernelci.org/images/rootfs/debian/stretchtests/20180627.0'
+    url: 'http://storage.kernelci.org/images/rootfs/debian/stretchtests/20181022.0'
     arch_map:
       armhf: {arch: arm}
 

--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -634,6 +634,15 @@ device_types:
     boot_method: uboot
     flags: ['lpae', 'fastboot']
 
+  rk3328_rock64:
+    name: 'rk3328-rock64'
+    mach: rockchip
+    class: arm64-dtb
+    boot_method: uboot
+    filters:
+      - blacklist: *allmodconfig_filter
+      - blacklist: {kernel: ['v3.', 'v4.4', 'v4.9']}
+
   rk3288_veyron_jaq:
     name: 'rk3288-veyron-jaq'
     mach: rockchip
@@ -962,6 +971,9 @@ test_configs:
 
   - device_type: rk3288_rock2_square
     test_plans: [boot, boot_nfs, kselftest, sleep, usb]
+
+  - device_type: rk3328_rock64
+    test_plans: [boot]
 
   - device_type: rk3288_veyron_jaq
     test_plans: [boot, boot_nfs, sleep, usb, v4l2, igt, cros_ec]


### PR DESCRIPTION
Summary:
* test-configs:
  * add rock64 device type and run plain boot tests on it
  * use 20181022.0 Debian rootfs
  * enable v4l2 on rk3388-gru-kevin
* debian:
  * add `test_overlay` config and tests overlay for `stretchtests` build
  * use `docker && debos` labels to run debos Jenkins jobs
* v4l2:
  * use /dev/kmsg to avoid log message collisions
  * add `v4l2-parser.sh` script in tests overlay to fix results parsing
* build.jpl: use `docker && builder` labels to run Jenkins kernel build jobs