### PR TITLE
Travis CI: extend pep8 to all *.py files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,4 @@ script:
   - make test
   - pycodestyle kernelci
   - pycodestyle kci_*
+  - pycodestyle *.py

--- a/push-source.py
+++ b/push-source.py
@@ -26,12 +26,14 @@ import requests
 from urllib.parse import urljoin
 import time
 
+
 def do_post_retry(url=None, data=None, headers=None, files=None):
     retry = True
     count = 5
     while retry and count >= 0:
         try:
-            response = requests.post(url, data=data, headers=headers, files=files)
+            response = requests.post(
+                url, data=data, headers=headers, files=files)
             if str(response.status_code)[:1] != "2":
                 raise Exception(response.content)
             else:
@@ -45,13 +47,15 @@ def do_post_retry(url=None, data=None, headers=None, files=None):
     print("Failed to push file")
     exit(1)
 
+
 parser = argparse.ArgumentParser()
 parser.add_argument("--token", help="KernelCI API Token")
 parser.add_argument("--tree", help="Kernel tree")
 parser.add_argument("--describe", help="Kernel describe", default='')
 parser.add_argument("--branch", help="Kernel branch")
 parser.add_argument("--file", nargs='+', help="File to upload")
-parser.add_argument("--api", help="KernelCI API URL", default="https://api.kernelci.org")
+parser.add_argument("--api", help="KernelCI API URL",
+                    default="https://api.kernelci.org")
 parser.add_argument("--publish_path", help="file path at destination")
 
 args = vars(parser.parse_args())
@@ -66,16 +70,18 @@ if not publish_path:
     build_data['job'] = args.get('tree')
     build_data['kernel'] = args.get('describe', '')
     build_data['git_branch'] = args.get('branch')
-    publish_path = os.path.join(build_data['job'], build_data['git_branch'], build_data['kernel'])
+    publish_path = os.path.join(
+        build_data['job'], build_data['git_branch'], build_data['kernel'])
 
 build_data['path'] = publish_path
 build_data['file_server_resource'] = publish_path
 file_count = 0
 filenames = args.get('file')
 for f in filenames:
-    artifacts.append(('file%d' % file_count,(f, open(f), 'rb')))
+    artifacts.append(('file%d' % file_count, (f, open(f), 'rb')))
     file_count += 1
 
 upload_url = urljoin(args.get('api'), '/upload')
 print("pushing %s to %s/%s" % (filenames, upload_url, publish_path))
-publish_response = do_post_retry(url=upload_url, data=build_data, headers=headers, files=artifacts)
+publish_response = do_post_retry(
+    url=upload_url, data=build_data, headers=headers, files=artifacts)


### PR DESCRIPTION
Extend Travis CI to run pep8 on all the *.py files in the top directory.