### PR TITLE
kernelci.config.build: Fix "variants" section reading from configuration

### DIFF
--- a/kernelci/config/build.py
+++ b/kernelci/config/build.py
@@ -318,7 +318,8 @@ class BuildConfig(YAMLObject):
         kw.update(cls._kw_from_yaml(
             config, ['name', 'tree', 'branch']))
         kw['tree'] = trees[kw['tree']]
-        config_variants = config.get('variants', defaults['variants'])
+        default_variants = defaults.get('variants', {})
+        config_variants = config.get('variants', default_variants)
         variants = [
             BuildVariant.from_yaml(variant, name, fragments, build_envs)
             for name, variant in config_variants.iteritems()


### PR DESCRIPTION
Lack of "build_configs_defaults" section or lack of "variants" section
within it caused KeyError during the build-configs.yaml parsing. This
fix provides appropriate default values in case these sections are
missing.

