### PR TITLE
test-configs.yaml: enable cros-ec test plan on rk3399-gru-kevin

### DIFF
--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -1211,6 +1211,7 @@ test_configs:
     test_plans:
       - baseline
       - boot
+      - cros-ec
       - v4l2_compliance_uvc
 
   - device_type: rk3399_gru_kevin


### PR DESCRIPTION
The rk3399-gru-kevin device is a device that, like other Chromebooks,
has a CrOS Embedded Controller. So, enable the cros-ec test plan for it.

Signed-off-by: Enric Balletbo i Serra <enric.balletbo@collabora.com>