### PR TITLE
test-configs.yaml: add two H6 boards

### DIFF
--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -876,6 +876,16 @@ device_types:
     class: arm64-dtb
     boot_method: uboot
 
+  sun50i-h6-orangepi-one-plus:
+    mach: allwinner
+    class: arm64-dtb
+    boot_method: uboot
+
+  sun50i-h6-pine-h64:
+    mach: allwinner
+    class: arm64-dtb
+    boot_method: uboot
+
   sun5i-a13-olinuxino-micro:
     mach: allwinner
     class: arm-dtb
@@ -1289,6 +1299,12 @@ test_configs:
     test_plans: [boot]
 
   - device_type: sun50i_h5_libretech_all_h3_cc
+    test_plans: [boot]
+
+  - device_type: sun50i-h6-orangepi-one-plus
+    test_plans: [boot]
+
+  - device_type: sun50i-h6-pine-h64
     test_plans: [boot]
 
   - device_type: sun5i-a13-olinuxino-micro


### PR DESCRIPTION
This patch adds two H6 boards:
- pineh64 tested on lab-baylibre
- OrangePi 1+ tested on my lab

They are present on upstream LAVA:
https://git.lavasoftware.org/lava/lava/merge_requests/661
https://git.lavasoftware.org/lava/lava/merge_requests/680