### PR TITLE
kci_build: install_kernel: add publish_path

### DIFF
--- a/kci_build
+++ b/kci_build
@@ -267,7 +267,7 @@ class cmd_install_kernel(Command):
     args = [Args.kdir]
     opt_args = [Args.config, Args.tree_name, Args.tree_url, Args.branch,
                 Args.commit, Args.describe, Args.describe_verbose,
-                Args.output]
+                Args.output, Args.publish_path]
 
     def __call__(self, configs, args):
         if args.config:
@@ -289,7 +289,7 @@ or
             return False
         return kernelci.build.install_kernel(
             args.kdir, tree_name, tree_url, branch, args.commit, args.describe,
-            args.describe_verbose, args.output)
+            args.describe_verbose, args.output, args.publish_path)
 
 
 class cmd_push_kernel(Command):

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -689,6 +689,7 @@ def build_kernel(build_env, kdir, arch, defconfig=None, jopt=None,
 
 def install_kernel(kdir, tree_name, tree_url, git_branch, git_commit=None,
                    describe=None, describe_v=None, output_path=None,
+                   publish_path=None,
                    install='_install_', mod_path='_modules_'):
     """Install the kernel binaries in a directory for a given built revision
 
@@ -794,9 +795,10 @@ def install_kernel(kdir, tree_name, tree_url, git_branch, git_commit=None,
     build_env = bmeta['build_environment']
     defconfig_full = bmeta['defconfig_full']
     defconfig_dir = defconfig_full.replace('/', '-')
-    publish_path = '/'.join([
-        tree_name, git_branch, describe, arch, defconfig_dir, build_env,
-    ])
+    if not publish_path:
+        publish_path = '/'.join([
+            tree_name, git_branch, describe, arch, defconfig_dir, build_env,
+        ])
 
     bmeta.update({
         'kconfig_fragments': 'frag.config' if os.path.exists(frags) else '',

--- a/kernelci/cli.py
+++ b/kernelci/cli.py
@@ -219,6 +219,11 @@ class Args(object):
         'type': int,
     }
 
+    publish_path = {
+        'name': '--publish-path',
+        'help': "Relative path where build artifacts are published",
+    }
+
 
 class Command(object):
     """A command helper class.


### PR DESCRIPTION
Add the ability to specify the 'publish_path' which is used
to set the 'file_server_resource' in the build metadata.

This feature is useful when using kci_build + kci_test without a
kernelci-backend, and where the build output is desired in a specific
place.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>