### PR TITLE
kernelci.build: set none defconfig when there is no defconfig

### DIFF
--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -616,6 +616,11 @@ def build_kernel(build_env, kdir, arch, defconfig=None, jopt=None,
             'defconfig': defconfig_target,
             'defconfig_full': '+'.join([defconfig_target] + fragments),
         })
+    else:
+        bmeta.update({
+            'defconfig': 'none',
+            'defconfig_full': 'none',
+        })
 
     vmlinux_file = os.path.join(output_path, 'vmlinux')
     if os.path.isfile(vmlinux_file):


### PR DESCRIPTION
When using the local .config file already present and no --defconfig
option is being used, set the defconfig name to "none" in the build
meta-data.  This should not happen with automated builds but can
happen with local builds with a .config manually created.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>