### PR TITLE
Define reference tree and branch for bisections

### DIFF
--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -253,6 +253,9 @@ build_configs_defaults:
           extra_configs: ['allmodconfig', 'allnoconfig']
           fragments: [x86_kvm_guest]
 
+  reference:
+    tree: mainline
+    branch: 'master'
 
 # Minimum architecture defconfigs
 arch_defconfigs: &arch_defconfigs

--- a/jenkins/bisect.jpl
+++ b/jenkins/bisect.jpl
@@ -381,7 +381,7 @@ def runTest(kci_core, describe, expected=0, runs=0) {
  * bisection
  */
 
-def findMergeBase(kdir, good, bad) {
+def findMergeBase(kdir, kci_core, good, bad) {
     def base = good
 
     dir(kdir) {
@@ -390,16 +390,32 @@ def findMergeBase(kdir, good, bad) {
             script: "git merge-base --is-ancestor ${base} HEAD")
 
         if (good_base != 0) {
-            def ref = "${params.REF_KERNEL_TREE}/${params.REF_KERNEL_BRANCH}"
+            def ref_url = params.REF_KERNEL_URL
+            def ref_tree = params.REF_KERNEL_TREE
+            def ref_branch = params.REF_KERNEL_BRANCH
+
+            if (!(ref_url && ref_tree && ref_branch)) {
+                dir(kci_core) {
+                    ref_config = sh(script: """\
+                                    ./kci_build get_reference --tree-name ${params.KERNEL_TREE} \
+                                    --branch ${params.KERNEL_BRANCH}""", returnStdout: true).trim().tokenize("\n")
+                    if (ref_config.size() > 0) {
+                        ref_url = ref_config[0]
+                        ref_tree = ref_config[1]
+                        ref_branch = ref_config[2]
+                    }
+                }
+            }
+            def ref = "${ref_tree}/${ref_branch}"
             print("Good commit not in current branch, finding base in ${ref}")
 
             print("""\
 Reference:
-    Tree:      ${params.REF_KERNEL_TREE}
-    URL:       ${params.REF_KERNEL_URL}
-    Branch:    ${params.REF_KERNEL_BRANCH}""")
+    Tree:      ${ref_tree}
+    URL:       ${ref_url}
+    Branch:    ${ref_branch}""")
 
-            setRemote(kdir, params.REF_KERNEL_TREE, params.REF_KERNEL_URL)
+            setRemote(kdir, ref_tree, ref_url)
             base = sh(script: "git merge-base ${bad} ${ref}",
                       returnStdout: true).trim()
             print("Merge base: ${base}")
@@ -539,7 +555,7 @@ def bisection(kci_core, kdir, checks) {
         }
 
         bad = params.BAD_COMMIT
-        good = findMergeBase(kdir, params.GOOD_COMMIT, bad)
+        good = findMergeBase(kdir, kci_core, params.GOOD_COMMIT, bad)
     }
 
     stage("Check pass") {

--- a/kci_build
+++ b/kci_build
@@ -210,6 +210,21 @@ class cmd_get_build_env(Command):
         return True
 
 
+class cmd_get_reference(Command):
+    help = "Print reference tree and branch for bisections"
+    args = [Args.tree_name, Args.branch]
+
+    def __call__(self, configs, args):
+        for conf in (c for c in configs['build_configs'].itervalues()
+                     if c.tree.name == args.tree_name and
+                        c.branch == args.branch):
+            print(conf.reference.tree.url)
+            print(conf.reference.tree.name)
+            print(conf.reference.branch)
+            return True
+        return False
+
+
 class cmd_show_build_env(Command):
     help = "Show parameters of a given build environment"
     args = [Args.build_env]

--- a/kernelci/config/build.py
+++ b/kernelci/config/build.py
@@ -49,6 +49,33 @@ class Tree(YAMLObject):
         return self._url
 
 
+class Reference(YAMLObject):
+    """Kernel reference tree and branch model."""
+
+    def __init__(self, tree, branch):
+        """Reference is a tree and branch used for bisections
+
+        *tree* is a Tree object
+        *branch* is the branch name to be used from the tree
+        """
+        self._tree = tree
+        self._branch = branch
+
+    @classmethod
+    def from_yaml(cls, reference, trees):
+        kw = cls._kw_from_yaml(reference, ['tree', 'branch'])
+        kw['tree'] = trees[kw['tree']]
+        return cls(**kw)
+
+    @property
+    def tree(self):
+        return self._tree
+
+    @property
+    def branch(self):
+        return self._branch
+
+
 class Fragment(YAMLObject):
     """Kernel config fragment model."""
 
@@ -290,7 +317,7 @@ class BuildVariant(YAMLObject):
 class BuildConfig(YAMLObject):
     """Build configuration model."""
 
-    def __init__(self, name, tree, branch, variants):
+    def __init__(self, name, tree, branch, variants, reference):
         """A build configuration defines the actual kernels to be built.
 
         *name* is the name of the build configuration.  It is arbitrary and
@@ -304,11 +331,16 @@ class BuildConfig(YAMLObject):
 
         *variants* is a list of BuildVariant objects, to define all the
                    variants to build for this tree / branch combination.
+
+        *reference* is a Reference object which defines the tree and branch
+                    for bisections when no base commit is found for
+                    the good and bad revisions.
         """
         self._name = name
         self._tree = tree
         self._branch = branch
         self._variants = variants
+        self._reference = reference
 
     @classmethod
     def from_yaml(cls, config, name, trees, fragments, build_envs, defaults):
@@ -325,6 +357,8 @@ class BuildConfig(YAMLObject):
             for name, variant in config_variants.iteritems()
         ]
         kw['variants'] = {v.name: v for v in variants}
+        reference = config.get('reference', defaults['reference'])
+        kw['reference'] = Reference.from_yaml(reference, trees)
         return cls(**kw)
 
     @property
@@ -345,6 +379,10 @@ class BuildConfig(YAMLObject):
 
     def get_variant(self, name):
         return self._variants[name]
+
+    @property
+    def reference(self):
+        return self._reference
 
 
 def from_yaml(yaml_path):


### PR DESCRIPTION
This PR consists of 2 changes:

1. Add get_reference subcommand to kci_build
2. Use the above in the bisection job definition
     

---
get_reference subcommand of kci_build prints reference tree and branch
for bisections. These are taken from the reference section of build
config or from reference_defaults when not found in the build config.

Default values of reference tree and branch are supposed to be in the build-configs.yaml file's `reference_defaults` section
e.g.
```yaml
[...]
reference_defaults:
  tree: mainline
  branch: 'master'
[...]
```

If specific values for a build config are needed they should be placed in the `reference` section of the appropriate build config.

e.g.

```yaml
build_configs:
[...]
 mgalka:
    tree: mgalka
    branch: 'mgalka'
    variants:
      gcc-8:
        build_environment: gcc-8
        architectures:
          x86_64: *x86_64_arch
    reference:
      tree: mytree
      branch: 'mgalka'

```

`tree` should be a tree name from the `trees` section of the build-configs.yaml 
`branch` should be a branch name present in the reference tree specified.

---

bisection.jpl was modified to use `kci_build get_reference`. Default behaviour of the job is to take values for reference tree url, name and branch from the kci_build get_reference. The values can be overriden by the job parameters:

- REF_KERNEL_URL
- REF_KERNEL_TREE
- REF_KERNEL_BRANCH