### PR TITLE
test-configs: fix running of test on qemu-x86_64/i386

### DIFF
--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -924,7 +924,7 @@ device_types:
     context:
       arch: i386
       cpu: 'qemu32'
-      guestfs_interface: 'virtio'
+      guestfs_interface: 'ide'
     filters:
       - whitelist: {defconfig: ['i386_defconfig']}
 
@@ -936,7 +936,7 @@ device_types:
     context:
       arch: x86_64
       cpu: 'qemu64'
-      guestfs_interface: 'virtio'
+      guestfs_interface: 'ide'
     filters:
       - whitelist: {defconfig: ['defconfig']}
 


### PR DESCRIPTION
The basic x86_64_defconfig does not permit to use any VIRTIO devices.
So all baseline jobs fail to mount the virtual drive with LAVA tests.

Let's use the already present ide interface for qemu-x86_64.
Same problem and same solution for i386.

Signed-off-by: Corentin LABBE <clabbe@baylibre.com>