### PR TITLE
Stop booting odroid-x2 with LPAE configs

### DIFF
--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -691,7 +691,6 @@ device_types:
     class: arm-dtb
     boot_method: uboot
     dtb: 'exynos4412-odroidx2.dtb'
-    flags: ['lpae']
 
   odroid_xu3:
     name: 'odroid-xu3'


### PR DESCRIPTION
This board has failed to boot this config for a long time, so blacklist it