### PR TITLE
Add kci_rootfs list_variants command

### DIFF
--- a/kci_rootfs
+++ b/kci_rootfs
@@ -59,6 +59,33 @@ class cmd_list_configs(Command):
         return True
 
 
+class cmd_list_variants(Command):
+    help = "Lists all rootfs variants"
+    opt_args = [Args.config, Args.arch]
+
+    def __call__(self, config_data, args, **kwargs):
+        rootfs_configs = config_data['rootfs_configs']
+        config_name = args.config
+        arch = args.arch
+
+        if config_name and config_name not in rootfs_configs:
+            print("{} : invalid config entry".format(config_name))
+            return False
+
+        if arch and config_name and \
+           arch not in rootfs_configs[config_name].arch_list:
+            print("{} : invalid arch entry".format(arch))
+            return False
+
+        configs = (config for config in rootfs_configs
+                   if config == config_name or config_name is None)
+        for config in configs:
+            for arch_type in rootfs_configs[config].arch_list:
+                if arch_type == arch or arch is None:
+                    print(' '.join([config, arch_type]))
+        return True
+
+
 class cmd_build(Command):
     help = "Build rootfs image"
     args = [Args.config, Args.data_path]


### PR DESCRIPTION
Display rootfs configurations along with their supported architectures.

Signed-off-by: Lakshmipathi Ganapathi <lakshmipathi.ganapathi@collabora.com>