### PR TITLE
build-configs: Add 'allmodconfig' builds to Armv7's default configuation

### DIFF
--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -229,6 +229,7 @@ build_configs_defaults:
         arm: &arm_arch
           base_defconfig: 'multi_v7_defconfig'
           extra_configs:
+            - 'allmodconfig'
             - 'allnoconfig'
             - 'multi_v7_defconfig+CONFIG_CPU_BIG_ENDIAN=y'
             - 'multi_v7_defconfig+CONFIG_SMP=n'


### PR DESCRIPTION
There shouldn't be any reason to have 'allmodconfig' builds for Arm64 and
x86_64 and to leave Armv7 out of the equation.

Signed-off-by: Lee Jones <lee.jones@linaro.org>