### PR TITLE
.travis.yml: Change Python version to 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,11 @@ dist: xenial
 language: python
 
 python:
-  - "2.7"
+  - "3.7"
 
 install:
-  - pip install -r requirements.txt
-  - pip install pycodestyle
+  - pip3 install -r requirements.txt
+  - pip3 install pycodestyle
 
 script:
   - make test


### PR DESCRIPTION
As KernelCI runs on Python3 now. This commit changes TravisCI
configration to use Python3 to run tests.