### PR TITLE
Add python3-yaml to kernelci/debos Dockerfile

### DIFF
--- a/jenkins/dockerfiles/debos/Dockerfile
+++ b/jenkins/dockerfiles/debos/Dockerfile
@@ -46,4 +46,5 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 RUN apt-get update && apt-get install --no-install-recommends -y \
     python3.7 \
     python3-requests \
+    python3-yaml \
     xz-utils


### PR DESCRIPTION
python3-yaml is needed by kci_rootfs tool which is going to be run
inside this docker image.

Tested locally.