### PR TITLE
Baseline barebox

### DIFF
--- a/kci_test
+++ b/kci_test
@@ -157,6 +157,9 @@ class cmd_generate(Command):
             params = kernelci.test.get_params(
                 bmeta, target, plan, args.storage)
             job = api.generate(params, target, plan, callback_opts)
+            if job is None:
+                print("Failed to generate the job definition")
+                return False
             if args.output:
                 file_name = api.job_file_name(params)
                 output_file = os.path.join(args.output, file_name)

--- a/templates/baseline/generic-barebox-tftp-ramdisk-baseline-template.jinja2
+++ b/templates/baseline/generic-barebox-tftp-ramdisk-baseline-template.jinja2
@@ -1,0 +1,7 @@
+{% extends 'boot/generic-barebox-tftp-ramdisk-boot-template.jinja2' %}
+{% block actions %}
+{{ super () }}
+
+{% include 'baseline/baseline.jinja2' %}
+
+{% endblock %}


### PR DESCRIPTION
Add template for the baseline test plan on barebox devices, to fix job submission with the Pengutronix lab.

Also fix error propagation in `kci_test` when a job definition fails to get generated.