### PR TITLE
push-source.py: open files in binary mode

### DIFF
--- a/push-source.py
+++ b/push-source.py
@@ -78,7 +78,7 @@ build_data['file_server_resource'] = publish_path
 file_count = 0
 filenames = args.get('file')
 for f in filenames:
-    artifacts.append(('file%d' % file_count, (f, open(f), 'rb')))
+    artifacts.append(('file%d' % file_count, (f, open(f, 'rb'), 'rb')))
     file_count += 1
 
 upload_url = urljoin(args.get('api'), '/upload')


### PR DESCRIPTION
Open the files to push in binary mode, otherwise some UTF-8 decoding
errors appear such as this one:

  'utf-8' codec can't decode byte 0x8b in position 1: invalid start byte

Fixes: 984d70940cdf ("Convert all Python files to Python 3")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>