### PR TITLE
Dont remove gcc from the clang docker images

### DIFF
--- a/jenkins/dockerfiles/clang-8/Dockerfile
+++ b/jenkins/dockerfiles/clang-8/Dockerfile
@@ -12,5 +12,3 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     clang-8
 
 RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-8 500
-
-RUN apt-get autoremove -y gcc

--- a/jenkins/dockerfiles/clang-9/Dockerfile
+++ b/jenkins/dockerfiles/clang-9/Dockerfile
@@ -12,5 +12,3 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     clang-9
 
 RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-9 500
-
-RUN apt-get autoremove -y gcc


### PR DESCRIPTION
Turns out GCC is needed when merging configs such as adding
BIG_ENDIAN