### PR TITLE
build-configs.yaml: remove deprecated android-4.19-gki-dev branch

### DIFF
--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -404,10 +404,6 @@ build_configs:
     tree: android
     branch: 'android-4.19'
 
-  android_4.19-gki-dev:
-    tree: android
-    branch: 'android-4.19-gki-dev'
-
   android_4.19-q:
     tree: android
     branch: 'android-4.19-q'


### PR DESCRIPTION
The android-4.19-gki-dev branch has now been deprecated and renamed to
deprecated/android-4.19-gki-dev.  Remove it from the build
configurations.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>