### PR TITLE
T16583 kci_test

### DIFF
--- a/jenkins/monitor.jpl
+++ b/jenkins/monitor.jpl
@@ -49,7 +49,7 @@ def checkConfig(config, kci_core, trees_dir) {
     def commit = sh(
         script: """
 ${kci_core}/kci_build \
---build-configs=${kci_core}/build-configs.yaml \
+--yaml-configs=${kci_core}/build-configs.yaml \
 check_new_commit \
 --config=${config} \
 --storage=${params.KCI_STORAGE_URL} \

--- a/kci_build
+++ b/kci_build
@@ -17,157 +17,11 @@
 # along with this library; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-import argparse
-import os
-import subprocess
 import sys
-import time
 
+from kernelci.cli import Args, Command, parse_args
 import kernelci.build
 import kernelci.config.build
-
-
-# -----------------------------------------------------------------------------
-# Standard arguments that can be used in sub-commands
-#
-
-class Args(object):
-    config= {
-        'name': '--config',
-        'help': "Build config name",
-    }
-
-    variant = {
-        'name': '--variant',
-        'help': "Build config variant name",
-    }
-
-    build_env = {
-        'name': '--build-env',
-        'help': "Build environment name",
-    }
-
-    storage = {
-        'name': '--storage',
-        'help': "Storage URL",
-        'default': "https://storage.kernelci.org",
-        'required': False,
-    }
-
-    api = {
-        'name': '--api',
-        'help': "Backend API URL",
-        'default': "https://api.kernelci.org",
-        'required': False,
-    }
-
-    token = {
-        'name': '--token',
-        'help': "Backend API token",
-    }
-
-    commit = {
-        'name': '--commit',
-        'help': "Git commit checksum",
-    }
-
-    describe = {
-        'name': '--describe',
-        'help': "Git describe",
-    }
-
-    describe_verbose = {
-        'name': '--describe-verbose',
-        'help': "Verbose version of git describe",
-    }
-
-    tree_name = {
-        'name': '--tree-name',
-        'help': "Name of a kernel tree",
-    }
-
-    tree_url = {
-        'name': '--tree-url',
-        'help': "URL of a kernel tree",
-    }
-
-    branch = {
-        'name': '--branch',
-        'help': "Name of a kernel branch in a tree",
-    }
-
-    mirror = {
-        'name': '--mirror',
-        'help': "Path to the local kernel git mirror",
-    }
-
-    kdir = {
-        'name': '--kdir',
-        'help': "Path to the kernel checkout directory",
-    }
-
-    arch = {
-        'name': '--arch',
-        'help': "CPU architecture name",
-    }
-
-    defconfig = {
-        'name': '--defconfig',
-        'help': "Kernel defconfig name",
-    }
-
-    j = {
-        'name': '-j',
-        'help': "Number of parallel build processes",
-    }
-
-    verbose = {
-        'name': '--verbose',
-        'help': "Verbose output",
-        'action': 'store_true',
-    }
-
-    output = {
-        'name': '--output',
-        'help': "Path the output directory",
-    }
-
-    json_path = {
-        'name': '--json-path',
-        'help': "Path to the JSON file",
-    }
-
-
-# -----------------------------------------------------------------------------
-# Commands
-#
-
-class Command(object):
-    help = None
-    args = None
-    opt_args = None
-
-    def __init__(self, sub_parser, name):
-        if not self.help:
-            raise AttributeError("Missing help message for {}".format(name))
-        self._parser = sub_parser.add_parser(name, help=self.help)
-        if self.args:
-            for arg in self.args:
-                self._add_arg(arg, True)
-        if self.opt_args:
-            for arg in self.opt_args:
-                self._add_arg(arg, False)
-        self._parser.set_defaults(func=self)
-
-    def __call__(self, *args, **kw):
-        raise NotImplementedError("Command not implemented")
-
-    def _add_arg(self, arg, required=True):
-        kw = dict(arg)
-        arg_name = kw.pop('name')
-        if required:
-            kw.setdefault('required', True)
-        self._parser.add_argument(arg_name, **kw)
 
 
 class cmd_list_configs(Command):
@@ -233,7 +87,6 @@ class cmd_update_repo(Command):
         conf = configs['build_configs'][args.config]
         kernelci.build.update_repo(conf, args.kdir, args.mirror)
         return True
-
 
 
 class cmd_describe(Command):
@@ -449,27 +302,9 @@ Invalid arguments, please provide at least one of these sets of options:
             args.kdir, api=args.api, token=args.token,
             json_path=args.json_path)
 
-# -----------------------------------------------------------------------------
-# Main
-#
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser("kci_build")
-    parser.add_argument("--build-configs", default="build-configs.yaml",
-                        help="Path to build configs file")
-    sub_parser = parser.add_subparsers(title="Commands",
-                                       help="List of available commands")
-
-    commands = dict()
-    for k in globals().keys():
-        split = k.split('cmd_')
-        if len(split) == 2:
-            obj = globals().get(k)
-            if issubclass(obj, Command):
-                cmd_name = split[1]
-                commands[cmd_name] = obj(sub_parser, cmd_name)
-
-    args = parser.parse_args()
-    configs = kernelci.config.build.from_yaml(args.build_configs)
+    args = parse_args("kci_build", "build-configs.yaml", globals())
+    configs = kernelci.config.build.from_yaml(args.yaml_configs)
     status = args.func(configs, args)
     sys.exit(0 if status is True else 1)

--- a/kci_test
+++ b/kci_test
@@ -1,0 +1,181 @@
+#!/usr/bin/env python
+#
+# Copyright (C) 2019 Collabora Limited
+# Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+#
+# This module is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+import argparse
+import glob
+import json
+import os
+import sys
+
+from kernelci.cli import Args, Command, parse_args
+import kernelci.config.lab
+import kernelci.config.test
+import kernelci.lab
+import kernelci.test
+
+
+# -----------------------------------------------------------------------------
+# Commands
+#
+
+class cmd_list_jobs(Command):
+    help = "List all the jobs that need to be run for a given build and lab"
+    args = [Args.bmeta_json, Args.dtbs_json, Args.lab, Args.user, Args.token]
+    opt_args = [Args.lab_json]
+
+    def __call__(self, test_configs, lab_configs, args):
+        with open(args.bmeta_json) as json_file:
+            bmeta = json.load(json_file)
+        with open(args.dtbs_json) as json_file:
+            dtbs = json.load(json_file)['dtbs']
+        lab = lab_configs['labs'][args.lab]
+        lab_api = kernelci.lab.get_api(lab, args.user, args.token)
+        if args.lab_json:
+            with open(args.lab_json) as json_file:
+                devices = json.load(json_file)['devices']
+                lab_api.import_devices(devices)
+        configs = kernelci.test.match_configs(
+            test_configs['test_configs'], bmeta, dtbs, lab)
+        for device_type, plan in configs:
+            if not lab_api.device_type_online(device_type):
+                continue
+            print(' '.join([device_type.name, plan.name]))
+        return True
+
+
+class cmd_list_plans(Command):
+    help = "List all the existing test plan names"
+
+    def __call__(self, test_configs, lab_configs, args):
+        plans = set(plan.name for plan in test_configs['test_plans'].values())
+        for plan in sorted(plans):
+            print(plan)
+        return True
+
+
+class cmd_list_labs(Command):
+    help = "List all the existing lab names"
+
+    def __call__(self, test_configs, lab_configs, args):
+        for lab in sorted(lab_configs['labs'].keys()):
+            print(lab)
+        return True
+
+
+class cmd_get_lab_info(Command):
+    help = "Get the information about a lab into a JSON file"
+    args = [Args.lab, Args.lab_json]
+    opt_args = [Args.user, Args.token]
+
+    def __call__(self, test_configs, lab_configs, args):
+        lab = lab_configs['labs'][args.lab]
+        lab_api = kernelci.lab.get_api(lab, args.user, args.token)
+        data = {
+            'lab': lab.name,
+            'lab_type': lab.lab_type,
+            'url': lab.url,
+            'devices': lab_api.devices,
+        }
+        with open(args.lab_json, 'w') as json_file:
+            json.dump(data, json_file, indent=4, sort_keys=True)
+        return True
+
+
+class cmd_generate(Command):
+    help = "Generate the job definition for a given target, plan and build"
+    args = [Args.bmeta_json, Args.plan, Args.target, Args.storage,
+            Args.lab, Args.user, Args.token]
+    opt_args = [Args.job_file, Args.output, Args.lab_json,
+                Args.callback_id, Args.callback_dataset,
+                Args.callback_type, Args.callback_url]
+
+    def __call__(self, test_configs, lab_configs, args):
+        with open(args.bmeta_json) as json_file:
+            bmeta = json.load(json_file)
+        lab = lab_configs['labs'][args.lab]
+        target = test_configs['device_types'][args.target]
+        plan = test_configs['test_plans'][args.plan]
+        if args.callback_id and not args.callback_url:
+            print("--callback-url is required with --callback-id")
+            return False
+        lab_api = kernelci.lab.get_api(lab, args.user, args.token)
+        if args.lab_json:
+            with open(args.lab_json) as json_file:
+                devices = json.load(json_file)['devices']
+                lab_api.import_devices(devices)
+
+        # ToDo: deal with a JSON file containing a list of builds to iterate
+        # over, such as the one produced by "kci_build publish" or saved as a
+        # result of a new command "kci_build get_meta" to download meta-data
+        # from the backend API.
+        params = kernelci.test.get_params(bmeta, target, plan, args.storage)
+        callback_opts = {
+            'id': args.callback_id,
+            'dataset': args.callback_dataset,
+            'type': args.callback_type,
+            'url': args.callback_url,
+        }
+        job = lab_api.generate(params, target, plan, callback_opts)
+        if args.output:
+            if not os.path.exists(args.output):
+                os.makedirs(args.output)
+            file_name = args.job_file or lab_api.job_file_name(params)
+            output_file = os.path.join(args.output, file_name)
+            print(output_file)
+            with open(output_file, 'wb') as output:
+                output.write(job)
+        else:
+            print(job)
+        return True
+
+
+class cmd_submit(Command):
+    help = "Submit job definitions to a lab"
+    args = [Args.lab, Args.user, Args.token, Args.jobs]
+
+    def __call__(self, test_configs, lab_configs, args):
+        lab = lab_configs['labs'][args.lab]
+        lab_api = kernelci.lab.get_api(lab, args.user, args.token)
+        job_paths = glob.glob(args.jobs)
+        for path in job_paths:
+            if not os.path.isfile(path):
+                continue
+            with open(path, 'rb') as job_file:
+                job = job_file.read()
+                job_id = lab_api.submit(job)
+                print("{} {}".format(job_id, path))
+        return True
+
+
+# -----------------------------------------------------------------------------
+# Main
+#
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser("kci_test")
+    parser.add_argument("--yaml-test-configs", default="test-configs.yaml",
+                        help="Path to the YAML test configs file")
+    parser.add_argument("--yaml-lab-configs", default="lab-configs.yaml",
+                        help="Path to the YAML lab configs file")
+    kernelci.cli.add_subparser(parser, globals())
+    args = parser.parse_args()
+    test_configs = kernelci.config.test.from_yaml(args.yaml_test_configs)
+    lab_configs = kernelci.config.lab.from_yaml(args.yaml_lab_configs)
+    status = args.func(test_configs, lab_configs, args)
+    sys.exit(0 if status is True else 1)

--- a/kernelci/cli.py
+++ b/kernelci/cli.py
@@ -52,9 +52,46 @@ class Args(object):
         'required': False,
     }
 
+    user = {
+        'name': '--user',
+        'help': "User name",
+    }
+
     token = {
         'name': '--token',
         'help': "Backend API token",
+    }
+
+    callback_id = {
+        'name': '--callback-id',
+        'help': "Callback identifier used to look up an authentication token",
+    }
+
+    callback_dataset = {
+        'name': '--callback-dataset',
+        'help': "Dataset to include in a lab callback",
+        'default': 'all',
+    }
+
+    callback_type = {
+        'name': '--callback-type',
+        'help': "Type of callback URL",
+        'default': 'kernelci',
+    }
+
+    callback_url = {
+        'name': '--callback-url',
+        'help': "Base URL for the callback",
+    }
+
+    job_file = {
+        'name': '--job-file',
+        'help': "Path where to write the job definition",
+    }
+
+    jobs = {
+        'name': '--jobs',
+        'help': "File pattern with jobs to submit",
     }
 
     commit = {
@@ -102,6 +139,31 @@ class Args(object):
         'help': "CPU architecture name",
     }
 
+    bmeta_json = {
+        'name': '--bmeta-json',
+        'help': "Path to the build.json file",
+    }
+
+    dtbs_json = {
+        'name': '--dtbs-json',
+        'help': "Path to the dtbs.json file",
+    }
+
+    lab_json = {
+        'name': '--lab-json',
+        'help': "Path to a JSON file with lab-specific info",
+    }
+
+    lab = {
+        'name': '--lab',
+        'help': "Name of a test lab",
+    }
+
+    target = {
+        'name': '--target',
+        'help': "Name of a target platform",
+    }
+
     defconfig = {
         'name': '--defconfig',
         'help': "Kernel defconfig name",
@@ -126,6 +188,11 @@ class Args(object):
     json_path = {
         'name': '--json-path',
         'help': "Path to the JSON file",
+    }
+
+    plan = {
+        'name': '--plan',
+        'help': "Test plan name",
     }
 
 

--- a/kernelci/cli.py
+++ b/kernelci/cli.py
@@ -1,0 +1,184 @@
+# Copyright (C) 2018, 2019 Collabora Limited
+# Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+#
+# This module is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+import argparse
+
+
+# -----------------------------------------------------------------------------
+# Standard arguments that can be used in sub-commands
+#
+
+class Args(object):
+    config = {
+        'name': '--config',
+        'help': "Build config name",
+    }
+
+    variant = {
+        'name': '--variant',
+        'help': "Build config variant name",
+    }
+
+    build_env = {
+        'name': '--build-env',
+        'help': "Build environment name",
+    }
+
+    storage = {
+        'name': '--storage',
+        'help': "Storage URL",
+        'default': "https://storage.kernelci.org",
+        'required': False,
+    }
+
+    api = {
+        'name': '--api',
+        'help': "Backend API URL",
+        'default': "https://api.kernelci.org",
+        'required': False,
+    }
+
+    token = {
+        'name': '--token',
+        'help': "Backend API token",
+    }
+
+    commit = {
+        'name': '--commit',
+        'help': "Git commit checksum",
+    }
+
+    describe = {
+        'name': '--describe',
+        'help': "Git describe",
+    }
+
+    describe_verbose = {
+        'name': '--describe-verbose',
+        'help': "Verbose version of git describe",
+    }
+
+    tree_name = {
+        'name': '--tree-name',
+        'help': "Name of a kernel tree",
+    }
+
+    tree_url = {
+        'name': '--tree-url',
+        'help': "URL of a kernel tree",
+    }
+
+    branch = {
+        'name': '--branch',
+        'help': "Name of a kernel branch in a tree",
+    }
+
+    mirror = {
+        'name': '--mirror',
+        'help': "Path to the local kernel git mirror",
+    }
+
+    kdir = {
+        'name': '--kdir',
+        'help': "Path to the kernel checkout directory",
+    }
+
+    arch = {
+        'name': '--arch',
+        'help': "CPU architecture name",
+    }
+
+    defconfig = {
+        'name': '--defconfig',
+        'help': "Kernel defconfig name",
+    }
+
+    j = {
+        'name': '-j',
+        'help': "Number of parallel build processes",
+    }
+
+    verbose = {
+        'name': '--verbose',
+        'help': "Verbose output",
+        'action': 'store_true',
+    }
+
+    output = {
+        'name': '--output',
+        'help': "Path the output directory",
+    }
+
+    json_path = {
+        'name': '--json-path',
+        'help': "Path to the JSON file",
+    }
+
+
+class Command(object):
+    help = None
+    args = None
+    opt_args = None
+
+    def __init__(self, sub_parser, name):
+        if not self.help:
+            raise AttributeError("Missing help message for {}".format(name))
+        self._parser = sub_parser.add_parser(name, help=self.help)
+        if self.args:
+            for arg in self.args:
+                self._add_arg(arg, True)
+        if self.opt_args:
+            for arg in self.opt_args:
+                self._add_arg(arg, False)
+        self._parser.set_defaults(func=self)
+
+    def __call__(self, *args, **kw):
+        raise NotImplementedError("Command not implemented")
+
+    def _add_arg(self, arg, required=True):
+        kw = dict(arg)
+        arg_name = kw.pop('name')
+        if required:
+            kw.setdefault('required', True)
+        self._parser.add_argument(arg_name, **kw)
+
+
+def make_parser(title, default_yaml):
+    parser = argparse.ArgumentParser(title)
+    parser.add_argument("--yaml-configs", default=default_yaml,
+                        help="Path to the YAML configs file")
+    return parser
+
+
+def add_subparser(parser, glob):
+    sub_parser = parser.add_subparsers(title="Commands",
+                                       help="List of available commands")
+    commands = dict()
+    for k in glob.keys():
+        split = k.split('cmd_')
+        if len(split) == 2:
+            obj = glob.get(k)
+            if issubclass(obj, Command):
+                cmd_name = split[1]
+                commands[cmd_name] = obj(sub_parser, cmd_name)
+
+
+def parse_args(title, default_yaml, glob):
+    parser = make_parser(title, default_yaml)
+    add_subparser(parser, glob)
+    args = parser.parse_args()
+    return args

--- a/kernelci/lab/__init__.py
+++ b/kernelci/lab/__init__.py
@@ -1,0 +1,74 @@
+# Copyright (C) 2019 Collabora Limited
+# Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+#
+# This module is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+import importlib
+import urlparse
+import xmlrpclib
+
+
+class LabAPI(object):
+
+    def __init__(self, config, user, token):
+        self._config = config
+        self._connect(user, token)
+        self._devices = None
+
+    @property
+    def config(self):
+        return self._config
+
+    @property
+    def devices(self):
+        if self._devices is None:
+            self._devices = self._get_devices()
+        return self._devices
+
+    def _connect(self, user=None, token=None):
+        if user and token:
+            url = urlparse.urlparse(self.config.url)
+            api_url = "{scheme}://{user}:{token}@{loc}{path}".format(
+                scheme=url.scheme, user=user, token=token,
+                loc=url.netloc, path=url.path)
+        else:
+            api_url = self.config.url
+        self._server = xmlrpclib.ServerProxy(api_url)
+
+    def _get_devices(self):
+        return list()
+
+    def import_devices(self, data):
+        self._devices = data
+
+    def device_type_online(self, device_type_name):
+        return True
+
+    def job_file_name(self, params):
+        return params['name']
+
+    def match(self, filter_data):
+        return self.config.match(filter_data)
+
+    def generate(self, params, target, plan, callback_opts):
+        raise NotImplementedError("Lab.generate() is required")
+
+    def submit(self, job):
+        raise NotImplementedError("Lab.submit() is required")
+
+
+def get_api(lab, user, token):
+    m = importlib.import_module('.'.join(['kernelci', 'lab', lab.lab_type]))
+    return m.get_api(lab, user, token)

--- a/kernelci/lab/lava.py
+++ b/kernelci/lab/lava.py
@@ -1,0 +1,137 @@
+# Copyright (C) 2019 Collabora Limited
+# Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+#
+# Copyright (C) 2019 Linaro Limited
+# Author: Dan Rue <dan.rue@linaro.org>
+#
+# This module is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+from jinja2 import Environment, FileSystemLoader
+import os
+from kernelci.lab import LabAPI
+
+DEVICE_ONLINE_STATUS = ['idle', 'running', 'reserved']
+
+
+def get_device_type_by_name(name, device_types, aliases=[]):
+    """
+        Return a device type named name. In the case of an alias, resolve the
+        alias to a device_type
+
+        Example:
+        IN:
+            name = "x15"
+            device_types = ['x15', 'beaglebone-black'],
+            aliases = [
+              {'name': 'x15', 'device_type': 'am57xx-beagle-x15'}
+            ]
+        OUT:
+            'am57xx-beagle-x15'
+
+    """
+    for device_type in device_types:
+        if device_type == name:
+            return device_type
+    for alias in aliases:
+        if alias["name"] == name:
+            for device_type in device_types:
+                if alias["device_type"] == device_type:
+                    return device_type
+    return None
+
+
+class LAVA(LabAPI):
+
+    def _get_aliases(self):
+        aliases = []
+        for alias in self._server.scheduler.aliases.list():
+            aliases.append(self._server.scheduler.aliases.show(alias))
+        return aliases
+
+    def _get_devices(self):
+        all_devices = self._server.scheduler.all_devices()
+        all_aliases = []
+        for alias in self._server.scheduler.aliases.list():
+            all_aliases.append(self._server.scheduler.aliases.show(alias))
+        device_types = {}
+        for device in all_devices:
+            name, device_type, status, _, _ = device
+            device_list = device_types.setdefault(device_type, list())
+            device_list.append({
+                'name': name,
+                'online': status in DEVICE_ONLINE_STATUS,
+            })
+        device_type_online = {
+            device_type: any(device['online'] for device in devices)
+            for device_type, devices in device_types.iteritems()
+        }
+        return {
+            'device_type_online': device_type_online,
+            'aliases': all_aliases,
+        }
+
+    def _add_callback_params(self, params, opts):
+        callback_id = opts.get('id')
+        if not callback_id:
+            return
+        callback_type = opts.get('type')
+        if callback_type == 'kernelci':
+            lava_cb = 'boot' if params['plan_name'] == 'boot' else 'test'
+            # ToDo: consolidate this to just have to pass the callback_url
+            params['callback_name'] = '/'.join(['lava', lava_cb])
+        params.update({
+            'callback': callback_id,
+            'callback_url': opts['url'],
+            'callback_dataset': opts['dataset'],
+            'callback_type': callback_type,
+        })
+
+    def device_type_online(self, device_type):
+        devices = self.devices['device_type_online']
+        device_type_name = get_device_type_by_name(
+            device_type.base_name, devices.keys(), self.devices['aliases'])
+        return self.devices['device_type_online'].get(device_type_name, False)
+
+    def job_file_name(self, params):
+        return '.'.join([params['name'], 'yaml'])
+
+    def generate(self, params, target, plan, callback_opts):
+        short_template_file = plan.get_template_path(target.boot_method)
+        template_file = os.path.join('templates', short_template_file)
+        if not os.path.exists(template_file):
+            print("Template not found: {}".format(template_file))
+            return None
+        devices = self.devices['device_type_online']
+        base_name = params['base_device_type']
+        params.update({
+            'template_file': template_file,
+            'priority': self.config.priority,
+            'lab_name': self.config.name,
+            'base_device_type': get_device_type_by_name(
+                base_name, devices.keys(), self.devices['aliases']),
+        })
+        self._add_callback_params(params, callback_opts)
+        jinja2_env = Environment(loader=FileSystemLoader('templates'),
+                                 extensions=["jinja2.ext.do"])
+        template = jinja2_env.get_template(short_template_file)
+        data = template.render(params)
+        return data
+
+    def submit(self, job):
+        return self._server.scheduler.submit_job(job)
+
+
+def get_api(lab, user, token):
+    return LAVA(lab, user, token)

--- a/kernelci/test.py
+++ b/kernelci/test.py
@@ -1,0 +1,126 @@
+# Copyright (C) 2019 Collabora Limited
+# Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+#
+# This module is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+import os
+import urlparse
+
+
+def match_configs(configs, bmeta, dtbs, lab):
+    defconfig = bmeta['defconfig_full']
+    arch = bmeta['arch']
+
+    filters = {
+        'arch': arch,
+        'defconfig': defconfig,
+        'kernel': bmeta['git_describe'],
+        'build_environment': bmeta['build_environment'],
+        'tree': bmeta['job'],
+    }
+
+    flags = {
+        'big_endian': 'BIG_ENDIAN' in defconfig,
+        'lpae': 'LPAE' in defconfig,
+    }
+
+    match = set()
+
+    for test_config in configs:
+        if not test_config.match(arch, flags, filters):
+            continue
+        dtb = test_config.device_type.dtb
+        if dtb and dtb not in dtbs:
+            continue
+        for plan_name, plan in test_config.test_plans.iteritems():
+            filters['plan'] = plan_name
+            if lab.match(filters):
+                match.add((test_config.device_type, plan))
+
+    return match
+
+
+def get_params(bmeta, target, plan_config, storage):
+    arch = target.arch
+    dtb = dtb_full = target.dtb
+    if arch == 'arm64' and dtb:
+        dtb = os.path.basename(dtb)  # hack for arm64 dtbs in subfolders
+    file_server_resource = bmeta['file_server_resource']
+    job_px = file_server_resource.replace('/', '-')
+    url_px = file_server_resource
+    job_name = '-'.join([job_px, dtb or 'no-dtb',
+                         target.name, plan_config.name])
+    base_url = urlparse.urljoin(storage, '/'.join([url_px, '']))
+    kernel_img = bmeta['kernel_image']
+    kernel_url = urlparse.urljoin(storage, '/'.join([url_px, kernel_img]))
+    if dtb_full and dtb_full.endswith('.dtb'):
+        dtb_url = urlparse.urljoin(
+            storage, '/'.join([url_px, 'dtbs', dtb_full]))
+        platform = dtb.split('.')[0]
+    else:
+        dtb_url = None
+        platform = target.name
+    modules = bmeta.get('modules')
+    modules_url = (
+        urlparse.urljoin(storage, '/'.join([url_px, modules]))
+        if modules else None
+    )
+    rootfs = plan_config.rootfs
+    defconfig = bmeta['defconfig']
+    defconfig_base = ''.join(defconfig.split('+')[:1])
+    endian = 'big' if 'BIG_ENDIAN' in defconfig else 'little'
+    describe = bmeta['git_describe']
+
+    params = {
+        'name': job_name,
+        'dtb_url': dtb_url,
+        'dtb_short': dtb,
+        'dtb_full': dtb_full,
+        'platform': platform,
+        'mach': target.mach,
+        'kernel_url': kernel_url,
+        'image_type': 'kernel-ci',
+        'image_url': base_url,
+        'modules_url': modules_url,
+        'plan': plan_config.base_name,
+        'plan_name': plan_config.base_name,
+        'kernel': describe,
+        'tree': bmeta['job'],
+        'defconfig': defconfig,
+        'arch_defconfig': '-'.join([arch, defconfig]),
+        'fastboot': str(target.get_flag('fastboot')).lower(),
+        'device_type': target.name,
+        'base_device_type': target.base_name,
+        'base_url': base_url,
+        'endian': endian,
+        'arch': arch,
+        'git_branch': bmeta['git_branch'],
+        'git_commit': bmeta['git_commit'],
+        'git_describe': describe,
+        'git_url': bmeta['git_url'],
+        'defconfig_base': defconfig_base,
+        'initrd_url': rootfs.get_url('ramdisk', arch, endian),
+        'kernel_image': kernel_img,
+        'nfsrootfs_url': rootfs.get_url('nfs', arch, endian),
+        'context': target.context,
+        'rootfs_prompt': rootfs.prompt,
+        'file_server_resource': file_server_resource,
+        'build_environment': bmeta['build_environment'],
+    }
+
+    params.update(plan_config.params)
+    params.update(target.params)
+
+    return params


### PR DESCRIPTION
Add a `kci_test` command line utility to generate and submit all the tests for a given kernel build.  It can talk to LAVA labs directly, but other types of labs can be added with extra Python modules implementing `kernelci.lab.LabAPI`.