### PR TITLE
lab-configs.yaml: blacklist android jobs in lab-collabora

### DIFF
--- a/lab-configs.yaml
+++ b/lab-configs.yaml
@@ -33,6 +33,7 @@ labs:
     lab_type: lava
     url: 'https://lava.collabora.co.uk/RPC2/'
     filters:
+      - blacklist: {tree: [android]}
       - whitelist:
           plan:
             - baseline

--- a/lab-configs.yaml
+++ b/lab-configs.yaml
@@ -38,11 +38,8 @@ labs:
           plan:
             - baseline
             - boot
-            - boot-nfs
             - cros-ec
             - igt-drm-kms
-            - kselftest
-            - simple
             - sleep
             - usb
             - v4l2-compliance-uvc


### PR DESCRIPTION
The android tree is causing a lot of builds from downstream kernel
branches.  As such, they are not part of the initial goal of
kernelci.org which is to test the upstream kernel.  The extra load
added to test labs is significant enough to justify blacklisting this
tree when needed.

For these reasons, blacklist the android tree in lab-collabora as it
is starting to hit the limit of the lab's capacity.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>