### PR TITLE
test-configs: Add more boards

### DIFF
--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -632,6 +632,13 @@ device_types:
     filters:
       - blacklist: {defconfig: ['allnoconfig', 'allmodconfig']}
 
+  meson-g12b-a311d-khadas-vim3:
+    mach: amlogic
+    class: arm64-dtb
+    boot_method: uboot
+    filters:
+      - blacklist: {defconfig: ['allnoconfig', 'allmodconfig']}
+
   meson-gxbb-nanopi-k2:
     mach: amlogic
     class: arm64-dtb
@@ -697,6 +704,14 @@ device_types:
       - blacklist: {defconfig: ['allnoconfig', 'allmodconfig']}
 
   meson-gxm-khadas-vim2:
+    mach: amlogic
+    class: arm64-dtb
+    boot_method: uboot
+    flags: ['big_endian']
+    filters:
+      - blacklist: {defconfig: ['allnoconfig', 'allmodconfig']}
+
+  meson-gxm-q200:
     mach: amlogic
     class: arm64-dtb
     boot_method: uboot
@@ -932,6 +947,11 @@ device_types:
       - blacklist: *allmodconfig_filter
       - blacklist: {defconfig: ['multi_v7_defconfig+CONFIG_SMP=n']}
 
+  sun4i-a10-olinuxino-lime:
+    mach: allwinner
+    class: arm-dtb
+    boot_method: uboot
+
   sun50i-a64-bananapi-m64:
     mach: allwinner
     class: arm64-dtb
@@ -971,6 +991,11 @@ device_types:
       - blacklist: {defconfig: ['multi_v7_defconfig+CONFIG_LKDTM=n']}
 
   sun7i-a20-cubieboard2:
+    mach: allwinner
+    class: arm-dtb
+    boot_method: uboot
+
+  sun7i-a20-olinuxino-lime2:
     mach: allwinner
     class: arm-dtb
     boot_method: uboot
@@ -1415,6 +1440,14 @@ test_configs:
       - boot
       - simple
 
+  - device_type: meson-g12b-a311d-khadas-vim3
+    test_plans:
+      - baseline
+      - boot
+      - boot-nfs
+      - kselftest
+      - simple
+
   - device_type: meson-gxbb-nanopi-k2
     test_plans:
       - baseline
@@ -1470,6 +1503,14 @@ test_configs:
       - simple
 
   - device_type: meson-gxm-khadas-vim2
+    test_plans:
+      - baseline
+      - boot
+      - boot-nfs
+      - kselftest
+      - simple
+
+  - device_type: meson-gxm-q200
     test_plans:
       - baseline
       - boot
@@ -1666,6 +1707,14 @@ test_configs:
       - boot-nfs
       - kselftest
 
+  - device_type: sun4i-a10-olinuxino-lime
+    test_plans:
+      - baseline
+      - boot
+      - boot-nfs
+      - kselftest
+      - simple
+
   - device_type: sun50i-a64-bananapi-m64
     test_plans:
       - baseline
@@ -1705,6 +1754,14 @@ test_configs:
     test_plans:
       - baseline
       - boot
+
+  - device_type: sun7i-a20-olinuxino-lime2
+    test_plans:
+      - baseline
+      - boot
+      - boot-nfs
+      - kselftest
+      - simple
 
   - device_type: sun8i-a23-evb
     test_plans:


### PR DESCRIPTION
This patch adds support for:
meson-g12b-a311d-khadas-vim3
meson-gxm-q200
sun4i-a10-olinuxino-lime
sun7i-a20-olinuxino-lime2
sun7i-a20-olinuxino-micro

LAVA commit for q200 and olinuxino-micro
https://git.lavasoftware.org/lava/lava/commit/175c2678a414fc71a9197f3b30503c5fd46b1b16
LAVA commit for limes
https://git.lavasoftware.org/lava/lava/commit/324746e822732258a62ee1bff25bf52b59b505d0
LAVA commit for vim3
https://git.lavasoftware.org/lava/lava/commit/45d2120e5a8ed534660cb1e3ffa21b79a604c0d3