### PR TITLE
kci_build: Add option to delete the tarball after downloading

### DIFF
--- a/jenkins/build.jpl
+++ b/jenkins/build.jpl
@@ -146,6 +146,7 @@ node("docker" && params.NODE_LABEL) {
                                 --kdir ${kdir} \
                                 --url ${params.SRC_TARBALL} \
                                 --retries=12 \
+                                --delete \
                   """)
                 }
             }

--- a/kci_build
+++ b/kci_build
@@ -325,11 +325,12 @@ Invalid arguments, please provide at least one of these sets of options:
 class cmd_pull_tarball(Command):
     help = "Downloads and untars kernel sources"
     args = [Args.kdir, Args.url]
-    opt_args = [Args.filename, Args.retries]
+    opt_args = [Args.filename, Args.retries, Args.delete]
 
     def __call__(self, configs, args):
         return kernelci.build.pull_tarball(args.kdir, args.url,
-                                           args.filename, args.retries)
+                                           args.filename, args.retries,
+                                           args.delete)
 
 
 if __name__ == '__main__':

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -349,7 +349,7 @@ def _download_file(url, dest_filename, chunk_size=1024):
         return False
 
 
-def pull_tarball(kdir, url, dest_filename, retries):
+def pull_tarball(kdir, url, dest_filename, retries, delete):
     if os.path.exists(kdir):
         shutil.rmtree(kdir)
     os.makedirs(kdir)
@@ -362,6 +362,9 @@ def pull_tarball(kdir, url, dest_filename, retries):
         return False
     with tarfile.open(dest_filename, 'r:*') as tarball:
         tarball.extractall(kdir)
+    if delete:
+        if os.path.isfile(dest_filename):
+            os.remove(dest_filename)
     return True
 
 

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -363,8 +363,7 @@ def pull_tarball(kdir, url, dest_filename, retries, delete):
     with tarfile.open(dest_filename, 'r:*') as tarball:
         tarball.extractall(kdir)
     if delete:
-        if os.path.isfile(dest_filename):
-            os.remove(dest_filename)
+        os.remove(dest_filename)
     return True
 
 

--- a/kernelci/cli.py
+++ b/kernelci/cli.py
@@ -256,6 +256,12 @@ class Args(object):
         'help': "Upload path on Storage where rootfs stored",
     }
 
+    delete = {
+        'name': '--delete',
+        'help': "Delete the tarball after extracting",
+        'action': 'store_true'
+    }
+
 
 class Command(object):
     """A command helper class.


### PR DESCRIPTION
Slightly lower the required disk space for kernel builds, by removing
the tarball after it has been extracted.

Change-Id: I7d0f51906446e9a81786d2e92be7b263c12700c1