### PR TITLE
Convert all Python files to Python 3

### DIFF
--- a/jenkins/dockerfiles/build-base/Dockerfile
+++ b/jenkins/dockerfiles/build-base/Dockerfile
@@ -33,16 +33,11 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     wget \
     xz-utils
 
-# Python 2.7
+# Python 3.7
 RUN apt-get update && apt-get install --no-install-recommends -y \
-    python2.7 \
-    python-jinja2 \
-    python-keyring \
-    python-pyelftools \
-    python-requests \
-    python-yaml
-
-# Gradually moving everything to Python 3
-RUN apt-get update && apt-get install --no-install-recommends -y \
-    python3 \
+    python3.7 \
+    python3-jinja2 \
+    python3-keyring \
+    python3-pyelftools \
+    python3-requests \
     python3-yaml

--- a/jenkins/dockerfiles/debos/Dockerfile
+++ b/jenkins/dockerfiles/debos/Dockerfile
@@ -44,6 +44,6 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 
 # Extra packages needed by kernelCI
 RUN apt-get update && apt-get install --no-install-recommends -y \
-    python \
-    python-requests \
+    python3.7 \
+    python3-requests \
     xz-utils

--- a/kci_build
+++ b/kci_build
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright (C) 2018, 2019 Collabora Limited
 # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
@@ -28,7 +28,7 @@ class cmd_list_configs(Command):
     help = "List the build configurations"
 
     def __call__(self, configs, args):
-        for conf_name in configs['build_configs'].keys():
+        for conf_name in list(configs['build_configs'].keys()):
             print(conf_name)
         return True
 
@@ -215,7 +215,7 @@ class cmd_get_reference(Command):
     args = [Args.tree_name, Args.branch]
 
     def __call__(self, configs, args):
-        for conf in configs['build_configs'].itervalues():
+        for conf in configs['build_configs'].values():
             if conf.tree.name == args.tree_name and conf.branch == args.branch:
                 if conf.reference:
                     print(conf.reference.tree.url)

--- a/kci_test
+++ b/kci_test
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright (C) 2019 Collabora Limited
 # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
@@ -63,7 +63,8 @@ class cmd_list_plans(Command):
     help = "List all the existing test plan names"
 
     def __call__(self, test_configs, lab_configs, args):
-        plans = set(plan.name for plan in test_configs['test_plans'].values())
+        plans = set(plan.name
+                    for plan in list(test_configs['test_plans'].values()))
         for plan in sorted(plans):
             print(plan)
         return True

--- a/kci_test
+++ b/kci_test
@@ -156,7 +156,7 @@ class cmd_generate(Command):
                 file_name = api.job_file_name(params)
                 output_file = os.path.join(args.output, file_name)
                 print(output_file)
-                with open(output_file, 'wb') as output:
+                with open(output_file, 'w') as output:
                     output.write(job)
             else:
                 print("# Job: {}".format(params['name']))
@@ -176,7 +176,7 @@ class cmd_submit(Command):
         for path in job_paths:
             if not os.path.isfile(path):
                 continue
-            with open(path, 'rb') as job_file:
+            with open(path, 'r') as job_file:
                 job = job_file.read()
                 try:
                     job_id = lab_api.submit(job)

--- a/kernelci/__init__.py
+++ b/kernelci/__init__.py
@@ -22,4 +22,4 @@ def shell_cmd(cmd, ret_code=False):
     if ret_code:
         return False if subprocess.call(cmd, shell=True) else True
     else:
-        return subprocess.check_output(cmd, shell=True)
+        return subprocess.check_output(cmd, shell=True).decode()

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -26,7 +26,7 @@ import stat
 import tarfile
 import tempfile
 import time
-import urlparse
+import urllib.parse
 
 from kernelci import shell_cmd
 import kernelci.elf
@@ -68,9 +68,9 @@ def _upload_files(api, token, path, input_files):
     }
     files = {
         'file{}'.format(i): (name, fobj)
-        for i, (name, fobj) in enumerate(input_files.iteritems())
+        for i, (name, fobj) in enumerate(input_files.items())
     }
-    url = urlparse.urljoin(api, 'upload')
+    url = urllib.parse.urljoin(api, 'upload')
     resp = requests.post(url, headers=headers, data=data, files=files)
     resp.raise_for_status()
 
@@ -451,7 +451,7 @@ def _run_make(kdir, arch, target=None, jopt=None, silent=True, cc='gcc',
     args = ['make']
 
     if opts:
-        args += ['='.join([k, v]) for k, v in opts.iteritems()]
+        args += ['='.join([k, v]) for k, v in opts.items()]
 
     args += ['-C{}'.format(kdir)]
 
@@ -901,12 +901,12 @@ def publish_kernel(kdir, install='_install_', api=None, token=None,
             'build_environment': 'build_environment',
             'defconfig': 'defconfig',
             'defconfig_full': 'defconfig_full',
-        }.iteritems()}
+        }.items()}
         headers = {
             'Authorization': token,
             'Content-Type': 'application/json',
         }
-        url = urlparse.urljoin(api, '/build')
+        url = urllib.parse.urljoin(api, '/build')
         data_json = json.dumps(data)
         resp = requests.post(url, headers=headers, data=data_json)
         resp.raise_for_status()

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -292,7 +292,7 @@ def make_tarball(kdir, tarball_name):
     cwd = os.getcwd()
     os.chdir(kdir)
     _, dirs, files = next(os.walk('.'))
-    with tarfile.open(os.path.join(cwd, tarball_name), "w:gz") as tarball:
+    with tarfile.open(os.path.join(cwd, tarball_name), 'w:gz') as tarball:
         for item in itertools.chain(dirs, files):
             tarball.add(item, filter=lambda f: f if f.name != '.git' else None)
     os.chdir(cwd)
@@ -348,7 +348,7 @@ def push_tarball(config, kdir, storage, api, token):
     tarball = "{}.tar.gz".format(config.name)
     make_tarball(kdir, tarball)
     path = '/'.join([config.tree.name, config.branch, describe]),
-    _upload_files(api, token, path, {tarball_name: open(tarball)})
+    _upload_files(api, token, path, {tarball_name: open(tarball, 'rb')})
     os.unlink(tarball)
     return tarball_url
 
@@ -844,7 +844,7 @@ def push_kernel(kdir, api, token, install='_install_'):
     for root, _, files in os.walk(install_path):
         for f in files:
             px = os.path.relpath(root, install_path)
-            artifacts[os.path.join(px, f)] = open(os.path.join(root, f))
+            artifacts[os.path.join(px, f)] = open(os.path.join(root, f), "rb")
     upload_path = bmeta['file_server_resource']
     print("Upload path: {}".format(upload_path))
     _upload_files(api, token, upload_path, artifacts)

--- a/kernelci/cli.py
+++ b/kernelci/cli.py
@@ -292,7 +292,7 @@ def add_subparser(parser, glob):
     sub_parser = parser.add_subparsers(title="Commands",
                                        help="List of available commands")
     commands = dict()
-    for k in glob.keys():
+    for k in list(glob.keys()):
         split = k.split('cmd_')
         if len(split) == 2:
             obj = glob.get(k)

--- a/kernelci/config/__init__.py
+++ b/kernelci/config/__init__.py
@@ -63,7 +63,7 @@ class Blacklist(Filter):
     """
 
     def match(self, **kw):
-        for k, v in kw.iteritems():
+        for k, v in kw.items():
             bl = self._items.get(k)
             if not bl:
                 continue
@@ -82,7 +82,7 @@ class Whitelist(Filter):
     """
 
     def match(self, **kw):
-        for k, wl in self._items.iteritems():
+        for k, wl in self._items.items():
             v = kw.get(k)
             if not v:
                 return False
@@ -103,10 +103,10 @@ class Regex(Filter):
 
     def __init__(self, *args, **kw):
         super(Regex, self).__init__(*args, **kw)
-        self._re_items = {k: re.compile(v) for k, v in self._items.iteritems()}
+        self._re_items = {k: re.compile(v) for k, v in self._items.items()}
 
     def match(self, **kw):
-        for k, r in self._re_items.iteritems():
+        for k, r in self._re_items.items():
             v = kw.get(k)
             return v and r.match(v)
 
@@ -145,7 +145,7 @@ class FilterFactory(YAMLObject):
         """Iterate through the YAML filters and return Filter objects."""
         filter_list = []
         for f in filter_params:
-            for filter_type, items in f.iteritems():
+            for filter_type, items in f.items():
                 filter_cls = cls._classes[filter_type]
                 filter_list.append(filter_cls(items))
         return filter_list

--- a/kernelci/config/build.py
+++ b/kernelci/config/build.py
@@ -284,7 +284,7 @@ class BuildVariant(YAMLObject):
         kw['build_environment'] = build_environments[kw['build_environment']]
         kw['architectures'] = list(
             Architecture.from_yaml(data or {}, name, fragments)
-            for name, data in config['architectures'].iteritems()
+            for name, data in config['architectures'].items()
         )
         cf = kw.get('fragments')
         kw['fragments'] = [fragments[name] for name in cf] if cf else None
@@ -296,7 +296,7 @@ class BuildVariant(YAMLObject):
 
     @property
     def arch_list(self):
-        return self._architectures.keys()
+        return list(self._architectures.keys())
 
     @property
     def architectures(self):
@@ -355,7 +355,7 @@ class BuildConfig(YAMLObject):
         config_variants = config.get('variants', default_variants)
         variants = [
             BuildVariant.from_yaml(variant, name, fragments, build_envs)
-            for name, variant in config_variants.iteritems()
+            for name, variant in config_variants.items()
         ]
         kw['variants'] = {v.name: v for v in variants}
         reference = config.get('reference', defaults.get('reference'))
@@ -393,17 +393,17 @@ def from_yaml(yaml_path):
 
     trees = {
         name: Tree.from_yaml(config, name)
-        for name, config in data['trees'].iteritems()
+        for name, config in data['trees'].items()
     }
 
     fragments = {
         name: Fragment.from_yaml(config, name)
-        for name, config in data.get('fragments', {}).iteritems()
+        for name, config in data.get('fragments', {}).items()
     }
 
     build_environments = {
         name: BuildEnvironment.from_yaml(config, name)
-        for name, config in data['build_environments'].iteritems()
+        for name, config in data['build_environments'].items()
     }
 
     defaults = data.get('build_configs_defaults', {})
@@ -411,7 +411,7 @@ def from_yaml(yaml_path):
     build_configs = {
         name: BuildConfig.from_yaml(config, name, trees, fragments,
                                     build_environments, defaults)
-        for name, config in data['build_configs'].iteritems()
+        for name, config in data['build_configs'].items()
     }
 
     config_data = {

--- a/kernelci/config/lab.py
+++ b/kernelci/config/lab.py
@@ -101,7 +101,7 @@ def from_yaml(yaml_path):
 
     labs = {
         name: LabFactory.from_yaml(name, lab)
-        for name, lab in data['labs'].iteritems()
+        for name, lab in data['labs'].items()
     }
 
     config_data = {

--- a/kernelci/config/test.py
+++ b/kernelci/config/test.py
@@ -91,7 +91,7 @@ class DeviceType(YAMLObject):
     def match(self, flags, config):
         """Checks if the given *flags* and *config* match this device type."""
         return (
-            all(not v or self.get_flag(k) for k, v in flags.iteritems()) and
+            all(not v or self.get_flag(k) for k, v in flags.items()) and
             all(f.match(**config) for f in self._filters)
         )
 
@@ -189,9 +189,9 @@ class RootFSType(YAMLObject):
         arch_map = fs_type.get('arch_map')
         if arch_map:
             arch_dict = {}
-            for arch_name, arch_dicts in arch_map.iteritems():
+            for arch_name, arch_dicts in arch_map.items():
                 for d in arch_dicts:
-                    key = tuple((k, v) for (k, v) in d.iteritems())
+                    key = tuple((k, v) for (k, v) in d.items())
                     arch_dict[key] = arch_name
             kw['arch_dict'] = arch_dict
         return cls(**kw)
@@ -234,7 +234,7 @@ class RootFS(YAMLObject):
         """
         self._url_format = url_formats
         self._fs_type = fs_type
-        self._root_type = root_type or url_formats.keys()[0]
+        self._root_type = root_type or list(url_formats.keys())[0]
         self._boot_protocol = boot_protocol
         self._prompt = prompt
         self._arch_dict = {}
@@ -421,26 +421,26 @@ def from_yaml(yaml_path):
 
     fs_types = {
         name: RootFSType.from_yaml(fs_type)
-        for name, fs_type in data['file_system_types'].iteritems()
+        for name, fs_type in data['file_system_types'].items()
     }
 
     file_systems = {
         name: RootFS.from_yaml(fs_types, rootfs)
-        for name, rootfs in data['file_systems'].iteritems()
+        for name, rootfs in data['file_systems'].items()
     }
 
     plan_filters = FilterFactory.from_yaml(data['test_plan_default_filters'])
 
     test_plans = {
         name: TestPlan.from_yaml(name, test_plan, file_systems, plan_filters)
-        for name, test_plan in data['test_plans'].iteritems()
+        for name, test_plan in data['test_plans'].items()
     }
 
     device_filters = FilterFactory.from_yaml(data['device_default_filters'])
 
     device_types = {
         name: DeviceTypeFactory.from_yaml(name, device_type, device_filters)
-        for name, device_type in data['device_types'].iteritems()
+        for name, device_type in data['device_types'].items()
     }
 
     test_configs = [

--- a/kernelci/lab/__init__.py
+++ b/kernelci/lab/__init__.py
@@ -17,8 +17,8 @@
 
 import importlib
 import json
-import urlparse
-import xmlrpclib
+import urllib.parse
+import xmlrpc.client
 
 
 class LabAPI(object):
@@ -53,13 +53,13 @@ class LabAPI(object):
         *token* is the token associated with the user to connect to the lab
         """
         if user and token:
-            url = urlparse.urlparse(self.config.url)
+            url = urllib.parse.urlparse(self.config.url)
             api_url = "{scheme}://{user}:{token}@{loc}{path}".format(
                 scheme=url.scheme, user=user, token=token,
                 loc=url.netloc, path=url.path)
         else:
             api_url = self.config.url
-        self._server = xmlrpclib.ServerProxy(api_url)
+        self._server = xmlrpc.client.ServerProxy(api_url)
 
     def import_devices(self, data):
         self._devices = data

--- a/kernelci/lab/lava.py
+++ b/kernelci/lab/lava.py
@@ -83,7 +83,7 @@ class LAVA(LabAPI):
             })
         device_type_online = {
             device_type: any(device['online'] for device in devices)
-            for device_type, devices in device_types.iteritems()
+            for device_type, devices in device_types.items()
         }
         return {
             'device_type_online': device_type_online,
@@ -109,7 +109,8 @@ class LAVA(LabAPI):
     def device_type_online(self, device_type):
         devices = self.devices['device_type_online']
         device_type_name = get_device_type_by_name(
-            device_type.base_name, devices.keys(), self.devices['aliases'])
+            device_type.base_name, list(devices.keys()),
+            self.devices['aliases'])
         return self.devices['device_type_online'].get(device_type_name, False)
 
     def job_file_name(self, params):
@@ -128,7 +129,7 @@ class LAVA(LabAPI):
             'priority': self.config.priority,
             'lab_name': self.config.name,
             'base_device_type': get_device_type_by_name(
-                base_name, devices.keys(), self.devices['aliases']),
+                base_name, list(devices.keys()), self.devices['aliases']),
         })
         self._add_callback_params(params, callback_opts)
         jinja2_env = Environment(loader=FileSystemLoader('templates'),

--- a/kernelci/test.py
+++ b/kernelci/test.py
@@ -16,7 +16,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 import os
-import urlparse
+import urllib.parse
 
 
 def match_configs(configs, bmeta, dtbs, lab):
@@ -54,7 +54,7 @@ def match_configs(configs, bmeta, dtbs, lab):
         dtb = test_config.device_type.dtb
         if dtb and dtb not in dtbs:
             continue
-        for plan_name, plan in test_config.test_plans.iteritems():
+        for plan_name, plan in test_config.test_plans.items():
             if not plan.match(filters):
                 continue
             filters['plan'] = plan_name
@@ -81,11 +81,11 @@ def get_params(bmeta, target, plan_config, storage):
     url_px = file_server_resource
     job_name = '-'.join([job_px, dtb or 'no-dtb',
                          target.name, plan_config.name])
-    base_url = urlparse.urljoin(storage, '/'.join([url_px, '']))
+    base_url = urllib.parse.urljoin(storage, '/'.join([url_px, '']))
     kernel_img = bmeta['kernel_image']
-    kernel_url = urlparse.urljoin(storage, '/'.join([url_px, kernel_img]))
+    kernel_url = urllib.parse.urljoin(storage, '/'.join([url_px, kernel_img]))
     if dtb_full and dtb_full.endswith('.dtb'):
-        dtb_url = urlparse.urljoin(
+        dtb_url = urllib.parse.urljoin(
             storage, '/'.join([url_px, 'dtbs', dtb_full]))
         platform = dtb.split('.')[0]
     else:
@@ -93,7 +93,7 @@ def get_params(bmeta, target, plan_config, storage):
         platform = target.name
     modules = bmeta.get('modules')
     modules_url = (
-        urlparse.urljoin(storage, '/'.join([url_px, modules]))
+        urllib.parse.urljoin(storage, '/'.join([url_px, modules]))
         if modules else None
     )
     rootfs = plan_config.rootfs

--- a/push-bisection-results.py
+++ b/push-bisection-results.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (C) 2018, 2019 Collabora Limited
 # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
@@ -23,10 +23,10 @@ import re
 import requests
 import subprocess
 try:
-    from cStringIO import StringIO
+    from io import StringIO
 except ImportError:
-    from StringIO import StringIO
-import urlparse
+    from io import StringIO
+import urllib.parse
 
 RE_ADDR = r'.*@.*\.[a-z]+'
 RE_TRAILER = re.compile(r'^(?P<tag>[A-Z][a-z-]*)\: (?P<value>.*)$')
@@ -120,7 +120,7 @@ def add_git_recipients(kdir, revision, to, cc):
     }
     people = git_people(kdir, revision)
 
-    for category, entries in people.iteritems():
+    for category, entries in people.items():
         recip = recipients_map[category]
         for e in entries:
             recip.add(e)
@@ -148,7 +148,7 @@ def upload_log(args, upload_path, log_file_name, token, api):
     files = {
         ('file1', (log_file_name, StringIO(json.dumps(log_data, indent=4)))),
     }
-    url = urlparse.urljoin(api, '/upload')
+    url = urllib.parse.urljoin(api, '/upload')
     response = requests.post(url, headers=headers, data=data, files=files)
     response.raise_for_status()
 
@@ -171,7 +171,7 @@ def send_result(args, log_file_name, token, api):
         'good_commit': 'good',
         'bad_commit': 'bad',
     }
-    data = {k: getattr(args, v) for k, v in data_map.iteritems()}
+    data = {k: getattr(args, v) for k, v in data_map.items()}
     kdir = args.kdir
     data.update({
         'log': log_file_name,
@@ -180,7 +180,7 @@ def send_result(args, log_file_name, token, api):
         'found_summary': git_summary(kdir, 'refs/bisect/bad'),
         'checks': checks_dict(args),
     })
-    url = urlparse.urljoin(api, '/bisect')
+    url = urllib.parse.urljoin(api, '/bisect')
     response = requests.post(url, headers=headers, data=json.dumps(data))
     response.raise_for_status()
 
@@ -206,9 +206,9 @@ def send_report(args, log_file_name, token, api):
         'subject': 'subject',
     }
 
-    data = {k: getattr(args, v) for k, v in data_map.iteritems()}
+    data = {k: getattr(args, v) for k, v in data_map.items()}
     to, cc = set(args.to.split(' ')), set()
-    if all(check == 'PASS' for check in checks_dict(args).values()):
+    if all(check == 'PASS' for check in list(checks_dict(args).values())):
         add_git_recipients(kdir, 'refs/bisect/bad', to, cc)
     cc = cc.difference(to)
     data.update({
@@ -220,7 +220,7 @@ def send_report(args, log_file_name, token, api):
         'delay': '60',
     })
 
-    url = urlparse.urljoin(api, '/send')
+    url = urllib.parse.urljoin(api, '/send')
     response = requests.post(url, headers=headers, data=json.dumps(data))
     response.raise_for_status()
 

--- a/push-source.py
+++ b/push-source.py
@@ -3,6 +3,9 @@
 # Copyright (C) 2017 Linaro Limited
 # Author: Matt Hart <matthew.hart@linaro.org>
 #
+# Copyright (C) 2019 Collabora Limited
+# Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+#
 # This module is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
 # Software Foundation; either version 2.1 of the License, or (at your option)
@@ -20,7 +23,7 @@
 import os
 import argparse
 import requests
-from urlparse import urljoin
+from urllib.parse import urljoin
 import time
 
 def do_post_retry(url=None, data=None, headers=None, files=None):
@@ -35,11 +38,11 @@ def do_post_retry(url=None, data=None, headers=None, files=None):
                 return response.content
                 retry = False
         except Exception as e:
-            print "ERROR: failed to publish"
-            print e
+            print("ERROR: failed to publish")
+            print(e)
             count = count - 1
             time.sleep(10)
-    print "Failed to push file"
+    print("Failed to push file")
     exit(1)
 
 parser = argparse.ArgumentParser()
@@ -72,7 +75,7 @@ filenames = args.get('file')
 for f in filenames:
     artifacts.append(('file%d' % file_count,(f, open(f), 'rb')))
     file_count += 1
-    
+
 upload_url = urljoin(args.get('api'), '/upload')
 print("pushing %s to %s/%s" % (filenames, upload_url, publish_path))
 publish_response = do_post_retry(url=upload_url, data=build_data, headers=headers, files=artifacts)


### PR DESCRIPTION
Convert all the kci_* utilities, the kernelci package and other
scripts to Python 3.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>