### PR TITLE
kernelci.build: make all for mips

### DIFF
--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -40,7 +40,6 @@ MAKE_TARGETS = {
     'arm': 'zImage',
     'arm64': 'Image',
     'arc': 'uImage.gz',
-    'mips': 'uImage.gz',
 }
 
 # Hard-coded binary kernel image names for each CPU architecture


### PR DESCRIPTION
Revert to running "make all" for mips as not all defconfigs enable
uImage.gz to be built.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>