### PR TITLE
linusw build config

### DIFF
--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -247,31 +247,31 @@ build_configs_defaults:
 
 
 # Minimum architecture defconfigs
-arch_defconfigs:
+arch_defconfigs: &all_defconfigs
   arc: &arc_defconfig
     base_defconfig: 'nsim_hs_defconfig'
     filters:
-      - whitelist: { defconfig: ['nsim_hs_defconfig'] }
+      - regex: { defconfig: 'nsim_hs_defconfig' }
   arm: &arm_defconfig
     base_defconfig: 'multi_v7_defconfig'
     filters:
-      - whitelist: { defconfig: ['multi_v7_defconfig'] }
+      - regex: { defconfig: 'multi_v7_defconfig' }
   arm64: &arm64_defconfig
     base_defconfig: 'defconfig'
     filters:
-      - whitelist: { defconfig: ['defconfig'] }
+      - regex: { defconfig: 'defconfig' }
   mips: &mips_defconfig
     base_defconfig: '32r2el_defconfig'
     filters:
-      - whitelist: { defconfig: ['32r2el_defconfig'] }
+      - regex: { defconfig: '32r2el_defconfig' }
   riscv: &riscv_defconfig
     base_defconfig: 'defconfig'
     filters:
-      - whitelist: { defconfig: ['defconfig'] }
+      - regex: { defconfig: 'defconfig' }
   x86_64: &x86_64_defconfig
     base_defconfig: 'x86_64_defconfig'
     filters:
-      - whitelist: { defconfig: ['x86_64_defconfig'] }
+      - regex: { defconfig: 'x86_64_defconfig' }
 
 
 # Build fewer kernel configs with stable branches

--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -519,14 +519,26 @@ build_configs:
   linusw_devel:
     tree: linusw
     branch: 'devel'
+    variants:
+      gcc-8:
+        build_environment: gcc-8
+        architectures: *all_defconfigs
 
   linusw_fixes:
     tree: linusw
     branch: 'fixes'
+    variants:
+      gcc-8:
+        build_environment: gcc-8
+        architectures: *all_defconfigs
 
   linusw_for-next:
     tree: linusw
     branch: 'for-next'
+    variants:
+      gcc-8:
+        build_environment: gcc-8
+        architectures: *all_defconfigs
 
   lsk_for-test:
     tree: lsk

--- a/jenkins/kernel-arch-complete.sh
+++ b/jenkins/kernel-arch-complete.sh
@@ -95,6 +95,10 @@ if [[ BUILDS_FINISHED -eq 1 ]]; then
         echo "Sending results to Tony Lindgren"
         curl -X POST -H "Authorization: $EMAIL_AUTH_TOKEN" -H "Content-Type: application/json" -d '{"job": "'$TREE_NAME'", "kernel": "'$GIT_DESCRIBE'", "git_branch": "'$BRANCH'", "build_report": 1, "send_to": ["tony@atomide.com", "fellows@kernelci.org"], "format": ["txt", "html"], "delay": 10}' ${API}/send
         curl -X POST -H "Authorization: $EMAIL_AUTH_TOKEN" -H "Content-Type: application/json" -d '{"job": "'$TREE_NAME'", "kernel": "'$GIT_DESCRIBE'", "git_branch": "'$BRANCH'", "boot_report": 1, "send_to": ["tony@atomide.com", "fellows@kernelci.org"], "format": ["txt", "html"], "delay": 12600}' ${API}/send
+    elif [ "$TREE_NAME" == "linusw" ]; then
+        echo "Sending results to linux-gpio"
+        curl -X POST -H "Authorization: $EMAIL_AUTH_TOKEN" -H "Content-Type: application/json" -d '{"job": "'$TREE_NAME'", "kernel": "'$GIT_DESCRIBE'", "git_branch": "'$BRANCH'", "build_report": 1, "send_to": ["linux-gpio@vger.kernel.org", "fellows@kernelci.org"], "format": ["txt"], "delay": 10}' ${API}/send
+        curl -X POST -H "Authorization: $EMAIL_AUTH_TOKEN" -H "Content-Type: application/json" -d '{"job": "'$TREE_NAME'", "kernel": "'$GIT_DESCRIBE'", "git_branch": "'$BRANCH'", "boot_report": 1, "send_to": ["linux-gpio@vger.kernel.org", "fellows@kernelci.org"], "format": ["txt"], "delay": 2700}' ${API}/send
     elif [ "$TREE_NAME" == "lsk" ]; then
         echo "Sending results to LSK team"
         curl -X POST -H "Authorization: $EMAIL_AUTH_TOKEN" -H "Content-Type: application/json" -d '{"job": "'$TREE_NAME'", "kernel": "'$GIT_DESCRIBE'", "git_branch": "'$BRANCH'", "build_report": 1, "send_to": ["lsk-team@linaro.org", "alex.shi@linaro.org", "fellows@kernelci.org"], "format": ["txt", "html"], "delay": 10}' ${API}/send

--- a/kernelci/configs.py
+++ b/kernelci/configs.py
@@ -15,6 +15,7 @@
 # along with this library; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+import re
 import yaml
 
 
@@ -91,6 +92,26 @@ class Whitelist(Filter):
         return True
 
 
+class Regex(Filter):
+    """Regex filter to only accept certain configurations.
+
+    Regex *items* are a dictionary associating keys with regular expressions.
+    The should be one regular expression for each key, not a list of them.  For
+    a configuration to be accepted, its value must match the regular expression
+    for each key specified in the filter items.
+    """
+
+    def __init__(self, *args, **kw):
+        super(Regex, self).__init__(*args, **kw)
+        self._re_items = {k: re.compile(v) for k, v in self._items.iteritems()}
+
+
+    def match(self, **kw):
+        for k, r in self._re_items.iteritems():
+            v = kw.get(k)
+            return v and r.match(v)
+
+
 class Combination(Filter):
     """Combination filter to only accept some combined configurations.
 
@@ -116,6 +137,7 @@ class FilterFactory(YAMLObject):
     _classes = {
         'blacklist': Blacklist,
         'whitelist': Whitelist,
+        'regex': Regex,
         'combination': Combination,
     }
 


### PR DESCRIPTION
Reduce the number of builds for the `linusw` build configs and add support for regex filters to be able to do that.  Also send email reports to the linux-gpio mailing list.

See discussion: https://groups.io/g/kernelci/message/428