### PR TITLE
Add kernelci tree

### DIFF
--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -52,6 +52,9 @@ trees:
   gtucker:
     url: 'https://gitlab.collabora.com/gtucker/linux.git'
 
+  kernelci:
+    url: "https://github.com/kernelci/linux.git"
+
   khilman:
     url: "https://git.kernel.org/pub/scm/linux/kernel/git/khilman/linux.git"
 
@@ -498,6 +501,11 @@ build_configs:
   gtucker_stable:
     tree: gtucker
     branch: 'kernelci-stable'
+    variants: *stable_variants
+
+  kernelci:
+    tree: kernelci
+    branch: 'kernelci.org'
     variants: *stable_variants
 
   khilman:

--- a/labs.ini
+++ b/labs.ini
@@ -53,11 +53,11 @@ tree_blacklist: linaro-android drm-tip android
 api: http://lava.streamtester.net/RPC2/
 
 [lab-linaro-lkft]
-tree_whitelist: stable#linux-4.4.y stable#linux-4.9.y stable#linux-4.14.y stable-rc#linux-4.4.y stable-rc#linux-4.9.y stable-rc#linux-4.14.y next
+tree_whitelist: stable#linux-4.4.y stable#linux-4.9.y stable#linux-4.14.y stable-rc#linux-4.4.y stable-rc#linux-4.9.y stable-rc#linux-4.14.y next kernelci
 api: https://lkft.validation.linaro.org/RPC2/
 
 [lab-linaro-lkft-dev]
-tree_whitelist: stable#linux-4.4.y stable#linux-4.9.y stable#linux-4.14.y stable-rc#linux-4.4.y stable-rc#linux-4.9.y stable-rc#linux-4.14.y next
+tree_whitelist: stable#linux-4.4.y stable#linux-4.9.y stable#linux-4.14.y stable-rc#linux-4.4.y stable-rc#linux-4.9.y stable-rc#linux-4.14.y next kernelci
 api: https://lkft.validation.linaro.org/RPC2/
 
 [lab-theobroma-systems]


### PR DESCRIPTION
Add the definition for the kernelci tree to be able to use it in production with a `kernelci.org` branch.  The `staging.kernelci.org` branch should not be in this file on the master branch to avoid triggering production every time a new revision is pushed to test on staging.

Also enable kernels build from this tree to run in the LKFT lab.