### PR TITLE
T16848 build-trigger.jpl: build arm64 defconfig with medium-config-builder

### DIFF
--- a/jenkins/build-trigger.jpl
+++ b/jenkins/build-trigger.jpl
@@ -220,6 +220,9 @@ def buildKernelStep(job, arch, defconfig, build_env, opts, labs, kci_core) {
     if (defconfig.matches(".*allmodconfig.*")) {
         node_label = "big-config-builder"
         parallel_builds = ""
+    } else if (defconfig.matches("^defconfig.*") && arch == "arm64") {
+        node_label = "medium-config-builder"
+        parallel_builds = ""
     }
 
     def str_params = [


### PR DESCRIPTION
Now that allmodconfig is being built on large builders with the
big-config-builder label, the arm64 defconfig is clearly the one that
takes the longest to complete with the default "make -j4" approach.
This can take up to 45min.  For this kind of medium-sized builds, we
can have dedicated smaller builders to run say at -j8 or -j12 and keep
each individual build well under 30min.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>