### PR TITLE
Makefile: run pytest in tests directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 test:
 	# Note that just running 'pytest' will not work here because there is no setup.py. See
 	# https://docs.pytest.org/en/latest/pythonpath.html#invoking-pytest-versus-python-m-pytest
-	python -m pytest
+	python -m pytest tests


### PR DESCRIPTION
Rather than letting pytest discover unit tests in the whole tree,
limit the scope to the tests directory.  This is where all the tests
currently hare, and if there is a kernel tree checked out locally it
won't be scanned by mistake.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>