### PR TITLE
build-configs: add android-5.4

### DIFF
--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -425,6 +425,10 @@ build_configs:
     tree: android
     branch: 'android-4.19'
 
+  android_5.4:
+    tree: android
+    branch: 'android-5.4'
+
   android_mainline:
     tree: android
     branch: 'android-mainline'


### PR DESCRIPTION
Todd Kjos <tkjos@google.com> writes:

> We recently added the android-5.4 kernel, please add it to kernelci testing.
>
> repo: https://android.googlesource.com/kernel/common
> branch: android-5.4

Signed-off-by: Kevin Hilman <khilman@baylibre.com>