### PR TITLE
Remove hard coded qemu context

### DIFF
--- a/templates/boot/generic-qemu-boot-template.jinja2
+++ b/templates/boot/generic-qemu-boot-template.jinja2
@@ -1,19 +1,14 @@
 {% extends 'base/kernel-ci-base.jinja2' %}
-{% set ctx_arch = arch %}
 {% if arch == "arm" %}
-{% set ctx_cpu = 'cortex-a15' %}
 {% set console_dev = 'ttyAMA0' %}
 {% endif %}
 {% if arch == "arm64" %}
-{% set ctx_cpu = 'cortex-a57' %}
 {% set console_dev = 'ttyAMA0' %}
 {% endif %}
 {% if arch == 'x86_64' %}
-{% set ctx_cpu = 'qemu64' %}
 {% set console_dev = 'ttyS0' %}
 {% endif %}
 {% if arch == 'i386' %}
-{% set ctx_cpu = 'qemu32' %}
 {% set console_dev = 'ttyS0' %}
 {% endif %}
 {% block metadata %}
@@ -23,13 +18,6 @@
 {{ super() }}
 {% endblock %}
 {% block actions %}
-context:
-  arch: {{ ctx_arch }}
-  cpu: {{ ctx_cpu }}
-  guestfs_interface: virtio
-{%- if qemu_machine %}
-  machine: {{ qemu_machine }}
-{%- endif %}
 
 actions:
 - deploy:

--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -139,32 +139,16 @@ test_plans:
   sleep:
     rootfs: debian_buster_ramdisk
 
-  uefi-arm-gicv2:
+  uefi-arm:
     rootfs: buildroot_ramdisk
     pattern: 'boot/generic-qemu-boot-template.jinja2'
     params:
-      qemu_machine: 'virt,gic-version=2'
       bios_url: 'https://storage.kernelci.org/images/uefi/111bbcf87621/QEMU_EFI.fd-ARM-RELEASE-111bbcf87621'
 
-  uefi-arm-gicv3:
+  uefi-arm64:
     rootfs: buildroot_ramdisk
     pattern: 'boot/generic-qemu-boot-template.jinja2'
     params:
-      qemu_machine: 'virt,gic-version=3'
-      bios_url: 'https://storage.kernelci.org/images/uefi/111bbcf87621/QEMU_EFI.fd-ARM-RELEASE-111bbcf87621'
-
-  uefi-arm64-gicv2:
-    rootfs: buildroot_ramdisk
-    pattern: 'boot/generic-qemu-boot-template.jinja2'
-    params:
-      qemu_machine: 'virt,gic-version=2'
-      bios_url: 'https://storage.kernelci.org/images/uefi/111bbcf87621/QEMU_EFI.fd-AARCH64-RELEASE-111bbcf87621'
-
-  uefi-arm64-gicv3:
-    rootfs: buildroot_ramdisk
-    pattern: 'boot/generic-qemu-boot-template.jinja2'
-    params:
-      qemu_machine: 'virt,gic-version=3'
       bios_url: 'https://storage.kernelci.org/images/uefi/111bbcf87621/QEMU_EFI.fd-AARCH64-RELEASE-111bbcf87621'
 
   uefi-x86_64:
@@ -751,27 +735,48 @@ device_types:
       - whitelist: {defconfig: ['defconfig']}
       - blacklist: {kernel: ['v3.']}
 
-  qemu_arm:
+  qemu_arm-virt-gicv2:
     type: qemu
     mach: qemu
     arch: arm
     boot_method: qemu
+    context: {arch: 'arm', cpu: 'cortex-a15', guestfs_interface: 'virtio', machine: 'virt,gic-version=2'}
     filters:
       - whitelist: {defconfig: ['multi_v7_defconfig', 'vexpress_defconfig']}
 
-  qemu_arm64:
+  qemu_arm-virt-gicv3:
+    type: qemu
+    mach: qemu
+    arch: arm
+    boot_method: qemu
+    context: {arch: 'arm', cpu: 'cortex-a15', guestfs_interface: 'virtio', machine: 'virt,gic-version=3'}
+    filters:
+      - whitelist: {defconfig: ['multi_v7_defconfig', 'vexpress_defconfig']}
+
+  qemu_arm64-virt-gicv2:
     type: qemu
     mach: qemu
     arch: arm64
     boot_method: qemu
+    context: {arch: 'arm64', cpu: 'cortex-a57', guestfs_interface: 'virtio', machine: 'virt,gic-version=2'}
+    filters:
+      - whitelist: {defconfig: ['defconfig']}
+
+  qemu_arm64-virt-gicv3:
+    type: qemu
+    mach: qemu
+    arch: arm64
+    boot_method: qemu
+    context: {arch: 'arm64', cpu: 'cortex-a57', guestfs_interface: 'virtio', machine: 'virt,gic-version=3'}
     filters:
       - whitelist: {defconfig: ['defconfig']}
 
   qemu_i386:
-    name: qemu
+    type: qemu
     mach: qemu
     arch: i386
     boot_method: qemu
+    context: {arch: 'i386', cpu: 'qemu32', guestfs_interface: 'virtio'}
     filters:
       - whitelist: {defconfig: ['i386_defconfig']}
 
@@ -780,6 +785,7 @@ device_types:
     mach: qemu
     arch: x86_64
     boot_method: qemu
+    context: {arch: 'x86_64', cpu: 'qemu64', guestfs_interface: 'virtio'}
     filters:
       - whitelist: {defconfig: ['defconfig']}
 
@@ -1328,27 +1334,37 @@ test_configs:
   - device_type: qcom-qdf2400
     test_plans: [boot]
 
-  - device_type: qemu_arm
+  - device_type: qemu_arm-virt-gicv2
     test_plans:
       - boot_qemu
       - simple_qemu
-      - uefi-arm-gicv2
-      - uefi-arm-gicv3
+      - uefi-arm
+
+  - device_type: qemu_arm-virt-gicv3
+    test_plans:
+      - boot_qemu
+      - simple_qemu
+      - uefi-arm
       - v4l2_compliance_qemu_vivid
 
-  - device_type: qemu_arm64
+  - device_type: qemu_arm64-virt-gicv2
     test_plans:
       - boot_qemu
       - simple_qemu
-      - uefi-arm64-gicv2
-      - uefi-arm64-gicv3
+      - uefi-arm64
+
+  - device_type: qemu_arm64-virt-gicv3
+    test_plans:
+      - boot_qemu
+      - simple_qemu
+      - uefi-arm64
       - v4l2_compliance_qemu_vivid
 
   - device_type: qemu_i386
     test_plans:
       - boot
-      - uefi-x86_i386
       - simple_qemu
+      - uefi-x86_i386
       - v4l2_compliance_qemu_vivid
 
   - device_type: qemu_x86_64


### PR DESCRIPTION
This patch remove the hardcoded job context, and move all its content to
test-configs.yaml.
This will permit more customization of qemu machines templates.