### PR TITLE
Enable clang-8 builds on linux-next for arm64

### DIFF
--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -581,6 +581,11 @@ build_configs:
               - 'multi_v7_defconfig+CONFIG_EFI=y+CONFIG_ARM_LPAE=y'
               - 'allnoconfig'
               - 'allmodconfig'
+      clang-8:
+        build_environment: clang-8
+        fragments: *default_fragments
+        architectures:
+          arm64: *arm64_arch
 
   next_pending-fixes:
     tree: next


### PR DESCRIPTION
Once the build and boots email fixes are tested and merged, we should be good to enable clang-8 builds for arm64 on linux-next.

Tested locally that the right outputs come out of kci_build