### PR TITLE
kci_test: catch exception when failing to submit a job

### DIFF
--- a/kci_test
+++ b/kci_test
@@ -153,14 +153,19 @@ class cmd_submit(Command):
         lab = lab_configs['labs'][args.lab]
         lab_api = kernelci.lab.get_api(lab, args.user, args.token)
         job_paths = glob.glob(args.jobs)
+        res = True
         for path in job_paths:
             if not os.path.isfile(path):
                 continue
             with open(path, 'rb') as job_file:
                 job = job_file.read()
-                job_id = lab_api.submit(job)
-                print("{} {}".format(job_id, path))
-        return True
+                try:
+                    job_id = lab_api.submit(job)
+                    print("{} {}".format(job_id, path))
+                except Exception as e:
+                    print("ERROR {}: {}".format(path, e))
+                    res = False
+        return res
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
If a job fails to get submitted, print an error message and carry on
with the others.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>