### PR TITLE
Device type fixup

### DIFF
--- a/kernelci/configs.py
+++ b/kernelci/configs.py
@@ -500,7 +500,7 @@ class BuildConfig(YAMLObject):
 class DeviceType(YAMLObject):
     """Device type model."""
 
-    def __init__(self, name, mach, arch, boot_method, dtb=None, type_name=None,
+    def __init__(self, name, mach, arch, boot_method, dtb=None, base_name=None,
                  flags=None, filters=None, context=None):
         """A device type describes a category of equivalent hardware devices.
 
@@ -509,7 +509,7 @@ class DeviceType(YAMLObject):
         *arch* is the CPU architecture following the Linux kernel convention.
         *boot_method* is the name of the boot method to use.
         *dtb* is an optional name for a device tree binary.
-        *type_name* is the actual device type name to use in test labs.
+        *base_name* is the name of the base device type used in test labs.
         *flags* is a list of optional arbitrary strings.
         *filters* is a list of Filter objects associated with this device type.
         *context* is an arbirary dictionary used when scheduling tests.
@@ -519,7 +519,7 @@ class DeviceType(YAMLObject):
         self._arch = arch
         self._boot_method = boot_method
         self._dtb = dtb
-        self._type_name = type_name or name
+        self._base_name = base_name or name
         self._flags = flags or list()
         self._filters = filters or list()
         self._context = context or dict()
@@ -532,8 +532,8 @@ class DeviceType(YAMLObject):
         return self._name
 
     @property
-    def type_name(self):
-        return self._type_name
+    def base_name(self):
+        return self._base_name
 
     @property
     def mach(self):
@@ -614,7 +614,7 @@ class DeviceTypeFactory(YAMLObject):
             'mach', 'arch', 'boot_method', 'dtb', 'flags', 'context'])
         kw.update({
             'name': name,
-            'type_name': device_type.get('type'),
+            'base_name': device_type.get('base_name'),
             'filters': FilterFactory.from_data(device_type, default_filters),
         })
         cls_name = device_type.get('class')

--- a/lava-v2-jobs-from-api.py
+++ b/lava-v2-jobs-from-api.py
@@ -119,7 +119,7 @@ def get_job_params(config, test_config, defconfig, opts, build, plan):
         url_px = '/'.join(parts)
 
     job_name = '-'.join([job_name_prefix, dtb or 'no-dtb',
-                         device_type.type_name, plan])
+                         device_type.name, plan])
 
     base_url = urlparse.urljoin(storage, '/'.join([url_px, '']))
     kernel_url = urlparse.urljoin(

--- a/lava-v2-jobs-from-api.py
+++ b/lava-v2-jobs-from-api.py
@@ -158,7 +158,7 @@ def get_job_params(config, test_config, defconfig, opts, build, plan):
         'fastboot': str(device_type.get_flag('fastboot')).lower(),
         'priority': config.get('priority'),
         'device_type': device_type.name,
-        'device_type_name': device_type.type_name,
+        'base_device_type': device_type.base_name,
         'template_file': template_file,
         'base_url': base_url,
         'endian': opts['endian'],

--- a/templates/base/kernel-ci-base.jinja2
+++ b/templates/base/kernel-ci-base.jinja2
@@ -33,7 +33,7 @@ metadata:
   job.build_environment: {{ build_environment }}
 {%- endblock %}
 {% block main %}
-device_type: {{ device_type_name }}
+device_type: {{ base_device_type }}
 
 {% if context %}
 context:

--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -752,7 +752,7 @@ device_types:
       - blacklist: {kernel: ['v3.']}
 
   qemu_arm:
-    type: qemu
+    base_name: qemu
     mach: qemu
     arch: arm
     boot_method: qemu
@@ -764,7 +764,7 @@ device_types:
       - whitelist: {defconfig: ['multi_v7_defconfig', 'vexpress_defconfig']}
 
   qemu_arm64:
-    type: qemu
+    base_name: qemu
     mach: qemu
     arch: arm64
     boot_method: qemu
@@ -776,7 +776,7 @@ device_types:
       - whitelist: {defconfig: ['defconfig']}
 
   qemu_i386:
-    name: qemu
+    base_name: qemu
     mach: qemu
     arch: i386
     boot_method: qemu
@@ -788,7 +788,7 @@ device_types:
       - whitelist: {defconfig: ['i386_defconfig']}
 
   qemu_x86_64:
-    type: qemu
+    base_name: qemu
     mach: qemu
     arch: x86_64
     boot_method: qemu

--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -1365,7 +1365,6 @@ test_configs:
       - boot
       - uefi-x86_i386
       - simple_qemu
-      - v4l2_compliance_qemu_vivid
 
   - device_type: qemu_x86_64
     test_plans:


### PR DESCRIPTION
As discussed in previous PRs, this is to fix rename the `DeviceType.type_name` attribute to clarify things.