### PR TITLE
test-configs.yaml: Add support for the sun5i-a13-olinuxino-micro

### DIFF
--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -851,6 +851,11 @@ device_types:
     class: arm64-dtb
     boot_method: uboot
 
+  sun5i-a13-olinuxino-micro:
+    mach: allwinner
+    class: arm-dtb
+    boot_method: uboot
+
   sun8i_a23_evb:
     name: 'sun8i-a23-evb'
     mach: allwinner
@@ -1234,6 +1239,9 @@ test_configs:
     test_plans: [boot, boot_nfs, kselftest]
 
   - device_type: sun50i_h5_libretech_all_h3_cc
+    test_plans: [boot]
+
+  - device_type: sun5i-a13-olinuxino-micro
     test_plans: [boot]
 
   - device_type: sun8i_a23_evb


### PR DESCRIPTION
We have a sun5i-a13-olinuxino-micro in lab-baylibre, ready to accept jobs.