### PR TITLE
templates: truncate LAVA job names at 200 characters

### DIFF
--- a/templates/base/kernel-ci-base.jinja2
+++ b/templates/base/kernel-ci-base.jinja2
@@ -58,7 +58,7 @@ notify:
     content-type: json
 {% endif %}
 
-job_name: {{ name }}
+job_name: {{ name|truncate(200) }}
 timeouts:
   job:
     minutes: {{ job_timeout|default("10") }}


### PR DESCRIPTION
LAVA doesn't accept job names over 200 characters, this is the error
it produces when that happens:

  <Fault 400: "Problem with submitted job data: length of value must be at most 200 for dictionary value @ data['job_name']">

While we should be trying to keep the generate name length under 200
anyway, truncating it in the template ensures we're not causing some
job submission failures due that that.  The job name is only for
informative purposes, all the actual data saved in the KernelCI
database comes from the meta-data in the job definition so this should
not have any side-effects.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>