### PR TITLE
test-configs: imx8mn-ddr4-evk drop boot-nfs

### DIFF
--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -1534,7 +1534,6 @@ test_configs:
     test_plans:
       - baseline
       - boot
-      - boot-nfs
       - kselftest
 
   - device_type: jetson-tk1


### PR DESCRIPTION
This platform cannot do NFS boots without a ramdisk providing network
modules.  Drop NFS boot tests for now.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>