### PR TITLE
build-trigger.jpl: set special build job params allmodconfig

### DIFF
--- a/jenkins/build-trigger.jpl
+++ b/jenkins/build-trigger.jpl
@@ -215,6 +215,14 @@ def scheduleTests(build_job_name, build_job_number, labs, kci_core) {
 }
 
 def buildKernelStep(job, arch, defconfig, build_env, opts, labs, kci_core) {
+    def node_label = "builder"
+    def parallel_builds = "4"
+
+    if (defconfig.matches(".*allmodconfig.*")) {
+        node_label = "big-config-builder"
+        parallel_builds = ""
+    }
+
     def str_params = [
         'ARCH': arch,
         'DEFCONFIG': defconfig,
@@ -224,6 +232,8 @@ def buildKernelStep(job, arch, defconfig, build_env, opts, labs, kci_core) {
         'SRC_TARBALL': opts['tarball_url'],
         'BUILD_CONFIG': opts['config'],
         'BUILD_ENVIRONMENT': build_env,
+        'NODE_LABEL': node_label,
+        'PARALLEL_BUILDS': parallel_builds,
     ]
     def job_params = []
 

--- a/jenkins/build.jpl
+++ b/jenkins/build.jpl
@@ -38,6 +38,8 @@ COMMIT_ID
   Git commit SHA1 at the revision of the snapshot
 BUILD_ENVIRONMENT
   Name of the build environment
+NODE_LABEL
+  Label to use to choose a node on which to run this job
 PUBLISH (boolean)
   Publish build results via the KernelCI backend API
 EMAIL (boolean)
@@ -63,6 +65,8 @@ import org.kernelci.build.Kernel
 import org.kernelci.util.Job
 
 def buildConfig(kdir, kci_core) {
+    def jopt = ""
+
     if (params.PARALLEL_BUILDS)
         jopt = "-j${params.PARALLEL_BUILDS}"
 
@@ -114,7 +118,7 @@ publish_kernel \
     }
 }
 
-node("docker && builder") {
+node("docker" && params.NODE_LABEL) {
     def j = new Job()
     def k = new Kernel()
     def kci_core = "${env.WORKSPACE}/kernelci-core"


### PR DESCRIPTION
Add a NODE_LABEL parameter in build.jpl to dynamically pick a Jenkins
node on which to run the build.  Use this in build-trigger.jpl to
select a "big-config-builder" node with maximum number of parallel
build processes when the defconfig contains allmodconfig.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>