### PR TITLE
Add first ARC device: hsdk

### DIFF
--- a/kernelci/configs.py
+++ b/kernelci/configs.py
@@ -538,6 +538,14 @@ class DeviceType(YAMLObject):
         )
 
 
+class DeviceType_arc(DeviceType):
+
+    def __init__(self, name, mach, arch='arc', *args, **kw):
+        """arc device type with a device tree."""
+        kw.setdefault('dtb', '{}.dtb'.format(name))
+        super(DeviceType_arc, self).__init__(name, mach, arch, *args, **kw)
+
+
 class DeviceType_arm(DeviceType):
 
     def __init__(self, name, mach, arch='arm', *args, **kw):
@@ -566,6 +574,7 @@ class DeviceTypeFactory(YAMLObject):
     """Factory to create device types from YAML data."""
 
     _classes = {
+        'arc-dtb': DeviceType_arc,
         'mips-dtb': DeviceType_mips,
         'arm-dtb': DeviceType_arm,
         'arm64-dtb': DeviceType_arm64,

--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -440,6 +440,11 @@ device_types:
     class: arm64-dtb
     boot_method: uboot
 
+  hsdk:
+    mach: arc
+    class: arc-dtb
+    boot_method: uboot
+
   imx23_olinuxino:
     name: 'imx23-olinuxino'
     mach: imx
@@ -1087,6 +1092,9 @@ test_configs:
 
   - device_type: hikey_uboot
     test_plans: [boot, boot_nfs, kselftest, simple]
+
+  - device_type: hsdk
+    test_plans: [boot]
 
   - device_type: imx23_olinuxino
     test_plans: [boot, boot_nfs, kselftest, sleep]


### PR DESCRIPTION
This patchs adds support for the ARC architecture.
It adds the first boards using this arch, the HSDK