### PR TITLE
jenkins/buildroot-builder: add fragment

### DIFF
--- a/jenkins/buildroot-builder.sh
+++ b/jenkins/buildroot-builder.sh
@@ -2,10 +2,10 @@
 env
 
 # Build 
-./configs/frags/build ${arch}
+./configs/frags/build ${arch} ${frag}
 
 # Publish
 set -x
-PUBLISH_PATH=images/rootfs/buildroot/$(git describe)/${arch}/base
+PUBLISH_PATH=images/rootfs/buildroot/$(git describe)/${arch}/${frag}
 ls -l output/images
 (cd output/images; push-source.py --token ${API_TOKEN} --api ${API} --publish_path ${PUBLISH_PATH} --file *)


### PR DESCRIPTION
Support addition fragments when building.  This will initially be used
to build the additional "baseline" fragment for bootrr.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>