### PR TITLE
Remove vexpres_defconfig for qemu_arm-virt-gicv3

### DIFF
--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -767,7 +767,7 @@ device_types:
       guestfs_interface: 'virtio'
       machine: 'virt,gic-version=2'
     filters:
-      - whitelist: {defconfig: ['multi_v7_defconfig', 'vexpress_defconfig']}
+      - whitelist: {defconfig: ['multi_v7_defconfig']}
 
   qemu_arm-virt-gicv3:
     base_name: qemu
@@ -780,7 +780,7 @@ device_types:
       guestfs_interface: 'virtio'
       machine: 'virt,gic-version=3'
     filters:
-      - whitelist: {defconfig: ['multi_v7_defconfig', 'vexpress_defconfig']}
+      - whitelist: {defconfig: ['multi_v7_defconfig']}
 
   qemu_arm64-virt-gicv2:
     base_name: qemu


### PR DESCRIPTION
The vexpres_defconfig produces unbootable kernel for
qemu_arm-virt-gicv3, let's remove it from the qemu_arm-virt-gicv3's defconfig used.