### PR TITLE
test-configs.yaml: add two orange pi opi0 and opi-r1

### DIFF
--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -735,6 +735,18 @@ device_types:
     class: arm-dtb
     boot_method: uboot
 
+  sun8i_h2_plus_orangepi_r1:
+    name: 'sun8i-h2-plus-orangepi-r1'
+    mach: allwinner
+    class: arm-dtb
+    boot_method: uboot
+
+  sun8i_h2_plus_orangepi_zero:
+    name: 'sun8i-h2-plus-orangepi-zero'
+    mach: allwinner
+    class: arm-dtb
+    boot_method: uboot
+
   sun8i_h2_plus_libretech_all_h3_cc:
     name: 'sun8i-h2-plus-libretech-all-h3-cc'
     mach: allwinner
@@ -1042,6 +1054,12 @@ test_configs:
     test_plans: [boot]
 
   - device_type: sun8i_a83t_allwinner_h8homlet_v2
+    test_plans: [boot]
+
+  - device_type: sun8i_h2_plus_orangepi_zero
+    test_plans: [boot]
+
+  - device_type: sun8i_h2_plus_orangepi_r1
     test_plans: [boot]
 
   - device_type: sun8i_h2_plus_libretech_all_h3_cc


### PR DESCRIPTION
This patch adds support for sun8i-h2-plus-orangepi-r1 and
sun8i-h2-plus-orangepi-zero

Signed-off-by: Corentin LABBE <clabbe@baylibre.com>