### PR TITLE
push-source: RootFS.groovy: Use explicitily Python 3

### DIFF
--- a/push-source.py
+++ b/push-source.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #
 # Copyright (C) 2017 Linaro Limited
 # Author: Matt Hart <matthew.hart@linaro.org>

--- a/src/org/kernelci/debian/RootFS.groovy
+++ b/src/org/kernelci/debian/RootFS.groovy
@@ -132,7 +132,7 @@ def makeImageStep(String pipeline_version,
                 stage("Upload images for ${arch}") {
                     withCredentials([string(credentialsId: params.KCI_TOKEN_ID, variable: 'API_TOKEN')]) {
                         sh """
-                            python push-source.py --token ${API_TOKEN} --api ${params.KCI_API_URL} \
+                            python3 push-source.py --token ${API_TOKEN} --api ${params.KCI_API_URL} \
                                 --publish_path images/rootfs/debian/${name}/ \
                                 --file ${pipeline_version}/${arch}/*.*
                         """


### PR DESCRIPTION
Python community recommends against making the python name point to
Python 3. The PEP-394 states that:

 "If the python command is installed, it should invoke the same version of
  Python as the python2 command."

Now that we switched to Python 3 the symlink is not created anymore and
the following error appears pushing the source

  python push-source.py --token **** --api
  python: not found

To fix this, call explicitily python3.

Signed-off-by: Enric Balletbo i Serra <enric.balletbo@collabora.com>