### PR TITLE
kernel-arch-complete.sh: trigger email when first arch is complete

### DIFF
--- a/jenkins/kernel-arch-complete.sh
+++ b/jenkins/kernel-arch-complete.sh
@@ -45,7 +45,7 @@ sudo touch ${BASEDIR}/${ARCH}.done
 # Check if all builds for all architectures have finished. The magic number here is 4 (arm, arm64, x86, mips64)
 # This magic number will need to be changed if new architectures are added.
 export BUILDS_FINISHED=$(ls ${BASEDIR}/ | grep .done | wc -l)
-if [[ BUILDS_FINISHED -eq 4 ]]; then
+if [[ BUILDS_FINISHED -eq 1 ]]; then
     echo "All builds have now finished, triggering testing..."
     # Tell the dashboard the job has finished build.
     echo "Build has now finished, reporting result to dashboard."


### PR DESCRIPTION
The way build-trigger.jpl works is that it waits for all the kernel
builds to have completed before calling kernel-arch-complete.sh once
for each architecture.  So all the builds are already there the first
time the script is called, and we can drop the magic number of "4".
This fixes cases where some trees build fewer architectures.

This is still not optimal but it will become a lot better when
replaced with a pipeline step to generate the test jobs on a per-build
basis.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>