### PR TITLE
Remove vivid no error from v4l2 test template

### DIFF
--- a/templates/v4l2-compliance/generic-qemu-v4l2-compliance-template.jinja2
+++ b/templates/v4l2-compliance/generic-qemu-v4l2-compliance-template.jinja2
@@ -7,5 +7,5 @@
 {% endblock %}
 
 {%- block image_arg %}
-        image_arg: '-kernel {kernel} -append "console={{ console_dev }},115200 root=/dev/ram0 debug verbose vivid.no_error_inj=1 {{ extra_kernel_args }}"'
+        image_arg: '-kernel {kernel} -append "console={{ console_dev }},115200 root=/dev/ram0 debug verbose {{ extra_kernel_args }}"'
 {%- endblock %}


### PR DESCRIPTION
Signed-off-by: Alex P <alexandra.pereira@collabora.com>

Stop passing the `no_error_inj=1`  parameter to the vivid driver as it's not required any more with the latest version of v4l2-compliance as per Hans Verkuil.