### PR TITLE
Add kci_rootfs command line tool

### DIFF
--- a/kci_rootfs
+++ b/kci_rootfs
@@ -45,9 +45,19 @@ class cmd_validate(Command):
             return True
 
 
+class cmd_list_configs(Command):
+    help = "Lists all rootfs config names"
+
+    def __call__(self, config_data, *args, **kwargs):
+        rootfs_configs = config_data['rootfs_configs']
+        for config_name in rootfs_configs:
+            print(config_name)
+        return True
+
 # -----------------------------------------------------------------------------
 # Main
 #
+
 
 if __name__ == '__main__':
     args = parse_args("kci_rootfs", "rootfs-configs.yaml", globals())

--- a/kci_rootfs
+++ b/kci_rootfs
@@ -28,14 +28,21 @@ import kernelci.config.rootfs
 
 
 class cmd_validate(Command):
-    help = "Lists all rootfs configs"
+    help = "Validate the rootfs YAML configuration"
 
     def __call__(self, config_data, *args, **kwargs):
         rootfs_configs = config_data['rootfs_configs']
-        print(rootfs_configs)
         for config_name, config in rootfs_configs.items():
-            print(config.name)
-            print('\t{}'.format(config.rootfs_type))
+            print(config_name)
+            print('\trootfs_type: {}'.format(config.rootfs_type))
+            print('\tarch_list: {}'.format(config.arch_list))
+            print('\tdebian_release: {}'.format(config.debian_release))
+            print('\textra_packages: {}'.format(config.extra_packages))
+            print('\textra_packages_remove: {}'
+                  .format(config.extra_packages_remove))
+            print('\textra_files_remove: {}'.format(config.extra_files_remove))
+            print('\tscript: {}'.format(config.script))
+            return True
 
 
 # -----------------------------------------------------------------------------

--- a/kci_rootfs
+++ b/kci_rootfs
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2019 Collabora Limited
+# Author: Michal Galka <michal.galka@collabora.com>
+#
+# This module is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+import sys
+
+from kernelci.cli import Args, Command, parse_args
+import kernelci.config.rootfs
+
+# -----------------------------------------------------------------------------
+# Commands
+#
+
+
+class cmd_validate(Command):
+    help = "Lists all rootfs configs"
+
+    def __call__(self, config_data, *args, **kwargs):
+        rootfs_configs = config_data['rootfs_configs']
+        print(rootfs_configs)
+        for config_name, config in rootfs_configs.items():
+            print(config.name)
+            print('\t{}'.format(config.rootfs_type))
+
+
+# -----------------------------------------------------------------------------
+# Main
+#
+
+if __name__ == '__main__':
+    args = parse_args("kci_rootfs", "rootfs-configs.yaml", globals())
+    configs = kernelci.config.rootfs.from_yaml(args.yaml_configs)
+    status = args.func(configs, args)
+    sys.exit(0 if status is True else 1)

--- a/kernelci/config/rootfs.py
+++ b/kernelci/config/rootfs.py
@@ -39,12 +39,51 @@ class RootFS(YAMLObject):
 
 
 class RootFS_Debos(RootFS):
-    def __init__(self, *args, **kwargs):
-        super(RootFS_Debos, self).__init__(*args, **kwargs)
+    def __init__(self, name, rootfs_type, debian_release=None,
+                 arch_list=None, extra_packages=None,
+                 extra_packages_remove=None,
+                 extra_files_remove=None, script=""):
+
+        super(RootFS_Debos, self).__init__(name, rootfs_type)
+        self._debian_release = debian_release
+        self._arch_list = arch_list or list()
+        self._extra_packages = extra_packages or list()
+        self._extra_packages_remove = extra_packages_remove or list()
+        self._extra_files_remove = extra_files_remove or list()
+        self._script = script
 
     @classmethod
-    def from_yaml(cls, name, kw):
+    def from_yaml(cls, config, name):
+        kw = name
+        kw.update(cls._kw_from_yaml(
+            config, ['name', 'debian_release', 'arch_list',
+                     'extra_packages', 'extra_packages_remove',
+                     'extra_files_remove', 'script']))
         return cls(**kw)
+
+    @property
+    def debian_release(self):
+        return self._debian_release
+
+    @property
+    def arch_list(self):
+        return list(self._arch_list)
+
+    @property
+    def extra_packages(self):
+        return list(self._extra_packages)
+
+    @property
+    def extra_packages_remove(self):
+        return list(self._extra_packages_remove)
+
+    @property
+    def extra_files_remove(self):
+        return list(self._extra_files_remove)
+
+    @property
+    def script(self):
+        return self._script
 
 
 class RootFSFactory(YAMLObject):
@@ -69,7 +108,7 @@ def from_yaml(yaml_path):
 
     rootfs_configs = {
         name: RootFSFactory.from_yaml(name, rootfs)
-        for name, rootfs in data['rootfs_configs'].iteritems()
+        for name, rootfs in data['rootfs_configs'].items()
     }
 
     config_data = {

--- a/kernelci/config/rootfs.py
+++ b/kernelci/config/rootfs.py
@@ -1,0 +1,79 @@
+# Copyright (C) 2019 Collabora Limited
+# Author: Michal Galka <michal.galka@collabora.com>
+#
+# This module is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+import yaml
+
+from kernelci.config import YAMLObject
+
+
+class RootFS(YAMLObject):
+    def __init__(self, name, rootfs_type):
+        self._name = name
+        self._rootfs_type = rootfs_type
+
+    @classmethod
+    def from_yaml(cls, rootfs, kw):
+        return cls(**kw)
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def rootfs_type(self):
+        return self._rootfs_type
+
+
+class RootFS_Debos(RootFS):
+    def __init__(self, *args, **kwargs):
+        super(RootFS_Debos, self).__init__(*args, **kwargs)
+
+    @classmethod
+    def from_yaml(cls, name, kw):
+        return cls(**kw)
+
+
+class RootFSFactory(YAMLObject):
+    _rootfs_types = {
+        'debos': RootFS_Debos
+    }
+
+    @classmethod
+    def from_yaml(cls, name, rootfs):
+        rootfs_type = rootfs.get('rootfs_type')
+        kw = {
+            'name': name,
+            'rootfs_type': rootfs_type,
+        }
+        rootfs_cls = cls._rootfs_types[rootfs_type] if rootfs_type else RootFS
+        return rootfs_cls.from_yaml(rootfs, kw)
+
+
+def from_yaml(yaml_path):
+    with open(yaml_path) as f:
+        data = yaml.safe_load(f)
+
+    rootfs_configs = {
+        name: RootFSFactory.from_yaml(name, rootfs)
+        for name, rootfs in data['rootfs_configs'].iteritems()
+    }
+
+    config_data = {
+        'rootfs_configs': rootfs_configs,
+    }
+
+    return config_data

--- a/rootfs-configs.yaml
+++ b/rootfs-configs.yaml
@@ -1,0 +1,3 @@
+rootfs_configs:
+  dummy-rootfs:
+    rootfs_type: debos

--- a/rootfs-configs.yaml
+++ b/rootfs-configs.yaml
@@ -1,3 +1,34 @@
 rootfs_configs:
-  dummy-rootfs:
+  buster:
     rootfs_type: debos
+    debian_release: buster
+    arch_list:
+      - 'amd64'
+      - 'arm64'
+      - 'armel'
+      - 'armhf'
+      - 'i386'
+      - 'mips'
+      - 'mipsel'
+      - 'mips64el'
+    extra_packages_remove:
+      - bash
+      - e2fslibs
+      - e2fsprogs
+      - klibc-utils
+      - libext2fs2
+      - libgnutls30
+      - libklibc
+      - libncursesw6
+      - libp11-kit0
+      - libunistring2
+      - sensible-utils
+    extra_files_remove:
+      - '*networkd*'
+      - '*resolved*'
+      - tar
+      - patch
+      - dir
+      - partx
+      - find
+    script: ""


### PR DESCRIPTION
Add basic initial implementation of the `kci_rootfs` tool which includes:
- configuration parser
- simple buster debos based rootfs configuration in rootfs-configs.yaml
- `kci_rootfs validate` subcommand that lists all configuration data based on the YAML file
- `kci_rootfs list_configs` subcommand that lists all rootfs configs available in the YAML file