### PR TITLE
v4l2: replace stretch rootfs image with buster rootfs

### DIFF
--- a/jenkins/buster-v4l2.jpl
+++ b/jenkins/buster-v4l2.jpl
@@ -11,12 +11,12 @@ DOCKER_BASE
 
 def r = new RootFS()
 
-def config = ['name':"stretch-v4l2",
+def config = ['name':"buster-v4l2",
               'arch_list':["armhf", "arm64", "amd64"],
-              'debian_release':"stretch",
+              'debian_release':"buster",
               'extra_packages':"",
               'extra_packages_remove':"bash e2fsprogs e2fslibs",
-              'script':"scripts/stretch-v4l2.sh",
+              'script':"scripts/buster-v4l2.sh",
               'test_overlay': "overlays/v4l2",
               'docker_image': "${params.DOCKER_BASE}debos",
              ]

--- a/jenkins/debian/debos/scripts/buster-v4l2.sh
+++ b/jenkins/debian/debos/scripts/buster-v4l2.sh
@@ -66,7 +66,7 @@ cd /tmp
 rm -rf /tmp/tests
 
 apt-get remove --purge -y ${BUILD_DEPS}
-apt-get remove --purge -y perl-modules-5.24
+apt-get remove --purge -y perl-modules-5.28
 apt-get autoremove --purge -y
 apt-get clean
 


### PR DESCRIPTION
Signed-off-by: Alex P <alexandra.pereira@collabora.com>

The goal is to update v4l2 to use a buster rootfs image, in order to complete this we need to have some steps: 

- [x] Create a new job to produce rootfs image in one architecture to test and ensure that everything will keep working well.
- [x] Create to all architectures.
- [x] Update test-config to use new images. 
- [x] Remove stretchv4l2 files and references.
- [x] Update commit message.