### PR TITLE
test-configs: Add ox820-cloudengines-pogoplug-series-3

### DIFF
--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -676,6 +676,11 @@ device_types:
     class: arm-dtb
     boot_method: uboot
 
+  ox820-cloudengines-pogoplug-series-3:
+    mach: oxnas
+    class: arm-dtb
+    boot_method: uboot
+
   panda:
     mach: omap2
     class: arm-dtb
@@ -1131,6 +1136,9 @@ test_configs:
 
   - device_type: orion5x_rd88f5182_nas
     test_plans: [boot_nfs]
+
+  - device_type: ox820-cloudengines-pogoplug-series-3
+    test_plans: [boot, boot_nfs]
 
   - device_type: panda
     test_plans: [boot, kselftest]


### PR DESCRIPTION
The ox820-cloudengines-pogoplug-series-3 is on our lab since a long time
and is waiting for jobs!

- [x] `ox820-cloudengines-pogoplug-series-3` merged upstream in LAVA https://git.lavasoftware.org/lava/lava/merge_requests/574