### PR TITLE
bisect.jpl: remove kernel git clone if it appears broken

### DIFF
--- a/jenkins/bisect.jpl
+++ b/jenkins/bisect.jpl
@@ -176,9 +176,18 @@ Initialising kernel tree
   branch: ${params.KERNEL_BRANCH}
   path:   ${kdir}""")
 
-    if (sh(returnStatus: true, script: "test -d ${kdir}/.git") == 0) {
+    def is_git = !sh(returnStatus: true, script: "test -d ${kdir}/.git")
+    def is_valid = (is_git &&
+                    !sh(returnStatus: true, script: "cd ${kdir}; git status"))
+
+    if (is_valid) {
         setRemote(kdir, params.KERNEL_TREE, params.KERNEL_URL)
     } else {
+        if (is_git) {
+            print("Broken Git clone, recreating ${kdir}")
+            sh(script: "rm -rf ${kdir}")
+        }
+
         sh(script: """
 git clone ${params.KERNEL_URL} ${kdir} \
   -b ${params.KERNEL_BRANCH} \


### PR DESCRIPTION
If for any reason the kernel git clone appears to be broken, remove it
and create a new one.  This is pretty rare but it can happen as it's
kept from one job to the next to avoid recreating one every time.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>