### PR TITLE
test-configs: upgrade buildroot to 2018.11, add MIPS

### DIFF
--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -5,12 +5,13 @@
 file_system_types:
 
   buildroot:
-    url: 'https://storage.kernelci.org/images/rootfs/buildroot/kci-2018.05'
+    url: 'https://storage.kernelci.org/images/rootfs/buildroot/kci-2018.11'
     arch_map:
       arm64be: [{arch: arm64, endian: big}]
       armeb:   [{arch: arm,   endian: big}]
       armel:   [{arch: arm}]
       x86:     [{arch: i386}, {arch: x86_64}]
+      mipsel:  [{arch: mips}]
 
   debian:
     url: 'http://storage.kernelci.org/images/rootfs/debian'


### PR DESCRIPTION
Upgrade buildroot to version 2018.11, which includes working upstream
support for new arches: MIPS, ARC, and RISC-V

Signed-off-by: Kevin Hilman <khilman@baylibre.com>