### PR TITLE
build.jpl: enable --verbose kernel builds

### DIFF
--- a/jenkins/build.jpl
+++ b/jenkins/build.jpl
@@ -74,6 +74,7 @@ build_kernel \
 --defconfig=${params.DEFCONFIG} \
 --arch=${params.ARCH} \
 --build-env=${params.BUILD_ENVIRONMENT} \
+--verbose \
 ${jopt} \
 || echo 'Kernel build failed'
 """)


### PR DESCRIPTION
Run kci_build build_kernel --verbose to have the full output stored in
the build log.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>