### PR TITLE
Separate job name from job filename

### DIFF
--- a/kernelci/lab/lava.py
+++ b/kernelci/lab/lava.py
@@ -113,7 +113,7 @@ class LAVA(LabAPI):
         return self.devices['device_type_online'].get(device_type_name, False)
 
     def job_file_name(self, params):
-        return '.'.join([params['name'], 'yaml'])
+        return '.'.join([params['filename'], 'yaml'])
 
     def generate(self, params, target, plan, callback_opts):
         short_template_file = plan.get_template_path(target.boot_method)

--- a/kernelci/test.py
+++ b/kernelci/test.py
@@ -79,8 +79,11 @@ def get_params(bmeta, target, plan_config, storage):
     file_server_resource = bmeta['file_server_resource']
     job_px = file_server_resource.replace('/', '-')
     url_px = file_server_resource
-    job_name = '-'.join([job_px, dtb or 'no-dtb',
-                         target.name, plan_config.name])
+    job_name = '-'.join([job_px, target.name, plan_config.name])
+    if len(job_name) > 200:
+        job_name = '{}...'.format(job_name[:197])
+    job_filename = '-'.join([job_px, dtb or 'no-dtb',
+                             target.name, plan_config.name])
     base_url = urlparse.urljoin(storage, '/'.join([url_px, '']))
     kernel_img = bmeta['kernel_image']
     kernel_url = urlparse.urljoin(storage, '/'.join([url_px, kernel_img]))
@@ -104,6 +107,7 @@ def get_params(bmeta, target, plan_config, storage):
 
     params = {
         'name': job_name,
+        'filename': job_filename,
         'dtb_url': dtb_url,
         'dtb_short': dtb,
         'dtb_full': dtb_full,


### PR DESCRIPTION
    This commit adds filename parameter that'll be used as a name of the
    LAVA job file. Dtb information has been removed from the job name
    and it's length has been reduced to 200 characters. It's meant to fix
    an issue with job names longer than 200 characters.
