### PR TITLE
Add first RISCV device: hifive-unleashed-a00

### DIFF
--- a/kernelci/config/test.py
+++ b/kernelci/config/test.py
@@ -128,6 +128,14 @@ class DeviceType_arm64(DeviceType):
         super(DeviceType_arm64, self).__init__(name, mach, arch, *args, **kw)
 
 
+class DeviceType_riscv(DeviceType):
+
+    def __init__(self, name, mach, arch='riscv', *args, **kw):
+        """RISCV device type with a device tree."""
+        kw.setdefault('dtb', '{}/{}.dtb'.format(mach, name))
+        super(DeviceType_riscv, self).__init__(name, mach, arch, *args, **kw)
+
+
 class DeviceTypeFactory(YAMLObject):
     """Factory to create device types from YAML data."""
 
@@ -136,6 +144,7 @@ class DeviceTypeFactory(YAMLObject):
         'mips-dtb': DeviceType_mips,
         'arm-dtb': DeviceType_arm,
         'arm64-dtb': DeviceType_arm64,
+        'riscv-dtb': DeviceType_riscv,
     }
 
     @classmethod

--- a/lava-v2-jobs-from-api.py
+++ b/lava-v2-jobs-from-api.py
@@ -107,6 +107,8 @@ def get_job_params(config, test_config, defconfig, opts, build, plan_config):
     # hack for arm64 dtbs in subfolders
     if arch == 'arm64' and dtb:
         dtb = opts['dtb'] = os.path.basename(dtb)
+    if arch == 'riscv' and dtb:
+        dtb = opts['dtb'] = os.path.basename(dtb)
 
     file_server_resource = build.get('file_server_resource')
     if file_server_resource:

--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -439,6 +439,16 @@ device_types:
     class: arm64-dtb
     boot_method: uboot
 
+  hifive-unleashed-a00:
+    mach: sifive
+    class: riscv-dtb
+    boot_method: uboot
+    filters:
+    # no console in tinyconfig
+      - blacklist:
+          defconfig: ['tinyconfig']
+          kernel: ['v4.', 'v5.1', 'v5.2']
+
   hsdk:
     mach: arc
     class: arc-dtb
@@ -1263,6 +1273,11 @@ test_configs:
       - baseline
       - boot
       - boot-nfs
+
+  - device_type: hifive-unleashed-a00
+    test_plans:
+      - baseline
+      - boot
 
   - device_type: hsdk
     test_plans:


### PR DESCRIPTION
This patchs adds support for the RISCV architecture.
It adds the first boards using this arch, the hifive-unleashed-a00.

Support for LAVA is merged upstream:
https://git.lavasoftware.org/lava/lava/commit/1d5097e474fac155738994926395e27f22adfc99