### PR TITLE
test-config.yaml: Add support for meson-g12-odroid-n2

### DIFF
--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -590,6 +590,13 @@ device_types:
     filters:
       - blacklist: {defconfig: ['allnoconfig', 'allmodconfig']}
 
+  meson-g12b-odroid-n2:
+    mach: amlogic
+    class: arm64-dtb
+    boot_method: uboot
+    filters:
+      - blacklist: {defconfig: ['allnoconfig', 'allmodconfig']}
+
   meson_gxbb_p200:
     name: 'meson-gxbb-p200'
     mach: amlogic
@@ -1164,6 +1171,9 @@ test_configs:
     test_plans: [boot, simple]
 
   - device_type: meson-g12a-x96-max
+    test_plans: [boot, simple]
+
+  - device_type: meson-g12b-odroid-n2
     test_plans: [boot, simple]
 
   - device_type: meson_gxbb_p200


### PR DESCRIPTION
We have a meson-g12-odroid-n2 in lab-baylibre, ready to accept jobs.

Signed-off-by: Khouloud Touil <ktouil@baylibre.com>