### PR TITLE
Use yaml safe_load insteald of load

### DIFF
--- a/kernelci/configs.py
+++ b/kernelci/configs.py
@@ -867,7 +867,7 @@ class TestConfig(YAMLObject):
 
 def builds_from_yaml(yaml_path):
     with open(yaml_path) as f:
-        data = yaml.load(f)
+        data = yaml.safe_load(f)
 
     trees = {
         name: Tree.from_yaml(config, name)
@@ -904,7 +904,7 @@ def builds_from_yaml(yaml_path):
 
 def tests_from_yaml(yaml_path):
     with open(yaml_path) as f:
-        data = yaml.load(f)
+        data = yaml.safe_load(f)
 
     fs_types = {
         name: RootFSType.from_yaml(fs_type)


### PR DESCRIPTION
On my gentoo, using yaml.load now give:
  Traceback (most recent call last):
  raise RuntimeError("Unsafe load() call disabled by Gentoo. See bug #659348")
  RuntimeError: Unsafe load() call disabled by Gentoo. See bug #659348

Note that on recent ubuntu, a warning appears also.
  YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.

This is due to a security risk of using yaml.load()

Since kernelci-core does not rely on any behavour provided by load(), let's convert the call to safe_load().