### PR TITLE
T17213 kernelci.test: add plan_variant job param and  meta-data

### DIFF
--- a/kernelci/lab/lava.py
+++ b/kernelci/lab/lava.py
@@ -88,7 +88,7 @@ class LAVA(LabAPI):
             return
         callback_type = opts.get('type')
         if callback_type == 'kernelci':
-            lava_cb = 'boot' if params['plan_name'] == 'boot' else 'test'
+            lava_cb = 'boot' if params['plan'] == 'boot' else 'test'
             # ToDo: consolidate this to just have to pass the callback_url
             params['callback_name'] = '/'.join(['lava', lava_cb])
         params.update({

--- a/kernelci/test.py
+++ b/kernelci/test.py
@@ -97,7 +97,7 @@ def get_params(bmeta, target, plan_config, storage):
         'image_url': base_url,
         'modules_url': modules_url,
         'plan': plan_config.base_name,
-        'plan_name': plan_config.base_name,
+        'plan_variant': plan_config.name,
         'kernel': describe,
         'tree': bmeta['job'],
         'defconfig': defconfig,

--- a/templates/base/kernel-ci-base.jinja2
+++ b/templates/base/kernel-ci-base.jinja2
@@ -16,6 +16,7 @@ metadata:
   platform.name: {{ platform }}
   platform.mach: {{ mach }}
   test.plan: {{ plan }}
+  test.plan_variant: {{ plan_variant }}
   git.commit: {{ git_commit }}
   git.describe: {{ git_describe }}
   git.branch: {{ git_branch }}


### PR DESCRIPTION
Add a job parameter "plan_variant" and use it in the base job template
as "test.plan_variant" meta-data.  This is to be able to trace the
test plan variant used when generating the job, e.g. when running
baseline on QEMU the test plan variant is baseline_qemu.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>