### PR TITLE
v4l2: add device-presence test case

### DIFF
--- a/jenkins/debian/debos/overlays/v4l2/usr/bin/v4l2-parser.sh
+++ b/jenkins/debian/debos/overlays/v4l2/usr/bin/v4l2-parser.sh
@@ -40,9 +40,11 @@ device_path=$(v4l2-get-device -d $driver_name | head -n1)
 
 [ -z "$device_path" ] && {
     echo "No device found for driver $driver_name"
+    lava-test-case device-presence --result fail
     exit 1
 }
 
+lava-test-case device-presence --result pass
 echo "device: $device_path"
 
 v4l2-compliance -s -d $device_path | sed s/'\r'/'\n'/g | while read line; do


### PR DESCRIPTION
Signed-off-by: Alex P <alexandra.pereira@collabora.com>

This update will make update v4l2 test plan adding device present as a new test case. 
An important thing here is ensure that you have a media driver before running the v4l2-compliance test suite, otherwise it will works. 

You can verify the new test case in a v4l2 device available before running the v4l2-compliance test suite(https://lava.collabora.co.uk/results/1779885/0_v4l2-compliance-uvc?page=1#table).