### PR TITLE
doc: add detailed sections for kci_build and kci_test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,69 @@
 # Welcome to KernelCI
 
-This repository provides the core functions used on
-[kernelci.org](https://kernelci.org) to monitor upstream Linux kernel branches,
-build many kernel variants, run tests, run bisections and schedule email
-reports.
+The KernelCI project is dedicated to testing the upstream Linux kernel.  Its
+mission statement is defined as follows:
 
-This software can also be used to set up an independent instance and to build
-any arbitrary kernel branches and run any arbitrary tests.
+> To ensure the quality, stability and long-term maintenance of the Linux
+> kernel by maintaining an open ecosystem around test automation practices and
+> principles.
 
-You can find some general information as well as detailed technical
-instructions on the KernelCI
+The main instance of KernelCI is available on
+[kernelci.org](https://kernelci.org).
+
+This repository provides core functions to monitor upstream Linux kernel
+branches, build many kernel variants, run tests, run bisections and schedule
+email reports.
+
+It is also possible to set up an independent instance to build any arbitrary
+kernel and run any arbitrary tests.
+
+You can find some more general information about the KernelCI project on the
 [wiki](https://github.com/kernelci/kernelci-doc/wiki/KernelCI).
 
 
-# Contents of this repository
+## Command line tools
+
+All the steps of the KernelCI pipeline are implemented with portable command
+line tools.  They are used in [Jenkins pipeline
+jobs](https://github.com/kernelci/kernelci-core/tree/master/jenkins) for
+kernelci.org, but can also be run by hand in a shell or integrated with any CI
+environment.  The `kernelci/build-base` Docker image comes with all the
+dependencies needed.
+
+**The available command line tools are:**
+
+* **[`kci_build`](doc/kci_build.md)** to get the kernel source code, create a
+  foncig file, build kernels and push them to a storage server.
+
+* **[`kci_test`](doc/kci_test.md)** to generate and submit test definitions in
+  an automated test lab.
+
+**Other command line tools are being worked on** to replace the current legacy
+implementation which is still tied to Jenkins or hard-coded in shell scripts:
+
+* **`kci_rootfs` (WIP)** to produce root file systems containing test suites to
+  run on target platforms.
+
+* **`kci_bisect` (WIP)** To run KernelCI automated bisections.
+
+* **`kci_email` (WIP)** to generate an email report with test results.
 
 
 ## Configuration files
 
-All the builds are configured in [`build-configs.yaml`](https://github.com/kernelci/kernelci-core/blob/master/build-configs.yaml), with the list of
-branches to monitor and which kernel variants to build for each of them.
+All the builds are configured in
+[`build-configs.yaml`](https://github.com/kernelci/kernelci-core/blob/master/build-configs.yaml),
+with the list of branches to monitor and which kernel variants to build for
+each of them.
 
-Then all the tests are configured in [`test-configs.yaml`](https://github.com/kernelci/kernelci-core/blob/master/test-configs.yaml) with the list of
-devices, test suites and which tests to run on which devices.
+Then all the tests are configured in
+[`test-configs.yaml`](https://github.com/kernelci/kernelci-core/blob/master/test-configs.yaml)
+with the list of devices, test suites and which tests to run on which devices.
 
-Details for the format of these files can be found on the wiki pages for
-[build configurations](https://github.com/kernelci/kernelci-doc/wiki/Build-configurations)
-and [test configurations](https://github.com/kernelci/kernelci-doc/wiki/Test-configurations).
+Details for the format of these files can be found on the wiki pages for [build
+configurations](https://github.com/kernelci/kernelci-doc/wiki/Build-configurations)
+and [test
+configurations](https://github.com/kernelci/kernelci-doc/wiki/Test-configurations).
 
 
 ## Python modules
@@ -74,14 +111,3 @@ The kernelci.org tests typically run in [LAVA](https://lavasoftware.org/).
 Each LAVA test is generated using template files which can be found in the
 [`templates`](https://github.com/kernelci/kernelci-core/tree/master/templates)
 directory.
-
-# Reproducing KernelCI steps locally
-
-It's possible to reproduce KernelCI builds locally, see the
-[KernelCI command line](https://github.com/kernelci/kernelci-doc/wiki/KernelCI-command-line)
-wiki page.
-
-All the KernelCI steps are being gradually refactored into command line tools
-in order to be able to run them in a terminal, or in any automation system
-rather than just Jenkins.  The next steps to be added are to generate and
-submit test jobs and to run bisections.

--- a/doc/kci_build.md
+++ b/doc/kci_build.md
@@ -1,0 +1,123 @@
+## `kci_build`
+
+The
+[`kci_build`](https://github.com/kernelci/kernelci-core/blob/master/kci_build)
+tool is used to run all the KernelCI steps related to building kernels: getting
+the source, creating the config file, building the binaries, generating
+meta-data files and pushing the binaries to a storage server.  The
+[`build-configs.yaml`](https://github.com/kernelci/kernelci-core/blob/master/build-configs.yaml)
+file contains the definitions of which kernel source code should be built (git
+branches) and how (compilers, architectures, kernel configurations).
+
+Running `kci_build` does not require any other KernelCI components to be
+installed.  If a `kernelci-backend` instance is available, build binaries and
+meta-data can be sent to it to share them.  This is however not strictly
+required to run tests using kernel binaries stored locally, such as in an
+individual developer environment.
+
+The example below shows how to build a kernel from
+[`linux-next`](https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git)
+which is called the `next` build configuration in `build-configs.yaml`:
+
+### 1. Optional: set up a local mirror
+
+Setting up a git mirror helps if you need to have multiple copies of the source
+code checked out in different places.
+
+To create or update an existing mirror and fetch the git history for the `next`
+build configuration:
+
+```
+./kci_build update_mirror --config=next --mirror=linux-mirror.git
+```
+
+Tip: it's quicker to create a mainline mirror first if you already have a Linux
+kernel git repo checked out locally, using the `--reference` option.  For
+example:
+
+```
+git clone \
+  --mirror git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git \
+  --reference=~/src/linux \
+  linux-mirror.git
+```
+
+### 2. Create a local check-out (or update an existing one)
+
+Before building a Linux kernel revision, the source code needs to be available
+locally.  This is typically done using git but any source form will work
+(extracting a tarball archive...).  To create or update an existing local git
+repo, with the `--mirror` optional argument:
+
+```
+./kci_build update_repo --config=next --kdir=linux --mirror=linux-mirror.git
+```
+
+Optionally, to generate additional config fragments to then be able to build
+`defconfig+kselftest` or other KernelCI specific configurations:
+
+```
+./kci_build generate_fragments --config=next --kdir=linux
+```
+
+### 3. Build the kernel
+
+Once the git repo has been initialised, or the source code is available in any
+form, the kernel can be built with the `build_kernel` command.  In this
+example, it's building for the `x64_64` architecture with the `defconfig` and
+`gcc-8` compiler:
+
+```
+./kci_build build_kernel \
+  --defconfig=defconfig --arch=x86_64 --build-env=gcc-8 --kdir=linux
+```
+
+To see the compiler output, add `--verbose`.  The output binaries can be found
+in `linux/build`.
+
+To build again without regenerating the kernel config file, just omit the
+`--defconfig` argument:
+
+```
+./kci_build build_kernel \
+  --arch=x86_64 --build-env=gcc-8 --kdir=linux
+```
+
+Note: the `build-env` option is only used to know the name of the compiler
+(e.g. `gcc`) and populate the meta-data for the KernelCI database, it is not
+downloading a build environment or any particular toolchain version.  A future
+improvement would be to enable using a Docker image as with Jenkins builds
+([`jenkins/build.jpl`](https://github.com/kernelci/kernelci-core/blob/master/jenkins/build.jpl)).
+
+### 4. Install the kernel binaries in a local directory
+
+Once the kernel has been built, the binaries can be installed in a local
+directory with added meta-data in `bmeta.json` such as the list of device tree
+(`.dtb`) files, the build log and several other things needed to run some tests
+later on using [`kci_test`](kci_test.md).  It's also an intermediate step
+before publishing a kernel build to KernelCI.
+
+```
+./kci_build install_kernel --config=next --kdir=linux
+```
+
+See the output in `linux/_install_`.
+
+### 5. Optional: publish the kernel build
+
+If you have a `kernelci-backend` instance running, you can send the kernel
+binaries and also the meta-data with these commands:
+
+```
+./kci_build push_kernel \
+  --kdir=linux --api=https://localhost:12345 --token=1234-5678
+
+./kci_build publish_kernel \
+  --kdir=linux --api=https://localhost:12345 --token=1234-5678
+```
+
+Alternatively, to store the meta-data locally in a JSON file:
+
+```
+./kci_build publish_kernel --kdir=linux --json-path=build-meta.json
+```

--- a/doc/kci_test.md
+++ b/doc/kci_test.md
@@ -1,0 +1,128 @@
+## `kci_test`
+
+The output of [`kci_build`](kci_build.md) can be used with the
+[`kci_test`](https://github.com/kernelci/kernelci-core/blob/master/kci_test)
+tool to generate and submit test definitions.  It will be using the meta-data
+JSON files produced by `kci_build` and will also need to communicate with the
+test labs where to run the tests.  Currently, only
+[LAVA](https://www.lavasoftware.org/) is fully supported but other types of lab
+can be added.  Test configurations can be found in
+[`test-configs.yaml`](https://github.com/kernelci/kernelci-core/blob/master/test-configs.yaml)
+with the list of test plans and which devices should run them.  Likewise, the
+lab configurations can be found in
+[`lab-configs.yaml`](https://github.com/kernelci/kernelci-core/blob/master/lab-configs.yaml).
+
+Each lab is expected to have a remote API available with a URL and a user
+authentication token.
+
+Running `kci_build` does not strictly require anything else than the kernel
+binaries with metadata and a lab to run tests, typically LAVA.  If a
+`kernelci-backend` instance is available, it can be used to store test results.
+
+The example below uses the build output from the commands shown in the
+[`kci_build`](kci_build.md) section to generate and submit tests in a lab:
+
+### 1. Optional: save a local copy of any lab-specific data
+
+Generating a test definition relies on some information that may only be
+provided by the particular lab where the test needs to be submitted.  For
+example, some labs have soecial names for their device types.  Retrieving this
+information every time a job definition is generated can result in a
+significant overhead while in practice this information doesn't change very
+often.
+
+To avoid repeating the same queries with the labs, the `kci_test get_lab_info`
+command can be used to store it locally in a JSON file and then reuse it with
+subsequent commands.  This is mostly useful when running automated jobs that
+will determine when to get the information again (say, once for each kernel
+revision being built, or once every hour...).  When submitting only a few jobs
+manually, the overhead may not be so much of a problem.
+
+Here's a sample command to get the data from a lab and store it in a JSON file:
+
+```
+./kci_test get_lab_info \
+  --lab=lab-name \
+  --lab-json=lab-name.json \
+  --user=kernelci-user-name \
+  --token=abcd-7890
+```
+
+### 2. Generate test definitions
+
+The `kci_test generate` command will generate test definitions for a given set
+of build meta-data and a given lab.  It can either generate all the compatible
+test definitions based on the `test_config` entries in `test-configs.yaml`, or
+a subset of it, or a single arbitrary one specified entirely on the command
+line.
+
+The `--callback-id` and `--callback-url` options are only used to get a
+callback from the test lab to a service who can receive it.  It is not required
+to generate and run a job, if the results can be shared by other means or
+manually retrieved.
+
+To generate the definitions of all the jobs that can be run in a lab:
+
+```
+./kci_test generate \
+  --bmeta-json=linux/_install_/bmeta.json \
+  --dtbs-json=linux/_install_/dtbs.json \
+  --lab-json=lab-name.json \
+  --storage=https://some-storage-place.com/ \
+  --lab=lab-name \
+  --user=kernelci-user-name \
+  --token=abcd-7890 \
+  --output=jobs \
+  --callback-id=kernelci-callback \
+  --callback-url=https://callback-recipient.com/handler/
+```
+
+Extra options can be added to only generate a subset of those jobs, filtering
+by test plan, target or machine type respectively:
+
+```
+--plan=baseline
+```
+
+```
+--target=odroid-xu3
+```
+
+```
+--mach=qemu
+```
+
+To generate only one job definition with an arbitrary combination of test plan
+and target, even if it is not listed in any `test_config` entry:
+
+```
+./kci_test generate
+  --bmeta-json=linux/_install_/bmeta.json \
+  --dtbs-json=linux/_install_/dtbs.json \
+  --plan=baseline_qemu \
+  --target=qemu_arm64-virt-gicv3 \
+  --lab=lab-name \
+  --user=kernelci-user-name \
+  --token=abcd-7890 \
+  --lab-json=lab-name.json \
+  --storage=https://some-storage-place.com/ \
+  --callback-id=kernelci-callback-local \
+  --callback-url=https://callback-recipient.com/handler/ \
+  > job.yaml
+```
+
+### 3. Submit tests
+
+Once the test job definitions have been generated and stored in some files,
+they can be submitted to the test lab with the `kci_test submit` command:
+
+```
+./kci_test submit \
+  --lab=lab-name \
+  --user=kernelci-user-name \
+  --token=abcd-7890 \
+  --jobs=jobs/*
+```
+
+What happens next depends on where the test was scheduled and whether there is
+a service such as `kernelci-backend` to receive LAVA callback data.


### PR DESCRIPTION
Add a "doc" directory with detailed documentation for kci_build and
kci_test.  Update README.md with links to them and add some general
introduction about the project.

A rendered version of the files on the incoming branch can be seen here:
https://github.com/gctucker/kernelci-core/tree/cli-doc