### PR TITLE
test-configs: disable hsdk for v4.14

### DIFF
--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -504,6 +504,9 @@ device_types:
     mach: arc
     class: arc-dtb
     boot_method: uboot
+    filters:
+      - blacklist:
+          kernel: ['v4.14']
 
   imx23_olinuxino:
     name: 'imx23-olinuxino'


### PR DESCRIPTION
This board has never worked on v4.14, and fixes for more recent
kernels have not been backported this far and are unlikely to ever be.

Signed-off-by: Kevin Hilman <khilman@kernel.org>