### PR TITLE
T9980 kernelci.build: install bmeta.json and simplify JSON publish format

### DIFF
--- a/kci_build
+++ b/kci_build
@@ -395,7 +395,7 @@ class cmd_build_kernel(Command):
 
 
 class cmd_install_kernel(Command):
-    help = "Install the kernel binaries and build.json locally"
+    help = "Install the kernel binaries and bmeta.json locally"
     args = [Args.kdir]
     opt_args = [Args.config, Args.tree_name, Args.tree_url, Args.branch,
                 Args.commit, Args.describe, Args.describe_verbose,

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -599,7 +599,7 @@ def build_kernel(build_env, kdir, arch, defconfig=None, jopt=None,
     bmeta = {
         'build_threads': jopt,
         'build_time': round(build_time, 2),
-        'build_result': 'PASS' if result is True else 'FAIL',
+        'status': 'PASS' if result is True else 'FAIL',
         'arch': arch,
         'cross_compile': cross_compile,
         'compiler': cc,
@@ -832,9 +832,9 @@ def publish_kernel(kdir, install='_install_', api=None, token=None,
 
     if json_path:
         json_data = dict(data)
-        for k in ['kernel_image', 'modules', 'git_commit', 'git_url']:
+        for k in ['kernel_image', 'modules', 'git_commit', 'git_url',
+                  'status']:
             json_data[k] = bmeta[k]
-        json_data['status'] = bmeta['build_result']
         with open(os.path.join(install_path, 'dtbs.json')) as f:
             dtbs = json.load(f)['dtbs']
         json_data['dtb_dir_data'] = dtbs

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -756,7 +756,7 @@ def install_kernel(kdir, tree_name, tree_url, git_branch, git_commit=None,
         'file_server_resource': publish_path,
     })
 
-    with open(os.path.join(install_path, 'build.json'), 'w') as json_file:
+    with open(os.path.join(install_path, 'bmeta.json'), 'w') as json_file:
         json.dump(bmeta, json_file, indent=4, sort_keys=True)
 
     return True
@@ -778,7 +778,7 @@ def push_kernel(kdir, api, token, install='_install_'):
     """
     install_path = os.path.join(kdir, install)
 
-    with open(os.path.join(install_path, 'build.json')) as f:
+    with open(os.path.join(install_path, 'bmeta.json')) as f:
         bmeta = json.load(f)
 
     artifacts = {}
@@ -815,39 +815,34 @@ def publish_kernel(kdir, install='_install_', api=None, token=None,
     """
     install_path = os.path.join(kdir, install)
 
-    with open(os.path.join(install_path, 'build.json')) as f:
+    with open(os.path.join(install_path, 'bmeta.json')) as f:
         bmeta = json.load(f)
 
-    data = {k: bmeta[v] for k, v in {
-        'path': 'file_server_resource',
-        'file_server_resource': 'file_server_resource',
-        'job': 'job',
-        'git_branch': 'git_branch',
-        'arch': 'arch',
-        'kernel': 'git_describe',
-        'build_environment': 'build_environment',
-        'defconfig': 'defconfig',
-        'defconfig_full': 'defconfig_full',
-    }.iteritems()}
-
     if json_path:
-        json_data = dict(data)
-        for k in ['kernel_image', 'modules', 'git_commit', 'git_url',
-                  'status']:
-            json_data[k] = bmeta[k]
         with open(os.path.join(install_path, 'dtbs.json')) as f:
             dtbs = json.load(f)['dtbs']
-        json_data['dtb_dir_data'] = dtbs
+        bmeta['dtb_dir_data'] = dtbs
         try:
             with open(json_path, 'r') as json_file:
                 full_json = json.load(json_file)
-            full_json.append(json_data)
+            full_json.append(bmeta)
         except Exception as e:
-            full_json = [json_data]
+            full_json = [bmeta]
         with open(json_path, 'w') as json_file:
             json.dump(full_json, json_file)
 
     if api and token:
+        data = {k: bmeta[v] for k, v in {
+            'path': 'file_server_resource',
+            'file_server_resource': 'file_server_resource',
+            'job': 'job',
+            'git_branch': 'git_branch',
+            'arch': 'arch',
+            'kernel': 'git_describe',
+            'build_environment': 'build_environment',
+            'defconfig': 'defconfig',
+            'defconfig_full': 'defconfig_full',
+        }.iteritems()}
         headers = {
             'Authorization': token,
             'Content-Type': 'application/json',


### PR DESCRIPTION
Rename the build.json file created during the install phase as
bmeta.json and make it a superset of the bmeta.json file created
during the initial build.  Also simplify the builds.json created
during the publish step to have a list of data structures like
bmeta.json with the dtbs.json incorporated into them as dtb_dir_data
to match what gets stored in the backend.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>

This depends on https://github.com/kernelci/kernelci-backend/pull/163 to be merged at the same time.