### PR TITLE
T14893 kernelci.build: keep .ccache directory inside the build directory

### DIFF
--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -424,8 +424,8 @@ def _run_make(kdir, arch, target=None, jopt=None, silent=True, cc='gcc',
     if use_ccache:
         px = cross_compile if cc == 'gcc' and cross_compile else ''
         args.append('CC="ccache {}{}"'.format(px, cc))
-        os.environ.setdefault('CCACHE_DIR',
-                              os.path.join(kdir, '-'.join(['.ccache', arch])))
+        ccache_dir = '-'.join(['.ccache', arch, cc])
+        os.environ.setdefault('CCACHE_DIR', ccache_dir)
     elif cc != 'gcc':
         args.append('CC={}'.format(cc))
 


### PR DESCRIPTION
In order to make ccache more likely to be useful, and to be able to
discard it when necessary, keep the .ccache directory inside the
kernel build directory.  That way, it should always cache build data
relevant to the build done in that build directory, and when removing
unused build directories the cache will be removed at the same time.

Also include both the CPU arch and the compiler name in the ccache
directory name, in case a build directory is being reused multiple
times (typically, for manual builds rather than on kernelci.org).

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>