### PR TITLE
T15937 bisect.jpl: only keep one kernel build directory

### DIFF
--- a/jenkins/bisect.jpl
+++ b/jenkins/bisect.jpl
@@ -212,6 +212,12 @@ def buildKernel(kdir, kci_core) {
     dir(kci_core) {
         sh(script: "rm -f ${env._BUILD_JSON}")
 
+        sh(script: """\
+for d in \$(find ${kdir} -name "build-*" -type d); do
+  [ "\$d" = "${output}" ] || rm -rf "\$d"
+done
+""")
+
         sh(script:"""\
 ./kci_build \
 generate_defconfig_fragments \


### PR DESCRIPTION
Bisection jobs keep their data in the workspace in order to avoid
having to do a fresh git checkout.  However, build diretories can keep
accumulating if they are not removed as there are many possible
combinations of architectures and compilers.

To keep the disk usage under control, remove existing build
directories before starting a bisection except if there is one that
matches exactly the required arch/compiler combination as it may
contain some useful cached data when running similar bisections in a
row.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>