### PR TITLE
test-configs.yaml: Add sleep to the test_plan for rk3399-gru-kevin

### DIFF
--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -1613,6 +1613,7 @@ test_configs:
       - baseline
       - boot
       - cros-ec
+      - sleep
       - v4l2-compliance-uvc
 
   - device_type: rk3399-gru-kevin


### PR DESCRIPTION
Suspend/resume on kevin should just work but, specially, after a merge
window, breaks. In order to catch such regressions soon, enable the sleep
test plan for this board.

Signed-off-by: Enric Balletbo i Serra <enric.balletbo@collabora.com>