### PR TITLE
test-configs.yaml: define qemu arch and cpu directly in context

### DIFF
--- a/templates/boot/generic-qemu-boot-template.jinja2
+++ b/templates/boot/generic-qemu-boot-template.jinja2
@@ -1,19 +1,14 @@
 {% extends 'base/kernel-ci-base.jinja2' %}
-{% set ctx_arch = arch %}
 {% if arch == "arm" %}
-{% set ctx_cpu = 'cortex-a15' %}
 {% set console_dev = 'ttyAMA0' %}
 {% endif %}
 {% if arch == "arm64" %}
-{% set ctx_cpu = 'cortex-a57' %}
 {% set console_dev = 'ttyAMA0' %}
 {% endif %}
 {% if arch == 'x86_64' %}
-{% set ctx_cpu = 'qemu64' %}
 {% set console_dev = 'ttyS0' %}
 {% endif %}
 {% if arch == 'i386' %}
-{% set ctx_cpu = 'qemu32' %}
 {% set console_dev = 'ttyS0' %}
 {% endif %}
 {% block metadata %}
@@ -23,13 +18,6 @@
 {{ super() }}
 {% endblock %}
 {% block actions %}
-context:
-  arch: {{ ctx_arch }}
-  cpu: {{ ctx_cpu }}
-  guestfs_interface: virtio
-{%- if qemu_machine %}
-  machine: {{ qemu_machine }}
-{%- endif %}
 
 actions:
 - deploy:

--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -756,6 +756,10 @@ device_types:
     mach: qemu
     arch: arm
     boot_method: qemu
+    context:
+      arch: arm
+      cpu: 'cortex-a15'
+      guestfs_interface: 'virtio'
     filters:
       - whitelist: {defconfig: ['multi_v7_defconfig', 'vexpress_defconfig']}
 
@@ -764,6 +768,10 @@ device_types:
     mach: qemu
     arch: arm64
     boot_method: qemu
+    context:
+      arch: arm64
+      cpu: 'cortex-a57'
+      guestfs_interface: 'virtio'
     filters:
       - whitelist: {defconfig: ['defconfig']}
 
@@ -772,6 +780,10 @@ device_types:
     mach: qemu
     arch: i386
     boot_method: qemu
+    context:
+      arch: i386
+      cpu: 'qemu32'
+      guestfs_interface: 'virtio'
     filters:
       - whitelist: {defconfig: ['i386_defconfig']}
 
@@ -780,6 +792,10 @@ device_types:
     mach: qemu
     arch: x86_64
     boot_method: qemu
+    context:
+      arch: x86_64
+      cpu: 'qemu64'
+      guestfs_interface: 'virtio'
     filters:
       - whitelist: {defconfig: ['defconfig']}
 


### PR DESCRIPTION
test-configs.yaml: define qemu arch and cpu directly in context

Rather than having default values for arch and cpu defined in the qemu
boot template, define them in the YAML device configuration.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>