### PR TITLE
test-configs.yaml: add baseline to new QEMU devices

### DIFF
--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -808,6 +808,21 @@ device_types:
       - whitelist: {defconfig: ['defconfig']}
       - blacklist: {kernel: ['v3.']}
 
+  qemu_arm-versatilepb:
+    base_name: qemu
+    mach: qemu
+    arch: arm
+    context:
+      arch: 'arm'
+      machine: 'versatilepb'
+      cpu: 'arm926'
+      memory: 256
+      model: 'model=smc91c111'
+    dtb: 'versatile-pb.dtb'
+    boot_method: qemu
+    filters:
+      - whitelist: {defconfig: ['versatile_defconfig']}
+
   qemu_arm-vexpress-a9:
     base_name: qemu
     mach: qemu
@@ -835,21 +850,6 @@ device_types:
     boot_method: qemu
     filters:
       - whitelist: {defconfig: ['vexpress_defconfig']}
-
-  qemu_arm-versatilepb:
-    base_name: qemu
-    mach: qemu
-    arch: arm
-    context:
-      arch: 'arm'
-      machine: 'versatilepb'
-      cpu: 'arm926'
-      memory: 256
-      model: 'model=smc91c111'
-    dtb: 'versatile-pb.dtb'
-    boot_method: qemu
-    filters:
-      - whitelist: {defconfig: ['versatile_defconfig']}
 
   qemu_arm-virt-gicv2:
     base_name: qemu
@@ -1640,16 +1640,19 @@ test_configs:
       - baseline
       - boot
 
+  - device_type: qemu_arm-versatilepb
+    test_plans:
+      - baseline_qemu
+      - boot_qemu
+
   - device_type: qemu_arm-vexpress-a9
     test_plans:
+      - baseline_qemu
       - boot_qemu
 
   - device_type: qemu_arm-vexpress-a15
     test_plans:
-      - boot_qemu
-
-  - device_type: qemu_arm-versatilepb
-    test_plans:
+      - baseline_qemu
       - boot_qemu
 
   - device_type: qemu_arm-virt-gicv2


### PR DESCRIPTION
Run baseline_qemu on the new QEMU device variants, and fix the
alphabetical order of the device entries.

Fixes: 8e56ea5f5862 ("test-configs: add more ARM qemus")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>