### PR TITLE
T14955 Add buster rootfs

### DIFF
--- a/jenkins/buster.jpl
+++ b/jenkins/buster.jpl
@@ -1,0 +1,33 @@
+@Library('kernelci') _
+import org.kernelci.debian.RootFS
+
+/* ----------------------------------------------------------------------------
+ * Jenkins parameters
+
+DOCKER_BASE
+  Dockerhub base address used for the build images
+
+*/
+
+def r = new RootFS()
+
+def config = [
+    'name': "buster",
+    'arch_list': [
+        "amd64",
+        "arm64",
+        "armel",
+        "armhf",
+        "i386",
+        "mips",
+        "mipsel",
+        "mips64el",
+    ],
+    'debian_release': "buster",
+    'extra_packages': "",
+    'extra_packages_remove': "bash e2fsprogs e2fslibs",
+    'script': "",
+    'docker_image': "${params.DOCKER_BASE}debos",
+]
+
+r.buildImage(config)

--- a/jenkins/debian/debos/scripts/crush.sh
+++ b/jenkins/debian/debos/scripts/crush.sh
@@ -10,7 +10,7 @@ UNNEEDED_PACKAGES="apt libapt-pkg5.0 "\
 "ncurses-bin ncurses-base libncursesw5 libncurses5 "\
 "perl-base "\
 "debconf libdebconfclient0 "\
-"libfdisk1 libdevmapper1.02.1 "\
+"libfdisk1 "\
 "insserv "\
 "init-system-helpers "\
 "cpio "\
@@ -101,9 +101,9 @@ find usr etc -name '*fuse*' -prune -exec rm -r {} \;
 rm -rf usr/lib/lsb
 
 # Utils using ncurses
-rm usr/bin/pg
-rm usr/bin/watch
-rm usr/bin/slabtop
+rm -f usr/bin/pg
+rm -f usr/bin/watch
+rm -f usr/bin/slabtop
 
 # boot analyser
 rm usr/bin/systemd-analyze


### PR DESCRIPTION
Add a Debian Buster rootfs:

* add jenkins/buster.jpl to build a basic rootfs
* keep libdevmapper1.02.1 as it is required for systemd in Buster
* use "rm -f" for files that may be there in Stretch but not in Buster

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>