### PR TITLE
Staging 20190129

### DIFF
--- a/build.py
+++ b/build.py
@@ -368,8 +368,10 @@ extra_configs(dot_config, kbuild_output)
 #
 if len(args) >= 1:
     build_target = args[0]
-elif arch == "arc" or arch == "mips":
+elif arch == "arc":
     build_target = "uImage.gz"
+elif arch == "mips":
+    build_target = "all"
 result = do_make(build_target, log=True)
 
 # Build modules

--- a/build.py
+++ b/build.py
@@ -244,13 +244,16 @@ else:
 
 # CC
 cc = os.environ.get("CC", "gcc")
+cc_version = os.environ.get("CC_VERSION")
 cc_cmd = "%s --version 2>&1" % cc
 if cross_compile and cc == "gcc":
     cc_cmd = "%s%s --version 2>&1" %(cross_compile, cc)
-cc_version = subprocess.check_output(cc_cmd, shell=True).splitlines()[0]
+cc_version_full = subprocess.check_output(cc_cmd, shell=True).splitlines()[0]
+
+print("cc: {}, cc_version: {}".format(cc, cc_version))
 
 if not build_environment:
-    build_environment = cc
+    build_environment = '-'.join([cc, cc_version]) if cc_version else cc
 
 print("Build environment: {}".format(build_environment))
 
@@ -485,8 +488,10 @@ if install:
 
     bmeta['arch'] = "%s" %arch
     bmeta["cross_compile"] = "%s" %cross_compile
-    bmeta["compiler_version"] = "%s" %cc_version
-    bmeta["build_environment"] = "%s" % build_environment
+    bmeta["compiler"] = cc
+    bmeta["compiler_version"] = cc_version
+    bmeta["compiler_version_full"] = cc_version_full
+    bmeta["build_environment"] = build_environment
     bmeta["git_url"] = "%s" %git_url
     bmeta["git_branch"] =  "%s" %git_branch
     bmeta["git_describe"] =  "%s" %git_describe

--- a/jenkins/build.jpl
+++ b/jenkins/build.jpl
@@ -71,7 +71,7 @@ import org.kernelci.util.Job
 def buildConfig(config, kdir, kci_core) {
     def defconfig = sh(script: "echo ${config} | sed 's/\\+/ \\-c /g'",
                        returnStdout: true)
-    def opt = "-i"
+    def opt = "-i -E ${params.CC}-${params.CC_VERSION}"
 
     if (params.PUBLISH) {
         opt += " -e"

--- a/jenkins/debian/debos/overlays/v4l2/usr/bin/v4l2-parser.sh
+++ b/jenkins/debian/debos/overlays/v4l2/usr/bin/v4l2-parser.sh
@@ -39,7 +39,7 @@ test_io=""
 
 v4l2-compliance -s | sed s/'\r'/'\n'/g | while read line; do
     # Skip noisy video capture progress messages
-    echo "$line" | grep -q 'Video Capture' && continue
+    echo "$line" | grep -q 'Video Capture\|Output' && continue
 
     # Keep regular output in the log
     echo "$line"

--- a/jenkins/debian/debos/scripts/stretch-v4l2.sh
+++ b/jenkins/debian/debos/scripts/stretch-v4l2.sh
@@ -13,6 +13,7 @@ BUILD_DEPS="libglib2.0-dev \
     automake \
     gettext \
     build-essential \
+    ca-certificates \
 "
 
 apt-get install --no-install-recommends -y  ${BUILD_DEPS}
@@ -41,6 +42,20 @@ rm -rf  /tmp/tests/v4l2/usr/include /tmp/tests/v4l2/usr/share /tmp/tests/v4l2/us
 cp -a /tmp/tests/v4l2/usr/* /usr/
 
 echo '  ]}' >> $BUILDFILE
+
+# Build v4l2-get-device
+########################################################################
+
+echo "Building v4l2-get-device"
+
+dir="/tmp/tests/v4l2-get-device"
+url="https://gitlab.collabora.com/gtucker/v4l2-get-device.git"
+
+mkdir -p "$dir" && cd "$dir"
+git clone --depth=1 "$url" .
+make
+strip v4l2-get-device
+make install
 
 ########################################################################
 # Cleanup: remove files and packages we don't want in the images       #

--- a/jenkins/dockerfiles/gcc-7_arm/Dockerfile
+++ b/jenkins/dockerfiles/gcc-7_arm/Dockerfile
@@ -1,7 +1,8 @@
 FROM kernelci/build-base
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
-    gcc-7-arm-linux-gnueabihf
+    gcc-7-arm-linux-gnueabihf \
+    gcc-7-plugin-dev-arm-linux-gnueabihf
 
 RUN update-alternatives \
     --install /usr/bin/arm-linux-gnueabihf-gcc arm-linux-gnueabihf-gcc /usr/bin/arm-linux-gnueabihf-gcc-7 500 \

--- a/jenkins/dockerfiles/gcc-7_arm64/Dockerfile
+++ b/jenkins/dockerfiles/gcc-7_arm64/Dockerfile
@@ -1,7 +1,8 @@
 FROM kernelci/build-base
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
-    gcc-7-aarch64-linux-gnu
+    gcc-7-aarch64-linux-gnu \
+    gcc-7-plugin-dev-aarch64-linux-gnu
 
 RUN update-alternatives \
     --install /usr/bin/aarch64-linux-gnu-gcc aarch64-linux-gnu-gcc /usr/bin/aarch64-linux-gnu-gcc-7 500 \

--- a/jenkins/dockerfiles/gcc-7_x86/Dockerfile
+++ b/jenkins/dockerfiles/gcc-7_x86/Dockerfile
@@ -1,6 +1,7 @@
 FROM kernelci/build-base
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
-    gcc-7
+    gcc-7 \
+    gcc-7-plugin-dev
 
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 500

--- a/jenkins/dockerfiles/gcc-8_arm/Dockerfile
+++ b/jenkins/dockerfiles/gcc-8_arm/Dockerfile
@@ -1,7 +1,8 @@
 FROM kernelci/build-base
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
-    gcc-8-arm-linux-gnueabihf
+    gcc-8-arm-linux-gnueabihf \
+    gcc-8-plugin-dev-arm-linux-gnueabihf
 
 RUN update-alternatives \
     --install /usr/bin/arm-linux-gnueabihf-gcc arm-linux-gnueabihf-gcc /usr/bin/arm-linux-gnueabihf-gcc-8 500 \

--- a/jenkins/dockerfiles/gcc-8_arm64/Dockerfile
+++ b/jenkins/dockerfiles/gcc-8_arm64/Dockerfile
@@ -1,7 +1,8 @@
 FROM kernelci/build-base
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
-    gcc-8-aarch64-linux-gnu
+    gcc-8-aarch64-linux-gnu \
+    gcc-8-plugin-dev-aarch64-linux-gnu
 
 RUN update-alternatives \
     --install /usr/bin/aarch64-linux-gnu-gcc aarch64-linux-gnu-gcc /usr/bin/aarch64-linux-gnu-gcc-8 500 \

--- a/jenkins/dockerfiles/gcc-8_x86/Dockerfile
+++ b/jenkins/dockerfiles/gcc-8_x86/Dockerfile
@@ -1,6 +1,7 @@
 FROM kernelci/build-base
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
-    gcc-8
+    gcc-8 \
+    gcc-8-plugin-dev
 
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 500

--- a/jenkins/kernel-arch-complete.sh
+++ b/jenkins/kernel-arch-complete.sh
@@ -177,7 +177,8 @@ if [[ BUILDS_FINISHED -eq 4 ]]; then
         echo "Sending results to Guillaume"
         curl -X POST -H "Authorization: $EMAIL_AUTH_TOKEN" -H "Content-Type: application/json" -d '{"job": "'$TREE_NAME'", "kernel": "'$GIT_DESCRIBE'", "git_branch": "'$BRANCH'", "build_report": 1, "format": ["txt"], "send_to": ["guillaume.tucker@collabora.com"], "delay": 60}' ${API}/send
         curl -X POST -H "Authorization: $EMAIL_AUTH_TOKEN" -H "Content-Type: application/json" -d '{"job": "'$TREE_NAME'", "kernel": "'$GIT_DESCRIBE'", "git_branch": "'$BRANCH'", "boot_report": 1, "format": ["txt"], "send_to": ["guillaume.tucker@collabora.com"], "delay": 1800}' ${API}/send
-        curl -X POST -H "Authorization: $EMAIL_AUTH_TOKEN" -H "Content-Type: application/json" -d '{"job": "'$TREE_NAME'", "kernel": "'$GIT_DESCRIBE'", "git_branch": "'$BRANCH'",  "report_type": "test", "plan": "v4l2", "send_to": ["guillaume.tucker@collabora.com"], "format": ["txt"], "delay": 2700}' ${API}/send
+        curl -X POST -H "Authorization: $EMAIL_AUTH_TOKEN" -H "Content-Type: application/json" -d '{"job": "'$TREE_NAME'", "kernel": "'$GIT_DESCRIBE'", "git_branch": "'$BRANCH'",  "report_type": "test", "plan": "v4l2-vivid", "send_to": ["guillaume.tucker@collabora.com"], "format": ["txt"], "delay": 2700}' ${API}/send
+        curl -X POST -H "Authorization: $EMAIL_AUTH_TOKEN" -H "Content-Type: application/json" -d '{"job": "'$TREE_NAME'", "kernel": "'$GIT_DESCRIBE'", "git_branch": "'$BRANCH'",  "report_type": "test", "plan": "v4l2-uvc", "send_to": ["guillaume.tucker@collabora.com"], "format": ["txt"], "delay": 2700}' ${API}/send
         curl -X POST -H "Authorization: $EMAIL_AUTH_TOKEN" -H "Content-Type: application/json" -d '{"job": "'$TREE_NAME'", "kernel": "'$GIT_DESCRIBE'", "git_branch": "'$BRANCH'",  "report_type": "test", "plan": "igt", "send_to": ["guillaume.tucker@collabora.com"], "format": ["txt"], "delay": 2700}' ${API}/send
         curl -X POST -H "Authorization: $EMAIL_AUTH_TOKEN" -H "Content-Type: application/json" -d '{"job": "'$TREE_NAME'", "kernel": "'$GIT_DESCRIBE'", "git_branch": "'$BRANCH'",  "report_type": "test", "plan": "sleep", "send_to": ["guillaume.tucker@collabora.com"], "format": ["txt"], "delay": 2700}' ${API}/send
     elif [ "$TREE_NAME" == "tomeu" ]; then
@@ -194,7 +195,8 @@ if [[ BUILDS_FINISHED -eq 4 ]]; then
         curl -X POST -H "Authorization: $EMAIL_AUTH_TOKEN" -H "Content-Type: application/json" -d '{"job": "'$TREE_NAME'", "kernel": "'$GIT_DESCRIBE'", "git_branch": "'$BRANCH'", "boot_report": 1, "format": ["txt"], "send_to": ["sboyd+clkci@kernel.org", "mturquette+clkci@baylibre.com", "kernel-build-reports@lists.linaro.org"], "delay": 1800}' ${API}/send
     elif [ "$TREE_NAME" == "media" ]; then
         echo "Sending results for media tree"
-        curl -X POST -H "Authorization: $EMAIL_AUTH_TOKEN" -H "Content-Type: application/json" -d '{"job": "'$TREE_NAME'", "kernel": "'$GIT_DESCRIBE'", "git_branch": "'$BRANCH'",  "report_type": "test", "plan": "v4l2", "send_to": ["linux-media@vger.kernel.org", "ezequiel@collabora.com"], "format": ["txt"], "delay": 5400}' ${API}/send
+        curl -X POST -H "Authorization: $EMAIL_AUTH_TOKEN" -H "Content-Type: application/json" -d '{"job": "'$TREE_NAME'", "kernel": "'$GIT_DESCRIBE'", "git_branch": "'$BRANCH'",  "report_type": "test", "plan": "v4l2-vivid", "send_to": ["linux-media@vger.kernel.org", "ezequiel@collabora.com"], "format": ["txt"], "delay": 5400}' ${API}/send
+        curl -X POST -H "Authorization: $EMAIL_AUTH_TOKEN" -H "Content-Type: application/json" -d '{"job": "'$TREE_NAME'", "kernel": "'$GIT_DESCRIBE'", "git_branch": "'$BRANCH'",  "report_type": "test", "plan": "v4l2-uvc", "send_to": ["linux-media@vger.kernel.org", "ezequiel@collabora.com"], "format": ["txt"], "delay": 5400}' ${API}/send
     else
         # Private Mailing List
         echo "Sending results to private mailing list"

--- a/jenkins/lava-boot-v2.sh
+++ b/jenkins/lava-boot-v2.sh
@@ -21,7 +21,7 @@ elif [ ${LAB} = "lab-mhart" ] || [ ${LAB} = "lab-mhart-dev" ]; then
   python lava-v2-jobs-from-api.py --defconfigs ${DEFCONFIG_COUNT} --callback ${CALLBACK} --api ${API} --storage ${STORAGE} --lab ${LAB} --describe ${GIT_DESCRIBE} --tree ${TREE} --branch ${BRANCH} --arch ${ARCH} --plans boot boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp simple --token ${API_TOKEN} --priority medium
   python lava-v2-submit-jobs.py --username kernel-ci --jobs ${LAB} --token ${LAVA_MHART_TOKEN} --lab ${LAB}
 elif [ ${LAB} = "lab-collabora" ] || [ ${LAB} = "lab-collabora-dev" ]; then
-  python lava-v2-jobs-from-api.py --defconfigs ${DEFCONFIG_COUNT} --callback ${CALLBACK} --api ${API} --storage ${STORAGE} --lab ${LAB} --describe ${GIT_DESCRIBE} --tree ${TREE} --branch ${BRANCH} --arch ${ARCH} --plans boot boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp cros-ec igt kselftest simple sleep usb v4l2 --token ${API_TOKEN} --priority medium
+  python lava-v2-jobs-from-api.py --defconfigs ${DEFCONFIG_COUNT} --callback ${CALLBACK} --api ${API} --storage ${STORAGE} --lab ${LAB} --describe ${GIT_DESCRIBE} --tree ${TREE} --branch ${BRANCH} --arch ${ARCH} --plans boot boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp cros-ec igt kselftest simple sleep usb v4l2-vivid v4l2-uvc --token ${API_TOKEN} --priority medium
   python lava-v2-submit-jobs.py --username kernel-ci --jobs ${LAB} --token ${LAVA_COLLABORA_TOKEN} --lab ${LAB}
 elif [ ${LAB} = "lab-baylibre" ]; then
   python lava-v2-jobs-from-api.py --defconfigs ${DEFCONFIG_COUNT} --callback ${CALLBACK} --api ${API} --storage ${STORAGE} --lab ${LAB} --describe ${GIT_DESCRIBE} --tree ${TREE} --branch ${BRANCH} --arch ${ARCH} --plans boot boot-kvm boot-kvm-uefi kselftest --token ${API_TOKEN} --priority medium

--- a/lava-v2-jobs-from-api.py
+++ b/lava-v2-jobs-from-api.py
@@ -173,6 +173,8 @@ def get_job_params(config, test_config, defconfig, opts, build, plan):
         'context': device_type.context,
         'rootfs_prompt': rootfs.prompt,
         'plan_name': test_plan.name,
+        'file_server_resource': file_server_resource,
+        'build_environment': build.get('build_environment'),
     }
 
     job_params.update(test_plan.params)
@@ -224,10 +226,7 @@ def get_jobs_from_builds(config, builds, tests):
             continue
 
         defconfig = build['defconfig_full']
-
-        print("Working on build {}".format(' '.join(
-            [config.get('tree'), config.get('branch'), config.get('describe'),
-             arch, defconfig])))
+        print("Working on build: {}".format(build.get('file_server_resource')))
 
         for plan in config.get('plans'):
             opts = {

--- a/lava-v2-jobs-from-api.py
+++ b/lava-v2-jobs-from-api.py
@@ -135,7 +135,7 @@ def get_job_params(config, test_config, defconfig, opts, build, plan):
     else:
         modules_url = None
 
-    rootfs = test_config.test_plans[plan].rootfs
+    rootfs = test_plan.rootfs
 
     job_params = {
         'name': job_name,
@@ -172,6 +172,7 @@ def get_job_params(config, test_config, defconfig, opts, build, plan):
         'lab_name': config.get('lab'),
         'context': device_type.context,
         'rootfs_prompt': rootfs.prompt,
+        'plan_name': test_plan.name,
     }
 
     job_params.update(test_plan.params)

--- a/lava-v2-jobs-from-api.py
+++ b/lava-v2-jobs-from-api.py
@@ -100,6 +100,7 @@ def get_job_params(config, test_config, defconfig, opts, build, plan):
     arch = config.get('arch')
     storage = config.get('storage')
     device_type = test_config.device_type
+    test_plan = test_config.test_plans[plan]
     defconfig_base = ''.join(defconfig.split('+')[:1])
     dtb = dtb_full = opts['dtb_full'] = opts['dtb'] = device_type.dtb
 
@@ -173,6 +174,7 @@ def get_job_params(config, test_config, defconfig, opts, build, plan):
         'rootfs_prompt': rootfs.prompt,
     }
 
+    job_params.update(test_plan.params)
     add_callback_params(job_params, config, plan)
 
     return job_params

--- a/lib/test_configs.py
+++ b/lib/test_configs.py
@@ -357,14 +357,17 @@ class TestPlan(YAMLObject):
 
     _pattern = '{plan}/{category}-{method}-{protocol}-{rootfs}-{plan}-template.jinja2'
 
-    def __init__(self, name, rootfs, category='generic', filters=[],
-                 pattern=None):
+    def __init__(self, name, rootfs, params={}, category='generic',
+                 filters=[], pattern=None):
         """A test plan is an arbitrary group of test cases to be run.
 
         *name* is the overall arbitrary test plan name, used when looking for
                job template files.
 
         *rootfs* is a RootFS object to be used to run this test plan.
+
+        *params" is a dictionary with parameters to pass to the test job
+                 generator
 
         *category* is to classify the type of job to be run, used when looking
                    for job template files.
@@ -377,6 +380,7 @@ class TestPlan(YAMLObject):
         """
         self._name = name
         self._rootfs = rootfs
+        self._params = params
         self._category = category
         self._filters = filters
         if pattern:
@@ -389,7 +393,8 @@ class TestPlan(YAMLObject):
             'rootfs': file_systems[test_plan['rootfs']],
             'filters': FilterFactory.from_data(test_plan, default_filters),
         }
-        kw.update(cls._kw_from_yaml(test_plan, ['name', 'category', 'pattern']))
+        kw.update(cls._kw_from_yaml(test_plan, [
+            'name', 'category', 'pattern', 'params']))
         return cls(**kw)
 
     @property
@@ -399,6 +404,10 @@ class TestPlan(YAMLObject):
     @property
     def rootfs(self):
         return self._rootfs
+
+    @property
+    def params(self):
+        return dict(self._params)
 
     def get_template_path(self, boot_method):
         """Get the path to the template file for the given *boot_method*

--- a/templates/base/kernel-ci-base.jinja2
+++ b/templates/base/kernel-ci-base.jinja2
@@ -27,6 +27,8 @@ metadata:
   job.initrd_url: {{ initrd_url }}
   job.nfsrootfs_url: {{ nfsrootfs_url }}
   job.dtb_url: {{ dtb_url }}
+  job.file_server_resource: {{ file_server_resource }}
+  job.build_environment: {{ build_environment }}
 {%- endblock %}
 {% block main %}
 device_type: {{ device_type }}

--- a/templates/v4l2/v4l2.jinja2
+++ b/templates/v4l2/v4l2.jinja2
@@ -13,7 +13,7 @@
           - functional
         run:
           steps:
-          - /usr/bin/v4l2-parser.sh
+          - /usr/bin/v4l2-parser.sh {{ v4l2_driver }}
       from: inline
-      name: v4l2
+      name: {{ plan_name }}
       path: inline/v4l2.yaml

--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -470,6 +470,15 @@ device_types:
     filters:
       - blacklist: {defconfig: ['allnoconfig', 'allmodconfig']}
 
+  meson_gxl_s805x_p241:
+    name: 'meson-gxl-s805x-p241'
+    mach: amlogic
+    class: arm64-dtb
+    boot_method: uboot
+    flags: ['big_endian']
+    filters:
+      - blacklist: {defconfig: ['allnoconfig', 'allmodconfig']}
+
   meson_gxl_s905x_libretech_cc:
     name: 'meson-gxl-s905x-libretech-cc'
     mach: amlogic
@@ -934,6 +943,9 @@ test_configs:
 
   - device_type: meson_gxbb_p200
     test_plans: [boot, kselftest]
+
+  - device_type: meson_gxl_s805x_p241
+    test_plans: [boot, kselftest, simple]
 
   - device_type: meson_gxl_s905x_khadas_vim
     test_plans: [boot, kselftest, simple]

--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -117,18 +117,24 @@ test_plans:
   usb:
     rootfs: debian_stretch_ramdisk
 
-  v4l2:
+  v4l2_uvc:
+    name: v4l2-uvc
     rootfs: debian_stretch-v4l2_ramdisk
+    # FIXME - this is not very sustainable, improve template naming scheme
+    pattern: 'v4l2/{category}-{method}-{protocol}-{rootfs}-v4l2-template.jinja2'
+    params: {v4l2_driver: "uvcvideo"}
 
-  v4l2_qemu:
-    name: v4l2
+  v4l2_qemu_vivid:
+    name: v4l2-vivid
     rootfs: debian_stretch-v4l2_ramdisk
     pattern: 'v4l2/generic-qemu-v4l2-template.jinja2'
+    params: {v4l2_driver: "vivid"}
     filters:
       - whitelist:
           defconfig:
             - 'defconfig+virtualvideo'
             - 'multi_v7_defconfig+virtualvideo'
+
 
 device_default_filters:
 
@@ -981,19 +987,19 @@ test_configs:
     test_plans: [boot]
 
   - device_type: qemu_arm
-    test_plans: [boot_qemu, simple_qemu, v4l2_qemu]
+    test_plans: [boot_qemu, simple_qemu, v4l2_qemu_vivid]
 
   - device_type: qemu_arm64
-    test_plans: [boot_qemu, simple_qemu, v4l2_qemu]
+    test_plans: [boot_qemu, simple_qemu, v4l2_qemu_vivid]
 
   - device_type: qemu_x86_64
-    test_plans: [boot_qemu, simple_qemu, v4l2_qemu]
+    test_plans: [boot_qemu, simple_qemu, v4l2_qemu_vivid]
 
   - device_type: r8a7791_porter
     test_plans: [boot]
 
   - device_type: rk3399_gru_kevin
-    test_plans: [boot, v4l2]
+    test_plans: [boot, v4l2_uvc]
 
   - device_type: rk3399_puma_haikou
     test_plans: [boot, kselftest]
@@ -1005,7 +1011,7 @@ test_configs:
     test_plans: [boot]
 
   - device_type: rk3288_veyron_jaq
-    test_plans: [boot, boot_nfs, sleep, usb, v4l2, igt, cros_ec]
+    test_plans: [boot, boot_nfs, sleep, usb, v4l2_uvc, igt, cros_ec]
 
   - device_type: salvator_x
     test_plans: [boot, boot_nfs, kselftest, simple]

--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -125,7 +125,10 @@ test_plans:
     rootfs: debian_stretch-v4l2_ramdisk
     pattern: 'v4l2/generic-qemu-v4l2-template.jinja2'
     filters:
-        - whitelist: {defconfig: ['defconfig+virtualvideo']}
+      - whitelist:
+          defconfig:
+            - 'defconfig+virtualvideo'
+            - 'multi_v7_defconfig+virtualvideo'
 
 device_default_filters:
 


### PR DESCRIPTION
Summary:
* add GCC plugin dev packages for arm, arm64 and x86
* improve v4l2-compliance test plan to run on either vivid or uvcvideo driver
* add build environment meta-data
* pass original compiler version in the build meta-data so it can be used in bisections
* add meson-gxl-s805x-p241 board
* fix some MIPS builds using the `all` target

This depends on kernelci-backend `2019.1.2` and was tested on staging as described in https://github.com/kernelci/kernelci-backend/pull/111#issuecomment-458746284.