### PR TITLE
T15160 optimize buster rootfs size

### DIFF
--- a/jenkins/buster.jpl
+++ b/jenkins/buster.jpl
@@ -25,7 +25,29 @@ def config = [
     ],
     'debian_release': "buster",
     'extra_packages': "",
-    'extra_packages_remove': "bash e2fsprogs e2fslibs",
+    'extra_packages_remove': "\
+bash \
+e2fslibs \
+e2fsprogs \
+klibc-utils \
+libext2fs2 \
+libgnutls30 \
+libklibc \
+libncursesw6 \
+libp11-kit0 \
+libunistring2 \
+sensible-utils \
+",
+    'extra_files_remove': "\
+*networkd* \
+*resolved* \
+tar \
+patch \
+diff \
+dir \
+partx \
+find \
+",
     'script': "",
     'docker_image': "${params.DOCKER_BASE}debos",
 ]

--- a/jenkins/debian/debos/rootfs.yaml
+++ b/jenkins/debian/debos/rootfs.yaml
@@ -5,6 +5,7 @@
 {{- $script := or .script "scripts/nothing.sh" -}}
 {{- $test_overlay := .test_overlay -}}
 {{- $extra_packages_remove := or .extra_packages_remove -}}
+{{- $extra_files_remove := or .extra_files_remove -}}
 
 architecture: {{ $architecture }}
 
@@ -151,6 +152,18 @@ actions:
   - action: run
     chroot: true
     script: scripts/crush.sh
+
+{{ if $extra_files_remove }}
+  - action: run
+    description: remove extra files
+    chroot: true
+    command: |
+      for exp in {{ $extra_files_remove }}; do
+        for f in $(find . -name "$exp"); do
+          rm -rf "$f"
+        done
+      done
+{{ end }}
 
   - action: run
     description: Set symbolic link to init

--- a/jenkins/debian/debos/rootfs.yaml
+++ b/jenkins/debian/debos/rootfs.yaml
@@ -137,16 +137,16 @@ actions:
     chroot: false
     command: mv ${ROOTDIR}/boot/initrd.img-min ${ARTIFACTDIR}/{{ $basename -}}/initrd.cpio.gz
 
+  - action: run
+    chroot: true
+    script: scripts/strip.sh
+
 {{ if $extra_packages_remove }}
   - action: run
     description: remove extra packages
     chroot: true
-    command: dpkg --purge  --force-remove-essential --force-depends {{ $extra_packages_remove }}
+    command: dpkg --purge --force-remove-essential --force-depends {{ $extra_packages_remove }}
 {{ end }}
-
-  - action: run
-    chroot: true
-    script: scripts/strip.sh
 
   - action: run
     chroot: true

--- a/jenkins/debian/debos/scripts/crush.sh
+++ b/jenkins/debian/debos/scripts/crush.sh
@@ -77,10 +77,10 @@ rm -rf usr/lib/xtables
 rm -rf usr/lib/locale/*
 
 # partition helpers
-rm usr/sbin/*fdisk
+rm -f usr/sbin/*fdisk
 
 # local compiler
-rm usr/bin/localedef
+rm -f usr/bin/localedef
 
 # Systemd dns resolver
 #find usr etc -name '*systemd-resolve*' -prune -exec rm -r {} \;
@@ -106,22 +106,22 @@ rm -f usr/bin/watch
 rm -f usr/bin/slabtop
 
 # boot analyser
-rm usr/bin/systemd-analyze
+rm -f usr/bin/systemd-analyze
 
 # Only needed when adding libraries
-rm usr/sbin/ldconfig*
+rm -f usr/sbin/ldconfig*
 
 # Games, unused
-rmdir usr/games
+rm -rf usr/games
 
 # Unused systemd generators
-rm lib/systemd/system-generators/systemd-cryptsetup-generator
-rm lib/systemd/system-generators/systemd-debug-generator
-rm lib/systemd/system-generators/systemd-gpt-auto-generator
-rm lib/systemd/system-generators/systemd-hibernate-resume-generator
-rm lib/systemd/system-generators/systemd-rc-local-generator
-rm lib/systemd/system-generators/systemd-system-update-generator
-rm lib/systemd/system-generators/systemd-sysv-generator
+rm -f lib/systemd/system-generators/systemd-cryptsetup-generator
+rm -f lib/systemd/system-generators/systemd-debug-generator
+rm -f lib/systemd/system-generators/systemd-gpt-auto-generator
+rm -f lib/systemd/system-generators/systemd-hibernate-resume-generator
+rm -f lib/systemd/system-generators/systemd-rc-local-generator
+rm -f lib/systemd/system-generators/systemd-system-update-generator
+rm -f lib/systemd/system-generators/systemd-sysv-generator
 
 
 # Efi blobs
@@ -131,25 +131,25 @@ rm -rf usr/lib/systemd/boot
 rm -rf usr/lib/systemd/catalog
 
 # Misc systemd utils
-rm usr/bin/bootctl
-rm usr/bin/busctl
-rm usr/bin/hostnamectl
-rm usr/bin/localectl
-rm usr/bin/systemd-cat
-rm usr/bin/systemd-cgls
-rm usr/bin/systemd-cgtop
-rm usr/bin/systemd-delta
-rm usr/bin/systemd-detect-virt
-rm usr/bin/systemd-mount
-rm usr/bin/systemd-path
-rm usr/bin/systemd-run
-rm usr/bin/systemd-socket-activate
+rm -f usr/bin/bootctl
+rm -f usr/bin/busctl
+rm -f usr/bin/hostnamectl
+rm -f usr/bin/localectl
+rm -f usr/bin/systemd-cat
+rm -f usr/bin/systemd-cgls
+rm -f usr/bin/systemd-cgtop
+rm -f usr/bin/systemd-delta
+rm -f usr/bin/systemd-detect-virt
+rm -f usr/bin/systemd-mount
+rm -f usr/bin/systemd-path
+rm -f usr/bin/systemd-run
+rm -f usr/bin/systemd-socket-activate
 
 # Remove pam module to authenticate against a DB
 # plus libdb-5.3.so that is only used by this pam module
-rm usr/lib/*/security/pam_userdb.so
-rm usr/lib/*/libdb-5.3.so
+rm -f usr/lib/*/security/pam_userdb.so
+rm -f usr/lib/*/libdb-5.3.so
 
 # remove NSS support for nis, nisplus and hesiod
-rm usr/lib/*/libnss_hesiod*
-rm usr/lib/*/libnss_nis*
+rm -f usr/lib/*/libnss_hesiod*
+rm -f usr/lib/*/libnss_nis*

--- a/jenkins/debian/debos/scripts/crush.sh
+++ b/jenkins/debian/debos/scripts/crush.sh
@@ -76,8 +76,10 @@ rm -rf usr/lib/xtables
 # TODO: only remaining locale is actually "C". Should we really remove it?
 rm -rf usr/lib/locale/*
 
-# partition helpers
+# Partition and file system tools
 rm -f usr/sbin/*fdisk
+rm -f usr/sbin/mkfs*
+rm -f usr/sbin/fsck*
 
 # local compiler
 rm -f usr/bin/localedef
@@ -122,7 +124,6 @@ rm -f lib/systemd/system-generators/systemd-hibernate-resume-generator
 rm -f lib/systemd/system-generators/systemd-rc-local-generator
 rm -f lib/systemd/system-generators/systemd-system-update-generator
 rm -f lib/systemd/system-generators/systemd-sysv-generator
-
 
 # Efi blobs
 rm -rf usr/lib/systemd/boot

--- a/src/org/kernelci/debian/RootFS.groovy
+++ b/src/org/kernelci/debian/RootFS.groovy
@@ -52,6 +52,7 @@ def buildImage(config) {
     }
 
     def extraPackagesRemove = config.extra_packages_remove ?: ""
+    def extraFilesRemove = config.extra_files_remove ?: ""
 
     // defaults to empty script scripts/nothing.sh
     def script = "scripts/nothing.sh"
@@ -74,6 +75,7 @@ def buildImage(config) {
                                                     debosFile,
                                                     extraPackages,
                                                     extraPackagesRemove,
+                                                    extraFilesRemove,
                                                     name,
                                                     script,
                                                     test_overlay,
@@ -91,6 +93,7 @@ def makeImageStep(String pipeline_version,
                   String debosFile,
                   String extraPackages,
                   String extraPackagesRemove,
+                  String extraFilesRemove,
                   String name,
                   String script,
                   String test_overlay,
@@ -113,6 +116,7 @@ def makeImageStep(String pipeline_version,
                             -t basename:${pipeline_version}/${arch} \
                             -t extra_packages:'${extraPackages}' \
                             -t extra_packages_remove:'${extraPackagesRemove}' \
+                            -t extra_files_remove:'${extraFilesRemove}' \
                             -t script:${script} \
                             -t test_overlay:'${test_overlay}' \
                             ${debosFile}

--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -20,6 +20,12 @@ file_system_types:
       armhf: [{arch: arm}]
       amd64: [{arch: x86_64}]
 
+  debian_staging:
+    url: 'http://staging-storage.kernelci.org/images/rootfs/debian'
+    arch_map:
+      armhf: [{arch: arm}]
+      amd64: [{arch: x86_64}]
+
 
 file_systems:
 
@@ -40,8 +46,8 @@ file_systems:
     ramdisk: '{arch}/tests/rootfs.cpio.gz'
 
   debian_buster_ramdisk:
-    type: debian
-    ramdisk: 'buster/20190607.0/{arch}/rootfs.cpio.gz'
+    type: debian_staging
+    ramdisk: 'buster/20190613.0/{arch}/rootfs.cpio.gz'
 
   debian_stretch_ramdisk:
     type: debian


### PR DESCRIPTION
This is to reduce the size of the Buster file system.  On `arm64`, the Stretch ramdisk is 11MB:
http://staging-storage.kernelci.org/images/rootfs/debian/stretch/20190506.0/arm64/rootfs.cpio.gz

The current Buster one is around 18MB:
https://storage.kernelci.org/images/rootfs/debian/buster/20190607.0/arm64/

This PR should bring it down to about 14MB by fixing things in the build scripts and removing a couple more things.  The `buster-igt` file system (#84) should also get smaller as a result.