### PR TITLE
T13960 stretch-igt: disable MIPS builds as currently broken in i-g-t

### DIFF
--- a/jenkins/stretch-igt.jpl
+++ b/jenkins/stretch-igt.jpl
@@ -12,8 +12,7 @@ DOCKER_BASE
 def r = new RootFS()
 
 def config = ['name':"stretch-igt",
-              'arch_list':["armhf", "armel", "arm64", "i386", "amd64",
-                           "mips", "mipsel"],
+              'arch_list':["armhf", "armel", "arm64", "i386", "amd64"],
               'debian_release':"stretch",
               'extra_packages':"libpciaccess0 libkmod2 libprocps6 libcairo2 \
                                 libssl1.1 libunwind8 libudev1 libglib2.0-0 \


### PR DESCRIPTION
The current master branch of i-g-t doesn't build on MIPS due to the
use of some hardware atomics that are not supported on MIPS.  An
upstream fix is being worked on, but disable MIPS builds in the
meantime so we can get the latest version on other architectures.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>