### PR TITLE
lab/lava: fix alias handling

### DIFF
--- a/kernelci/lab/lava.py
+++ b/kernelci/lab/lava.py
@@ -47,7 +47,7 @@ def get_device_type_by_name(name, device_types, aliases=[]):
     for alias in aliases:
         if alias["name"] == name:
             for device_type in device_types:
-                if alias["device_type"] == device_type:
+                if device_type in alias["device_types"]:
                     return device_type
     return None
 


### PR DESCRIPTION
The aliases dict key is called "device_types" (plural), and is
a list, not a string, so check if the device_type being searched for
is in the list, not matching a string.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>