### PR TITLE
build.py: mips: use uImage.gz build_target

### DIFF
--- a/build.py
+++ b/build.py
@@ -365,10 +365,8 @@ extra_configs(dot_config, kbuild_output)
 #
 if len(args) >= 1:
     build_target = args[0]
-elif arch == "arc":
+elif arch == "arc" or arch == "mips":
     build_target = "uImage.gz"
-elif arch == "mips":
-    build_target = "all"
 result = do_make(build_target, log=True)
 
 # Build modules


### PR DESCRIPTION
The 'make all' target doesn't actually build uImage.gz, which is the
image file needed to boot the current MIPS boards in
kernelCI (pistachio_marduk)

Signed-off-by: Kevin Hilman <khilman@baylibre.com>