### PR TITLE
test-configs.yaml: upgrade buildroot to HEAD of kernelci/latest

### DIFF
--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -5,7 +5,7 @@
 file_system_types:
 
   buildroot:
-    url: 'https://storage.kernelci.org/images/rootfs/buildroot/kci-2019.02-2-gefc755ba4a02'
+    url: 'https://storage.kernelci.org/images/rootfs/buildroot/kci-2019.02-6-gaa3933f214ce'
 
     arch_map:
       arm64be: [{arch: arm64, endian: big}]


### PR DESCRIPTION
Upgrade the version of the buildroot file systems to the latest
version of the kernelci/latest branch.  This includes the standard
dmesg implementation from util-linux in the baseline rootfs in
particular.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>