### PR TITLE
buster-igt.jpl: enable mips architecture again

### DIFF
--- a/jenkins/buster-igt.jpl
+++ b/jenkins/buster-igt.jpl
@@ -17,6 +17,7 @@ def config = [
         "amd64",
         "armhf",
         "arm64",
+        "mips",
     ],
     'debian_release': "buster",
     'extra_packages': "\


### PR DESCRIPTION
Now that i-g-t builds again for MIPS we can re-enable it in the
buster-igt variants.

Patches that fixed the MIPS build for i-g-t:

  https://patchwork.freedesktop.org/series/62048/

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>