### PR TITLE
kernelci.build: fix initial git clone with no reference

### DIFF
--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -144,9 +144,10 @@ git init --bare
 
 def update_repo(config, path, ref):
     if not os.path.exists(path):
+        ref_opt = '--reference={ref}'.format(ref=ref) if ref else ''
         shell_cmd("""
-git clone --reference={ref} -o {remote} {url} {path}
-""".format(ref=ref, remote=config.tree.name, url=config.tree.url, path=path))
+git clone {ref} -o {remote} {url} {path}
+""".format(ref=ref_opt, remote=config.tree.name, url=config.tree.url, path=path))
 
     _update_remote(config, path)
     _fetch_tags(path)


### PR DESCRIPTION
Fix the case where a new git repo needs to be initialised and no
reference repo/mirror is provided.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>