### PR TITLE
Creation of buster-xfstests rootfs

### DIFF
--- a/jenkins/buster-xfstests.jpl
+++ b/jenkins/buster-xfstests.jpl
@@ -1,0 +1,25 @@
+@Library('kernelci') _
+import org.kernelci.debian.RootFS
+
+/* ----------------------------------------------------------------------------
+ * Jenkins parameters
+
+DOCKER_BASE
+  Dockerhub base address used for the build images
+
+*/
+
+def r = new RootFS()
+
+def config = ['name':"buster-xfstests",
+              'arch_list':["amd64"],
+              'debian_release':"buster",
+              'extra_packages':"",
+              'extra_packages_remove':"",
+              'crush_image_options':"-s filesystem",
+              'multiple_partition':"yes",
+              'script':"scripts/buster-xfstests.sh",
+              'docker_image': "${params.DOCKER_BASE}debos",
+             ]
+
+r.buildImage(config)

--- a/jenkins/debian/debos/rootfs.yaml
+++ b/jenkins/debian/debos/rootfs.yaml
@@ -6,6 +6,8 @@
 {{- $test_overlay := .test_overlay -}}
 {{- $extra_packages_remove := or .extra_packages_remove -}}
 {{- $extra_files_remove := or .extra_files_remove -}}
+{{- $crush_image_options := or .crush_image_options " " -}}
+{{- $multiple_partition := or .multiple_partition -}}
 
 architecture: {{ $architecture }}
 
@@ -105,6 +107,29 @@ actions:
     chroot: false
     command: cd ${ROOTDIR} ; find -H  |  cpio -H newc -v -o | gzip -c - > ${ARTIFACTDIR}/{{ $basename -}}/full.rootfs.cpio.gz
 
+{{ if $multiple_partition }}
+  - action: image-partition
+    imagename: rootfs.ext4
+    imagesize: 15GB
+    partitiontype: msdos
+    mountpoints:
+      - mountpoint: /
+        partition: root
+    partitions:
+      - name: root
+        fs: ext4
+        start: 0%
+        end: 10%
+        flags: [ boot ]
+      - name: test
+        fs: ext4
+        start: 10%
+        end: 55%
+      - name: scratch
+        fs: ext4
+        start: 55%
+        end: 100%
+{{ else }}
   - action: image-partition
     imagename: rootfs.ext4
     imagesize: 1GB
@@ -118,6 +143,7 @@ actions:
         start: 0%
         end: 100%
         flags: [ boot ]
+{{ end }}
 
   - action: filesystem-deploy
     description: Deploying filesystem onto image
@@ -151,7 +177,7 @@ actions:
 
   - action: run
     chroot: true
-    script: scripts/crush.sh
+    script: scripts/crush.sh {{ $crush_image_options }}
 
 {{ if $extra_files_remove }}
   - action: run

--- a/jenkins/debian/debos/scripts/buster-xfstests.sh
+++ b/jenkins/debian/debos/scripts/buster-xfstests.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+#####################################################
+# This script create buster image for xfstests
+#####################################################
+
+set -e
+
+# Install required xfstests packages
+apt-get install --no-install-recommends xfslibs-dev uuid-dev libtool-bin \
+	        e2fsprogs automake gcc libuuid1 quota attr libattr1-dev make \
+	        libacl1-dev libaio-dev xfsprogs libgdbm-dev gawk fio dbench \
+	        uuid-runtime python sqlite3 git bc bsdmainutils acl -y
+
+apt-get install perl hostname net-tools -y
+
+# Clone repo
+git clone git://git.kernel.org/pub/scm/fs/xfs/xfstests-dev.git /xfstests
+
+# Setup xfstests accounts, directory
+useradd fsgqa -m
+useradd 123456-fsgqa
+
+mkdir /test /scratch
+
+# Setup default xfstests config 
+cat > /xfstests/local.config <<'EOF'
+export TEST_DEV=/dev/sda2
+export TEST_DIR=/test
+export SCRATCH_DEV=/dev/sda3
+export SCRATCH_MNT=/scratch
+#export SCRATCH_DEV_POOL="/dev/xvdc /dev/xvdd /dev/xvde /dev/xvdf /dev/xvdg"
+EOF
+
+# Build xfstests 
+cd /xfstests && make && make install


### PR DESCRIPTION
Modified rootfs.yaml to accept crush_image_options,multiple_partition as optional parameters.
Added xfstests rootfs build script and jpl template file.

Signed-off-by: Lakshmipathi.G <lakshmipathi.ganapathi@Collabora.com>