### PR TITLE
buster.jpl: keep "diff"

### DIFF
--- a/jenkins/buster.jpl
+++ b/jenkins/buster.jpl
@@ -43,7 +43,6 @@ sensible-utils \
 *resolved* \
 tar \
 patch \
-diff \
 dir \
 partx \
 find \


### PR DESCRIPTION
Keep the "diff" utility in the Buster rootfs as it is needed for the
usb test plan.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>