### PR TITLE
test-configs.yaml: fix x86 default defconfig filters

### DIFF
--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -54,8 +54,8 @@ test_plan_default_filters:
       values:
         - ['arm', 'multi_v7_defconfig']
         - ['arm64', 'defconfig']
-        - ['i386', 'defconfig']
-        - ['x86_64', 'defconfig']
+        - ['i386', 'i386_defconfig']
+        - ['x86_64', 'x86_64_defconfig']
 
 
 test_plans:


### PR DESCRIPTION
Fix the x86 default filters with the standard defconfig names as these
are now specific to i386 and x86_64 since the x86 arch was split and
the base defconfigs are named in build-configs.yaml.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>