### PR TITLE
docker: add testing and experimental repos for clang-8 and clang-9

### DIFF
--- a/jenkins/dockerfiles/clang-8/Dockerfile
+++ b/jenkins/dockerfiles/clang-8/Dockerfile
@@ -3,8 +3,12 @@ FROM kernelci/build-base
 RUN apt-get update && apt-get install --no-install-recommends -y \
     software-properties-common \
     gnupg2
-RUN wget -q -O - https://apt.llvm.org/llvm-snapshot.gpg.key| apt-key add -
+
+RUN wget -q -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 RUN apt-add-repository 'deb http://apt.llvm.org/unstable/ llvm-toolchain-8 main'
+
+RUN apt-add-repository 'deb https://deb.debian.org/debian testing main'
+
 RUN apt-get update && apt-get install --no-install-recommends -y \
     binutils-aarch64-linux-gnu \
     binutils-arm-linux-gnueabi \

--- a/jenkins/dockerfiles/clang-9/Dockerfile
+++ b/jenkins/dockerfiles/clang-9/Dockerfile
@@ -3,8 +3,12 @@ FROM kernelci/build-base
 RUN apt-get update && apt-get install --no-install-recommends -y \
     software-properties-common \
     gnupg2
-RUN wget -q -O - https://apt.llvm.org/llvm-snapshot.gpg.key| apt-key add -
+
+RUN wget -q -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 RUN apt-add-repository 'deb http://apt.llvm.org/unstable/ llvm-toolchain main'
+
+RUN apt-add-repository 'deb https://deb.debian.org/debian experimental main'
+
 RUN apt-get update && apt-get install --no-install-recommends -y \
     binutils-aarch64-linux-gnu \
     binutils-arm-linux-gnueabi \


### PR DESCRIPTION
Add Debian testing for clang-8 and experimental for clang-9 to resolve
the dependencies with the latest versions of these packages from
apt.llvm.org.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>