### PR TITLE
Fix the arc imagetype

### DIFF
--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -39,14 +39,14 @@ TORVALDS_GIT_URL = \
 MAKE_TARGETS = {
     'arm': 'zImage',
     'arm64': 'Image',
-    'arc': 'uImage.gz',
+    'arc': 'uImage',
 }
 
 # Hard-coded binary kernel image names for each CPU architecture
 KERNEL_IMAGE_NAMES = {
     'arm': ['zImage', 'xipImage'],
     'arm64': ['Image'],
-    'arc': ['uImage.gz'],
+    'arc': ['uImage'],
     'i386': ['bzImage'],
     'mips': ['uImage.gz', 'vmlinux.gz.itb'],
     'riscv': ['Image', 'Image.gz'],


### PR DESCRIPTION
All jobs generated for ARC devices uses "type: uImage.gz".
Since this type is unknow, LAVA try to convert the kernel file to an
uImage and corrupt it.
Using "type: uImage" fix this problem.

Since the file is not strictly speaking gzip compressed, that the build
create a symlink uImage->uImage.gz, the easiest fix is to tell kernelci
to use uImage.