### PR TITLE
Add binutils-arm-linux-gnueabihf to clang-8 docker

### DIFF
--- a/jenkins/dockerfiles/clang-8/Dockerfile
+++ b/jenkins/dockerfiles/clang-8/Dockerfile
@@ -7,6 +7,7 @@ RUN wget -q -O - https://apt.llvm.org/llvm-snapshot.gpg.key| apt-key add -
 RUN apt-add-repository 'deb http://apt.llvm.org/unstable/ llvm-toolchain-8 main'
 RUN apt-get update && apt-get install --no-install-recommends -y \
     binutils-aarch64-linux-gnu \
+    binutils-arm-linux-gnueabihf \
     clang-8
 
 RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-8 500


### PR DESCRIPTION
Install armv7 binutils to enable building armv7 kernels with the clang-8 container

Currently fails with:
/usr/bin/as: unrecognized option '-EL'
clang: error: assembler command failed with exit code 1 (use -v to see invocation)