### PR TITLE
T12984 bisect with fragments

### DIFF
--- a/jenkins/bisect.jpl
+++ b/jenkins/bisect.jpl
@@ -218,9 +218,22 @@ def buildKernel(kdir, kci_core) {
 
         sh(script:"""\
 ./kci_build \
+generate_defconfig_fragments \
+--defconfig=${params.DEFCONFIG} \
+--kdir=${kdir} \
+""")
+
+        def expanded_defconfig = sh(script: """\
+./kci_build \
+expand_fragments \
+--defconfig=${params.DEFCONFIG} \
+""", returnStdout: true).trim()
+
+        sh(script:"""\
+./kci_build \
 build_kernel \
 --kdir=${kdir} \
---defconfig=${params.DEFCONFIG} \
+--defconfig=${expanded_defconfig} \
 --arch=${params.ARCH} \
 --build-env=${params.BUILD_ENVIRONMENT} \
 --output=${output} \

--- a/kci_build
+++ b/kci_build
@@ -262,6 +262,21 @@ class cmd_generate_fragments(Command):
         return True
 
 
+class cmd_generate_defconfig_fragments(Command):
+    help = "Generate the config fragment files for a given defconfig"
+    args = [Args.defconfig, Args.kdir]
+
+    def __call__(self, configs, args):
+        fragments = configs['fragments']
+        split = args.defconfig.split('+')
+        defconfig = split.pop(0)
+        for part in split:
+            frag = fragments.get(part)
+            if frag and frag.configs:
+                kernelci.build.generate_config_fragment(frag, args.kdir)
+        return True
+
+
 class cmd_expand_fragments(Command):
     help = "Expand a defconfig string with full fragment paths"
     args = [Args.defconfig]

--- a/kci_build
+++ b/kci_build
@@ -262,6 +262,24 @@ class cmd_generate_fragments(Command):
         return True
 
 
+class cmd_expand_fragments(Command):
+    help = "Expand a defconfig string with full fragment paths"
+    args = [Args.defconfig]
+
+    def __call__(self, configs, args):
+        frags = configs['fragments']
+        split = args.defconfig.split('+')
+        expanded = [split.pop(0)]
+        for part in split:
+            frag = frags.get(part)
+            if frag:
+                expanded.append(frag.path)
+            else:
+                expanded.append(part)
+        print('+'.join(expanded))
+        return True
+
+
 class cmd_push_tarball(Command):
     help = "Create and up a source tarball to the remote storage server"
     args = [Args.config, Args.kdir, Args.storage, Args.api, Args.token]

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -201,15 +201,21 @@ def make_tarball(path, tarball_name):
     subprocess.check_output(cmd, shell=True)
 
 
+def generate_config_fragment(frag, kdir):
+    with open(os.path.join(kdir, frag.path), 'w') as f:
+        print(frag.path)
+        for kernel_config in frag.configs:
+            f.write(kernel_config + '\n')
+
+
 def generate_fragments(config, kdir):
-    add_kselftest_fragment(kdir)
     for variant in config.variants:
         for frag in variant.fragments:
-            if frag.configs:
-                with open(os.path.join(kdir, frag.path), 'w') as f:
-                    print(frag.path)
-                    for kernel_config in frag.configs:
-                        f.write(kernel_config + '\n')
+            if frag.name == 'kselftest':
+                print(frag.path)
+                add_kselftest_fragment(kdir)
+            elif frag.configs:
+                generate_config_fragment(frag, kdir)
 
 
 def push_tarball(config, kdir, storage, api, token):


### PR DESCRIPTION
This is to enable running bisections with config fragments that are not in the kernel git tree, such as `kselftest` and `virtualvideo` but are generated using `kci_build`.