### PR TITLE
Staging 20190315

### DIFF
--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -192,6 +192,14 @@ build_configs:
     tree: android
     branch: 'android-3.18'
 
+  android_3.18-o-mr1:
+    tree: android
+    branch: 'android-3.18-o-mr1'
+
+  android_3.18-o-release:
+    tree: android
+    branch: 'android-3.18-o-release'
+
   android_4.4:
     tree: android
     branch: 'android-4.4'
@@ -200,9 +208,21 @@ build_configs:
     tree: android
     branch: 'android-4.4-o'
 
+  android_4.4-o-mr1:
+    tree: android
+    branch: 'android-4.4-o-mr1'
+
+  android_4.4-o-release:
+    tree: android
+    branch: 'android-4.4-o-release'
+
   android_4.4-p:
     tree: android
     branch: 'android-4.4-p'
+
+  android_4.4-p-release:
+    tree: android
+    branch: 'android-4.4-p-release'
 
   android_4.9:
     tree: android
@@ -212,9 +232,21 @@ build_configs:
     tree: android
     branch: 'android-4.9-o'
 
+  android_4.9-o-mr1:
+    tree: android
+    branch: 'android-4.9-o-mr1'
+
+  android_4.9-o-release:
+    tree: android
+    branch: 'android-4.9-o-release'
+
   android_4.9-p:
     tree: android
     branch: 'android-4.9-p'
+
+  android_4.9-p-release:
+    tree: android
+    branch: 'android-4.9-p-release'
 
   android_4.14:
     tree: android
@@ -223,6 +255,10 @@ build_configs:
   android_4.14-p:
     tree: android
     branch: 'android-4.14-p'
+
+  android_4.14-p-release:
+    tree: android
+    branch: 'android-4.14-p-release'
 
   android_4.19:
     tree: android

--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -115,13 +115,13 @@ fragments:
   virtualvideo:
     path: "kernel/configs/virtualvideo.config"
     configs:
-      - CONFIG_MEDIA_SUPPORT=y
-      - CONFIG_MEDIA_CAMERA_SUPPORT=y
-      - CONFIG_VIDEO_DEV=y
-      - CONFIG_VIDEO_V4L2=y
-      - CONFIG_V4L_TEST_DRIVERS=y
-      - CONFIG_VIDEO_VIVID=y
-      - CONFIG_VIDEO_VIVID_MAX_DEVS=64
+      - 'CONFIG_MEDIA_SUPPORT=y'
+      - 'CONFIG_MEDIA_CAMERA_SUPPORT=y'
+      - 'CONFIG_VIDEO_DEV=y'
+      - 'CONFIG_VIDEO_V4L2=y'
+      - 'CONFIG_V4L_TEST_DRIVERS=y'
+      - 'CONFIG_VIDEO_VIVID=y'
+      - 'CONFIG_VIDEO_VIVID_MAX_DEVS=64'
 
 
 build_environments:
@@ -130,9 +130,9 @@ build_environments:
     cc: gcc
     cc_version: 7
     arch_map: &gcc_arch_map
-      i386: x86
-      x86_64: x86
-      riscv: riscv64
+      i386: 'x86'
+      x86_64: 'x86'
+      riscv: 'riscv64'
 
   gcc-8:
     cc: gcc

--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -454,11 +454,11 @@ build_configs:
 
   renesas:
     tree: renesas
-    branch: 'next'
+    branch: 'devel'
 
   renesas_next:
     tree: renesas
-    branch: 'devel'
+    branch: 'next'
 
   rt-stable_v3.18-rt:
     tree: rt-stable

--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -464,9 +464,9 @@ build_configs:
     tree: stable
     branch: 'linux-4.14.y'
 
-  stable_4.18:
+  stable_4.19:
     tree: stable
-    branch: 'linux-4.18.y'
+    branch: 'linux-4.19.y'
 
   stable-rc_3.18:
     tree: stable-rc
@@ -484,9 +484,9 @@ build_configs:
     tree: stable-rc
     branch: 'linux-4.14.y'
 
-  stable-rc_4.18:
+  stable-rc_4.19:
     tree: stable-rc
-    branch: 'linux-4.18.y'
+    branch: 'linux-4.19.y'
 
   tegra:
     tree: tegra

--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -112,6 +112,22 @@ trees:
 
 fragments:
 
+  debug:
+    path: "kernel/configs/debug.config"
+
+  kselftest:
+    path: "kernel/configs/kselftest.config"
+
+  linaro_android_base:
+    path: "android/configs/android-base.cfg"
+
+  linaro_android_recommended:
+    path: "android/configs/android-recommended.cfg"
+
+  tinyconfig:
+    path: "kernel/configs/tiny.config"
+    defconfig: 'tinyconfig'
+
   virtualvideo:
     path: "kernel/configs/virtualvideo.config"
     configs:
@@ -122,6 +138,9 @@ fragments:
       - 'CONFIG_V4L_TEST_DRIVERS=y'
       - 'CONFIG_VIDEO_VIVID=y'
       - 'CONFIG_VIDEO_VIVID_MAX_DEVS=64'
+
+  x86_kvm_guest:
+    path: "arch/x86/configs/kvm_guest.config"
 
 
 build_environments:
@@ -158,16 +177,92 @@ build_environments:
 
 
 build_configs_defaults:
+
+  gcc-7:
+
+    build_environment: gcc-7
+
+    fragments: &default_fragments
+      - 'debug'
+      - 'kselftest'
+      - 'tinyconfig'
+
+    architectures: &default_architectures
+
+      arc: &arc_arch
+        base_defconfig: 'nsim_hs_defconfig'
+        extra_configs: ['allnoconfig']
+        filters: &arc_defconfig_filters
+          # remove any non-ARCv2 defconfigs since we only have ARCv2 toolchain
+          - blacklist:
+              defconfig:
+                - 'axs101_defconfig'
+                - 'nps_defconfig'
+                - 'nsim_700_defconfig'
+                - 'nsimosci_defconfig'
+                - 'tb10x_defconfig'
+
+      arm: &arm_arch
+        base_defconfig: 'multi_v7_defconfig'
+        extra_configs:
+          - 'allnoconfig'
+          - 'multi_v7_defconfig+CONFIG_CPU_BIG_ENDIAN=y'
+          - 'multi_v7_defconfig+CONFIG_SMP=n'
+          - 'multi_v7_defconfig+CONFIG_EFI=y+CONFIG_ARM_LPAE=y'
+
+      arm64: &arm64_arch
+        extra_configs:
+          - 'allmodconfig'
+          - 'allnoconfig'
+          - 'defconfig+CONFIG_CPU_BIG_ENDIAN=y'
+          - 'defconfig+CONFIG_RANDOMIZE_BASE=y'
+
+      i386: &i386_arch
+        base_defconfig: 'i386_defconfig'
+        extra_configs: ['allnoconfig']
+
+      mips: &mips_arch
+        base_defconfig: '32r2el_defconfig'
+        extra_configs: ['allnoconfig']
+        filters: &mips_defconfig_filters
+          - blacklist: {defconfig: ['generic_defconfig']}
+
+      riscv: &riscv_arch
+        extra_configs: ['allnoconfig']
+
+      x86_64: &x86_64_arch
+        base_defconfig: 'x86_64_defconfig'
+        extra_configs: ['allmodconfig', 'allnoconfig']
+        fragments: [x86_kvm_guest]
+
+
+# Build fewer kernel configs with stable branches
+stable_variants: &stable_variants
   gcc-7:
     build_environment: gcc-7
-    arch_list: &default_arch_list
-      - i386
-      - x86_64
-      - arm
-      - arm64
-      - mips
-      - arc
-      - riscv
+    fragments: ['tinyconfig']
+    architectures:
+      arc:
+        base_defconfig: 'nsim_hs_defconfig'
+        extra_configs: ['allnoconfig']
+        filters: *arc_defconfig_filters
+      arm:
+        base_defconfig: 'multi_v7_defconfig'
+        extra_configs: ['allnoconfig']
+      arm64:
+        extra_configs: ['allnoconfig']
+      i386:
+        base_defconfig: 'i386_defconfig'
+        extra_configs: ['allnoconfig']
+      mips:
+        base_defconfig: '32r2el_defconfig'
+        extra_configs: ['allnoconfig']
+        filters: *mips_defconfig_filters
+      riscv:
+        extra_configs: ['allnoconfig']
+      x86_64:
+        base_defconfig: 'x86_64_defconfig'
+        extra_configs: ['allnoconfig']
 
 
 build_configs:
@@ -275,6 +370,21 @@ build_configs:
   ardb_arm-kaslr-latest:
     tree: ardb
     branch: 'arm-kaslr-latest'
+    variants:
+      gcc-7:
+        build_environment: gcc-7
+        architectures:
+          x86_64: *x86_64_arch
+          arm64: *arm64_arch
+          arm:
+            base_defconfig: 'multi_v7_defconfig'
+            extra_configs:
+              - 'multi_v7_defconfig+CONFIG_CPU_BIG_ENDIAN=y'
+              - 'multi_v7_defconfig+CONFIG_SMP=n'
+              - 'multi_v7_defconfig+CONFIG_EFI=y+CONFIG_ARM_LPAE=y'
+              - 'multi_v7_defconfig+CONFIG_RANDOMIZE_BASE=y'
+              - 'multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y+CONFIG_RANDOMIZE_BASE=y'
+              - 'omap2plus_defconfig+CONFIG_RANDOMIZE_BASE=y'
 
   arnd:
     tree: arnd
@@ -374,6 +484,14 @@ build_configs:
   lsk_v4.4-android-test:
     tree: lsk
     branch: 'linux-linaro-lsk-v4.4-android-test'
+    variants:
+      gcc-7:
+        build_environment: gcc-7
+        fragments: [linaro_android_base, linaro_android_recommended]
+        architectures:
+          arm: *arm_arch
+          arm64: *arm64_arch
+          x86_64: *x86_64_arch
 
   lsk_v4.9:
     tree: lsk
@@ -417,8 +535,12 @@ build_configs:
     variants:
       gcc-7:
         build_environment: gcc-7
-        arch_list: ['i386', 'x86_64', 'arm', 'arm64']
         fragments: [virtualvideo]
+        architectures:
+          i386: *i386_arch
+          x86_64: *x86_64_arch
+          arm: *arm_arch
+          arm64: *arm64_arch
 
   net-next:
     tree: net-next
@@ -427,6 +549,25 @@ build_configs:
   next:
     tree: next
     branch: 'master'
+    variants:
+      gcc-7:
+        build_environment: gcc-7
+        fragments: *default_fragments
+        architectures:
+          i386: *i386_arch
+          x86_64: *x86_64_arch
+          mips: *mips_arch
+          riscv: *riscv_arch
+          arc: *arc_arch
+          arm64: *arm64_arch
+          arm:
+            base_defconfig: 'multi_v7_defconfig'
+            extra_configs:
+              - 'multi_v7_defconfig+CONFIG_CPU_BIG_ENDIAN=y'
+              - 'multi_v7_defconfig+CONFIG_SMP=n'
+              - 'multi_v7_defconfig+CONFIG_EFI=y+CONFIG_ARM_LPAE=y'
+              - 'allnoconfig'
+              - 'allmodconfig'
 
   next_pending-fixes:
     tree: next
@@ -487,42 +628,52 @@ build_configs:
   stable_3.18:
     tree: stable
     branch: 'linux-3.18.y'
+    variants: *stable_variants
 
   stable_4.4:
     tree: stable
     branch: 'linux-4.4.y'
+    variants: *stable_variants
 
   stable_4.9:
     tree: stable
     branch: 'linux-4.9.y'
+    variants: *stable_variants
 
   stable_4.14:
     tree: stable
     branch: 'linux-4.14.y'
+    variants: *stable_variants
 
   stable_4.19:
     tree: stable
     branch: 'linux-4.19.y'
+    variants: *stable_variants
 
   stable-rc_3.18:
     tree: stable-rc
     branch: 'linux-3.18.y'
+    variants: *stable_variants
 
   stable-rc_4.4:
     tree: stable-rc
     branch: 'linux-4.4.y'
+    variants: *stable_variants
 
   stable-rc_4.9:
     tree: stable-rc
     branch: 'linux-4.9.y'
+    variants: *stable_variants
 
   stable-rc_4.14:
     tree: stable-rc
     branch: 'linux-4.14.y'
+    variants: *stable_variants
 
   stable-rc_4.19:
     tree: stable-rc
     branch: 'linux-4.19.y'
+    variants: *stable_variants
 
   tegra:
     tree: tegra

--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -378,8 +378,11 @@ build_configs:
   media:
     tree: media
     branch: 'master'
-    arch_list: ['i386', 'x86_64', 'arm', 'arm64']
-    fragments: [virtualvideo]
+    variants:
+      gcc-7:
+        build_environment: gcc-7
+        arch_list: ['i386', 'x86_64', 'arm', 'arm64']
+        fragments: [virtualvideo]
 
   net-next:
     tree: net-next

--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -224,6 +224,10 @@ build_configs:
     tree: android
     branch: 'android-4.14-p'
 
+  android_4.19:
+    tree: android
+    branch: 'android-4.19'
+
   android_mainline_tracking:
     tree: android
     branch: 'android-mainline-tracking'

--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -58,6 +58,9 @@ trees:
   linaro-android:
     url: "https://android-git.linaro.org/git/kernel/linaro-android.git"
 
+  linusw:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/linusw/linux-gpio.git/"
+
   lsk:
     url: "https://git.linaro.org/kernel/linux-linaro-stable.git"
 
@@ -291,6 +294,18 @@ build_configs:
   linaro-android:
     tree: linaro-android
     branch: 'linaro-android-llct'
+
+  linusw_devel:
+    tree: linusw
+    branch: 'devel'
+
+  linusw_fixes:
+    tree: linusw
+    branch: 'fixes'
+
+  linusw_for-next:
+    tree: linusw
+    branch: 'for-next'
 
   lsk_for-test:
     tree: lsk

--- a/build.py
+++ b/build.py
@@ -182,8 +182,6 @@ for o, a in opts:
         for a in defs:
             if os.path.exists("arch/%s/configs/%s" % (arch, a)):
                 defconfig = a
-            elif a == "defconfig" or a == "tinyconfig" or re.match("all(\w*)config", a):
-                defconfig = a
             elif os.path.exists(a):
                 # Append fragment contents to temp frag file
                 frag = open(a)
@@ -197,9 +195,8 @@ for o, a in opts:
                 os.write(kconfig_tmpfile_fd, a + "\n")
                 os.fsync(kconfig_tmpfile_fd)
                 frag_names.append(a)
-            else:
-                print "ERROR: kconfig file/fragment (%s) doesn't exist" %a
-                sys.exit(1)
+            else: # assume it's a special build target
+                defconfig = a
 
     if o == '-i':
         install = True

--- a/jenkins/bisect.jpl
+++ b/jenkins/bisect.jpl
@@ -204,7 +204,7 @@ git bisect reset || echo -n
 git checkout --detach HEAD || echo -n
 git branch -D ${params.KERNEL_BRANCH} || echo -n
 for t in \$(git tag -l | grep ${env.JOB_NAME}); do git tag -d \$t; done
-git fetch ${params.KERNEL_TREE} ${params.KERNEL_BRANCH} --tags
+git fetch ${params.KERNEL_TREE} ${params.KERNEL_BRANCH} --tags -f
 git checkout ${params.BAD_COMMIT} -b ${params.KERNEL_BRANCH}
 git symbolic-ref HEAD refs/heads/${params.KERNEL_BRANCH}
 """)

--- a/jenkins/build-trigger.jpl
+++ b/jenkins/build-trigger.jpl
@@ -183,49 +183,49 @@ def addExtraConfigs(configs, kdir, arch, tree_name, branch) {
 }
 
 def configAlreadyBuilt(config, kci_core) {
-    def new_commit = sh(
+    def new_commit = null
+
+    dir(kci_core) {
+        new_commit = sh(
         script: """
-${kci_core}/kci_build \
---build-configs=${kci_core}/build-configs.yaml \
+./kci_build \
 --config=${config} \
 --storage=${params.KCI_STORAGE_URL} \
 check_new_commit""", returnStdout: true).trim()
+    }
 
     return (new_commit == "")
 }
 
 def pushTarball(config, kci_core, mirror, kdir, opts) {
-    sh(script: """\
-${kci_core}/kci_build \
---build-configs=${kci_core}/build-configs.yaml \
+    dir(kci_core) {
+        sh(script: """\
+./kci_build \
 --config=${config} \
 --mirror=${mirror} \
 update_mirror""")
 
-    sh(script: """\
-${kci_core}/kci_build \
---build-configs=${kci_core}/build-configs.yaml \
+        sh(script: """\
+./kci_build \
 --config=${config} \
 --kdir=${kdir} \
 --mirror=${mirror} \
 update_repo""")
 
-    def describe_raw = sh(script: """\
-${kci_core}/kci_build \
---build-configs=${kci_core}/build-configs.yaml \
+        def describe_raw = sh(script: """\
+./kci_build \
 --config=${config} \
 --kdir=${kdir} \
 describe""", returnStdout: true).trim()
-    def describe_list = describe_raw.tokenize('\n')
-    opts['commit'] = describe_list[0]
-    opts['describe'] = describe_list[1]
-    opts['describe_verbose'] = describe_list[2]
+        def describe_list = describe_raw.tokenize('\n')
+        opts['commit'] = describe_list[0]
+        opts['describe'] = describe_list[1]
+        opts['describe_verbose'] = describe_list[2]
 
-    withCredentials([string(credentialsId: params.KCI_TOKEN_ID,
-                            variable: 'SECRET')]) {
-        sh(script: """\
-${kci_core}/kci_build \
---build-configs=${kci_core}/build-configs.yaml \
+        withCredentials([string(credentialsId: params.KCI_TOKEN_ID,
+                                variable: 'SECRET')]) {
+            sh(script: """\
+./kci_build \
 --config=${config} \
 --kdir=${kdir} \
 --commit=${opts['commit']} \
@@ -234,15 +234,15 @@ ${kci_core}/kci_build \
 --token=${SECRET} \
 update_last_commit""")
 
-        opts['tarball_url'] = sh(script: """\
-${kci_core}/kci_build \
---build-configs=${kci_core}/build-configs.yaml \
+            opts['tarball_url'] = sh(script: """\
+./kci_build \
 --config=${config} \
 --kdir=${kdir} \
 --storage=${params.KCI_STORAGE_URL} \
 --api=${params.KCI_API_URL} \
 --token=${SECRET} \
 push_tarball""", returnStdout: true).trim()
+        }
     }
 }
 

--- a/jenkins/build-trigger.jpl
+++ b/jenkins/build-trigger.jpl
@@ -46,142 +46,6 @@ ALLOW_REBUILD (false)
 import org.kernelci.build.Kernel
 import org.kernelci.util.Job
 
-def addDefconfigs(configs, kdir, arch, tree_name, branch) {
-    def configs_dir = "${kdir}/arch/${arch}/configs"
-
-    if (fileExists(configs_dir)) {
-        dir(configs_dir) {
-            def found = sh(script: "ls -1 *defconfig || echo -n",
-                           returnStdout: true)
-            for (String config: found.tokenize(' \n'))
-                configs.add(config)
-        }
-        if (arch == "mips") {
-            configs.remove("generic_defconfig")
-        }
-        if (arch == "arc") {
-            // remove any non ARCv2 defconfigs since we only have ARCv2 toolchain
-            dir(configs_dir) {
-                def found = sh(script: "grep -L CONFIG_ISA_ARCV2 *defconfig || echo -n",
-                               returnStdout: true)
-                for (String config: found.tokenize(' \n'))
-                    configs.remove(config)
-            }
-	    // also remove "nsim_hs_defconfig" since this will be base_defconfig later
-	    configs.remove("nsim_hs_defconfig")
-        }
-    } else {
-        echo("WARNING: No configs directory: ${configs_dir}")
-    }
-
-    if (fileExists("${kdir}/kernel/configs/tiny.config"))
-        configs.add("tinyconfig")
-}
-
-def addExtraIfExists(extra, kdir, path) {
-    if (fileExists("${kdir}/${path}"))
-        extra.add(path)
-}
-
-def addExtraConfigs(configs, kdir, arch, tree_name, branch) {
-    def configs_dir = "${kdir}/arch/${arch}/configs"
-    def base_defconfig = "defconfig"
-    def extra = []
-
-    if (arch == "arc") {
-        // default "defconfig" is not ARCv2, and we only have ARCv2 toolchain
-        base_defconfig = "nsim_hs_defconfig"
-    } else if (arch == "arm") {
-        base_defconfig = "multi_v7_defconfig"
-
-        extra = [
-            "CONFIG_CPU_BIG_ENDIAN=y",
-            "CONFIG_SMP=n",
-            "CONFIG_EFI=y+CONFIG_ARM_LPAE=y",
-        ]
-
-        if (fileExists("${configs_dir}/mvebu_v7_defconfig"))
-            configs.add("mvebu_v7_defconfig+CONFIG_CPU_BIG_ENDIAN=y")
-
-        if (tree_name == "next")
-            configs.add("allmodconfig")
-
-        if (tree_name == "ardb" && branch == "arm-kaslr-latest"){
-            extra.add("CONFIG_RANDOMIZE_BASE=y")
-            extra.add("CONFIG_THUMB2_KERNEL=y+CONFIG_RANDOMIZE_BASE=y")
-            configs.add("multi_v5_defconfig")
-            configs.add("omap2plus_defconfig+CONFIG_RANDOMIZE_BASE=y")
-            configs.add("omap2plus_defconfig")
-        }
-    } else if (arch == "arm64") {
-        configs.add("allmodconfig")
-
-        extra = [
-            "CONFIG_CPU_BIG_ENDIAN=y",
-            "CONFIG_RANDOMIZE_BASE=y",
-        ]
-    } else if (arch == "x86") {
-        configs.add("allmodconfig")
-        addExtraIfExists(extra, kdir, "arch/x86/configs/kvm_guest.config")
-    }
-
-    for (String frag: ["debug", "kselftest"])
-        addExtraIfExists(extra, kdir, "kernel/configs/${frag}.config")
-
-    if (tree_name == "lsk" || tree_name == "anders") {
-        def frags = "linaro/configs/kvm-guest.conf"
-
-        /* For -rt kernels, build with RT fragment */
-        def rt_frag = "kernel/configs/preempt-rt.config"
-
-        if (!fileExists("${kdir}/${rt_frag}"))
-            rt_frag = "linaro/configs/preempt-rt.conf"
-
-        def has_preempt_rt_full = sh(
-            returnStatus: true,
-            script: "grep -q \"config PREEMPT_RT_FULL\" ${kdir}/kernel/Kconfig.preempt")
-
-        if (has_preempt_rt_full)
-            extra.add(rt_frag)
-
-        if (arch == "arm") {
-            def kvm_host_frag = "linaro/configs/kvm-host.conf"
-            if (fileExists("${kdir}/${kvm_host_frag}")) {
-                def lpae_base = "multi_v7_defconfig+CONFIG_ARM_LPAE=y"
-                configs.add("${lpae_base}+${kvm_host_frag}")
-            }
-        }
-
-        for (String frag: ["linaro-base", "distribution"])
-            addExtraIfExists(extra, kdir, "linaro/configs/${frag}.conf")
-
-        if (fileExists("${kdir}/android/configs")) {
-            for (String frag: ['base', 'recommended']) {
-                def path = "android/configs/android-${frag}.cfg"
-                def android_extra = ""
-
-                if (fileExists(path))
-                    android_extra += "+${path}"
-            }
-
-            if (android_extra) {
-                configs.add("${base_defconfig}${android_extra}")
-
-                /* Also build vexpress_defconfig for testing on QEMU */
-                configs.add("vexpress_defconfig${android_extra}")
-            }
-        }
-    }
-
-    addExtraIfExists(extra, kdir, "kernel/configs/virtualvideo.config")
-
-    if (!configs.contains(base_defconfig))
-        configs.add(base_defconfig)
-
-    for (String e: extra)
-        configs.add("${base_defconfig}+${e}")
-}
-
 def configAlreadyBuilt(config, kci_core) {
     def new_commit = null
 
@@ -234,6 +98,12 @@ describe""", returnStdout: true).trim()
 --token=${SECRET} \
 update_last_commit""")
 
+            sh(script: """\
+./kci_build \
+--config=${config} \
+--kdir=${kdir} \
+generate_fragments""")
+
             opts['tarball_url'] = sh(script: """\
 ./kci_build \
 --config=${config} \
@@ -246,28 +116,27 @@ push_tarball""", returnStdout: true).trim()
     }
 }
 
-def getVariants(config, kci_core) {
-    def variants = null
-
+def listConfigs(config, kci_core, kdir, config_list) {
     dir(kci_core) {
-        def raw_variants = sh(
-            script: """\
+        def kernel_config_list_raw = sh(script: """\
 ./kci_build \
 --config=${config} \
-list_variants""", returnStdout: true).trim()
-        variants = raw_variants.tokenize('\n')
-    }
+--kdir=${kdir} \
+list_kernel_configs""", returnStdout: true).trim()
+        def kernel_config_list = kernel_config_list_raw.tokenize('\n')
 
-    return variants
+        for (String kernel_config_raw: kernel_config_list) {
+            def data = kernel_config_raw.tokenize(' ')
+            def arch = data[0]
+            def defconfig = data[1]
+            def cc = data[2]
+            def cc_version = data[3]
+            config_list.add([arch, defconfig, cc, cc_version])
+        }
+    }
 }
 
-def listConfigs(config, kci_core, kdir, opts, variant, config_list) {
-    def tree_name = null
-    def branch = null
-    def arch_list = null
-    def cc = null
-    def cc_version = null
-
+def addBuildOpts(config, kci_core, opts) {
     dir(kci_core) {
         def opts_raw = sh(
             script: """\
@@ -275,48 +144,32 @@ def listConfigs(config, kci_core, kdir, opts, variant, config_list) {
 --config=${config} \
 tree_branch""", returnStdout: true).trim()
         def opt_list = opts_raw.tokenize('\n')
-        tree_name = opt_list[0]
-        branch = opt_list[2]
-        opts['tree'] = tree_name
+        opts['tree'] = opt_list[0]
         opts['git_url'] = opt_list[1]
-        opts['branch'] = branch
+        opts['branch'] = opt_list[2]
 
-        def raw_arch_list = sh(
+        def raw_variants = sh(
             script: """\
+./kci_build \
+--config=${config} \
+list_variants""", returnStdout: true).trim()
+        def variants = raw_variants.tokenize('\n')
+
+        def arch_list = []
+        for (String variant: variants) {
+            def raw_variant_arch_list = sh(
+                script: """\
 ./kci_build \
 --config=${config} \
 --variant=${variant} \
 arch_list""", returnStdout: true).trim()
-        arch_list = raw_arch_list.tokenize('\n')
+            def variant_arch_list = raw_variant_arch_list.tokenize('\n')
 
-        def opt_arch_list = opts['arch_list']
-        print("opt_arch_list: ${opt_arch_list}")
-        for (String arch: arch_list)
-            if (!opt_arch_list.contains(arch))
-                opt_arch_list.add(arch)
-        opts['arch_list'] = opt_arch_list
-
-        def build_env_raw = sh(script: """\
-./kci_build \
---config=${config} \
---variant=${variant} \
-build_environment""", returnStdout: true).trim()
-        def build_env_list = build_env_raw.tokenize('\n')
-        def build_env = build_env_list[0]
-        cc = build_env_list[1]
-        cc_version = build_env_list[2]
-    }
-
-    for (String arch: arch_list) {
-        def configs = ["allnoconfig"]
-
-        addDefconfigs(configs, kdir, arch, tree_name, branch)
-
-        if ((tree_name != "stable") && (tree_name != "stable-rc"))
-            addExtraConfigs(configs, kdir, arch, tree_name, branch)
-
-        for (String kernel_config: configs)
-            config_list.add([arch, kernel_config, cc, cc_version])
+            for (String arch: variant_arch_list)
+                if (!arch_list.contains(arch))
+                    arch_list.add(arch)
+        }
+        opts['arch_list'] = arch_list
     }
 }
 
@@ -396,18 +249,14 @@ node("defconfig-creator") {
         }
 
         stage("Configs") {
-            def variants = getVariants(params.BUILD_CONFIG, kci_core)
-            opts['arch_list'] = []
-
-            for (String variant: variants) {
-                listConfigs(params.BUILD_CONFIG, kci_core, kdir, opts,
-                            variant, configs)
-            }
+            listConfigs(params.BUILD_CONFIG, kci_core, kdir, configs)
         }
 
         stage("Build") {
             def builds = [:]
             def i = 0
+
+            addBuildOpts(params.BUILD_CONFIG, kci_core, opts)
 
             for (x in configs) {
                 def arch = x[0]

--- a/jenkins/lava-boot-v2.sh
+++ b/jenkins/lava-boot-v2.sh
@@ -50,4 +50,7 @@ elif [ ${LAB} = "lab-linaro-lkft" ] || [ ${LAB} = "lab-linaro-lkft-dev" ]; then
 elif [ ${LAB} = "lab-theobroma-systems" ] || [ ${LAB} = "lab-theobroma-systems-dev" ]; then
   python lava-v2-jobs-from-api.py --defconfigs ${DEFCONFIG_COUNT} --callback ${CALLBACK} --api ${API} --storage ${STORAGE} --lab ${LAB} --describe ${GIT_DESCRIBE} --tree ${TREE} --branch ${BRANCH} --arch ${ARCH} --plans boot kselftest --token ${API_TOKEN}
   python lava-v2-submit-jobs.py --username kernel-ci --jobs ${LAB} --token ${LAVA_THEOBROMA_SYSTEMS_TOKEN} --lab ${LAB}
+elif [ ${LAB} = "lab-drue" ] || [ ${LAB} = "lab-drue-dev" ]; then
+  python lava-v2-jobs-from-api.py --defconfigs ${DEFCONFIG_COUNT} --callback ${CALLBACK} --api ${API} --storage ${STORAGE} --lab ${LAB} --describe ${GIT_DESCRIBE} --tree ${TREE} --branch ${BRANCH} --arch ${ARCH} --plans boot boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp simple --token ${API_TOKEN} --priority medium
+  python lava-v2-submit-jobs.py --username kernel-ci --jobs ${LAB} --token ${LAVA_DRUE_TOKEN} --lab ${LAB}
 fi

--- a/kci_build
+++ b/kci_build
@@ -69,8 +69,7 @@ def cmd_update_mirror(configs, args):
 
 def cmd_update_repo(configs, args):
     conf = configs['build_configs'][args.config]
-    kdir = args.kdir or args.config
-    kernelci.build.update_repo(conf, kdir, args.mirror)
+    kernelci.build.update_repo(conf, args.kdir, args.mirror)
     return True
 
 

--- a/kci_build
+++ b/kci_build
@@ -84,6 +84,12 @@ def cmd_describe(configs, args):
     return True
 
 
+def cmd_generate_fragments(configs, args):
+    conf = configs['build_configs'][args.config]
+    kernelci.build.generate_fragments(conf, args.kdir)
+    return True
+
+
 def cmd_push_tarball(configs, args):
     conf = configs['build_configs'][args.config]
     func_args = (conf, args.kdir, args.storage, args.api, args.token)

--- a/kci_build
+++ b/kci_build
@@ -128,6 +128,16 @@ def cmd_build_environment(configs, args):
         print(variant.build_environment.get_arch_name(args.arch))
     return True
 
+
+def cmd_list_kernel_configs(configs, args):
+    conf = configs['build_configs'][args.config]
+    configs = kernelci.build.list_kernel_configs(
+        conf, args.kdir, args.variant, args.arch)
+    for item in configs:
+        print(' '.join(item))
+    return True
+
+
 # -----------------------------------------------------------------------------
 # Main
 #

--- a/kernelci/configs.py
+++ b/kernelci/configs.py
@@ -38,7 +38,7 @@ class YAMLObject(object):
         """
         return {
             k: v for k, v in ((k, data.get(k)) for k in args) if v
-        }
+        } if data else dict()
 
 
 class Filter(object):

--- a/kernelci/configs.py
+++ b/kernelci/configs.py
@@ -170,17 +170,20 @@ class Tree(YAMLObject):
 
 class Fragment(YAMLObject):
 
-    def __init__(self, name, path, configs=None):
+    def __init__(self, name, path, configs=None, defconfig=None):
         self._name = name
         self._path = path
         self._configs = configs or list()
+        self._defconfig = defconfig
 
     @classmethod
     def from_yaml(cls, config, name):
         kw = {
             'name': name,
         }
-        kw.update(cls._kw_from_yaml(config, ['name', 'path', 'configs']))
+        kw.update(cls._kw_from_yaml(config, [
+            'name', 'path', 'configs', 'defconfig',
+        ]))
         return cls(**kw)
 
     @property
@@ -194,6 +197,10 @@ class Fragment(YAMLObject):
     @property
     def configs(self):
         return list(self._configs)
+
+    @property
+    def defconfig(self):
+        return self._defconfig
 
 
 class BuildEnvironment(YAMLObject):

--- a/kernelci/configs.py
+++ b/kernelci/configs.py
@@ -130,7 +130,7 @@ class FilterFactory(YAMLObject):
         return filter_list
 
     @classmethod
-    def from_data(cls, data, default_filters=[]):
+    def from_data(cls, data, default_filters=None):
         """Look for filters in YAML *data* or return *default_filters*.
 
         Look for a *filters* element in the YAML *data* dictionary.  If there
@@ -170,10 +170,10 @@ class Tree(YAMLObject):
 
 class Fragment(YAMLObject):
 
-    def __init__(self, name, path, configs):
+    def __init__(self, name, path, configs=None):
         self._name = name
         self._path = path
-        self._configs = configs
+        self._configs = configs or list()
 
     @classmethod
     def from_yaml(cls, config, name):
@@ -202,7 +202,7 @@ class BuildEnvironment(YAMLObject):
         self._name = name
         self._cc = cc
         self._cc_version = cc_version
-        self._arch_map = arch_map or {}
+        self._arch_map = arch_map or dict()
 
     @classmethod
     def from_yaml(cls, config, name):
@@ -235,7 +235,7 @@ class BuildVariant(YAMLObject):
         self._name = name
         self._arch_list = arch_list
         self._build_environment = build_environment
-        self._fragments = fragments or []
+        self._fragments = fragments or list()
 
     @classmethod
     def from_yaml(cls, config, name, fragments, build_environments):
@@ -319,7 +319,7 @@ class DeviceType(YAMLObject):
     """Device type model."""
 
     def __init__(self, name, mach, arch, boot_method, dtb=None,
-                 flags=[], filters=[], context={}):
+                 flags=None, filters=None, context=None):
         """A device type describes a category of equivalent hardware devices.
 
         *name* is unique for the device type, typically as used by LAVA.
@@ -336,9 +336,9 @@ class DeviceType(YAMLObject):
         self._arch = arch
         self._boot_method = boot_method
         self._dtb = dtb
-        self._flags = flags
-        self._filters = filters
-        self._context = context
+        self._flags = flags or list()
+        self._filters = filters or list()
+        self._context = context or dict()
 
     def __repr__(self):
         return self.name
@@ -403,7 +403,7 @@ class DeviceTypeFactory(YAMLObject):
     }
 
     @classmethod
-    def from_yaml(cls, name, device_type, default_filters=[]):
+    def from_yaml(cls, name, device_type, default_filters=None):
         kw = cls._kw_from_yaml(device_type, [
             'mach', 'arch', 'boot_method', 'dtb', 'flags', 'context'])
         kw.update({
@@ -418,7 +418,7 @@ class DeviceTypeFactory(YAMLObject):
 class RootFSType(YAMLObject):
     """Root file system type model."""
 
-    def __init__(self, url, arch_dict={}):
+    def __init__(self, url, arch_dict=None):
         """A root file system type covers common file system features.
 
         *url* is the base URL for file system binaries.  Each file system
@@ -433,7 +433,7 @@ class RootFSType(YAMLObject):
                     properties such as the endinanness.
         """
         self._url = url
-        self._arch_dict = arch_dict
+        self._arch_dict = arch_dict or dict()
 
     @classmethod
     def from_yaml(cls, fs_type):
@@ -535,8 +535,8 @@ class TestPlan(YAMLObject):
 
     _pattern = '{plan}/{category}-{method}-{protocol}-{rootfs}-{plan}-template.jinja2'
 
-    def __init__(self, name, rootfs, params={}, category='generic',
-                 filters=[], pattern=None):
+    def __init__(self, name, rootfs, params=None, category='generic',
+                 filters=None, pattern=None):
         """A test plan is an arbitrary group of test cases to be run.
 
         *name* is the overall arbitrary test plan name, used when looking for
@@ -558,14 +558,14 @@ class TestPlan(YAMLObject):
         """
         self._name = name
         self._rootfs = rootfs
-        self._params = params
+        self._params = params or dict()
         self._category = category
-        self._filters = filters
+        self._filters = filters or list()
         if pattern:
             self._pattern = pattern
 
     @classmethod
-    def from_yaml(cls, name, test_plan, file_systems, default_filters=[]):
+    def from_yaml(cls, name, test_plan, file_systems, default_filters=None):
         kw = {
             'name': name,
             'rootfs': file_systems[test_plan['rootfs']],
@@ -608,7 +608,7 @@ class TestPlan(YAMLObject):
 class TestConfig(YAMLObject):
     """Test configuration model."""
 
-    def __init__(self, device_type, test_plans, filters=[]):
+    def __init__(self, device_type, test_plans, filters=None):
         """A test configuration has a *device_type* and a list of *test_plans*.
 
         *device_type* is a DeviceType object.
@@ -618,11 +618,11 @@ class TestConfig(YAMLObject):
         self._test_plans = {
             t.name: t for t in test_plans
         }
-        self._filters = filters
+        self._filters = filters or list()
 
     @classmethod
     def from_yaml(cls, test_config, device_types, test_plans,
-                  default_filters=[]):
+                  default_filters=None):
         kw = {
             'device_type': device_types[test_config['device_type']],
             'test_plans': [test_plans[test]

--- a/kernelci/configs.py
+++ b/kernelci/configs.py
@@ -201,7 +201,7 @@ class BuildEnvironment(YAMLObject):
     def __init__(self, name, cc, cc_version, arch_map=None):
         self._name = name
         self._cc = cc
-        self._cc_version = cc_version
+        self._cc_version = str(cc_version)
         self._arch_map = arch_map or dict()
 
     @classmethod

--- a/labs.ini
+++ b/labs.ini
@@ -18,6 +18,12 @@ api: https://lava.collabora.co.uk/RPC2/
 [lab-collabora-dev]
 api: https://lava.collabora.co.uk/RPC2/
 
+[lab-drue]
+api: https://lava.therub.org/RPC2/
+
+[lab-drue-dev]
+api: https://lava.therub.org/RPC2/
+
 [lab-embeddedbits]
 api: http://kernelci.embedded-bits.co.uk/RPC2/
 


### PR DESCRIPTION
Summary:

* add `lab-drue` for staging and production
* add missing android release branches and new android-4.19 branch
* add Linus Walleij's GPIO tree with 2 branches
* monitor linux-4.19.y which is the new LTS and drop linux-4.18.y which has reached end-of-life
* accept any `make` target in `build.py` to fix issue with MIPS defconfig `32r2el_defconfig`
* describe which kernels to build in `build-configs.yaml` and remove logic in `build-trigger.jpl`

Note: #21 will also be merged along before this one.

Going forward, we'll start using branches in this `kernelci-core` project and stop using `kernelci-core-staging` as it's causing confusion.  More on this later on the mailing list `kernelci@groups.io`.