### PR TITLE
Add android-q branches to build-configs

### DIFF
--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -343,6 +343,10 @@ build_configs:
     tree: android
     branch: 'android-4.9-p-release'
 
+  android_4.9-q:
+    tree: android
+    branch: 'android-4.9-q'
+
   android_4.14:
     tree: android
     branch: 'android-4.14'
@@ -355,9 +359,17 @@ build_configs:
     tree: android
     branch: 'android-4.14-p-release'
 
+  android_4.14-q:
+    tree: android
+    branch: 'android-4.14-q'
+
   android_4.19:
     tree: android
     branch: 'android-4.19'
+
+  android_4.19-q:
+    tree: android
+    branch: 'android-4.19-q'
 
   android_mainline_tracking:
     tree: android


### PR DESCRIPTION
These branches are expected to only be updated to LTS once a week.

I have tested that they parse with kci_build and produce the expected results