### PR TITLE
Build Buster rootfs using kci_rootfs

### DIFF
--- a/jenkins/rootfs-builder.jpl
+++ b/jenkins/rootfs-builder.jpl
@@ -1,0 +1,91 @@
+#!/usr/bin/env groovy
+
+/*
+  Copyright (C) 2020 Collabora Limited
+  Author: Lakshmipathi Ganapathi <lakshmipathi.ganapathi@collabora.com>
+
+  This module is free software; you can redistribute it and/or modify it under
+  the terms of the GNU Lesser General Public License as published by the Free
+  Software Foundation; either version 2.1 of the License, or (at your option)
+  any later version.
+
+  This library is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+  details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with this library; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+/* ----------------------------------------------------------------------------
+ * Jenkins parameters
+
+KCI_CORE_URL (https://github.com/kernelci/kernelci-core.git)
+  URL of the kernelci-core repository
+KCI_CORE_BRANCH (master)
+  Name of the branch to use in the kernelci-core repository
+KCI_API_URL (https://api.kernelci.org)
+  URL of the KernelCI backend API
+KCI_TOKEN_ID
+  Identifier of the KernelCI backend API token stored in Jenkins
+DOCKER_BASE
+  Dockerhub base address used for the build images
+ROOTFS_CONFIG
+  Configuration name to build RootFS images
+ROOTFS_ARCH
+  RootFS image architecture
+*/
+
+
+@Library('kernelci') _
+import org.kernelci.util.Job
+
+def build_rootfs(config, arch, pipeline_version, kci_core) {
+    dir(kci_core) {
+        sh(script: """\
+./kci_rootfs \
+build \
+--config ${config} \
+--arch  ${arch} \
+--data-path jenkins/debian/debos 
+mkdir -p ${pipeline_version} 
+mv jenkins/debian/debos/${config}/* ${pipeline_version}
+""")
+
+    archiveArtifacts artifacts: "${pipeline_version}/**"
+
+    withCredentials([string(credentialsId: params.KCI_TOKEN_ID, variable: 'API_TOKEN')]) {
+            sh(script: """\
+./kci_rootfs \
+upload \
+--token ${API_TOKEN} \
+--api ${params.KCI_API_URL} \
+--rootfs-dir ${pipeline_version} \
+--upload-path images/rootfs/debian/${config}/${pipeline_version}
+""")
+        }
+    }
+}
+
+node("debos && docker") {
+    def j = new Job()
+    def kci_core = "${env.WORKSPACE}/kernelci-core"
+    def config = "${params.ROOTFS_CONFIG}"
+    def arch = "${params.ROOTFS_ARCH}"
+    def docker_image = "${params.DOCKER_BASE}debos"
+    def pipeline_version =  "${params.PIPELINE_VERSION}"
+
+    j.dockerPullWithRetry(docker_image).inside() {
+        j.cloneKciCore(kci_core, params.KCI_CORE_URL, params.KCI_CORE_BRANCH)
+    }
+
+    j.dockerPullWithRetry(docker_image).inside(" --privileged --device /dev/kvm ") {
+        stage("Build ${config} ${arch}") {
+            timeout(time: 4, unit: 'HOURS') {
+	        build_rootfs(config, arch, pipeline_version, kci_core)
+            }
+        }
+    }
+}

--- a/jenkins/rootfs-trigger.jpl
+++ b/jenkins/rootfs-trigger.jpl
@@ -1,0 +1,143 @@
+#!/usr/bin/env groovy
+
+/*
+  Copyright (C) 2020 Collabora Limited
+  Author: Lakshmipathi Ganapathi <lakshmipathi.ganapathi@collabora.com>
+
+  This module is free software; you can redistribute it and/or modify it under
+  the terms of the GNU Lesser General Public License as published by the Free
+  Software Foundation; either version 2.1 of the License, or (at your option)
+  any later version.
+
+  This library is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+  details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with this library; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+/* ----------------------------------------------------------------------------
+ * Jenkins parameters
+
+KCI_CORE_URL (https://github.com/kernelci/kernelci-core.git)
+  URL of the kernelci-core repository
+KCI_CORE_BRANCH (master)
+  Name of the branch to use in the kernelci-core repository
+DOCKER_BASE
+  Dockerhub base address used for the build images
+ROOTFS_CONFIG
+  Configuration name to build RootFS images
+ROOTFS_ARCH
+  RootFS image architecture
+*/
+
+@Library('kernelci') _
+import org.kernelci.util.Job
+
+
+def listVariants(kci_core, config_list, rootfs_config, rootfs_arch) {
+    def cli_opts = ' '
+
+    if (rootfs_config) {
+        cli_opts += " --config ${rootfs_config}"
+    }
+       
+    if (rootfs_arch) {
+        cli_opts += " --arch ${rootfs_arch}"
+    }
+
+    dir(kci_core) {
+        def rootfs_config_list_raw = sh(script: """\
+./kci_rootfs \
+list_variants \
+${cli_opts} 
+""", returnStdout: true).trim()
+
+        def rootfs_config_list =  rootfs_config_list_raw.tokenize('\n')
+
+        for (String rootfs_config_raw: rootfs_config_list) {
+            def data = rootfs_config_raw.tokenize(' ')
+            def config = data[0]
+            def arch = data[1]
+            config_list.add([config, arch])
+        }
+    }
+}
+
+
+def buildRootfsStep(job, config ,arch) {
+    def pipeline_version = VersionNumber(
+        versionNumberString: '${BUILD_DATE_FORMATTED,"yyyyMMdd"}.${BUILDS_TODAY_Z}')
+
+    def str_params = [
+        'ROOTFS_CONFIG': config,
+        'ROOTFS_ARCH': arch,
+        'PIPELINE_VERSION':pipeline_version,
+    ]
+    def job_params = []
+
+    def j = new Job()
+    j.addStrParams(job_params, str_params)
+
+    return {
+          def res = build(job: job, parameters: job_params, propagate: false)
+    }
+}
+
+
+node("docker && build-trigger") {
+    def j = new Job()
+    def kci_core = "${env.WORKSPACE}/kernelci-core"
+    def docker_image = "${params.DOCKER_BASE}debos"
+    def ROOTFS_CONFIG = "${params.ROOTFS_CONFIG}"
+    def ROOTFS_ARCH = "${params.ROOTFS_ARCH}"
+
+    def configs = []
+
+    print("""\
+    rootfs_config:  ${params.ROOTFS_CONFIG}
+    rootfs_arch:    ${params.ROOTFS_ARCH}
+    Container:      ${docker_image}""")
+
+    if (params.ROOTFS_ARCH == ''){
+        print("Please provide valid architecture.")
+        currentBuild.result = 'ABORTED'
+        return
+    }
+
+    j.dockerPullWithRetry(docker_image).inside() {
+
+        stage("Init") {
+            timeout(time: 15, unit: 'MINUTES') {
+                j.cloneKciCore(
+                    kci_core, params.KCI_CORE_URL, params.KCI_CORE_BRANCH)
+            }
+        }
+
+        stage("Configs") {
+            listVariants(kci_core, configs, rootfs_config, rootfs_arch)
+        }
+
+        stage("Build") {
+            def builds = [:]
+            def i = 0
+
+            for (item in configs) {
+                def config_name = item[0]
+                def arch = item[1]
+                def step_name = "${i} ${config_name} ${arch}"
+                print(step_name)
+
+                builds[step_name] = buildRootfsStep(
+                    "rootfs-builder", config_name, arch)
+
+                i += 1
+            }
+
+            parallel(builds)
+        }
+    }
+}


### PR DESCRIPTION
Use kci_rootfs in Jenkins job to create required rootfs for given architecture.

Signed-off-by: Lakshmipathi Ganapathi <lakshmipathi.ganapathi@collabora.co.uk>