### PR TITLE
kernelci.test: add missing plan filter check in match_configs()

### DIFF
--- a/kernelci/config/test.py
+++ b/kernelci/config/test.py
@@ -360,8 +360,6 @@ class TestPlan(YAMLObject):
             plan=self.name)
 
     def match(self, config):
-        if self.name == 'boot':
-            return True
         return all(f.match(**config) for f in self._filters)
 
 

--- a/kernelci/test.py
+++ b/kernelci/test.py
@@ -45,6 +45,8 @@ def match_configs(configs, bmeta, dtbs, lab):
         if dtb and dtb not in dtbs:
             continue
         for plan_name, plan in test_config.test_plans.iteritems():
+            if not plan.match(filters):
+                continue
             filters['plan'] = plan_name
             if lab.match(filters):
                 match.add((test_config.device_type, plan))


### PR DESCRIPTION
Add missing call to TestPlan.match() for all the test plans in a test
config before adding it to the list of jobs to run.  This was causing
unwanted things such as v4l2-compliance-vivid being run on all kernel
builds rather than only those with +virtualvideo fragment.

Fixes: a1a08c3876cf ("add kernelci.test with functions to generate test jobs")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>