### PR TITLE
Add pyelftools to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 jinja2
 keyring
+pyelftools
 pytest
 pyyaml
 requests


### PR DESCRIPTION
pyelftools is a requirement for elf.py (import elftools):

    $ ./kci_build
    Traceback (most recent call last):
      File "./kci_build", line 26, in <module>
        import kernelci.build
      File "/home/drue/src/kernelci/kernelci-core/kernelci/build.py", line 32, in <module>
        import kernelci.elf
      File "/home/drue/src/kernelci/kernelci-core/kernelci/elf.py", line 24, in <module>
        import elftools.elf.constants as elfconst
    ImportError: No module named elftools.elf.constants

Signed-off-by: Dan Rue <dan.rue@linaro.org>