### PR TITLE
T14553 stretch-v4l2: add autopoint to fix v4l2-compliance build

### DIFF
--- a/jenkins/debian/debos/scripts/stretch-v4l2.sh
+++ b/jenkins/debian/debos/scripts/stretch-v4l2.sh
@@ -5,15 +5,17 @@
 set -e
 
 # Build-depends needed to build the test suites, they'll be removed later
-BUILD_DEPS="libglib2.0-dev \
+BUILD_DEPS="\
+    build-essential \
+    ca-certificates \
     git \
     autoconf \
     autogen \
-    libtool \
     automake \
+    autopoint \
     gettext \
-    build-essential \
-    ca-certificates \
+    libglib2.0-dev \
+    libtool \
 "
 
 apt-get install --no-install-recommends -y  ${BUILD_DEPS}


### PR DESCRIPTION
Fix the v4l2-compliance build by adding the autopoint package as a
build requirement.  Also reorder the packages alphabetically.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>