### PR TITLE
debian: add new buster-crostests rootfs

### DIFF
--- a/jenkins/buster-cros-ec.jpl
+++ b/jenkins/buster-cros-ec.jpl
@@ -1,0 +1,24 @@
+@Library('kernelci') _
+import org.kernelci.debian.RootFS
+
+/* ----------------------------------------------------------------------------
+ * Jenkins parameters
+
+DOCKER_BASE
+  Dockerhub base address used for the build images
+
+*/
+
+def r = new RootFS()
+
+def config = ['name':"buster-cros-ec",
+              'arch_list':["armhf", "arm64", "amd64"],
+              'debian_release':"buster",
+              'extra_packages':"python3-minimal python3-unittest2",
+              'extra_packages_remove':"bash e2fsprogs e2fslibs libext2fs2",
+              'script':"scripts/buster-cros-ec-tests.sh",
+              'test_overlay': "",
+              'docker_image': "${params.DOCKER_BASE}debos",
+             ]
+
+r.buildImage(config)

--- a/jenkins/debian/debos/scripts/buster-cros-ec-tests.sh
+++ b/jenkins/debian/debos/scripts/buster-cros-ec-tests.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -x
+
+# Important: This script is run under QEMU
+
+set -e
+
+# Build-depends needed to build the test suites, they'll be removed later
+BUILD_DEPS="\
+    git \
+    python3-setuptools \
+    python3-pip \
+"
+
+apt-get install --no-install-recommends -y ${BUILD_DEPS}
+
+########################################################################
+# Build tests                                                          #
+########################################################################
+
+BUILDFILE=/test_suites.json
+echo '{  "tests_suites": [' >> $BUILDFILE
+
+########################################################################
+# Build and install tests                                              #
+########################################################################
+
+CROS_URL="https://git.kernel.org/pub/scm/linux/kernel/git/chrome-platform/cros-ec-tests.git"
+CROS_SHA=$(git ls-remote ${CROS_URL} | head -n 1 | cut -f 1)
+
+pip3 install git+${CROS_URL}@${CROS_SHA}
+
+echo '    {"name": "cros-ec-tests", "git_url": "'$CROS_URL'", "git_commit": "'$CROS_SHA'" }' >> $BUILDFILE
+echo '  ]}' >> $BUILDFILE
+
+########################################################################
+# Cleanup: remove files and packages we don't want in the images       #
+########################################################################
+
+rm -fr /src/cros-ec-tests
+apt-get remove --purge -y ${BUILD_DEPS} perl-modules-5.28
+apt-get autoremove --purge -y
+apt-get clean
+


### PR DESCRIPTION
This new rootfs contains the python packages required to run the
Chromebooks Test Suite written in python and the test suite itself. This
is a replacement of the current cros-ec tests.

Signed-off-by: Enric Balletbo i Serra <enric.balletbo@collabora.com>