### PR TITLE
Use yaml safe_load insteald of load

### DIFF
--- a/kernelci/config/lab.py
+++ b/kernelci/config/lab.py
@@ -97,7 +97,7 @@ class LabFactory(YAMLObject):
 
 def from_yaml(yaml_path):
     with open(yaml_path) as f:
-        data = yaml.load(f)
+        data = yaml.safe_load(f)
 
     labs = {
         name: LabFactory.from_yaml(name, lab)


### PR DESCRIPTION
On my gentoo, using yaml.load now give:
Traceback (most recent call last):
raise RuntimeError("Unsafe load() call disabled by Gentoo. See bug #659348")
RuntimeError: Unsafe load() call disabled by Gentoo. See bug #659348
Note that on recent ubuntu, a warning appears also.
YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default
Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.

This is due to a security risk of using yaml.load()
Since kernelci-core does not rely on any behavour provided by load(), let's
convert the call to safe_load().