### PR TITLE
kernelci.config.build: make reference optional

### DIFF
--- a/kci_build
+++ b/kci_build
@@ -215,13 +215,13 @@ class cmd_get_reference(Command):
     args = [Args.tree_name, Args.branch]
 
     def __call__(self, configs, args):
-        for conf in (c for c in configs['build_configs'].itervalues()
-                     if c.tree.name == args.tree_name and
-                        c.branch == args.branch):
-            print(conf.reference.tree.url)
-            print(conf.reference.tree.name)
-            print(conf.reference.branch)
-            return True
+        for conf in configs['build_configs'].itervalues():
+            if conf.tree.name == args.tree_name and conf.branch == args.branch:
+                if conf.reference:
+                    print(conf.reference.tree.url)
+                    print(conf.reference.tree.name)
+                    print(conf.reference.branch)
+                    return True
         return False
 
 

--- a/kernelci/config/build.py
+++ b/kernelci/config/build.py
@@ -317,7 +317,7 @@ class BuildVariant(YAMLObject):
 class BuildConfig(YAMLObject):
     """Build configuration model."""
 
-    def __init__(self, name, tree, branch, variants, reference):
+    def __init__(self, name, tree, branch, variants, reference=None):
         """A build configuration defines the actual kernels to be built.
 
         *name* is the name of the build configuration.  It is arbitrary and
@@ -332,9 +332,10 @@ class BuildConfig(YAMLObject):
         *variants* is a list of BuildVariant objects, to define all the
                    variants to build for this tree / branch combination.
 
-        *reference* is a Reference object which defines the tree and branch
-                    for bisections when no base commit is found for
-                    the good and bad revisions.
+        *reference* is a Reference object which defines the tree and branch for
+                    bisections when no base commit is found for the good and
+                    bad revisions.  It can also be None if no reference branch
+                    can be used with this build configuration.
         """
         self._name = name
         self._tree = tree
@@ -357,8 +358,9 @@ class BuildConfig(YAMLObject):
             for name, variant in config_variants.iteritems()
         ]
         kw['variants'] = {v.name: v for v in variants}
-        reference = config.get('reference', defaults['reference'])
-        kw['reference'] = Reference.from_yaml(reference, trees)
+        reference = config.get('reference', defaults.get('reference'))
+        if reference:
+            kw['reference'] = Reference.from_yaml(reference, trees)
         return cls(**kw)
 
     @property


### PR DESCRIPTION
If for any reason no reference can be used with a build configuration,
and none is set either in the build configuration or in the defaults,
then set the reference to None.

Update kci_build accordingly to return False if there was no matchin
build configuration with a reference.

This also fixes the unit tests.

Fixes: 3b40138f4f4e ("kci_build: Add get_reference subcommand")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>