### PR TITLE
test-configs: meson8b-odroidc1: use amlogic for mach

### DIFF
--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -598,7 +598,7 @@ device_types:
       - blacklist: {defconfig: ['allnoconfig', 'allmodconfig']}
 
   meson8b-odroidc1:
-    mach: meson
+    mach: amlogic
     class: arm-dtb
     boot_method: uboot
 


### PR DESCRIPTION
Convert the only 32-bit amlogic platform from mach=meson to
mach=amlogic to match the 64-bit platforms.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>