### PR TITLE
build-configs.yaml: fix arc defconfig name

### DIFF
--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -205,7 +205,7 @@ build_configs_defaults:
       architectures: &default_architectures
 
         arc: &arc_arch
-          base_defconfig: 'nsim_hs_defconfig'
+          base_defconfig: 'haps_hs_smp_defconfig'
           extra_configs: ['allnoconfig']
           filters: &arc_default_filters
             # remove any non-ARCv2 defconfigs since we only have ARCv2 toolchain
@@ -258,9 +258,9 @@ build_configs_defaults:
 # Minimum architecture defconfigs
 arch_defconfigs: &arch_defconfigs
   arc: &arc_defconfig
-    base_defconfig: 'nsim_hs_defconfig'
+    base_defconfig: 'haps_hs_smp_defconfig'
     filters:
-      - regex: { defconfig: 'nsim_hs_defconfig' }
+      - regex: { defconfig: 'haps_hs_smp_defconfig' }
   arm: &arm_defconfig
     base_defconfig: 'multi_v7_defconfig'
     filters:
@@ -296,7 +296,7 @@ stable_variants: &stable_variants
     fragments: ['tinyconfig']
     architectures:
       arc:
-        base_defconfig: 'nsim_hs_defconfig'
+        base_defconfig: 'haps_hs_smp_defconfig'
         extra_configs: ['allnoconfig']
         filters: *arc_default_filters
       arm:


### PR DESCRIPTION
Update the main defconfig for the "arc" CPU architecture which is now
haps_hs_smp_defconfig.

Link: https://lore.kernel.org/lkml/20191018121545.8907-7-Eugeniy.Paltsev@synopsys.com/
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>