### PR TITLE
kci_test: get_lab_info: ensure dir exists

### DIFF
--- a/kci_test
+++ b/kci_test
@@ -92,6 +92,9 @@ class cmd_get_lab_info(Command):
             'url': lab.url,
             'devices': lab_api.devices,
         }
+        dir = os.path.dirname(args.lab_json)
+        if dir and not os.path.exists(dir):
+            os.makedirs(dir)
         with open(args.lab_json, 'w') as json_file:
             json.dump(data, json_file, indent=4, sort_keys=True)
         return True


### PR DESCRIPTION
When creating the lab-json file, make sure that any directory
components exist before creating the file.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>