### PR TITLE
stretch-v4l2: treat "OK (Not Supported)" results as PASS

### DIFF
--- a/jenkins/debian/debos/overlays/v4l2/usr/bin/v4l2-parser.sh
+++ b/jenkins/debian/debos/overlays/v4l2/usr/bin/v4l2-parser.sh
@@ -96,7 +96,7 @@ v4l2-compliance -s -d $device_path | sed s/'\r'/'\n'/g | while read line; do
         res=$( \
             echo $line | \
                 sed s/'\(.*\): \([OK|FAIL].*\)'/'\2'/ | \
-                sed s/'OK (Not Supported)'/skip/ | \
+                sed s/'OK (Not Supported)'/pass/ | \
                 sed s/OK/pass/ | \
                 sed s/FAIL/fail/)
 


### PR DESCRIPTION
As discussed with Hans, v4l2-compliance tests that produce a "OK (Not
Supported)" result should be considered as passing rather than
skipped.  It means the test actually verified that it is correct for a
feature to not be supported and that there are no actual functional
errors.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>