### PR TITLE
lava-v2-jobs-from-api.py: distinguish device.type from device_type

### DIFF
--- a/lava-v2-jobs-from-api.py
+++ b/lava-v2-jobs-from-api.py
@@ -130,7 +130,7 @@ def get_job_params(config, test_config, defconfig, opts, build, plan):
         platform = opts['dtb'].split('.')[0]
     else:
         dtb_url = None
-        platform = device_type.type_name
+        platform = device_type.name
     if build['modules']:
         modules_url = urlparse.urljoin(
             storage, '/'.join([url_px, build['modules']]))
@@ -157,7 +157,8 @@ def get_job_params(config, test_config, defconfig, opts, build, plan):
         'arch_defconfig': opts['arch_defconfig'],
         'fastboot': str(device_type.get_flag('fastboot')).lower(),
         'priority': config.get('priority'),
-        'device_type': device_type.type_name,
+        'device_type': device_type.name,
+        'device_type_name': device_type.type_name,
         'template_file': template_file,
         'base_url': base_url,
         'endian': opts['endian'],

--- a/templates/base/kernel-ci-base.jinja2
+++ b/templates/base/kernel-ci-base.jinja2
@@ -33,7 +33,7 @@ metadata:
   job.build_environment: {{ build_environment }}
 {%- endblock %}
 {% block main %}
-device_type: {{ device_type }}
+device_type: {{ device_type_name }}
 
 {% if context %}
 context:


### PR DESCRIPTION
Use the device type names in YAML as the logical ones tracked by
KernelCI via the device.type meta-data, and use the "type:" attribute
as the the actual device type names to use in LAVA jobs.  By default,
these are the same.  Only qemu makes use of this feature, to introduce
different qemu_* device type variants.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>