### PR TITLE
kernelci.build: fix git_describe_v in build meta-data

### DIFF
--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -810,7 +810,7 @@ def install_kernel(kdir, tree_name, tree_url, git_branch, git_commit=None,
         'git_url': tree_url,
         'git_branch': git_branch,
         'git_describe': describe,
-        'git_describe_verbose': describe_v,
+        'git_describe_v': describe_v,
         'git_commit': git_commit,
         'file_server_resource': publish_path,
     })


### PR DESCRIPTION
The git describe "verbose" attribute in the build meta-data should be
called git_describe_v rather than git_describe_verbose to match what
kernelci-backend is expecting.  Fix this so the git_describe_v gets
stored correctly in the build documents.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>