### PR TITLE
Add kci_rootfs build option

### DIFF
--- a/kci_rootfs
+++ b/kci_rootfs
@@ -20,6 +20,7 @@
 import sys
 
 from kernelci.cli import Args, Command, parse_args
+import kernelci.rootfs
 import kernelci.config.rootfs
 
 # -----------------------------------------------------------------------------
@@ -54,6 +55,21 @@ class cmd_list_configs(Command):
             print(config_name)
         return True
 
+
+class cmd_build(Command):
+    help = "Build rootfs image"
+    args = [Args.config, Args.data_path]
+
+    def __call__(self, config_data, args, **kwargs):
+        data_path = args.data_path
+        config_name = args.config
+        if config_name not in config_data['rootfs_configs']:
+            print("{} invalid. Check 'kci_rootfs list_configs' for valid \
+                    entries".format(config_name))
+            return False
+        config = config_data['rootfs_configs'][args.config]
+        kernelci.rootfs.build(config_name, config, data_path)
+        return True
 # -----------------------------------------------------------------------------
 # Main
 #

--- a/kernelci/cli.py
+++ b/kernelci/cli.py
@@ -229,6 +229,11 @@ class Args(object):
         'help': "Relative path where build artifacts are published",
     }
 
+    data_path = {
+        'name': '--data-path',
+        'help': "Path to the debos files",
+    }
+
 
 class Command(object):
     """A command helper class.

--- a/kernelci/config/rootfs.py
+++ b/kernelci/config/rootfs.py
@@ -15,6 +15,7 @@
 # along with this library; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+import sys
 import yaml
 
 from kernelci.config import YAMLObject
@@ -94,10 +95,15 @@ class RootFSFactory(YAMLObject):
     @classmethod
     def from_yaml(cls, name, rootfs):
         rootfs_type = rootfs.get('rootfs_type')
-        kw = {
-            'name': name,
-            'rootfs_type': rootfs_type,
-        }
+        if rootfs_type is None:
+            raise TypeError("rootfs_type cannot be Empty")
+        elif rootfs_type not in cls._rootfs_types:
+            raise ValueError("Unsupported value {}".format(rootfs_type))
+        else:
+            kw = {
+                'name': name,
+                'rootfs_type': rootfs_type,
+                }
         rootfs_cls = cls._rootfs_types[rootfs_type] if rootfs_type else RootFS
         return rootfs_cls.from_yaml(rootfs, kw)
 

--- a/kernelci/rootfs.py
+++ b/kernelci/rootfs.py
@@ -1,0 +1,52 @@
+# Copyright (C) 2019 Collabora Limited
+# Author: Lakshmipathi G <lakshmipathi.ganapathi@collabora.com>
+#
+# This module is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+from kernelci import shell_cmd
+import os
+
+
+def _build_debos(name, config, data_path):
+    for arch_type in config.arch_list:
+        cmd = 'cd {data_path} && debos \
+-t architecture:{arch} \
+-t suite:{release_name} \
+-t basename:{name}/{arch} \
+-t extra_packages:"{extra_packages}" \
+-t extra_packages_remove:"{extra_packages_remove}" \
+-t extra_files_remove:"{extra_files_remove}" \
+-t script:"{script}" \
+rootfs.yaml'.format(
+            name=name,
+            data_path=data_path,
+            arch=arch_type,
+            release_name=config.debian_release,
+            extra_packages=" ".join(config.extra_packages),
+            extra_packages_remove=" ".join(config.extra_packages_remove),
+            extra_files_remove=" ".join(config.extra_files_remove),
+            script=config.script
+            )
+        shell_cmd(cmd)
+
+    return True
+
+
+def build(name, config, data_path):
+    if config.rootfs_type == "debos":
+        return _build_debos(name, config, data_path)
+    else:
+        print("rootfs_type:{} not supported".format(config.rootfs_type))
+        return False


### PR DESCRIPTION
Build rootfs images using debos command.
Usage: kci_rootfs build --config buster --debos-path /path/to/debos

Signed-off-by: Lakshmipathi.G <Lakshmipathi.Ganapathi@Collabora.com>