### PR TITLE
kci_rootfs: Include --arch option

### DIFF
--- a/kci_rootfs
+++ b/kci_rootfs
@@ -61,17 +61,18 @@ class cmd_list_configs(Command):
 
 class cmd_build(Command):
     help = "Build rootfs image"
-    args = [Args.config, Args.data_path]
+    args = [Args.config, Args.data_path, Args.arch]
 
     def __call__(self, config_data, args, **kwargs):
         data_path = args.data_path
         config_name = args.config
+        arch = args.arch
         if config_name not in config_data['rootfs_configs']:
             print("{} invalid. Check 'kci_rootfs list_configs' for valid \
                     entries".format(config_name))
             return False
         config = config_data['rootfs_configs'][args.config]
-        kernelci.rootfs.build(config_name, config, data_path)
+        kernelci.rootfs.build(config_name, config, data_path, arch)
         return True
 
 

--- a/kernelci/rootfs.py
+++ b/kernelci/rootfs.py
@@ -20,9 +20,8 @@ from kernelci.storage import upload_files
 import os
 
 
-def _build_debos(name, config, data_path):
-    for arch_type in config.arch_list:
-        cmd = 'cd {data_path} && debos \
+def _build_debos(name, config, data_path, arch):
+    cmd = 'cd {data_path} && debos \
 -t architecture:{arch} \
 -t suite:{release_name} \
 -t basename:{name}/{arch} \
@@ -35,7 +34,7 @@ def _build_debos(name, config, data_path):
 rootfs.yaml'.format(
             name=name,
             data_path=data_path,
-            arch=arch_type,
+            arch=arch,
             release_name=config.debian_release,
             extra_packages=" ".join(config.extra_packages),
             extra_packages_remove=" ".join(config.extra_packages_remove),
@@ -44,17 +43,25 @@ rootfs.yaml'.format(
             test_overlay=config.test_overlay,
             crush_image_options=" ".join(config.crush_image_options)
             )
-        shell_cmd(cmd)
+    shell_cmd(cmd)
 
     return True
 
 
-def build(name, config, data_path):
+def build(name, config, data_path, arch):
+    """Build rootfs images.
+
+    *name* is the rootfs config
+    *config* contains rootfs-configs.yaml entries
+    *data_path* points to debos location
+    *arch* required architecture
+    """
+
     if config.rootfs_type == "debos":
-        return _build_debos(name, config, data_path)
+        _build_debos(name, config, data_path, arch)
     else:
-        print("rootfs_type:{} not supported".format(config.rootfs_type))
-        return False
+        raise ValueError("rootfs_type:{} not supported"
+                         .format(config.rootfs_type))
 
 
 def upload(api, token, upload_path, input_dir):


### PR DESCRIPTION
By default, rootfs will be created for all architecture listed under
rootfs-configs.yaml. With this option, if required, rootfs image for given
architecture can be created.

Signed-off-by: Lakshmipathi Ganapathi <lakshmipathi.ganapathi@collabora.co.uk>