### PR TITLE
kernelci: adding --always flag to git describe

### DIFF
--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -237,7 +237,7 @@ def git_describe(tree_name, path):
     cmd = """
 set -e
 cd {path}
-git describe {describe_args}
+git describe --always {describe_args}
 """.format(path=path, describe_args=describe_args)
     describe = shell_cmd(cmd)
     return describe.strip().replace('/', '_')
@@ -255,7 +255,7 @@ def git_describe_verbose(path):
     cmd = r"""
 set -e
 cd {path}
-git describe --match=v[1-9]\*
+git describe --always --match=v[1-9]\*
 """.format(path=path)
     describe = shell_cmd(cmd)
     return describe.strip()


### PR DESCRIPTION
Currently, the KernelCI command line tool page assumes that the kernel
directory is initialized through the update_repo command
(https://github.com/kernelci/kernelci-doc/wiki/KernelCI-command-line) in
which case git describe would return a tag. However, when a user sets
the kdir to their own local checkout possibly on a branch that doesn't
have default tags, a "fatal: no tags can describe ..." error occurs.
This is resolved by adding the --always flag to the git
describe commands.

Signed-off-by: Heidi Fahim <heidifahim@google.com>