### PR TITLE
Remove the android-4.4 branch from the android tree

### DIFF
--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -333,10 +333,6 @@ build_configs:
     tree: android
     branch: 'android-3.18-o-release'
 
-  android_4.4:
-    tree: android
-    branch: 'android-4.4'
-
   android_4.4-o:
     tree: android
     branch: 'android-4.4-o'


### PR DESCRIPTION
As per Todds request, the android-4.4 branch is being deprecated so remove it from build-configs.yaml