### PR TITLE
docker: build-base: add python3-pip

### DIFF
--- a/jenkins/dockerfiles/build-base/Dockerfile
+++ b/jenkins/dockerfiles/build-base/Dockerfile
@@ -38,6 +38,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     python3.7 \
     python3-jinja2 \
     python3-keyring \
+    python3-pip \
     python3-pyelftools \
     python3-requests \
     python3-yaml

--- a/jenkins/dockerfiles/build-base/Dockerfile
+++ b/jenkins/dockerfiles/build-base/Dockerfile
@@ -42,3 +42,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     python3-pyelftools \
     python3-requests \
     python3-yaml
+
+# kernelci-core tools and dependencies
+RUN git clone --depth 1 --branch master https://github.com/kernelci/kernelci-core.git /opt/kernelci-core; \
+  (cd /opt/kernelci-core; pip3 install `cat requirements.txt`)


### PR DESCRIPTION
Add python3-pip to the base images.  This enables build jobs to
install extra python dependencies without having to install pip first.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>