### PR TITLE
test-configs.yaml: use boot_qemu for qemu_i386

### DIFF
--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -1554,7 +1554,7 @@ test_configs:
     test_plans:
       - baseline
       - baseline-uefi_i386
-      - boot
+      - boot_qemu
       - simple_qemu
 
   - device_type: qemu_x86_64


### PR DESCRIPTION
Use the boot_qemu test plan for qemu_i386, otherwise the generated job
doesn't boot on qemu.

Fixes: b2c29012079c ("test-configs.yaml: add qemu_i386 and clean up")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>