### PR TITLE
Set the overall job timeout as a variable

### DIFF
--- a/templates/base/kernel-ci-base.jinja2
+++ b/templates/base/kernel-ci-base.jinja2
@@ -60,7 +60,7 @@ notify:
 job_name: {{ name }}
 timeouts:
   job:
-    minutes: 10
+    minutes: {{ job_timeout|default("10") }}
   action:
    minutes: 10
   actions:


### PR DESCRIPTION
As the job timeout is different from one job to another so we change this
to be a configurable variable with a 10 min per default value.

Signed-off-by: Khouloud Touil <ktouil@baylibre.com>