### PR TITLE
build-configs.yaml: disable fragments with clang builds

### DIFF
--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -656,9 +656,11 @@ build_configs:
               - 'allmodconfig'
       clang-8:
         build_environment: clang-8
-        fragments: *default_fragments
         architectures:
-          arm64: *arm64_arch
+          arm64:
+            extra_configs:
+              - 'allmodconfig'
+              - 'allnoconfig'
 
   next_pending-fixes:
     tree: next


### PR DESCRIPTION
Disable special fragments with clang builds on linux-next/master until
the issues related to merging fragments with defconfigs has been
solved.  This is to avoid noise in the build reports when we know
these are going to fail but not because of actual kernel issues.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>