### PR TITLE
Switch to use the new cros-ec test plan

### DIFF
--- a/templates/cros-ec/cros-ec.jinja2
+++ b/templates/cros-ec/cros-ec.jinja2
@@ -5,15 +5,15 @@
     - repository:
         metadata:
           format: Lava-Test Test Definition 1.0
-          name: cros-ec
-          description: "check /dev/cros_ec"
+          name: {{ plan }}
+          description: "cros-ec test plan"
           os:
           - oe
           scope:
           - functional
         run:
           steps:
-            - lava-test-case cros-ec-presence --shell test -c /dev/cros_ec
+            - python3 -m cros.runners.lava_runner
       from: inline
-      name: cros-ec
-      path: inline/cros-ec.yaml
+      name: {{ plan }}
+      path: inline/{{ plan }}.yaml

--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -43,6 +43,10 @@ file_systems:
     type: debian
     ramdisk: 'buster/20200127.0/{arch}/rootfs.cpio.gz'
 
+  debian_buster-cros-ec_ramdisk:
+    type: debian
+    ramdisk: 'buster-cros-ec/20200130.0/{arch}/rootfs.cpio.gz'
+
   debian_buster-igt_ramdisk:
     type: debian
     ramdisk: 'buster-igt/20200127.0/{arch}/rootfs.cpio.gz'
@@ -162,7 +166,7 @@ test_plans:
       - blacklist: *clang_environment_filter
 
   cros-ec:
-    rootfs: debian_buster_ramdisk
+    rootfs: debian_buster-cros-ec_ramdisk
 
   igt-drm-kms:
     rootfs: debian_buster-igt_ramdisk


### PR DESCRIPTION
We have now a cros-ec test plan for all Chromebooks devices. So remove the
dummy and obsolete cros-ec test and use the new cros test plan. The
cros-ec test plan is using the `cros-ec-tests` python package composed of
a number of modules that will help you to do stand alone tests or setup a
fully automated tests.

Signed-off-by: Enric Balletbo i Serra <enric.balletbo@collabora.com>