### PR TITLE
Add kci_rootfs upload option

### DIFF
--- a/kci_rootfs
+++ b/kci_rootfs
@@ -70,6 +70,15 @@ class cmd_build(Command):
         config = config_data['rootfs_configs'][args.config]
         kernelci.rootfs.build(config_name, config, data_path)
         return True
+
+
+class cmd_upload(Command):
+    help = "Upload rootfs image"
+    args = [Args.rootfs_dir, Args.upload_path, Args.api, Args.token]
+
+    def __call__(self, config_data, args):
+        return kernelci.rootfs.upload(args.api, args.token, args.upload_path,
+                                      args.rootfs_dir)
 # -----------------------------------------------------------------------------
 # Main
 #

--- a/kernelci/cli.py
+++ b/kernelci/cli.py
@@ -138,6 +138,11 @@ class Args(object):
         'help': "Path to the kernel checkout directory",
     }
 
+    rootfs_dir = {
+        'name': '--rootfs-dir',
+        'help': "Path to the rootfs images directory",
+    }
+
     arch = {
         'name': '--arch',
         'help': "CPU architecture name",
@@ -244,6 +249,11 @@ class Args(object):
     data_path = {
         'name': '--data-path',
         'help': "Path to the debos files",
+    }
+
+    upload_path = {
+        'name': '--upload-path',
+        'help': "Upload path on Storage where rootfs stored",
     }
 
 

--- a/kernelci/rootfs.py
+++ b/kernelci/rootfs.py
@@ -16,6 +16,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 from kernelci import shell_cmd
+from kernelci.storage import upload_files
 import os
 
 
@@ -50,3 +51,20 @@ def build(name, config, data_path):
     else:
         print("rootfs_type:{} not supported".format(config.rootfs_type))
         return False
+
+
+def upload(api, token, upload_path, input_dir):
+    """Upload rootfs to KernelCI backend.
+
+    *api* is the URL of the KernelCI backend API
+    *token* is the backend API token to use
+    *upload_path* is the target on KernelCI backend
+    *input_dir* is the local rootfs directory path to upload
+    """
+    artifacts = {}
+    for root, _, files in os.walk(input_dir):
+        for f in files:
+            px = os.path.relpath(root, input_dir)
+            artifacts[os.path.join(px, f)] = open(os.path.join(root, f), "rb")
+    upload_files(api, token, upload_path, artifacts)
+    return True

--- a/kernelci/storage.py
+++ b/kernelci/storage.py
@@ -1,0 +1,44 @@
+# Copyright (C) 2020 Collabora Limited
+# Author: Lakshmipathi Ganapathi <lakshmipathi.ganapathi@collabora.com>
+#
+# This module is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+import os
+import requests
+from urllib.parse import urljoin
+from kernelci import shell_cmd
+
+
+def upload_files(api, token, path, input_files):
+    """Upload rootfs to KernelCI backend.
+
+    *api* is the URL of the KernelCI backend API
+    *token* is the backend API token to use
+    *path* is the target on KernelCI backend
+    *input_files* dictionary of input files
+    """
+    headers = {
+        'Authorization': token,
+    }
+    data = {
+        'path': path,
+    }
+    files = {
+        'file{}'.format(i): (name, fobj)
+        for i, (name, fobj) in enumerate(input_files.items())
+    }
+    url = urljoin(api, 'upload')
+    resp = requests.post(url, headers=headers, data=data, files=files)
+    resp.raise_for_status()


### PR DESCRIPTION
Upload rootfs images to kernelci backend.
Usage: ./kci_rootfs upload --rootfs-dir=/path/to/rootfsdir
       --upload-path=path/to/uploaddir --api=ip-address --token <token>

Signed-off-by: Lakshmipathi Ganapathi <lakshmipathi.ganapathi@collabora.com>