### PR TITLE
templates/boot: add console_msg_format to kernel cmdline

### DIFF
--- a/lava-v2-jobs-from-api.py
+++ b/lava-v2-jobs-from-api.py
@@ -245,7 +245,7 @@ def write_jobs(config, jobs):
     for job in jobs:
         job_file = os.path.join(job_dir, '.'.join([job['name'], 'yaml']))
         with open(job_file, 'w') as f:
-            env = Environment(loader=FileSystemLoader('templates'))
+            env = Environment(loader=FileSystemLoader('templates'), extensions=["jinja2.ext.do"])
             template = env.get_template(job['short_template_file'])
             data = template.render(job)
             f.write(data)

--- a/templates/base/kernel-ci-base.jinja2
+++ b/templates/base/kernel-ci-base.jinja2
@@ -1,3 +1,5 @@
+{% set extra_kernel_args = "console_msg_format=syslog" %}
+
 {%- block metadata %}
 metadata:
   image.type: 'kernel-ci'

--- a/templates/boot/generic-depthcharge-tftp-ramdisk-boot-template.jinja2
+++ b/templates/boot/generic-depthcharge-tftp-ramdisk-boot-template.jinja2
@@ -3,6 +3,9 @@
 {{ super() }}
 {% endblock %}
 {% block main %}
+{%- if extra_kernel_args %}
+{% do context.update({"extra_kernel_args": extra_kernel_args}) %}
+{% endif %}
 {{ super() }}
 {% endblock %}
 {% block actions %}

--- a/templates/boot/generic-qemu-boot-template.jinja2
+++ b/templates/boot/generic-qemu-boot-template.jinja2
@@ -34,7 +34,7 @@ actions:
     images:
       kernel:
 {%- block image_arg %}
-        image_arg: '-kernel {kernel} -append "console={{ console_dev }},115200 root=/dev/ram0 debug verbose"'
+        image_arg: '-kernel {kernel} -append "console={{ console_dev }},115200 root=/dev/ram0 debug verbose {{ extra_kernel_args }}"'
 {%- endblock %}
         url: {{ kernel_url }}
       ramdisk:

--- a/templates/boot/generic-uboot-tftp-ramdisk-boot-template.jinja2
+++ b/templates/boot/generic-uboot-tftp-ramdisk-boot-template.jinja2
@@ -3,6 +3,9 @@
 {{ super() }}
 {% endblock %}
 {% block main %}
+{%- if extra_kernel_args %}
+{% do context.update({"extra_kernel_args": extra_kernel_args}) %}
+{% endif %}
 {{ super() }}
 {% endblock %}
 {% block actions %}

--- a/templates/v4l2-compliance/generic-qemu-v4l2-compliance-template.jinja2
+++ b/templates/v4l2-compliance/generic-qemu-v4l2-compliance-template.jinja2
@@ -7,5 +7,5 @@
 {% endblock %}
 
 {%- block image_arg %}
-        image_arg: '-kernel {kernel} -append "console={{ console_dev }},115200 root=/dev/ram0 debug verbose vivid.no_error_inj=1"'
+        image_arg: '-kernel {kernel} -append "console={{ console_dev }},115200 root=/dev/ram0 debug verbose vivid.no_error_inj=1 {{ extra_kernel_args }}"'
 {%- endblock %}


### PR DESCRIPTION
syslog-style printk message from the kernel are available when booting
with "console_msg_format=syslog" on the kernel command-line.  This
makes it much easier for log parsers to get the log-level information
from the kernel boot logs.

Automatically add this command-line argument to all u-boot and qemu
jobs.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>