### PR TITLE
Add basic configs tests using pytest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+test:
+	# Note that just running 'pytest' will not work here because there is no setup.py. See
+	# https://docs.pytest.org/en/latest/pythonpath.html#invoking-pytest-versus-python-m-pytest
+	python -m pytest

--- a/kernelci/configs.py
+++ b/kernelci/configs.py
@@ -373,7 +373,7 @@ class BuildVariant(YAMLObject):
             config, ['name', 'build_environment', 'fragments']))
         kw['build_environment'] = build_environments[kw['build_environment']]
         kw['architectures'] = list(
-            Architecture.from_yaml(data, name, fragments)
+            Architecture.from_yaml(data or {}, name, fragments)
             for name, data in config['architectures'].iteritems()
         )
         cf = kw.get('fragments')
@@ -818,7 +818,7 @@ def builds_from_yaml(yaml_path):
 
     fragments = {
         name: Fragment.from_yaml(config, name)
-        for name, config in data['fragments'].iteritems()
+        for name, config in data.get('fragments', {}).iteritems()
     }
 
     build_environments = {
@@ -826,7 +826,7 @@ def builds_from_yaml(yaml_path):
         for name, config in data['build_environments'].iteritems()
     }
 
-    defaults = data.get('build_configs_defaults')
+    defaults = data.get('build_configs_defaults', {})
 
     build_configs = {
         name: BuildConfig.from_yaml(config, name, trees, fragments,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 jinja2
 keyring
+pytest
 pyyaml
 requests

--- a/tests/configs/empty-architecture.yaml
+++ b/tests/configs/empty-architecture.yaml
@@ -1,0 +1,25 @@
+# See the KernelCI wiki page regarding the format of this file:
+# https://github.com/kernelci/kernelci-doc/wiki/Build-configurations
+
+trees:
+  agross:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/agross/linux.git"
+
+build_environments:
+  gcc-7:
+    cc: gcc
+    cc_version: 7
+    arch_map:
+      i386: 'x86'
+      x86_64: 'x86'
+      riscv: 'riscv64'
+
+build_configs:
+  agross:
+    tree: agross
+    branch: 'for-next'
+    variants:
+      gcc-7:
+        build_environment: gcc-7
+        architectures:
+          arm64: # no base_defconfig (use default); no extra_configs

--- a/tests/configs/minimal.yaml
+++ b/tests/configs/minimal.yaml
@@ -1,0 +1,20 @@
+# See the KernelCI wiki page regarding the format of this file:
+# https://github.com/kernelci/kernelci-doc/wiki/Build-configurations
+
+trees:
+  agross:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/agross/linux.git"
+
+build_environments:
+  gcc-7:
+    cc: gcc
+    cc_version: 7
+    arch_map:
+      i386: 'x86'
+      x86_64: 'x86'
+      riscv: 'riscv64'
+
+build_configs:
+  agross:
+    tree: agross
+    branch: 'for-next'

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -1,0 +1,28 @@
+import kernelci.configs
+
+def test_build_configs_parsing():
+    """ Verify build-configs.yaml """
+    configs = kernelci.configs.builds_from_yaml("build-configs.yaml")
+    assert len(configs) == 4
+    for key in ['build_configs', 'build_environments', 'fragments', 'trees']:
+        assert key in configs
+        assert len(configs[key]) > 0
+
+def test_build_configs_parsing_minimal():
+    configs = kernelci.configs.builds_from_yaml("tests/configs/minimal.yaml")
+    assert 'agross' in configs['build_configs']
+    assert 'agross' in configs['trees']
+    assert 'gcc-7' in configs['build_environments']
+    assert len(configs['fragments']) == 0
+
+def test_build_configs_parsing_empty_architecture():
+    configs = kernelci.configs.builds_from_yaml("tests/configs/empty-architecture.yaml")
+    assert len(configs) == 4
+
+def test_architecture_init_name_only():
+    architecture = kernelci.configs.Architecture("arm")
+    assert architecture.name == 'arm'
+    assert architecture.base_defconfig == 'defconfig'
+    assert architecture.extra_configs == []
+    assert architecture.fragments == []
+    assert architecture._filters == [] # filters does not have a property..


### PR DESCRIPTION
- Test parsing ./build-configs.yaml
- Add some additional test yaml files to verify edge cases
- Fix issues in configs.py related to empty fragments, build_config_defaults,
and when architecture is None

Makefile provided for convenience, with recommended invocation of
pytest. Due to the way this project is structured (specifically, that it
lacks a setup.poy), pytest must be run using python -m.

Example usage:

drue@xps:~/src/kernelci/kernelci-core$ make
python -m pytest
========================================== test session starts ==========================================
platform linux2 -- Python 2.7.15, pytest-4.3.1, py-1.8.0, pluggy-0.9.0
rootdir: /home/drue/src/kernelci/kernelci-core, inifile:
collected 3 items

tests/test_configs.py ...                                                                         [100%]

======================================= 3 passed in 0.13 seconds ========================================

Signed-off-by: Dan Rue <dan.rue@linaro.org>