### PR TITLE
debian: add new test rootfs with python for Chromebooks

### DIFF
--- a/jenkins/buster-cros-ec.jpl
+++ b/jenkins/buster-cros-ec.jpl
@@ -1,0 +1,24 @@
+@Library('kernelci') _
+import org.kernelci.debian.RootFS
+
+/* ----------------------------------------------------------------------------
+ * Jenkins parameters
+
+DOCKER_BASE
+  Dockerhub base address used for the build images
+
+*/
+
+def r = new RootFS()
+
+def config = ['name':"buster-cros-ec",
+              'arch_list':["armhf", "arm64", "amd64"],
+              'debian_release':"buster",
+              'extra_packages':"python3-minimal python3-unittest2 python3-numpy",
+              'extra_packages_remove':"",
+              'script':"",
+              'test_overlay': "",
+              'docker_image': "${params.DOCKER_BASE}debos",
+             ]
+
+r.buildImage(config)


### PR DESCRIPTION
This new rootfs contains the python packages required to run some
Chromebooks tests written in python. The tests are still under
developement so this doesn't contain the chromebooks test suite itself
but the rootfs can be used as a base for a job to run those tests.

Signed-off-by: Enric Balletbo i Serra <enric.balletbo@collabora.com>