### PR TITLE
bisect.jpl: tweak email subject

### DIFF
--- a/jenkins/bisect.jpl
+++ b/jenkins/bisect.jpl
@@ -466,7 +466,9 @@ def bisectNext(kdir, status) {
  */
 
 def pushResults(kci_core, kdir, checks, params_summary) {
-    def subject = "${params.KERNEL_TREE}/${params.KERNEL_BRANCH} ${params.PLAN} bisection: ${params.KERNEL_NAME} on ${params.TARGET}"
+    def subject = "\
+${params.KERNEL_TREE}/${params.KERNEL_BRANCH} bisection: \
+${params.TEST_PLAN} on ${params.TARGET}"
 
     dir(kci_core) {
         withCredentials([string(credentialsId: params.KCI_TOKEN_ID,


### PR DESCRIPTION
Remove the git describe to shorten the email subject and move the test
plan name after "bisection:" in preparation for test case bisections.

For example, rather than:
```
broonie-sound/for-next boot bisection: v5.4-rc6-292-gc1efaea10be0 on sun8i-h3-libretech-all-h3-cc
```

we would now have:
```
broonie-sound/for-next bisection: boot on sun8i-h3-libretech-all-h3-cc
```

or potentially:
```
broonie-sound/for-next bisection: v4l2-compliance on sun8i-h3-libretech-all-h3-cc
```

The git describe string was also a bit misleading as it's the "bad"
kernel revision initially tested, not the one found by the bisection.

To better connect this report with the commit it has found, we should
make it reply to the original thread when the patch was submitted on a
mailing list.