### PR TITLE
kernelci.build: build uImage.gz for MIPS

### DIFF
--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -40,7 +40,7 @@ MAKE_TARGETS = {
     'arm': 'zImage dtbs',
     'arm64': 'Image dtbs',
     'arc': 'uImage.gz dtbs',
-    'mips': 'all',
+    'mips': 'uImage.gz dtbs',
 }
 
 # Hard-coded binary kernel image names for each CPU architecture


### PR DESCRIPTION
Build uImage.gz by for MIPS, which isn't included in "make all".  This
is now the default kernel binary uploaded for MIPS.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>