### PR TITLE
kci_test: generate: support --mach

### DIFF
--- a/kci_test
+++ b/kci_test
@@ -103,7 +103,7 @@ class cmd_generate(Command):
     opt_args = [Args.plan, Args.target, Args.output,
                 Args.lab_json, Args.user, Args.token,
                 Args.callback_id, Args.callback_dataset,
-                Args.callback_type, Args.callback_url]
+                Args.callback_type, Args.callback_url, Args.mach]
 
     def __call__(self, test_configs, lab_configs, args):
         if args.callback_id and not args.callback_url:
@@ -132,6 +132,8 @@ class cmd_generate(Command):
                 if args.target and device_type.name != args.target:
                     continue
                 if args.plan and plan.name != args.plan:
+                    continue
+                if args.mach and device_type.mach != args.mach:
                     continue
                 jobs_list.append((device_type, plan))
 

--- a/kernelci/cli.py
+++ b/kernelci/cli.py
@@ -199,6 +199,11 @@ class Args(object):
         'help': "Test plan name",
     }
 
+    mach = {
+        'name': '--mach',
+        'help': "Mach name (aka SoC family)",
+    }
+
     url = {
         'name': '--url',
         'help': "Kernel sources download URL",


### PR DESCRIPTION
Add support for generating only jobs for a specific 'mach'.

This is useful for arch/platform/SoC maintainer trees where they are
primarily concerned with tests on a specific SoC family.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>