### PR TITLE
Add am57xx-beagle-x15

### DIFF
--- a/jenkins/lava-boot-v2.sh
+++ b/jenkins/lava-boot-v2.sh
@@ -51,6 +51,6 @@ elif [ ${LAB} = "lab-theobroma-systems" ] || [ ${LAB} = "lab-theobroma-systems-d
   python lava-v2-jobs-from-api.py --defconfigs ${DEFCONFIG_COUNT} --callback ${CALLBACK} --api ${API} --storage ${STORAGE} --lab ${LAB} --describe ${GIT_DESCRIBE} --tree ${TREE} --branch ${BRANCH} --arch ${ARCH} --plans boot kselftest --token ${API_TOKEN}
   python lava-v2-submit-jobs.py --username kernel-ci --jobs ${LAB} --token ${LAVA_THEOBROMA_SYSTEMS_TOKEN} --lab ${LAB}
 elif [ ${LAB} = "lab-drue" ] || [ ${LAB} = "lab-drue-dev" ]; then
-  python lava-v2-jobs-from-api.py --defconfigs ${DEFCONFIG_COUNT} --callback ${CALLBACK} --api ${API} --storage ${STORAGE} --lab ${LAB} --describe ${GIT_DESCRIBE} --tree ${TREE} --branch ${BRANCH} --arch ${ARCH} --plans boot boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp simple --token ${API_TOKEN} --priority medium
+  python lava-v2-jobs-from-api.py --defconfigs ${DEFCONFIG_COUNT} --callback ${CALLBACK} --api ${API} --storage ${STORAGE} --lab ${LAB} --describe ${GIT_DESCRIBE} --tree ${TREE} --branch ${BRANCH} --arch ${ARCH} --plans boot boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp simple sleep --token ${API_TOKEN} --priority medium
   python lava-v2-submit-jobs.py --username kernel-ci --jobs ${LAB} --token ${LAVA_DRUE_TOKEN} --lab ${LAB}
 fi

--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -151,6 +151,16 @@ device_types:
     class: arm-dtb
     boot_method: uboot
 
+  am57xx-beagle-x15:
+    mach: omap2
+    class: arm-dtb
+    boot_method: uboot
+    filters:
+      - blacklist: *allmodconfig_filter
+      # This board could boot v4.* if CONFIG_SERIAL_8250_OMAP is set. It was
+      # added to multi_v7_defconfig as of 5.0.
+      - blacklist: {kernel: ['v3.', 'v4.']}
+
   apm_mustang:
     name: 'mustang'
     mach: apm
@@ -839,6 +849,9 @@ test_configs:
 
   - device_type: alpine_db
     test_plans: [boot]
+
+  - device_type: am57xx-beagle-x15
+    test_plans: [boot, boot_nfs, simple, sleep]
 
   - device_type: apm_mustang
     test_plans: [boot, boot_nfs, kselftest]


### PR DESCRIPTION
BeagleBoard-X15 is the next generation Open Source Hardware BeagleBoard based
on TI's AM5728 SoC featuring dual core 1.5GHz A15 processor. The platform
features 2GB DDR3L (w/dual 32bit busses), eSATA, 3 USB3.0 ports, integrated
HDMI (1920x1080@60), separate LCD port, video In port, 4GB eMMC, uSD, Analog
audio in/out, dual 1G Ethernet.

For more information, refer to:
BeagleBoard-X15 Wiki:
http://www.elinux.org/Beagleboard:BeagleBoard-X15

Support for x15 was first added in linux v3.19. The LAVA implementation for
this board uses 'setenv console ttyS2,115200n8', which requires
CONFIG_SERIAL_8250_OMAP to be set. However, CONFIG_SERIAL_8250_OMAP was not
added to multi_v7_defconfig until v5.0.

This initial x15 implementation in kernelci will therefore restrict x15 to
v5.0+, so that it can use multi_v7_defconfig without an additional fragment.
Future kernelci work could add a fragment for CONFIG_SERIAL_8250_OMAP to boot
this board on v4.* kernel versions.

It is also worth noting that the default LAVA implementation uses the 'x15'
device-type name, while kernelci uses the dtb-based name 'am57xx-beagle-x15'.
Labs wishing to host the x15 for kernelci will therefore need to implement them
as device type name 'am57xx-beagle-x15'.

Signed-off-by: Dan Rue <dan.rue@linaro.org>