### PR TITLE
test-configs: fix at91-sama5dx name

### DIFF
--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -363,12 +363,12 @@ device_types:
       - blacklist: *allmodconfig_filter
       - blacklist: {defconfig: ['multi_v7_defconfig+CONFIG_SMP=n']}
 
-  at91-sama5d2-xplained:
+  at91-sama5d2_xplained:
     mach: at91
     class: arm-dtb
     boot_method: uboot
 
-  at91-sama5d4-xplained:
+  at91-sama5d4_xplained:
     mach: at91
     class: arm-dtb
     boot_method: uboot
@@ -1295,12 +1295,12 @@ test_configs:
   - device_type: arndale
     test_plans: [boot, kselftest]
 
-  - device_type: at91-sama5d2-xplained
+  - device_type: at91-sama5d2_xplained
     test_plans:
       - baseline
       - boot
 
-  - device_type: at91-sama5d4-xplained
+  - device_type: at91-sama5d4_xplained
     test_plans:
       - baseline
       - boot


### PR DESCRIPTION
There was a typo in both at91-sama5dx, preventing any job to be
generated in lab-baylibre for them.

Signed-off-by: Corentin LABBE <clabbe@baylibre.com>