### PR TITLE
test-configs: fix r8a7795-salvator-x boot method

### DIFF
--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -787,7 +787,7 @@ device_types:
     name: 'r8a7795-salvator-x'
     mach: renesas
     class: arm64-dtb
-    boot_method: qemu
+    boot_method: uboot
     flags: ['big_endian']
     filters:
       - blacklist: {defconfig: ['allnoconfig', 'allmodconfig']}


### PR DESCRIPTION
While doing some statistics about our lab, I found that the salavtor-x
didnt worked since a long time.
The boot-method of r8a7795-salvator-x is wrongly set as qemu.
Since this board is not a qemu device, this is wrong.