### PR TITLE
test-configs: Add 4 more amlogic boards

### DIFF
--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -606,8 +606,24 @@ device_types:
     filters:
       - blacklist: {defconfig: ['allnoconfig', 'allmodconfig']}
 
+  meson-gxl-s805x-libretech-ac:
+    mach: amlogic
+    class: arm64-dtb
+    boot_method: uboot
+    flags: ['big_endian']
+    filters:
+      - blacklist: {defconfig: ['allnoconfig', 'allmodconfig']}
+
   meson_gxl_s805x_p241:
     name: 'meson-gxl-s805x-p241'
+    mach: amlogic
+    class: arm64-dtb
+    boot_method: uboot
+    flags: ['big_endian']
+    filters:
+      - blacklist: {defconfig: ['allnoconfig', 'allmodconfig']}
+
+  meson-gxl-s905d-p230:
     mach: amlogic
     class: arm64-dtb
     boot_method: uboot
@@ -1188,7 +1204,13 @@ test_configs:
   - device_type: meson_gxbb_p200
     test_plans: [boot, kselftest]
 
+  - device_type: meson-gxl-s805x-libretech-ac
+    test_plans: [boot, kselftest, simple]
+
   - device_type: meson_gxl_s805x_p241
+    test_plans: [boot, kselftest, simple]
+
+  - device_type: meson-gxl-s905d-p230
     test_plans: [boot, kselftest, simple]
 
   - device_type: meson_gxl_s905x_khadas_vim


### PR DESCRIPTION
This patchs adds 4 more amlogic boards:
- meson-gxl-s805x-libretech-ac
- meson8b-ec100
- meson-gxl-s905d-p230
- meson-gxl-s905x-p212