### PR TITLE
T16420 baseline: add dmesg tests

### DIFF
--- a/templates/baseline/baseline.jinja2
+++ b/templates/baseline/baseline.jinja2
@@ -15,6 +15,42 @@
             - lava-test-shell
         run:
           steps:
+            - >
+                for level in warn err; do
+                  dmesg --level=$level --notime -x -k > dmesg.$level
+                done
+            - >
+                for level in crit alert emerg; do
+                  dmesg --level=$level --notime -x -k > dmesg.$level
+                  test -s dmesg.$level && res=fail || res=pass
+                  count=$(cat dmesg.$level | wc -l)
+                  lava-test-case $level \
+                    --result $res \
+                    --measurement $count \
+                    --units lines
+                done
+            - cat dmesg.emerg dmesg.alert dmesg.crit dmesg.err dmesg.warn
+      from: inline
+      name: dmesg
+      path: inline/dmesg.yaml
+
+- test:
+    timeout:
+      minutes: 10
+    definitions:
+    - repository:
+        metadata:
+          format: Lava-Test Test Definition 1.0
+          name: baseline
+          description: "baseline test plan"
+          os:
+            - debian
+          scope:
+            - functional
+          environment:
+            - lava-test-shell
+        run:
+          steps:
             - export PATH=/opt/bootrr/helpers:$PATH
             - cd /opt/bootrr && sh helpers/bootrr-auto
       lava-signal: kmsg


### PR DESCRIPTION
Add test cases to the baseline test plan to check for kernel errors
using dmesg.  One test case is created for each log level starting
from "error" and up to "emergency".  Log messages at the "warning"
level are also checked but not reported as a test case.

All the kernel log lines matching these levels are then output again
in the log for debugging purposes.  The backend can't at the moment
store anything like arbitrary log strings to track individual errors,
so detecting whether there were any errors is a first step.

This relies on the latest version of the "baseline" KernelCI buildroot
file system which has the standard dmesg implementation from
util-linux rather than the busybox one.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>