### PR TITLE
lab-configs.yaml: add lab-clabbe tree whitelist

### DIFF
--- a/lab-configs.yaml
+++ b/lab-configs.yaml
@@ -24,6 +24,10 @@ labs:
             - boot-nfs
             - simple
             - sleep
+          tree:
+            - kernelci
+            - next
+            - stable-rc
 
   lab-collabora:
     lab_type: lava


### PR DESCRIPTION
Add missing tree whitelist filter for lab-clabbe.

Fixes: 893bea670a4e ("add lab-configs.yaml")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>