### PR TITLE
T14297 kci_build to build kernels

### DIFF
--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -152,11 +152,19 @@ build_environments:
       i386: 'x86'
       x86_64: 'x86'
       riscv: 'riscv64'
+    cross_compile: &default_cross_compile
+      arc: 'arc-linux-'
+      arm: 'arm-linux-gnueabihf-'
+      arm64: 'aarch64-linux-gnu-'
+      mips: 'mips-linux-gnu-'
+      riscv: 'riscv64-linux-gnu-'
+
 
   gcc-8:
     cc: gcc
     cc_version: 8
     arch_map: *gcc_arch_map
+    cross_compile: *default_cross_compile
 
   clang-8:
     cc: clang
@@ -169,11 +177,13 @@ build_environments:
       mips:
       arc:
       riscv:
+    cross_compile: *default_cross_compile
 
   clang-9:
     cc: clang
     cc_version: 9
     arch_map: *clang_arch_map
+    cross_compile: *default_cross_compile
 
 
 build_configs_defaults:

--- a/build.py
+++ b/build.py
@@ -432,8 +432,8 @@ if install:
 
     vmlinux_file = os.path.join(kbuild_output, "vmlinux")
     if os.path.isfile(vmlinux_file):
-        import elf
-        bmeta.update(elf.read(vmlinux_file))
+        import kernelci.elf
+        bmeta.update(kernelci.elf.read(vmlinux_file))
         bmeta["vmlinux_file_size"] = os.stat(vmlinux_file).st_size
 
     if len(kimages) == 1:

--- a/jenkins/bisect.jpl
+++ b/jenkins/bisect.jpl
@@ -49,10 +49,6 @@ DEFCONFIG (defconfig)
   Name of the Linux kernel defconfig
 TARGET
   Name of the device type to test (typically LAVA device type name)
-CC (gcc)
-  Name of the compiler
-CC_VERSION (7)
-  Version of the compiler
 BUILD_ENVIRONMENT
   Name of the build environment
 LAB
@@ -216,22 +212,48 @@ git symbolic-ref HEAD refs/heads/${params.KERNEL_BRANCH}
  */
 
 def buildKernel(kdir, kci_core) {
-    dir(kdir) {
+    def output = "${kdir}/build-${params.ARCH}-${params.BUILD_ENVIRONMENT}"
+    dir(kci_core) {
         sh(script: "rm -f ${env._BUILD_JSON}")
+
+        sh(script:"""\
+./kci_build \
+build_kernel \
+--kdir=${kdir} \
+--defconfig=${params.DEFCONFIG} \
+--arch=${params.ARCH} \
+--build-env=${params.BUILD_ENVIRONMENT} \
+--output=${output} \
+""")
+
+        sh(script: """\
+./kci_build \
+install_kernel \
+--kdir=${kdir} \
+--tree-name=${params.KERNEL_TREE} \
+--tree-url=${params.KERNEL_URL} \
+--branch=${params.KERNEL_BRANCH} \
+--output=${output} \
+""")
+
         withCredentials([string(credentialsId: params.KCI_TOKEN_ID,
                                 variable: 'SECRET')]) {
-            sh(script: """
-API=${params.KCI_API_URL} \
-TOKEN=${SECRET} \
-TREE_NAME=${params.KERNEL_TREE} \
-TREE=${params.KERNEL_URL} \
-ARCH=${params.ARCH} \
-BRANCH=${params.KERNEL_BRANCH} \
-""" + kci_core + """/build.py -e -g -i \
--J ${env._BUILD_JSON} \
--E ${params.BUILD_ENVIRONMENT} \
--c ${params.DEFCONFIG}""")
+            sh(script: """\
+./kci_build \
+push_kernel \
+--kdir=${kdir} \
+--token=${SECRET} \
+--api=${params.KCI_API_URL} \
+""")
         }
+
+        sh(script: """\
+./kci_build \
+publish_kernel \
+--kdir=${kdir} \
+--json-path=${env._BUILD_JSON} \
+""")
+
         stash(name: env._BUILD_JSON, includes: env._BUILD_JSON)
     }
 }
@@ -597,11 +619,10 @@ node("docker && bisection") {
     env._BUILD_JSON = "build-data.json"
 
     def j = new Job()
-    def docker_image = j.dockerImageName(
-        params.DOCKER_BASE, params.CC, params.CC_VERSION, params.ARCH)
     def kci_core = "${env.WORKSPACE}/kernelci-core"
     def kdir = "${env.WORKSPACE}/linux"
     def checks = [:]
+    def docker_image = null
 
     def params_summary = """\
     Tree:      ${params.KERNEL_TREE}
@@ -611,7 +632,7 @@ node("docker && bisection") {
     Target:    ${params.TARGET}
     Lab:       ${params.LAB}
     Defconfig: ${params.DEFCONFIG}
-    Compiler:  ${params.CC} ${params.CC_VERSION}
+    Compiler:  ${params.BUILD_ENVIRONMENT}
     Plan:      ${params.PLAN}"""
     print("""\
     Good:      ${params.GOOD_COMMIT}
@@ -642,6 +663,13 @@ ${params_summary}""")
             currentBuild.result = 'ABORTED'
             return
         }
+    }
+
+    j.dockerPullWithRetry("${params.DOCKER_BASE}base").inside() {
+        j.cloneKciCore(kci_core, params.KCI_CORE_URL, params.KCI_CORE_BRANCH)
+        build_env_docker_image = j.dockerImageName(
+            kci_core, params.BUILD_ENVIRONMENT, params.ARCH)
+        docker_image = "${params.DOCKER_BASE}${build_env_docker_image}"
     }
 
     j.dockerPullWithRetry(docker_image).inside() {

--- a/jenkins/build-trigger.jpl
+++ b/jenkins/build-trigger.jpl
@@ -137,15 +137,16 @@ list_kernel_configs \
             def data = kernel_config_raw.tokenize(' ')
             def arch = data[0]
             def defconfig = data[1]
-            def cc = data[2]
-            def cc_version = data[3]
-            config_list.add([arch, defconfig, cc, cc_version])
+            def build_env = data[2]
+            config_list.add([arch, defconfig, build_env])
         }
     }
 }
 
 def addBuildOpts(config, kci_core, opts) {
     dir(kci_core) {
+        opts['config'] = config
+
         def opts_raw = sh(
             script: """\
 ./kci_build \
@@ -184,19 +185,16 @@ arch_list \
     }
 }
 
-def buildKernelStep(job, arch, config, opts, cc='gcc', cc_version='7') {
+def buildKernelStep(job, arch, defconfig, build_env, opts) {
     def str_params = [
         'ARCH': arch,
-        'DEFCONFIG': config,
-        'TREE': opts['git_url'],
-        'TREE_NAME': opts['tree'],
+        'DEFCONFIG': defconfig,
         'GIT_DESCRIBE': opts['describe'],
         'GIT_DESCRIBE_VERBOSE': opts['describe_verbose'],
         'COMMIT_ID': opts['commit'],
-        'BRANCH': opts['branch'],
         'SRC_TARBALL': opts['tarball_url'],
-        'CC': cc,
-        'CC_VERSION': cc_version,
+        'BUILD_CONFIG': opts['config'],
+        'BUILD_ENVIRONMENT': build_env,
     ]
     def job_params = []
 
@@ -271,15 +269,14 @@ node("defconfig-creator") {
 
             for (x in configs) {
                 def arch = x[0]
-                def config = x[1]
-                def cc = x[2]
-                def cc_version = x[3]
+                def defconfig = x[1]
+                def build_env = x[2]
 
-                def step_name = "${i} ${arch} ${config} ${cc} ${cc_version}"
+                def step_name = "${i} ${arch} ${defconfig} ${build_env}"
                 print(step_name)
 
                 builds[step_name] = buildKernelStep(
-                    "kernel-build", arch, config, opts, cc, cc_version)
+                    "kernel-build", arch, defconfig, build_env, opts)
 
                 i += 1
             }

--- a/jenkins/build.jpl
+++ b/jenkins/build.jpl
@@ -28,22 +28,16 @@ DEFCONFIG
   Linux kernel defconfig to build
 SRC_TARBALL
   URL of the kernel source tarball
-TREE
-  URL of the kernel Git repository
-TREE_NAME
-  Name of the kernel Git repository (tree)
-BRANCH
-  Name of the kernel branch within the tree
+BUILD_CONFIG
+  Name of the build configuration
 GIT_DESCRIBE
   Output of 'git describe' at the revision of the snapshot
 GIT_DESCRIBE_VERBOSE
   Verbose output of 'git describe' at the revision of the snapshot
 COMMIT_ID
   Git commit SHA1 at the revision of the snapshot
-CC (gcc)
-  Name of the compiler
-CC_VERSION (7)
-  Version of the compiler
+BUILD_ENVIRONMENT (gcc-7)
+  Name of the build environment
 PUBLISH (boolean)
   Publish build results via the KernelCI backend API
 EMAIL (boolean)
@@ -68,34 +62,51 @@ PARALLEL_BUILDS
 import org.kernelci.build.Kernel
 import org.kernelci.util.Job
 
-def buildConfig(config, kdir, kci_core) {
-    def defconfig = sh(script: "echo ${config} | sed 's/\\+/ \\-c /g'",
-                       returnStdout: true)
-    def opt = "-i -E ${params.CC}-${params.CC_VERSION}"
-
-    if (params.PUBLISH) {
-        opt += " -e"
-    } else {
-        echo "NOT PUBLISHING"
-    }
-
+def buildConfig(kdir, kci_core) {
     if (params.PARALLEL_BUILDS)
-        opt += " -j${params.PARALLEL_BUILDS}"
+        jopt = "-j${params.PARALLEL_BUILDS}"
 
-    dir(kdir) {
+    dir(kci_core) {
+        sh(script: """\
+./kci_build \
+build_kernel \
+--kdir=${kdir} \
+--defconfig=${params.DEFCONFIG} \
+--arch=${params.ARCH} \
+--build-env=${params.BUILD_ENVIRONMENT} \
+${jopt} \
+|| echo 'Kernel build failed'
+""")
+
+        sh(script: """\
+./kci_build \
+install_kernel \
+--kdir=${kdir} \
+--config=${params.BUILD_CONFIG} \
+--describe=${params.GIT_DESCRIBE} \
+--describe-verbose=${params.GIT_DESCRIBE_VERBOSE} \
+--commit=${params.COMMIT_ID} \
+""")
+
         withCredentials([string(credentialsId: params.KCI_TOKEN_ID,
                                 variable: 'SECRET')]) {
-            sh(script: """
-API=${params.KCI_API_URL} \
-TOKEN=${SECRET} \
-${kci_core}/build.py \
-  ${opt} \
-  -c ${defconfig} \
+            sh(script: """\
+./kci_build \
+push_kernel \
+--kdir=${kdir} \
+--token=${SECRET} \
+--api=${params.KCI_API_URL} \
+""")
+
+            sh(script: """\
+./kci_build \
+publish_kernel \
+--kdir=${kdir} \
+--token=${SECRET} \
+--api=${params.KCI_API_URL} \
 """)
         }
     }
-
-    sh(script: """rm -rf ${kdir}""")
 }
 
 node("docker && builder") {
@@ -103,35 +114,34 @@ node("docker && builder") {
     def k = new Kernel()
     def kci_core = "${env.WORKSPACE}/kernelci-core"
     def kdir = "${env.WORKSPACE}/linux"
-    def docker_image = j.dockerImageName(
-        params.DOCKER_BASE, params.CC, params.CC_VERSION, params.ARCH)
+    def docker_image = null
 
     print("""\
-    Tree:      ${params.TREE_NAME}
-    URL:       ${params.TREE}
-    Branch:    ${params.BRANCH}
+    Config:    ${params.BUILD_CONFIG}
     CPU arch:  ${params.ARCH}
     Describe:  ${params.GIT_DESCRIBE}
     Revision:  ${params.COMMIT_ID}
-    Config:    ${params.DEFCONFIG}
-    Compiler:  ${params.CC} ${params.CC_VERSION}
-    Container: ${docker_image}""")
+    Defconfig: ${params.DEFCONFIG}
+    Compiler:  ${params.BUILD_ENVIRONMENT}""")
+
+    j.dockerPullWithRetry("${params.DOCKER_BASE}base").inside() {
+        j.cloneKciCore(kci_core, params.KCI_CORE_URL, params.KCI_CORE_BRANCH)
+        build_env_docker_image = j.dockerImageName(
+            kci_core, params.BUILD_ENVIRONMENT, params.ARCH)
+        docker_image = "${params.DOCKER_BASE}${build_env_docker_image}"
+    }
 
     j.dockerPullWithRetry(docker_image).inside() {
         stage("Init") {
             timeout(time: 30, unit: 'MINUTES') {
-                parallel(
-                    clone: { j.cloneKciCore(kci_core,
-                                            params.KCI_CORE_URL,
-                                            params.KCI_CORE_BRANCH) },
-                    download: { k.downloadTarball(kdir, params.SRC_TARBALL) },
-                )
+                k.downloadTarball(kdir, params.SRC_TARBALL)
             }
         }
 
         stage("Build") {
             timeout(time: 180, unit: 'MINUTES') {
-                buildConfig(params.DEFCONFIG, kdir, kci_core)
+                buildConfig(kdir, kci_core)
+                sh(script: "rm -rf ${kdir}")
             }
         }
     }

--- a/jenkins/dockerfiles/build-base/Dockerfile
+++ b/jenkins/dockerfiles/build-base/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 
 # Host build tools
 RUN apt-get update && apt-get install --no-install-recommends -y \
+    bash \
     bc \
     bison \
     bsdmainutils \

--- a/kci_build
+++ b/kci_build
@@ -127,6 +127,11 @@ class Args(object):
         'action': 'store_true',
     }
 
+    output = {
+        'name': '--output',
+        'help': "Path the output directory",
+    }
+
 
 # -----------------------------------------------------------------------------
 # Commands
@@ -160,7 +165,6 @@ class Command(object):
         self._parser.add_argument(arg_name, **kw)
 
 
-# ToDo: filter using arch, compiler and defconfig
 class cmd_list_configs(Command):
     help = "List the build configurations"
 
@@ -344,20 +348,21 @@ class cmd_list_kernel_configs(Command):
 class cmd_build_kernel(Command):
     help = "Build a kernel"
     args = [Args.build_env, Args.arch, Args.kdir]
-    opt_args = [Args.defconfig, Args.j, Args.verbose]
+    opt_args = [Args.defconfig, Args.j, Args.verbose, Args.output]
 
     def __call__(self, configs, args):
         build_env = configs['build_environments'][args.build_env]
         return kernelci.build.build_kernel(
             build_env, args.kdir, args.arch, args.defconfig, args.j,
-            args.verbose)
+            args.verbose, args.output)
 
 
 class cmd_install_kernel(Command):
     help = "Install the kernel binaries and build.json locally"
     args = [Args.kdir]
     opt_args = [Args.config, Args.tree_name, Args.tree_url, Args.branch,
-                Args.commit, Args.describe, Args.describe_verbose]
+                Args.commit, Args.describe, Args.describe_verbose,
+                Args.output]
 
     def __call__(self, configs, args):
         if args.config:
@@ -379,7 +384,7 @@ or
             return False
         return kernelci.build.install_kernel(
             args.kdir, tree_name, tree_url, branch, args.commit, args.describe,
-            args.describe_verbose)
+            args.describe_verbose, args.output)
 
 
 class cmd_push_kernel(Command):

--- a/kci_build
+++ b/kci_build
@@ -42,6 +42,11 @@ class Args(object):
         'help': "Build config variant name",
     }
 
+    build_env = {
+        'name': '--build-env',
+        'help': "Build environment name",
+    }
+
     storage = {
         'name': '--storage',
         'help': "Storage URL",
@@ -247,18 +252,37 @@ class cmd_arch_list(Command):
         return True
 
 
-class cmd_build_environment(Command):
-    help = "Print the build environment name for a given build variant"
+def _show_build_env(build_env, arch=None):
+    print(build_env.name)
+    print(build_env.cc)
+    print(build_env.cc_version)
+    if arch:
+        print(build_env.get_arch_name(args.arch))
+        xc = build_env.get_cross_compile(args.arch)
+        if xc:
+            print(xc)
+
+
+class cmd_get_build_env(Command):
+    help = "Print the build environment parameters for a given build variant"
     args = [Args.config, Args.variant]
+    opt_args = [Args.arch]
 
     def __call__(self, configs, args):
         conf = configs['build_configs'][args.config]
         variant = conf.get_variant(args.variant)
-        print(variant.build_environment.name)
-        print(variant.build_environment.cc)
-        print(variant.build_environment.cc_version)
-        if args.arch:
-            print(variant.build_environment.get_arch_name(args.arch))
+        _show_build_env(variant.build_environment, args.arch)
+        return True
+
+
+class cmd_show_build_env(Command):
+    help = "Show parameters of a given build environment"
+    args = [Args.build_env]
+    opt_args = [Args.arch]
+
+    def __call__(self, configs, args):
+        build_env = configs['build_environments'][args.build_env]
+        _show_build_env(build_env, args.arch)
         return True
 
 

--- a/kci_build
+++ b/kci_build
@@ -188,9 +188,9 @@ class cmd_describe(Command):
 
     def __call__(self, configs, args):
         conf = configs['build_configs'][args.config]
-        commit = kernelci.build.head_commit(conf, args.kdir)
-        describe = kernelci.build.git_describe(conf, args.kdir)
-        verbose = kernelci.build.git_describe_verbose(conf, args.kdir)
+        commit = kernelci.build.head_commit(args.kdir)
+        describe = kernelci.build.git_describe(conf.tree.name, args.kdir)
+        verbose = kernelci.build.git_describe_verbose(args.kdir)
         print(commit)
         print(describe)
         print(verbose or describe)

--- a/kci_build
+++ b/kci_build
@@ -305,7 +305,7 @@ class cmd_list_kernel_configs(Command):
 #
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser("KernelCI build interface")
+    parser = argparse.ArgumentParser("kci_build")
     parser.add_argument("--build-configs", default="build-configs.yaml",
                         help="Path to build configs file")
     sub_parser = parser.add_subparsers(title="Commands",

--- a/kci_build
+++ b/kci_build
@@ -132,6 +132,11 @@ class Args(object):
         'help': "Path the output directory",
     }
 
+    json_path = {
+        'name': '--json-path',
+        'help': "Path to the JSON file",
+    }
+
 
 # -----------------------------------------------------------------------------
 # Commands
@@ -397,10 +402,20 @@ class cmd_push_kernel(Command):
 
 class cmd_publish_kernel(Command):
     help = "Publish the kernel meta-data"
-    args = [Args.kdir, Args.api, Args.token]
+    args = [Args.kdir]
+    opt_args = [Args.api, Args.token, Args.json_path]
 
     def __call__(self, configs, args):
-        return kernelci.build.publish_kernel(args.kdir, args.api, args.token)
+        if not ((args.api and args.token) or args.json_path):
+            print("""\
+Invalid arguments, please provide at least one of these sets of options:
+    --token, --api to publish to the backend server
+    --json-path to save the data in a local JSON file\
+""")
+            return False
+        return kernelci.build.publish_kernel(
+            args.kdir, api=args.api, token=args.token,
+            json_path=args.json_path)
 
 # -----------------------------------------------------------------------------
 # Main

--- a/kci_build
+++ b/kci_build
@@ -71,6 +71,31 @@ class Args(object):
         'help': "Git commit checksum",
     }
 
+    describe = {
+        'name': '--describe',
+        'help': "Git describe",
+    }
+
+    describe_verbose = {
+        'name': '--describe-verbose',
+        'help': "Verbose version of git describe",
+    }
+
+    tree_name = {
+        'name': '--tree-name',
+        'help': "Name of a kernel tree",
+    }
+
+    tree_url = {
+        'name': '--tree-url',
+        'help': "URL of a kernel tree",
+    }
+
+    branch = {
+        'name': '--branch',
+        'help': "Name of a kernel branch in a tree",
+    }
+
     mirror = {
         'name': '--mirror',
         'help': "Path to the local kernel git mirror",
@@ -84,6 +109,22 @@ class Args(object):
     arch = {
         'name': '--arch',
         'help': "CPU architecture name",
+    }
+
+    defconfig = {
+        'name': '--defconfig',
+        'help': "Kernel defconfig name",
+    }
+
+    j = {
+        'name': '-j',
+        'help': "Number of parallel build processes",
+    }
+
+    verbose = {
+        'name': '--verbose',
+        'help': "Verbose output",
+        'action': 'store_true',
     }
 
 
@@ -299,6 +340,62 @@ class cmd_list_kernel_configs(Command):
             print(' '.join(item))
         return True
 
+
+class cmd_build_kernel(Command):
+    help = "Build a kernel"
+    args = [Args.build_env, Args.arch, Args.kdir]
+    opt_args = [Args.defconfig, Args.j, Args.verbose]
+
+    def __call__(self, configs, args):
+        build_env = configs['build_environments'][args.build_env]
+        return kernelci.build.build_kernel(
+            build_env, args.kdir, args.arch, args.defconfig, args.j,
+            args.verbose)
+
+
+class cmd_install_kernel(Command):
+    help = "Install the kernel binaries and build.json locally"
+    args = [Args.kdir]
+    opt_args = [Args.config, Args.tree_name, Args.tree_url, Args.branch,
+                Args.commit, Args.describe, Args.describe_verbose]
+
+    def __call__(self, configs, args):
+        if args.config:
+            conf = configs['build_configs'][args.config]
+            tree_name = conf.tree.name
+            tree_url = conf.tree.url
+            branch = conf.branch
+        else:
+            tree_name = args.tree_name
+            tree_url = args.tree_url
+            branch = args.branch
+        if not all((tree_name, tree_url, branch)):
+            print("""\
+Invalid arguments, either of these 2 sets are possible:
+   --tree-name, --tree-url and --branch
+or
+   --config (in which case the tree and branch are read from the YAML config)\
+""")
+            return False
+        return kernelci.build.install_kernel(
+            args.kdir, tree_name, tree_url, branch, args.commit, args.describe,
+            args.describe_verbose)
+
+
+class cmd_push_kernel(Command):
+    help = "Push the kernel binaries"
+    args = [Args.kdir, Args.api, Args.token]
+
+    def __call__(self, configs, args):
+        return kernelci.build.push_kernel(args.kdir, args.api, args.token)
+
+
+class cmd_publish_kernel(Command):
+    help = "Publish the kernel meta-data"
+    args = [Args.kdir, Args.api, Args.token]
+
+    def __call__(self, configs, args):
+        return kernelci.build.publish_kernel(args.kdir, args.api, args.token)
 
 # -----------------------------------------------------------------------------
 # Main

--- a/kernelci/__init__.py
+++ b/kernelci/__init__.py
@@ -22,4 +22,4 @@ def shell_cmd(cmd, ret_code=False):
     if ret_code:
         return False if subprocess.call(cmd, shell=True) else True
     else:
-        subprocess.check_output(cmd, shell=True)
+        return subprocess.check_output(cmd, shell=True)

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -60,8 +60,7 @@ def update_last_commit(config, api, token, commit):
 def get_branch_head(config):
     cmd = "git ls-remote {url} refs/heads/{branch}".format(
         url=config.tree.url, branch=config.branch)
-    p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
-    head, _ = p.communicate()
+    head = shell_cmd(cmd)
     if not head:
         return False
     return head.split()[0]
@@ -133,8 +132,7 @@ def head_commit(path):
 cd {path} &&
 git log --pretty=format:%H -n1
 """.format(path=path)
-    p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
-    commit, _ = p.communicate()
+    commit = shell_cmd(cmd)
     return commit.strip()
 
 
@@ -144,8 +142,7 @@ def git_describe(tree_name, path):
 cd {path} && \
 git describe {describe_args} \
 """.format(path=path, describe_args=describe_args)
-    p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
-    describe, _ = p.communicate()
+    describe = shell_cmd(cmd)
     return describe.strip().replace('/', '_')
 
 
@@ -154,8 +151,7 @@ def git_describe_verbose(path):
 cd {path} &&
 git describe --match=v[1-9]\* \
 """.format(path=path)
-    p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
-    describe, _ = p.communicate()
+    describe = shell_cmd(cmd)
     return describe.strip()
 
 

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -244,8 +244,7 @@ def list_kernel_configs(config, kdir, single_variant=None, single_arch=None):
     for variant in config.variants:
         if single_variant and variant.name != single_variant:
             continue
-        cc = variant.build_environment.cc
-        cc_version = variant.build_environment.cc_version
+        build_env = variant.build_environment.name
         frag_paths = set()
         frag_configs = set()
         _add_frag_configs(kdir, variant.fragments, frag_paths, frag_configs)
@@ -266,7 +265,7 @@ def list_kernel_configs(config, kdir, single_variant=None, single_arch=None):
                         defconfigs.add(f)
             for defconfig in defconfigs:
                 if arch.match({'defconfig': defconfig}):
-                    kernel_configs.add((arch.name, defconfig, cc, cc_version))
+                    kernel_configs.add((arch.name, defconfig, build_env))
 
     return kernel_configs
 

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -128,7 +128,7 @@ git checkout --detach {remote}/{branch}
 """.format(path=path, remote=config.tree.name, branch=config.branch))
 
 
-def head_commit(config, path):
+def head_commit(path):
     cmd = """\
 cd {path} &&
 git log --pretty=format:%H -n1
@@ -138,8 +138,8 @@ git log --pretty=format:%H -n1
     return commit.strip()
 
 
-def git_describe(config, path):
-    describe_args = "--match=v\*" if config.tree.name == "arm-soc" else ""
+def git_describe(tree_name, path):
+    describe_args = "--match=v\*" if tree_name == "arm-soc" else ""
     cmd = """\
 cd {path} && \
 git describe {describe_args} \
@@ -149,7 +149,7 @@ git describe {describe_args} \
     return describe.strip().replace('/', '_')
 
 
-def git_describe_verbose(config, path):
+def git_describe_verbose(path):
     cmd = """\
 cd {path} &&
 git describe --match=v[1-9]\* \
@@ -200,7 +200,7 @@ def generate_fragments(config, kdir):
 
 def push_tarball(config, kdir, storage, api, token):
     tarball_name = "linux-src_{}.tar.gz".format(config.name)
-    describe = git_describe(config, kdir)
+    describe = git_describe(config.tree.name, kdir)
     tarball_url = '/'.join([
         storage, config.tree.name, config.branch, describe, tarball_name])
     resp = requests.head(tarball_url)

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -15,17 +15,45 @@
 # along with this library; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+import fnmatch
+import json
 import os
+import platform
 import requests
+import shutil
+import stat
 import subprocess
+import tempfile
+import time
 import urlparse
 
 from kernelci import shell_cmd
 import kernelci.configs
+import kernelci.elf
 
 # This is used to get the mainline tags as a minimum for git describe
 TORVALDS_GIT_URL = \
     "git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git"
+
+# Hard-coded make targets for each CPU architecture
+MAKE_TARGETS = {
+    'arm': 'zImage dtbs',
+    'arm64': 'Image dtbs',
+    'arc': 'uImage.gz dtbs',
+    'mips': 'all',
+}
+
+# Hard-coded binary kernel image names for each CPU architecture
+KERNEL_IMAGE_NAMES = {
+    'arm': ['zImage', 'xipImage'],
+    'arm64': ['Image'],
+    'arc': ['uImage.gz'],
+    'i386': ['bzImage'],
+    'mips': ['uImage.gz', 'vmlinux.gz.itb'],
+    'riscv': ['Image', 'Image.gz'],
+    'x86_64': ['bzImage'],
+    'x86': ['bzImage'],
+}
 
 
 def _get_last_commit_file_name(config):
@@ -241,3 +269,349 @@ def list_kernel_configs(config, kdir, single_variant=None, single_arch=None):
                     kernel_configs.add((arch.name, defconfig, cc, cc_version))
 
     return kernel_configs
+
+
+def _run_make(kdir, arch, target=None, jopt=None, silent=True, cc='gcc',
+              cross_compile=None, use_ccache=None, output=None, log_file=None,
+              opts=None):
+    args = ['make']
+
+    if opts:
+        args += ['='.join([k, v]) for k, v in opts.iteritems()]
+
+    if jopt:
+        args.append('-j{}'.format(jopt))
+
+    if silent:
+        args.append('-s')
+
+    args.append('ARCH={}'.format(arch))
+
+    if cross_compile:
+        args.append('CROSS_COMPILE={}'.format(cross_compile))
+
+    args.append('HOSTCC={}'.format(cc))
+
+    if use_ccache:
+        px = cross_compile if cc == 'gcc' and cross_compile else ''
+        args.append('CC="ccache {}{}"'.format(px, cc))
+        os.environ.setdefault('CCACHE_DIR',
+                              os.path.join(kdir, '-'.join(['.ccache', arch])))
+    elif cc != 'gcc':
+        args.append('CC={}'.format(cc))
+
+    if output:
+        args.append('O={}'.format(output))
+
+    if target:
+        args.append(target)
+
+    cmd = ' '.join(args)
+    print(cmd)
+    if log_file:
+        log_file_path = os.path.join(kdir, output, log_file)
+        open(log_file_path, 'a').write("#\n# {}\n#\n".format(cmd))
+        cmd = "/bin/bash -c '(set -o pipefail; {} 2>&1 | tee -a {})'".format(
+            cmd, log_file)
+    cmd = "cd {} && {}".format(kdir, cmd)
+    return shell_cmd(cmd, True)
+
+
+def _make_defconfig(defconfig, kwargs, fragments):
+    kdir, output = (kwargs.get(k) for k in ('kdir', 'output'))
+    kdir_output = os.path.join(kdir, output)
+    result = True
+
+    tmpfile_fd, tmpfile_path = tempfile.mkstemp(prefix='kconfig-')
+    tmpfile = os.fdopen(tmpfile_fd, 'w')
+    defs = defconfig.split('+')
+    target = defs.pop(0)
+    for d in defs:
+        if d.startswith('CONFIG_'):
+            tmpfile.write(d + '\n')
+            fragments.append(d)
+        else:
+            frag_path = os.path.join(kdir, d)
+            if os.path.exists(frag_path):
+                with open(frag_path) as frag:
+                    tmpfile.write("\n# fragment from : {}\n".format(d))
+                    tmpfile.writelines(frag)
+                fragments.append(os.path.basename(os.path.splitext(d)[0]))
+    tmpfile.flush()
+    if not _run_make(target=target, **kwargs):
+        result = False
+
+    if result and fragments:
+        kconfig_frag_name = 'frag.config'
+        kconfig_frag = os.path.join(kdir_output, kconfig_frag_name)
+        shutil.copy(tmpfile_path, kconfig_frag)
+        os.chmod(kconfig_frag,
+                 stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH)
+        cmd = """\
+cd {kdir}
+export ARCH={arch}
+scripts/kconfig/merge_config.sh -O {output} '{base}' '{frag}' > /dev/null 2>&1
+""".format(kdir=kdir, arch=kwargs['arch'], output=output,
+           base=os.path.join(output, '.config'),
+           frag=os.path.join(output, kconfig_frag_name))
+        print(cmd.strip())
+        result = shell_cmd(cmd, True)
+
+    tmpfile.close()
+    os.unlink(tmpfile_path)
+
+    return result
+
+
+def build_kernel(build_env, kdir, arch, defconfig=None, jopt=None,
+                 verbose=False, output='build', mod_path='_modules_'):
+    cc = build_env.cc
+    cross_compile = build_env.get_cross_compile(arch) or None
+    use_ccache = shell_cmd("which ccache > /dev/null", True)
+    kdir_output = os.path.join(kdir, output)
+    build_log = 'build.log'
+    log_file = os.path.join(kdir_output, build_log)
+    dot_config = os.path.join(kdir_output, '.config')
+    target = MAKE_TARGETS.get(arch)
+    if jopt is None:
+        jopt = int(shell_cmd("nproc")) + 2
+    if not os.path.exists(kdir_output):
+        os.mkdir(kdir_output)
+    if os.path.exists(log_file):
+        os.unlink(log_file)
+
+    opts = {
+        'KBUILD_BUILD_USER': 'KernelCI',
+    }
+
+    kwargs = {
+        'kdir': kdir,
+        'arch': arch,
+        'cc': cc,
+        'cross_compile': cross_compile,
+        'use_ccache': use_ccache,
+        'output': output,
+        'silent': not verbose,
+        'log_file': build_log,
+        'opts': opts,
+    }
+
+    start_time = time.time()
+    fragments = []
+    if defconfig:
+        result = _make_defconfig(defconfig, kwargs, fragments)
+    elif os.path.exists(dot_config):
+        print("Re-using {}".format(dot_config))
+        result = True
+    else:
+        print("ERROR: Missing kernel config")
+        result = False
+    if result:
+        result = _run_make(jopt=jopt, target=target, **kwargs)
+    mods = shell_cmd('grep -cq CONFIG_MODULES=y {}'.format(dot_config), True)
+    if result and mods:
+        result = _run_make(jopt=jopt, target='modules', **kwargs)
+    build_time = time.time() - start_time
+
+    if result and mods and mod_path:
+        abs_mod_path = os.path.join(kdir_output, mod_path)
+        if os.path.exists(abs_mod_path):
+            shutil.rmtree(abs_mod_path)
+        os.makedirs(abs_mod_path)
+        opts.update({
+            'INSTALL_MOD_PATH': mod_path,
+            'INSTALL_MOD_STRIP': '1',
+            'STRIP': "{}strip".format(cross_compile or ''),
+        })
+        result = _run_make(target='modules_install', **kwargs)
+
+    cc_version_cmd = "{}{} --version 2>&1".format(
+        cross_compile if cross_compile and cc == 'gcc' else '', cc)
+    cc_version_full = shell_cmd(cc_version_cmd).splitlines()[0]
+
+    bmeta = {
+        'build_threads': jopt,
+        'build_time': round(build_time, 2),
+        'build_result': 'PASS' if result is True else 'FAIL',
+        'arch': arch,
+        'cross_compile': cross_compile,
+        'compiler': cc,
+        'compiler_version': build_env.cc_version,
+        'compiler_version_full': cc_version_full,
+        'build_environment': build_env.name,
+        'build_log': build_log,
+        'build_platform': platform.uname(),
+    }
+
+    if defconfig:
+        defconfig_target = defconfig.split('+')[0]
+        bmeta.update({
+            'defconfig': defconfig_target,
+            'defconfig_full': '+'.join([defconfig_target] + fragments),
+        })
+
+    vmlinux_file = os.path.join(kdir_output, 'vmlinux')
+    if os.path.isfile(vmlinux_file):
+        vmlinux_meta = kernelci.elf.read(vmlinux_file)
+        bmeta.update(vmlinux_meta)
+        bmeta['vmlinux_file_size'] = os.stat(vmlinux_file).st_size
+
+    with open(os.path.join(kdir_output, 'bmeta.json'), 'w') as json_file:
+        json.dump(bmeta, json_file, indent=4, sort_keys=True)
+
+    return result
+
+
+def install_kernel(kdir, tree_name, tree_url, git_branch,
+                   git_commit=None, describe=None, describe_v=None,
+                   output='build', install='_install_', mod_path='_modules_'):
+    kdir_output = os.path.join(kdir, output)
+    install_path = os.path.join(kdir, install)
+    if not git_commit:
+        git_commit = head_commit(kdir)
+    if not describe:
+        describe = git_describe(tree_name, kdir)
+    if not describe_v:
+        describe_v = git_describe_verbose(kdir)
+
+    if os.path.exists(install_path):
+        shutil.rmtree(install_path)
+    os.makedirs(install_path)
+
+    with open(os.path.join(kdir_output, 'bmeta.json')) as json_file:
+        bmeta = json.load(json_file)
+
+    system_map = os.path.join(kdir, output, 'System.map')
+    if os.path.exists(system_map):
+        virt_text = shell_cmd('grep " _text" {}'.format(system_map)).split()[0]
+        text_offset = int(virt_text, 16) & (1 << 30)-1  # phys: cap at 1G
+        shutil.copy(system_map, install_path)
+    else:
+        text_offset = None
+
+    dot_config = os.path.join(kdir_output, '.config')
+    dot_config_installed = os.path.join(install_path, 'kernel.config')
+    shutil.copy(dot_config, dot_config_installed)
+
+    build_log = os.path.join(kdir_output, 'build.log')
+    shutil.copy(build_log, install_path)
+
+    frags = os.path.join(kdir_output, 'frag.config')
+    if os.path.exists(frags):
+        shutil.copy(frags, install_path)
+
+    arch = bmeta['arch']
+    boot_dir = os.path.join(kdir, output, 'arch', arch, 'boot')
+    kimage_names = KERNEL_IMAGE_NAMES[arch]
+    kimages = []
+    kimage_file = None
+    for root, _, files in os.walk(boot_dir):
+        for name in kimage_names:
+            if name in files:
+                kimages.append(name)
+                image_path = os.path.join(root, name)
+                shutil.copy(image_path, install_path)
+    if kimages:
+        for name in kimage_names:
+            if name in kimages:
+                kimage_file = name
+                break
+    if not kimage_file:
+        print("Warning: no kernel image found")
+
+    dts_dir = os.path.join(boot_dir, 'dts')
+    dtbs = os.path.join(install_path, 'dtbs')
+    for root, _, files in os.walk(dts_dir):
+        for f in fnmatch.filter(files, '*.dtb'):
+            dtb_path = os.path.join(root, f)
+            dtb_rel = os.path.relpath(dtb_path, dts_dir)
+            dest_path = os.path.join(dtbs, dtb_rel)
+            dest_dir = os.path.dirname(dest_path)
+            if not os.path.exists(dest_dir):
+                os.makedirs(dest_dir)
+            shutil.copy(dtb_path, dest_path)
+
+    modules_tarball = None
+    if mod_path:
+        abs_mod_path = os.path.join(kdir_output, mod_path)
+        if os.path.exists(abs_mod_path):
+            modules_tarball = 'modules.tar.xz'
+            modules_tarball_path = os.path.join(install_path, modules_tarball)
+            shell_cmd("tar -C{path} -cJf {tarball} .".format(
+                path=abs_mod_path, tarball=modules_tarball_path))
+
+    build_env = bmeta['build_environment']
+    defconfig_full = bmeta['defconfig_full']
+    publish_path = '/'.join([
+        tree_name, git_branch, describe, arch, defconfig_full, build_env,
+    ])
+
+    bmeta.update({
+        'kconfig_fragments': 'frag.config' if os.path.exists(frags) else '',
+        'kernel_image': kimage_file,
+        'kernel_config': os.path.basename(dot_config_installed),
+        'system_map': 'System.map' if os.path.exists(system_map) else None,
+        'text_offset': '0x{:08x}'.format(text_offset) if text_offset else None,
+        'dtb_dir': 'dtbs' if os.path.exists(dtbs) else None,
+        'modules': modules_tarball,
+        'job': tree_name,
+        'git_url': tree_url,
+        'git_branch': git_branch,
+        'git_describe': describe,
+        'git_describe_verbose': describe_v,
+        'git_commit': git_commit,
+        'file_server_resource': publish_path,
+    })
+
+    with open(os.path.join(install_path, 'build.json'), 'w') as json_file:
+        json.dump(bmeta, json_file, indent=4, sort_keys=True)
+
+    return True
+
+
+def push_kernel(kdir, api, token, install='_install_'):
+    install_path = os.path.join(kdir, install)
+
+    with open(os.path.join(install_path, 'build.json')) as f:
+        bmeta = json.load(f)
+
+    artifacts = {}
+    for root, _, files in os.walk(install_path):
+        for f in files:
+            px = os.path.relpath(root, install_path)
+            artifacts[os.path.join(px, f)] = open(os.path.join(root, f))
+    upload_path = bmeta['file_server_resource']
+    print("Upload path: {}".format(upload_path))
+    _upload_files(api, token, upload_path, artifacts)
+
+    return True
+
+
+def publish_kernel(kdir, api, token, install='_install_'):
+    install_path = os.path.join(kdir, install)
+
+    with open(os.path.join(install_path, 'build.json')) as f:
+        bmeta = json.load(f)
+
+    data = {k: bmeta[v] for k, v in {
+        'path': 'file_server_resource',
+        'job': 'job',
+        'git_branch': 'git_branch',
+        'arch': 'arch',
+        'kernel': 'git_describe',
+        'build_environment': 'build_environment',
+        'defconfig': 'defconfig',
+        'defconfig_full': 'defconfig_full',
+    }.iteritems()}
+
+    headers = {
+        'Authorization': token,
+        'Content-Type': 'application/json',
+    }
+
+    url = urlparse.urljoin(api, '/build')
+    json_data = json.dumps(data)
+    resp = requests.post(url, headers=headers, data=json_data)
+    resp.raise_for_status()
+
+    return True

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -278,6 +278,8 @@ def _run_make(kdir, arch, target=None, jopt=None, silent=True, cc='gcc',
     if opts:
         args += ['='.join([k, v]) for k, v in opts.iteritems()]
 
+    args += ['-C{}'.format(kdir)]
+
     if jopt:
         args.append('-j{}'.format(jopt))
 
@@ -300,7 +302,7 @@ def _run_make(kdir, arch, target=None, jopt=None, silent=True, cc='gcc',
         args.append('CC={}'.format(cc))
 
     if output:
-        args.append('O={}'.format(output))
+        args.append('O={}'.format(os.path.relpath(output, kdir)))
 
     if target:
         args.append(target)
@@ -308,17 +310,14 @@ def _run_make(kdir, arch, target=None, jopt=None, silent=True, cc='gcc',
     cmd = ' '.join(args)
     print(cmd)
     if log_file:
-        log_file_path = os.path.join(kdir, output, log_file)
-        open(log_file_path, 'a').write("#\n# {}\n#\n".format(cmd))
+        open(log_file, 'a').write("#\n# {}\n#\n".format(cmd))
         cmd = "/bin/bash -c '(set -o pipefail; {} 2>&1 | tee -a {})'".format(
             cmd, log_file)
-    cmd = "cd {} && {}".format(kdir, cmd)
     return shell_cmd(cmd, True)
 
 
 def _make_defconfig(defconfig, kwargs, fragments):
-    kdir, output = (kwargs.get(k) for k in ('kdir', 'output'))
-    kdir_output = os.path.join(kdir, output)
+    kdir, output_path = (kwargs.get(k) for k in ('kdir', 'output'))
     result = True
 
     tmpfile_fd, tmpfile_path = tempfile.mkstemp(prefix='kconfig-')
@@ -342,17 +341,18 @@ def _make_defconfig(defconfig, kwargs, fragments):
 
     if result and fragments:
         kconfig_frag_name = 'frag.config'
-        kconfig_frag = os.path.join(kdir_output, kconfig_frag_name)
+        kconfig_frag = os.path.join(output_path, kconfig_frag_name)
         shutil.copy(tmpfile_path, kconfig_frag)
         os.chmod(kconfig_frag,
                  stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH)
+        rel_path = os.path.relpath(output_path, kdir)
         cmd = """\
 cd {kdir}
 export ARCH={arch}
 scripts/kconfig/merge_config.sh -O {output} '{base}' '{frag}' > /dev/null 2>&1
-""".format(kdir=kdir, arch=kwargs['arch'], output=output,
-           base=os.path.join(output, '.config'),
-           frag=os.path.join(output, kconfig_frag_name))
+""".format(kdir=kdir, arch=kwargs['arch'],output=rel_path,
+           base=os.path.join(rel_path, '.config'),
+           frag=os.path.join(rel_path, kconfig_frag_name))
         print(cmd.strip())
         result = shell_cmd(cmd, True)
 
@@ -363,19 +363,20 @@ scripts/kconfig/merge_config.sh -O {output} '{base}' '{frag}' > /dev/null 2>&1
 
 
 def build_kernel(build_env, kdir, arch, defconfig=None, jopt=None,
-                 verbose=False, output='build', mod_path='_modules_'):
+                 verbose=False, output_path=None, mod_path='_modules_'):
     cc = build_env.cc
     cross_compile = build_env.get_cross_compile(arch) or None
     use_ccache = shell_cmd("which ccache > /dev/null", True)
-    kdir_output = os.path.join(kdir, output)
-    build_log = 'build.log'
-    log_file = os.path.join(kdir_output, build_log)
-    dot_config = os.path.join(kdir_output, '.config')
     target = MAKE_TARGETS.get(arch)
     if jopt is None:
         jopt = int(shell_cmd("nproc")) + 2
-    if not os.path.exists(kdir_output):
-        os.mkdir(kdir_output)
+    if not output_path:
+        output_path = os.path.join(kdir, 'build')
+    if not os.path.exists(output_path):
+        os.mkdir(output_path)
+    build_log = 'build.log'
+    log_file = os.path.join(output_path, build_log)
+    dot_config = os.path.join(output_path, '.config')
     if os.path.exists(log_file):
         os.unlink(log_file)
 
@@ -389,9 +390,9 @@ def build_kernel(build_env, kdir, arch, defconfig=None, jopt=None,
         'cc': cc,
         'cross_compile': cross_compile,
         'use_ccache': use_ccache,
-        'output': output,
+        'output': output_path,
         'silent': not verbose,
-        'log_file': build_log,
+        'log_file': log_file,
         'opts': opts,
     }
 
@@ -413,7 +414,7 @@ def build_kernel(build_env, kdir, arch, defconfig=None, jopt=None,
     build_time = time.time() - start_time
 
     if result and mods and mod_path:
-        abs_mod_path = os.path.join(kdir_output, mod_path)
+        abs_mod_path = os.path.join(output_path, mod_path)
         if os.path.exists(abs_mod_path):
             shutil.rmtree(abs_mod_path)
         os.makedirs(abs_mod_path)
@@ -449,23 +450,24 @@ def build_kernel(build_env, kdir, arch, defconfig=None, jopt=None,
             'defconfig_full': '+'.join([defconfig_target] + fragments),
         })
 
-    vmlinux_file = os.path.join(kdir_output, 'vmlinux')
+    vmlinux_file = os.path.join(output_path, 'vmlinux')
     if os.path.isfile(vmlinux_file):
         vmlinux_meta = kernelci.elf.read(vmlinux_file)
         bmeta.update(vmlinux_meta)
         bmeta['vmlinux_file_size'] = os.stat(vmlinux_file).st_size
 
-    with open(os.path.join(kdir_output, 'bmeta.json'), 'w') as json_file:
+    with open(os.path.join(output_path, 'bmeta.json'), 'w') as json_file:
         json.dump(bmeta, json_file, indent=4, sort_keys=True)
 
     return result
 
 
-def install_kernel(kdir, tree_name, tree_url, git_branch,
-                   git_commit=None, describe=None, describe_v=None,
-                   output='build', install='_install_', mod_path='_modules_'):
-    kdir_output = os.path.join(kdir, output)
+def install_kernel(kdir, tree_name, tree_url, git_branch, git_commit=None,
+                   describe=None, describe_v=None, output_path=None,
+                   install='_install_', mod_path='_modules_'):
     install_path = os.path.join(kdir, install)
+    if not output_path:
+        output_path = os.path.join(kdir, 'build')
     if not git_commit:
         git_commit = head_commit(kdir)
     if not describe:
@@ -477,10 +479,10 @@ def install_kernel(kdir, tree_name, tree_url, git_branch,
         shutil.rmtree(install_path)
     os.makedirs(install_path)
 
-    with open(os.path.join(kdir_output, 'bmeta.json')) as json_file:
+    with open(os.path.join(output_path, 'bmeta.json')) as json_file:
         bmeta = json.load(json_file)
 
-    system_map = os.path.join(kdir, output, 'System.map')
+    system_map = os.path.join(output_path, 'System.map')
     if os.path.exists(system_map):
         virt_text = shell_cmd('grep " _text" {}'.format(system_map)).split()[0]
         text_offset = int(virt_text, 16) & (1 << 30)-1  # phys: cap at 1G
@@ -488,19 +490,19 @@ def install_kernel(kdir, tree_name, tree_url, git_branch,
     else:
         text_offset = None
 
-    dot_config = os.path.join(kdir_output, '.config')
+    dot_config = os.path.join(output_path, '.config')
     dot_config_installed = os.path.join(install_path, 'kernel.config')
     shutil.copy(dot_config, dot_config_installed)
 
-    build_log = os.path.join(kdir_output, 'build.log')
+    build_log = os.path.join(output_path, 'build.log')
     shutil.copy(build_log, install_path)
 
-    frags = os.path.join(kdir_output, 'frag.config')
+    frags = os.path.join(output_path, 'frag.config')
     if os.path.exists(frags):
         shutil.copy(frags, install_path)
 
     arch = bmeta['arch']
-    boot_dir = os.path.join(kdir, output, 'arch', arch, 'boot')
+    boot_dir = os.path.join(output_path, 'arch', arch, 'boot')
     kimage_names = KERNEL_IMAGE_NAMES[arch]
     kimages = []
     kimage_file = None
@@ -532,7 +534,7 @@ def install_kernel(kdir, tree_name, tree_url, git_branch,
 
     modules_tarball = None
     if mod_path:
-        abs_mod_path = os.path.join(kdir_output, mod_path)
+        abs_mod_path = os.path.join(output_path, mod_path)
         if os.path.exists(abs_mod_path):
             modules_tarball = 'modules.tar.xz'
             modules_tarball_path = os.path.join(install_path, modules_tarball)

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -588,7 +588,8 @@ def push_kernel(kdir, api, token, install='_install_'):
     return True
 
 
-def publish_kernel(kdir, api, token, install='_install_'):
+def publish_kernel(kdir, install='_install_', api=None, token=None,
+                   json_path=None):
     install_path = os.path.join(kdir, install)
 
     with open(os.path.join(install_path, 'build.json')) as f:
@@ -596,6 +597,7 @@ def publish_kernel(kdir, api, token, install='_install_'):
 
     data = {k: bmeta[v] for k, v in {
         'path': 'file_server_resource',
+        'file_server_resource': 'file_server_resource',
         'job': 'job',
         'git_branch': 'git_branch',
         'arch': 'arch',
@@ -605,14 +607,38 @@ def publish_kernel(kdir, api, token, install='_install_'):
         'defconfig_full': 'defconfig_full',
     }.iteritems()}
 
-    headers = {
-        'Authorization': token,
-        'Content-Type': 'application/json',
-    }
+    if json_path:
+        json_data = dict(data)
+        for k in ['kernel_image', 'modules', 'git_commit', 'git_url']:
+            json_data[k] = bmeta[k]
+        json_data['status'] = bmeta['build_result']
+        dtb_data = []
+        if bmeta['dtb_dir']:
+            dtb_dir = os.path.join(install_path, bmeta['dtb_dir'])
+            for root, dirs, files in os.walk(dtb_dir):
+                if root != dtb_dir:
+                    rel = os.path.relpath(root, dtb_dir)
+                    files = list(os.path.join(rel, dtb) for dtb in files)
+                dtb_data += files
+        json_data['dtb_dir_data'] = dtb_data
+        try:
+            with open(json_path, 'r') as json_file:
+                full_json = json.load(json_file)
+            full_json.append(json_data)
+        except Exception as e:
+            full_json = [json_data]
+        with open(json_path, 'w') as json_file:
+            json.dump(full_json, json_file)
 
-    url = urlparse.urljoin(api, '/build')
-    json_data = json.dumps(data)
-    resp = requests.post(url, headers=headers, data=json_data)
-    resp.raise_for_status()
+    if api and token:
+        headers = {
+            'Authorization': token,
+            'Content-Type': 'application/json',
+        }
+
+        url = urlparse.urljoin(api, '/build')
+        json_data = json.dumps(data)
+        resp = requests.post(url, headers=headers, data=json_data)
+        resp.raise_for_status()
 
     return True

--- a/kernelci/elf.py
+++ b/kernelci/elf.py
@@ -1,15 +1,23 @@
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as
-# published by the Free Software Foundation, either version 3 of the
-# License, or (at your option) any later version.
+# Copyright (C) 2017 Linaro Limited
+# Author: Milo Casagrande <milo.casagrande@linaro.org>
+# Author: Matt Hart <matthew.hart@linaro.org>
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
+# Copyright (C) 2017 Baylibre SAS
+# Author: Kevin Hilman <khilman@baylibre.com>
 #
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This module is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 """Open the ELF file and read some of its content."""
 

--- a/src/org/kernelci/util/Job.groovy
+++ b/src/org/kernelci/util/Job.groovy
@@ -43,8 +43,16 @@ def cloneKciCore(path, url, branch) {
     }
 }
 
-def dockerImageName(base, cc, cc_version, kernel_arch) {
-    def image_name = "${base}${cc}-${cc_version}"
+def dockerImageName(kci_core, build_env, kernel_arch) {
+    def image_name = build_env
+    def cc = null
+
+    dir(kci_core) {
+        def build_env_raw = sh(
+            script: "./kci_build show_build_env --build-env=${build_env}",
+            returnStdout: true).trim()
+        cc = build_env_raw.tokenize('\n')[1]
+    }
 
     if (cc == "gcc") {
         def docker_arch
@@ -59,7 +67,7 @@ def dockerImageName(base, cc, cc_version, kernel_arch) {
 	image_name = "${image_name}_${docker_arch}"
     }
 
-    return image_name;
+    return image_name
 }
 
 def dockerPullWithRetry(image_name, retries=10, sleep_time=1) {


### PR DESCRIPTION
Add build commands to the `kci_build` tool and the `kernelci.build` library and use that in the build job in place of the legacy `build.py` script.  It makes the code more maintainable and focused on the KernelCI use-case with still some flexibility to build kernels manually with arbitrary configs.  It also relies on the `build-configs.yaml` data to simplify job parameters.

Following this change, the current `build.py` script will not be used any more in this repo and could therefore be removed.

Sample commands to use this locally to build a kernel from linux-next:

1. Optional: set up a local mirror
If you already have a linux check out:
```
git clone \
  --mirror git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git \
  --reference=~/src/linux linux-mirror.git
```
Then to update the mirror, or create it if you skipped the command above:

```
./kci_build update_mirror --config=next --mirror=linux-mirror.git
```

2. Create a local check-out (or update an existing one when running this again)
```
./kci_build update_repo --config=next --kdir=linux --mirror=linux-mirror.git
```
Optionally, to generate additional config fragments (e.g. to then build `defconfig+kselftest`):
```
./kci_build generate_fragments --config=next --kdir=linux
```

3. Build the kernel with defconfig
```
./kci_build build_kernel --defconfig=defconfig --arch=x86 --build-env=gcc-7 --kdir=linux
```

To see the compiler output, add `--verbose`.
The output can be found in `linux/build`.

To build again without regenerating the kernel config file, just omit the `--defconfig` argument:
```
./kci_build build_kernel --arch=x86 --build-env=gcc-7 --kdir=linux
```

Note: the build-env option is only used to populate the meta-data for the KernelCI database, it is not downloading a build environment.  A future improvement would be to enable using a Docker image as with Jenkins builds (`jenkins/build.jpl`).

4. Install the kernel binaries in a local directory
```
./kci_build install_kernel --config=next --kdir=linux 
```

See the output in `linux/_install_`.

5. If you have a kernelci-backend instance running, you can send the kernel and also the meta-data with these commands:
```
./kci_build push_kernel --kdir=linux --api=https://localhost:12345 --token=1234-5678
./kci_build publish_kernel --kdir=linux --api=https://localhost:12345 --token=1234-5678
```
Alternatively, to store the meta-data locally in a JSON file:
```
./kci_build publish_kernel --kdir=linux --json-path=build-meta.json
```
