### PR TITLE
T9980 kernelci.config.test: optional plan name in TestConfig.match()

### DIFF
--- a/kernelci/config/test.py
+++ b/kernelci/config/test.py
@@ -391,10 +391,12 @@ class TestConfig(YAMLObject):
     def test_plans(self):
         return self._test_plans
 
-    def match(self, arch, plan, flags, config):
+    def match(self, arch, flags, config, plan=None):
         return (
-            plan in self._test_plans and
-            self._test_plans[plan].match(config) and
+            plan is None or (
+                plan in self._test_plans and
+                self._test_plans[plan].match(config)
+            ) and
             self.device_type.arch == arch and
             self.device_type.match(flags, config) and
             all(f.match(**config) for f in self._filters)

--- a/lava-v2-jobs-from-api.py
+++ b/lava-v2-jobs-from-api.py
@@ -205,7 +205,7 @@ def add_jobs(jobs, config, tests, opts, build, plan_config, arch, defconfig):
             print("device not in targets: {}".format(
                 test_config.device_type, targets))
             continue
-        if not test_config.match(arch, plan_config.name, flags, filters):
+        if not test_config.match(arch, flags, filters, plan_config.name):
             print("test config did not match: {}".format(
                 test_config.device_type))
             continue


### PR DESCRIPTION
Make the plan argument optional in TestConfig.match() to be able to
use it to filter based on build meta-data only.

Update lava-v2-jobs-from-api.py accordingly.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>