### PR TITLE
baseline: set 1min timeout for each sub-test

### DIFF
--- a/templates/baseline/baseline.jinja2
+++ b/templates/baseline/baseline.jinja2
@@ -3,7 +3,7 @@
     namespace: {{ test_namespace }}
 {%- endif %}
     timeout:
-      minutes: 10
+      minutes: 1
     definitions:
     - repository:
         metadata:
@@ -42,7 +42,7 @@
     namespace: {{ test_namespace }}
 {%- endif %}
     timeout:
-      minutes: 10
+      minutes: 1
     definitions:
     - repository:
         metadata:


### PR DESCRIPTION
Baseline tests should be very quick, a few seconds at most.  Reduce
the timeout from 10min to 1min for both dmesg and bootrr tests to
avoid having failing jobs stuck for much longer than needed.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>