### PR TITLE
add UEFI test plan

### DIFF
--- a/jenkins/lava-boot-v2.sh
+++ b/jenkins/lava-boot-v2.sh
@@ -45,7 +45,7 @@ elif [ ${LAB} = "lab-pengutronix" ] || [ ${LAB} = "lab-pengutronix-dev" ]; then
   python lava-v2-jobs-from-api.py --defconfigs ${DEFCONFIG_COUNT} --callback ${CALLBACK} --api ${API} --storage ${STORAGE} --lab ${LAB} --describe ${GIT_DESCRIBE} --tree ${TREE} --branch ${BRANCH} --arch ${ARCH} --plans boot boot-kvm boot-kvm-uefi --token ${API_TOKEN}
   python lava-v2-submit-jobs.py --username kernel-ci --jobs ${LAB} --token ${LAVA_PENGUTRONIX_TOKEN} --lab ${LAB}
 elif [ ${LAB} = "lab-linaro-lkft" ] || [ ${LAB} = "lab-linaro-lkft-dev" ]; then
-  python lava-v2-jobs-from-api.py --defconfigs ${DEFCONFIG_COUNT} --callback ${CALLBACK} --api ${API} --storage ${STORAGE} --lab ${LAB} --describe ${GIT_DESCRIBE} --tree ${TREE} --branch ${BRANCH} --arch ${ARCH} --plans boot --token ${API_TOKEN} --priority low
+  python lava-v2-jobs-from-api.py --defconfigs ${DEFCONFIG_COUNT} --callback ${CALLBACK} --api ${API} --storage ${STORAGE} --lab ${LAB} --describe ${GIT_DESCRIBE} --tree ${TREE} --branch ${BRANCH} --arch ${ARCH} --plans boot uefi-arm64-gicv2 uefi-arm64-gicv3 uefi-arm-gicv2 uefi-arm-gicv3 uefi-x86_64 uefi-x86_i386 uefi-x86-mixed --token ${API_TOKEN} --priority low
   python lava-v2-submit-jobs.py --username kernel-ci --jobs ${LAB} --token ${LAVA_LINARO_LKFT_TOKEN} --lab ${LAB}
 elif [ ${LAB} = "lab-theobroma-systems" ] || [ ${LAB} = "lab-theobroma-systems-dev" ]; then
   python lava-v2-jobs-from-api.py --defconfigs ${DEFCONFIG_COUNT} --callback ${CALLBACK} --api ${API} --storage ${STORAGE} --lab ${LAB} --describe ${GIT_DESCRIBE} --tree ${TREE} --branch ${BRANCH} --arch ${ARCH} --plans boot kselftest --token ${API_TOKEN}

--- a/templates/uefi/generic-qemu-uefi-boot-template.jinja2
+++ b/templates/uefi/generic-qemu-uefi-boot-template.jinja2
@@ -1,0 +1,62 @@
+{% extends 'base/kernel-ci-base.jinja2' %}
+{% set ctx_arch = arch %}
+{% if arch == "arm" %}
+{% set ctx_arch = 'arm64' %}
+{% set ctx_cpu = 'cortex-a15' %}
+{% set console_dev = 'ttyAMA0' %}
+{% endif %}
+{% if arch == "arm64" %}
+{% set ctx_arch = 'arm64' %}
+{% set console_dev = 'ttyAMA0' %}
+{% endif %}
+{% if arch == 'x86_64' %}
+{% set ctx_arch = 'amd64' %}
+{% set console_dev = 'ttyS0' %}
+{% endif %}
+{% if arch == 'i386' %}
+{% set ctx_arch = 'i386' %}
+{% set ctx_cpu = 'host' %}
+{% set console_dev = 'ttyS0' %}
+{% endif %}
+{% block metadata %}
+{{ super() }}
+{% endblock %}
+{% block main %}
+{{ super() }}
+{% endblock %}
+{% block actions %}
+context:
+  arch: {{ ctx_arch }}
+  cpu: {{ ctx_cpu }}
+  guestfs_interface: virtio
+{% if arch == 'arm' or arch == 'arm64' %}
+  machine: virt,{{ ctx_gicversion }}
+{% endif %}
+
+actions:
+- deploy:
+    timeout:
+      minutes: 3
+    to: tmpfs
+    os: oe
+    images:
+      bios:
+        image_arg: '-bios {bios}'
+        url: {{ image_url_uefi }}
+      kernel:
+{%- block image_arg %}
+        image_arg: '-kernel {kernel} -append "console={{ console_dev }},115200 root=/dev/ram0 debug verbose {{ extra_kernel_args }}"'
+{%- endblock %}
+        url: {{ kernel_url }}
+      ramdisk:
+        image_arg: '-initrd {ramdisk}'
+        url: {{ initrd_url }}
+
+- boot:
+    timeout:
+      minutes: 5
+    method: qemu
+    media: tmpfs
+    prompts:
+      - '{{ rootfs_prompt }}'
+{% endblock %}

--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -160,6 +160,72 @@ test_plans:
             - 'defconfig+virtualvideo'
             - 'multi_v7_defconfig+virtualvideo'
 
+  uefi-arm64-gicv2:
+    rootfs: buildroot_ramdisk
+    params:
+        ctx_gicversion: "gic-version=2"
+        ctx_cpu: "cortex-a57"
+        image_url_uefi: 'https://staging-storage.kernelci.org/images/uefi/111bbcf87621/QEMU_EFI.fd-AARCH64-RELEASE-111bbcf87621'
+    pattern: 'uefi/generic-qemu-uefi-boot-template.jinja2'
+    filters:
+      - whitelist: {defconfig: ['defconfig']}
+
+  uefi-arm64-gicv3:
+    rootfs: buildroot_ramdisk
+    params:
+        ctx_gicversion: "gic-version=3"
+        ctx_cpu: "cortex-a57"
+        image_url_uefi: 'https://staging-storage.kernelci.org/images/uefi/111bbcf87621/QEMU_EFI.fd-AARCH64-RELEASE-111bbcf87621'
+    pattern: 'uefi/generic-qemu-uefi-boot-template.jinja2'
+    filters:
+      - whitelist: {defconfig: ['defconfig']}
+
+  uefi-arm-gicv2:
+    rootfs: buildroot_ramdisk
+    params:
+        ctx_gicversion: "gic-version=2"
+        ctx_cpu: "cortex-a15"
+        image_url_uefi: 'https://staging-storage.kernelci.org/images/uefi/111bbcf87621/QEMU_EFI.fd-ARM-RELEASE-111bbcf87621'
+    pattern: 'uefi/generic-qemu-uefi-boot-template.jinja2'
+    filters:
+      - whitelist: {defconfig: ['multi_v7_defconfig']}
+
+  uefi-arm-gicv3:
+    rootfs: buildroot_ramdisk
+    params:
+        ctx_gicversion: "gic-version=3"
+        ctx_cpu: "cortex-a15"
+        image_url_uefi: 'https://staging-storage.kernelci.org/images/uefi/111bbcf87621/QEMU_EFI.fd-ARM-RELEASE-111bbcf87621'
+    pattern: 'uefi/generic-qemu-uefi-boot-template.jinja2'
+    filters:
+      - whitelist: {defconfig: ['multi_v7_defconfig']}
+
+  uefi-x86_64:
+    rootfs: buildroot_ramdisk
+    params:
+        ctx_cpu: "host"
+        image_url_uefi: 'https://staging-storage.kernelci.org/images/uefi/111bbcf87621/OVMF.fd-X64-RELEASE-111bbcf87621'
+    pattern: 'uefi/generic-qemu-uefi-boot-template.jinja2'
+    filters:
+      - whitelist: {defconfig: ['defconfig']}
+
+  uefi-x86_i386:
+    rootfs: buildroot_ramdisk
+    params:
+        ctx_cpu: "host"
+        image_url_uefi: 'https://staging-storage.kernelci.org/images/uefi/111bbcf87621/OVMF.fd-IA32-RELEASE-111bbcf87621'
+    pattern: 'uefi/generic-qemu-uefi-boot-template.jinja2'
+    filters:
+      - whitelist: {defconfig: ['i386_defconfig']}
+
+  uefi-x86-mixed:
+    rootfs: buildroot_ramdisk
+    params:
+        ctx_cpu: "i386"
+        image_url_uefi: 'https://staging-storage.kernelci.org/images/uefi/111bbcf87621/OVMF.fd-IA32-RELEASE-111bbcf87621'
+    pattern: 'uefi/generic-qemu-uefi-boot-template.jinja2'
+    filters:
+      - whitelist: {defconfig: ['i386_defconfig']}
 
 device_default_filters:
 
@@ -779,6 +845,14 @@ device_types:
     filters:
       - whitelist: {defconfig: ['defconfig']}
 
+  qemu_i386:
+    name: qemu
+    mach: qemu
+    arch: i386
+    boot_method: qemu
+    filters:
+      - whitelist: {defconfig: ['i386_defconfig']}
+
   qemu_x86_64:
     name: qemu
     mach: qemu
@@ -1230,13 +1304,31 @@ test_configs:
     test_plans: [boot]
 
   - device_type: qemu_arm
-    test_plans: [boot_qemu, simple_qemu, v4l2_compliance_qemu_vivid]
+    test_plans:
+      - boot_qemu
+      - simple_qemu
+      - v4l2_compliance_qemu_vivid
+      - uefi-arm-gicv2
+      - uefi-arm-gicv3
 
   - device_type: qemu_arm64
-    test_plans: [boot_qemu, simple_qemu, v4l2_compliance_qemu_vivid]
+    test_plans:
+      - boot_qemu
+      - simple_qemu
+      - v4l2_compliance_qemu_vivid
+      - uefi-arm64-gicv2
+      - uefi-arm64-gicv3
 
   - device_type: qemu_x86_64
-    test_plans: [boot_qemu, simple_qemu, v4l2_compliance_qemu_vivid]
+    test_plans:
+      - boot_qemu
+      - simple_qemu
+      - v4l2_compliance_qemu_vivid
+      - uefi-x86_64
+      - uefi-x86-mixed
+
+  - device_type: qemu_i386
+    test_plans: [uefi-x86_i386]
 
   - device_type: r8a7791_porter
     test_plans: [boot]


### PR DESCRIPTION
Initital test plan for UEFI boot testing.
Run the test in qemu in these combinations:

- host arm64 guest arm64 enable gic-version=2 and 3.
- host arm64 guest arm enable gic-version=2 and 3.
- host x86_64 guest x86_64.
- host x86_i386 guest x86_i386.
- host x86_64 guest x86_i386.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>