### PR TITLE
T17441 recover git repo

### DIFF
--- a/jenkins/build-trigger.jpl
+++ b/jenkins/build-trigger.jpl
@@ -74,13 +74,23 @@ update_mirror \
 --mirror=${mirror} \
 """)
 
-        sh(script: """\
+        while (true) {
+            try {
+                sh(script: """\
 ./kci_build \
 update_repo \
 --config=${config} \
 --kdir=${kdir} \
 --mirror=${mirror} \
 """)
+                break
+            } catch (error) {
+                print("Failed to update repo: ${error}")
+                print("Removing clone and retrying")
+                sh(script: "rm -rf ${kdir}")
+                sleep 1
+            }
+        }
 
         def describe_raw = sh(script: """\
 ./kci_build \


### PR DESCRIPTION
Deal with failure to update a git repo in build-trigger.jpl by removing it and starting again.  Also improve error propagation in `kernelci.build`.