### PR TITLE
Normalize repo URLs to HTTPS where possible

### DIFF
--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -17,10 +17,10 @@ trees:
     url: "https://android.googlesource.com/kernel/common"
 
   ardb:
-    url: "git://git.kernel.org/pub/scm/linux/kernel/git/ardb/linux.git"
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/ardb/linux.git"
 
   arm64:
-    url: "git://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git"
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git"
 
   arnd:
     url: "https://git.kernel.org/pub/scm/linux/kernel/git/arnd/playground.git"
@@ -68,22 +68,22 @@ trees:
     url: "https://git.kernel.org/pub/scm/linux/kernel/git/linusw/linux-gpio.git/"
 
   mainline:
-    url: 'git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git'
+    url: 'https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git'
 
   media:
     url: "https://git.linuxtv.org/media_tree.git"
 
   net-next:
-    url: "git://git.kernel.org/pub/scm/linux/kernel/git/davem/net-next.git"
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net-next.git"
 
   next:
-    url: 'git://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git'
+    url: 'https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git'
 
   omap:
     url: "https://git.kernel.org/pub/scm/linux/kernel/git/tmlind/linux-omap.git"
 
   pm:
-    url: "git://git.kernel.org/pub/scm/linux/kernel/git/rafael/linux-pm.git"
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/rafael/linux-pm.git"
 
   pmwg:
     url: "https://git.linaro.org/power/linux.git"


### PR DESCRIPTION
Normalize repo URLs to `https://`, where possible, to satisfy [KCIDB schema
requirements][1]. Fallback to `git://` where that's not possible (to be
permitted by KCIDB schema).

This will help the URLs to match between CI systems.

[1]: https://github.com/kernelci/kcidb/blob/c1d776df9490ed26a587b830a9b8e485df88b96e/kcidb/io_schema.py#L80-L86