### PR TITLE
build-configs.yaml: add sashal tree with stable-next branch

### DIFF
--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -100,6 +100,9 @@ trees:
   samsung:
     url: "https://git.kernel.org/pub/scm/linux/kernel/git/kgene/linux-samsung.git"
 
+  sashal:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/sashal/linux-stable.git"
+
   soc:
     url: "https://git.kernel.org/pub/scm/linux/kernel/git/soc/soc.git"
 
@@ -702,6 +705,11 @@ build_configs:
   samsung:
     tree: samsung
     branch: 'for-next'
+
+  sashal_stable-next:
+    tree: sashal
+    branch: 'stable-next'
+    variants: *stable_variants
 
 #  Disabled as the branch name contains a '/'.  See discussion here:
 #  https://github.com/kernelci/kernelci-core/issues/23

--- a/jenkins/kernel-arch-complete.sh
+++ b/jenkins/kernel-arch-complete.sh
@@ -218,6 +218,11 @@ if [[ BUILDS_FINISHED -eq 1 ]]; then
         echo "Sending results for vireshk's tree"
         curl -X POST -H "Authorization: $EMAIL_AUTH_TOKEN" -H "Content-Type: application/json" -d '{"job": "'$TREE_NAME'", "kernel": "'$GIT_DESCRIBE'", "git_branch": "'$BRANCH'", "build_report": 1, "format": ["txt"], "send_to": ["vireshk@kernel.org"], "delay": 60}' ${API}/send
         curl -X POST -H "Authorization: $EMAIL_AUTH_TOKEN" -H "Content-Type: application/json" -d '{"job": "'$TREE_NAME'", "kernel": "'$GIT_DESCRIBE'", "git_branch": "'$BRANCH'", "boot_report": 1, "format": ["txt"], "send_to": ["vireshk@kernel.org"], "delay": 2700}' ${API}/send
+    elif [ "$TREE_NAME" == "sashal" ]; then
+        echo "Sending results for sashal's tree"
+        curl -X POST -H "Authorization: $EMAIL_AUTH_TOKEN" -H "Content-Type: application/json" -d '{"job": "'$TREE_NAME'", "kernel": "'$GIT_DESCRIBE'", "git_branch": "'$BRANCH'", "build_report": 1, "format": ["txt"], "send_to": ["sashal@kernel.org", "kernel-build-reports@lists.linaro.org"], "delay": 60}' ${API}/send
+        curl -X POST -H "Authorization: $EMAIL_AUTH_TOKEN" -H "Content-Type: application/json" -d '{"job": "'$TREE_NAME'", "kernel": "'$GIT_DESCRIBE'", "git_branch": "'$BRANCH'", "boot_report": 1, "format": ["txt"], "send_to": ["sashal@kernel.org", "kernel-build-reports@lists.linaro.org"], "delay": 2700}' ${API}/send
+        curl -X POST -H "Authorization: $EMAIL_AUTH_TOKEN" -H "Content-Type: application/json" -d '{"job": "'$TREE_NAME'", "kernel": "'$GIT_DESCRIBE'", "git_branch": "'$BRANCH'",  "report_type": "test", "plan": "baseline", "send_to": ["sashal@kernel.org", "kernel-build-reports@lists.linaro.org"], "format": ["txt"], "delay": 2700}' ${API}/send
     elif [ "$TREE_NAME" == "kernelci" ]; then
         echo "Sending results to kernelci folks"
         curl -X POST -H "Authorization: $EMAIL_AUTH_TOKEN" -H "Content-Type: application/json" -d '{"job": "'$TREE_NAME'", "kernel": "'$GIT_DESCRIBE'", "git_branch": "'$BRANCH'", "build_report": 1, "format": ["txt"], "send_to": ["gtucker@collabora.com", "mgalka@collabora.com", "alexandra.pereira@collabora.com", "dan.rue@linaro.org", "matthew.hart@linaro.org", "broonie@kernel.org", "kernelci@baylibre.com", "anders.roxell@linaro.org"], "delay": 0}' ${API}/send


### PR DESCRIPTION
Add Sasha's tree "sashal" and the stable-next branch to build with the
same filters as stable branches.

Suggested-by: Sasha Levin <sashal@kernel.org>
Link: https://github.com/kernelci/kernelci-core/issues/191
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>