### PR TITLE
templates/sleep: increase rtcwake delay to 5s

### DIFF
--- a/templates/sleep/sleep.jinja2
+++ b/templates/sleep/sleep.jinja2
@@ -13,8 +13,16 @@
           - functional
         run:
           steps:
-            - for i in $(seq 1 10); do lava-test-case rtcwake-mem-$i --shell rtcwake -d rtc0 -m mem -s 1; done
-            - for i in $(seq 1 10); do lava-test-case rtcwake-freeze-$i --shell rtcwake -d rtc0 -m freeze -s 1; done
+            - >
+              for i in $(seq 1 10); do
+                lava-test-case rtcwake-mem-$i --shell \
+                  rtcwake -d rtc0 -m mem -s 5
+              done
+            - >
+              for i in $(seq 1 10); do
+                lava-test-case rtcwake-freeze-$i --shell \
+                  rtcwake -d rtc0 -m freeze -s 5
+              done
       lava-signal: kmsg
       from: inline
       name: sleep


### PR DESCRIPTION
Increase the rtcwake delay from 1s to 5s in the sleep test plan to
give enough time for the system to fully suspend before triggering
resume.

Also use multi-line YAML string to make it easier to read the shell
commands.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>