### PR TITLE
restrict clang defconfigs

### DIFF
--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -607,13 +607,22 @@ build_configs:
           arm64:
             extra_configs:
               - 'allmodconfig'
+              - 'allnoconfig'
           arm:
-            base_defconfig: 'multi_v7_defconfig'
+            filters:
+              - regex: {
+                defconfig: '(?:aspeed_g5_def|multi_v5_def|multi_v7_def|allmod|allno)config',
+              }
             extra_configs:
               - 'aspeed_g5_defconfig'
               - 'multi_v5_defconfig'
               - 'allmodconfig'
-          x86_64: *x86_64_arch
+              - 'allnoconfig'
+          x86_64:
+            extra_configs:
+              - 'allmodconfig'
+              - 'allnoconfig'
+            fragments: []
 
   next_pending-fixes:
     tree: next


### PR DESCRIPTION
With this commit:
$ ./kci_build list_kernel_configs --kdir=<linux kernel dir> \
  --config=next | grep clang | sort
arm64 allmodconfig clang-9
arm64 allnoconfig clang-9
arm64 defconfig clang-9
arm allmodconfig clang-9
arm allnoconfig clang-9
arm aspeed_g5_defconfig clang-9
arm multi_v5_defconfig clang-9
arm multi_v7_defconfig clang-9
x86_64 allmodconfig clang-9
x86_64 allnoconfig clang-9
x86_64 defconfig clang-9

Before this commit, we were testing 113 targets with Clang, including
broken fragments like x86_64_defconfig+kernel/configs/kvm_guest.config
and most ARM configs. The above listing gives us basic coverage of
ARMv{5|6|7|8} and x86_64.