### PR TITLE
Qemu 3.1

### DIFF
--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -920,6 +920,7 @@ device_types:
     filters:
       - whitelist: {defconfig: ['vexpress_defconfig']}
 
+# we use virt-2.11 due to https://bugzilla.redhat.com/show_bug.cgi?id=1633328
   qemu_arm-virt-gicv2:
     base_name: qemu
     mach: qemu
@@ -929,7 +930,7 @@ device_types:
       arch: arm
       cpu: 'cortex-a15'
       guestfs_interface: 'virtio'
-      machine: 'virt,gic-version=2'
+      machine: 'virt-2.11,gic-version=2'
     filters:
       - whitelist: {defconfig: ['multi_v7_defconfig']}
 
@@ -942,7 +943,7 @@ device_types:
       arch: arm
       cpu: 'cortex-a15'
       guestfs_interface: 'virtio'
-      machine: 'virt,gic-version=3'
+      machine: 'virt-2.11,gic-version=3'
     filters:
       - whitelist: {defconfig: ['multi_v7_defconfig']}
 

--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -882,6 +882,7 @@ device_types:
       cpu: 'arm926'
       memory: 256
       model: 'model=smc91c111'
+      guestfs_interface: 'scsi'
     dtb: 'versatile-pb.dtb'
     boot_method: qemu
     filters:

--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -897,6 +897,8 @@ device_types:
       machine: 'vexpress-a9'
       cpu: 'cortex-a9'
       model: 'model=lan9118'
+      guestfs_interface: 'none'
+      extra_options: ['-device virtio-blk-device,drive=lavatest']
     dtb: 'vexpress-v2p-ca9.dtb'
     boot_method: qemu
     filters:
@@ -911,6 +913,8 @@ device_types:
       machine: 'vexpress-a15'
       cpu: 'cortex-a15'
       model: 'model=lan9118'
+      guestfs_interface: 'none'
+      extra_options: ['-device virtio-blk-device,drive=lavatest']
     dtb: 'vexpress-v2p-ca15-tc1.dtb'
     boot_method: qemu
     filters:


### PR DESCRIPTION
We have upgraded our lab to LAVA 2020.02 and so upgraded to buster.
Buster came with a more recent qemu which breaks some test jobs.