### PR TITLE
Increase deploy timeout

### DIFF
--- a/templates/base/kernel-ci-base-tftp-deploy.jinja2
+++ b/templates/base/kernel-ci-base-tftp-deploy.jinja2
@@ -9,7 +9,7 @@
 actions:
 - deploy:
     timeout:
-      minutes: 2
+      minutes: 10
     to: tftp
     kernel:
       url: {{ kernel_url }}


### PR DESCRIPTION
On lab-baylibre, we have many slaves running on potato.
While they are still powerful enough for running lot of jobs in
parallel, they lack a bit on IO.
So while running many deploy in parallel, they hit sometimes the deploy timeout.

This patch increases the deploy timeout, 2 minutes is too short.