### PR TITLE
test-configs.yaml: Add support for the meson-gxm-khadas-vim2

### DIFF
--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -591,6 +591,14 @@ device_types:
     filters:
       - blacklist: {defconfig: ['allnoconfig', 'allmodconfig']}
 
+  meson-gxm-khadas-vim2:
+    mach: amlogic
+    class: arm64-dtb
+    boot_method: uboot
+    flags: ['big_endian']
+    filters:
+      - blacklist: {defconfig: ['allnoconfig', 'allmodconfig']}
+
   minnowboard_turbot_E3826:
     name: 'minnowboard-turbot-E3826'
     mach: x86
@@ -1098,6 +1106,9 @@ test_configs:
 
   - device_type: meson_gxl_s905x_libretech_cc
     test_plans: [boot, kselftest, simple]
+
+  - device_type: meson-gxm-khadas-vim2
+    test_plans: [boot, kselftest, simple, boot_nfs]
 
   - device_type: m3ulcb
     test_plans: [boot, simple, usb]


### PR DESCRIPTION
We have a meson-gxm-khadas-vim2 in lab-baylibre, ready to accept jobs.