### PR TITLE
test-configs: add meson-sm1-khadas-vim3l

### DIFF
--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -757,6 +757,14 @@ device_types:
     filters:
       - blacklist: {defconfig: ['allnoconfig', 'allmodconfig']}
 
+  meson-sm1-khadas-vim3l:
+    mach: amlogic
+    class: arm64-dtb
+    boot_method: uboot
+    flags: ['big_endian']
+    filters:
+      - blacklist: {defconfig: ['allnoconfig', 'allmodconfig']}
+
   meson-sm1-sei610:
     mach: amlogic
     class: arm64-dtb
@@ -1662,6 +1670,12 @@ test_configs:
       - boot
       - boot-nfs
       - kselftest
+      - simple
+
+  - device_type: meson-sm1-khadas-vim3l
+    test_plans:
+      - baseline
+      - boot
       - simple
 
   - device_type: meson-sm1-sei610


### PR DESCRIPTION
This patch adds support for meson-sm1-khadas-vim3l.
LAVA device-type merged: https://git.lavasoftware.org/lava/lava/merge_requests/958
Device up in lab-baylibre.