### PR TITLE
Find LAVA devices by aliases, when available

### DIFF
--- a/kernelci/lava.py
+++ b/kernelci/lava.py
@@ -1,0 +1,48 @@
+#!/usr/bin/python
+#
+# Copyright (C) 2019 Linaro Limited
+# Author: Dan Rue <dan.rue@linaro.org>
+#
+# This module is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+
+def get_device_type_by_name(name, device_types, aliases=[]):
+    """
+        Return a device type named name. In the case of an alias, resolve the
+        alias to a device_type
+
+        Example:
+        IN:
+            name = "x15"
+            device_types = [
+              {'busy': 1, 'idle': 0, 'name': 'x15', 'offline': 0},
+              {'busy': 1, 'idle': 0, 'name': 'beaglebone-black', 'offline': 0},
+            ]
+            aliases = [
+              {'name': 'am57xx-beagle-x15', 'device_type': 'x15'}
+            ]
+        OUT:
+            {'busy': 1, 'idle': 0, 'name': 'x15', 'offline': 0}
+
+    """
+    for device_type in device_types:
+        if device_type["name"] == name:
+            return device_type
+    for alias in aliases:
+        if alias["name"] == name:
+            for device_type in device_types:
+                if alias["device_type"] == device_type["name"]:
+                    return device_type
+    return None

--- a/tests/test_lava.py
+++ b/tests/test_lava.py
@@ -1,0 +1,55 @@
+import kernelci.lava
+import pytest
+
+
+def test_get_device_type_by_name_1():
+    assert kernelci.lava.get_device_type_by_name("some_board", []) is None
+
+
+def test_get_device_type_by_name_2():
+    assert kernelci.lava.get_device_type_by_name("some_board", [], []) is None
+
+
+@pytest.fixture
+def device_types():
+    device_types = [
+        {"busy": 1, "idle": 0, "name": "x15", "offline": 0},
+        {"busy": 1, "idle": 0, "name": "beaglebone-black", "offline": 0},
+    ]
+    return device_types
+
+
+@pytest.fixture
+def aliases():
+    aliases = [{"name": "am57xx-beagle-x15", "device_type": "x15"}]
+    return aliases
+
+
+def test_get_device_type_by_name_3(device_types, aliases):
+    assert (
+        kernelci.lava.get_device_type_by_name("some_board", device_types,
+                                              aliases) is None
+    )
+
+
+def test_get_device_type_by_name_4(device_types, aliases):
+    assert (
+        kernelci.lava.get_device_type_by_name("x15", device_types, aliases)
+        == device_types[0]
+    )
+
+
+def test_get_device_type_by_name_5(device_types, aliases):
+    assert (
+        kernelci.lava.get_device_type_by_name(
+            "am57xx-beagle-x15", device_types, aliases
+        )
+        == device_types[0]
+    )
+
+
+def test_get_device_type_by_name_6(device_types, aliases):
+    assert (
+        kernelci.lava.get_device_type_by_name("beaglebone-black", device_types)
+        == device_types[1]
+    )


### PR DESCRIPTION
In addition to looking up available device_types in each lava instance,
also look for aliases.

Create a new lookup function, get_device_type_by_name(), to simplify the
lookup. Provide 6 unit tests for the new function.

Example run:

    ./lava-v2-submit-jobs.py --username dan.rue --token='XXX' --lab lab-linaro-lkft --jobs foo
    Loading jobs from foo
    LAVA API: https://lkft.validation.linaro.org/RPC2/
    Connecting to Server...
    Connection Successful!
    connect-to-server : pass
    Fetching all devices from LAVA
    Fetching all device-types from LAVA
    Fetching all device-type aliases from LAVA
    Submitting Jobs to Server...
    Submitting job kernelci-staging.kernelci.org-v5.2-rc5-178-gdac6ebf0e111-arm-multi_v7_defconfig-gcc-8-no-dtb-qemu-boot to device-type qemu
    Submitting job arm-soc-for-next-v5.2-rc5-110-ge57f4f2c4506-arm-multi_v7_defconfig-gcc-8-am57xx-beagle-x15.dtb-am57xx-beagle-x15-simple to device-type am57xx-beagle-x15
    Submitting job lkft-ltp-quickhit-master-1894 to device-type x15

Signed-off-by: Dan Rue <dan.rue@linaro.org>