### PR TITLE
kernelci.config.test: fix TestConfig.match()

### DIFF
--- a/kernelci/config/test.py
+++ b/kernelci/config/test.py
@@ -393,10 +393,10 @@ class TestConfig(YAMLObject):
 
     def match(self, arch, flags, config, plan=None):
         return (
-            plan is None or (
+            (plan is None or (
                 plan in self._test_plans and
                 self._test_plans[plan].match(config)
-            ) and
+            )) and
             self.device_type.arch == arch and
             self.device_type.match(flags, config) and
             all(f.match(**config) for f in self._filters)


### PR DESCRIPTION
Fix the logic in TestConfig.match() with brackets around the condition
where there is no test plan defined.  The "and" operator takes
precedence over the "or" operator, leading to wrong results in the
corner case when the plan is None.

Fixes: b301fc1e1888 ("kernelci.config.test: optional plan name in TestConfig.match()")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>