### PR TITLE
build-configs: fix path to the kvm_guest.config fragment

### DIFF
--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -149,7 +149,7 @@ fragments:
       - 'CONFIG_VIDEO_VIVID_MAX_DEVS=64'
 
   x86_kvm_guest:
-    path: "arch/x86/configs/kvm_guest.config"
+    path: "kernel/configs/kvm_guest.config"
 
 
 build_environments:


### PR DESCRIPTION
x86 kernels with kvm guest support isn't built since the path to the
fragment isn't correct.
kvm_guest.config got moved from arch/x86/configs to kernel/configs.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>