### PR TITLE
test-configs.yaml: add sun8i-r40-bananapi-m2-ultra

### DIFF
--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -1139,6 +1139,12 @@ device_types:
     class: arm-dtb
     boot_method: uboot
 
+  sun8i-r40-bananapi-m2-ultra:
+    mach: allwinner
+    class: arm-dtb
+    boot_method: uboot
+    flags: ['big_endian']
+
   synquacer-acpi:
     mach: socionext
     arch: arm64
@@ -1953,6 +1959,11 @@ test_configs:
       - boot
 
   - device_type: sun8i-h3-orangepi-pc
+    test_plans:
+      - baseline
+      - boot
+
+  - device_type: sun8i-r40-bananapi-m2-ultra
     test_plans:
       - baseline
       - boot


### PR DESCRIPTION
This patch adds sun8i-r40-bananapi-m2-ultra which is ready in my lab.
The LAVA device-type is upstream for a long time.