### PR TITLE
Revert "build.py: mips: use uImage.gz build_target"

### DIFF
--- a/build.py
+++ b/build.py
@@ -365,8 +365,10 @@ extra_configs(dot_config, kbuild_output)
 #
 if len(args) >= 1:
     build_target = args[0]
-elif arch == "arc" or arch == "mips":
+elif arch == "arc":
     build_target = "uImage.gz"
+elif arch == "mips":
+    build_target = "all"
 result = do_make(build_target, log=True)
 
 # Build modules


### PR DESCRIPTION
This was a mistake as not all MIPS defconfigs actually have a
uImage.gz target.  Switch back to 'make all'

This reverts commit c781f6d72d983334e375371fb31429c6a03919dc.