### PR TITLE
dockerfiles: arc: update toolchain to 2019.03-rc1

### DIFF
--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -153,7 +153,7 @@ build_environments:
       x86_64: 'x86'
       riscv: 'riscv64'
     cross_compile: &default_cross_compile
-      arc: 'arc-linux-'
+      arc: 'arc-elf32-'
       arm: 'arm-linux-gnueabihf-'
       arm64: 'aarch64-linux-gnu-'
       mips: 'mips-linux-gnu-'

--- a/jenkins/dockerfiles/gcc-8_arc/Dockerfile
+++ b/jenkins/dockerfiles/gcc-8_arc/Dockerfile
@@ -4,6 +4,6 @@ FROM kernelci/build-base
 # pre-built toolchains for ARC available here:
 #    https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/releases/
 #
-ENV CROSS_TARBALL arc_gnu_2018.09-rc1_prebuilt_glibc_le_archs_linux_install.tar.gz
-ENV CROSS_URL https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/releases/download/arc-2018.09-rc1/${CROSS_TARBALL}
+ENV CROSS_TARBALL arc_gnu_2019.03-rc1_prebuilt_elf32_le_linux_install.tar.gz
+ENV CROSS_URL https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/releases/download/arc-2019.03-rc1/${CROSS_TARBALL}
 RUN cd /tmp; wget -q ${CROSS_URL}; tar -C /usr --strip-components=1 -xaf ${CROSS_TARBALL}; rm -f ${CROSS_TARBALL}


### PR DESCRIPTION
Current toolchain produces unbootable kernel.
When using the new 2019.03-rc1, I produces working kernel.