### PR TITLE
build-configs: android updates

### DIFF
--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -421,9 +421,9 @@ build_configs:
     tree: android
     branch: 'android-4.14-q-release'
 
-  android_4.14-r:
+  android_4.14:
     tree: android
-    branch: 'android-4.14-r'
+    branch: 'android-4.14'
 
   android_4.19-q:
     tree: android
@@ -433,9 +433,9 @@ build_configs:
     tree: android
     branch: 'android-4.19-q-release'
 
-  android_4.19-r:
+  android_4.19:
     tree: android
-    branch: 'android-4.19-r'
+    branch: 'android-4.19'
 
   android_mainline:
     tree: android


### PR DESCRIPTION
Todd Kjos <tkjos@google.com> writes:

> ... please undo my previous request to enable testing on "-r"
> branches
>
> Specifically:
>
> repo: https://android.googlesource.com/kernel/common
>
> 1) android-4.14 will live on and android-4.14-r won't
>
> delete: android-4.14-r
> add: android-4.14
>
> 2) android-4.19 will live on and android-4.19-r won't
>
> delete: android-4.19-r
> add: android-4.19

Signed-off-by: Kevin Hilman <khilman@baylibre.com>