### PR TITLE
build.py: fix riscv kernel image install

### DIFF
--- a/build.py
+++ b/build.py
@@ -415,7 +415,7 @@ if install:
     # Patterns for matching kernel images by architecture
     if arch == 'arm':
         patterns = ['zImage', 'xipImage']
-    elif arch == 'arm64':
+    elif arch == 'arm64' or arch == "riscv":
         patterns = ['Image']
     elif arch == "arc" or arch == "mips":
         patterns = ['uImage.gz']


### PR DESCRIPTION
The install phase is not installing any kernel images for RISC-V.  Fix
that.

Signed-off-by: Kevin Hilman <khilman@kernel.org>