### PR TITLE
test-configs.yaml: add sun50i-h5-nanopi-neo-plus2

### DIFF
--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -1029,6 +1029,12 @@ device_types:
     class: arm64-dtb
     boot_method: uboot
 
+  sun50i-h5-nanopi-neo-plus2:
+    mach: allwinner
+    class: arm64-dtb
+    boot_method: uboot
+    flags: ['big_endian']
+
   sun50i-h6-orangepi-3:
     mach: allwinner
     class: arm64-dtb
@@ -1850,6 +1856,11 @@ test_configs:
       - boot
 
   - device_type: sun50i-h5-libretech-all-h3-cc
+    test_plans:
+      - baseline
+      - boot
+
+  - device_type: sun50i-h5-nanopi-neo-plus2
     test_plans:
       - baseline
       - boot


### PR DESCRIPTION
This patch adds sun50i-h5-nanopi-neo-plus2 which is ready in my lab.
The LAVA device-type is upstream for a long time.