### PR TITLE
test-configs.yaml: align all URLs to use plain HTTP

### DIFF
--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -5,7 +5,7 @@
 file_system_types:
 
   buildroot:
-    url: 'https://storage.kernelci.org/images/rootfs/buildroot/kci-2019.02-9-g25091c539382'
+    url: 'http://storage.kernelci.org/images/rootfs/buildroot/kci-2019.02-9-g25091c539382'
 
     arch_map:
       arm64be: [{arch: arm64, endian: big}]
@@ -101,35 +101,35 @@ test_plans:
     rootfs: buildroot_baseline_ramdisk
     pattern: 'baseline/generic-qemu-baseline-template.jinja2'
     params:
-      bios_url: 'https://storage.kernelci.org/images/uefi/111bbcf87621/QEMU_EFI.fd-ARM-RELEASE-111bbcf87621'
+      bios_url: 'http://storage.kernelci.org/images/uefi/111bbcf87621/QEMU_EFI.fd-ARM-RELEASE-111bbcf87621'
 
   baseline-uefi_arm64:
     base_name: baseline-uefi
     rootfs: buildroot_baseline_ramdisk
     pattern: 'baseline/generic-qemu-baseline-template.jinja2'
     params:
-      bios_url: 'https://storage.kernelci.org/images/uefi/111bbcf87621/QEMU_EFI.fd-AARCH64-RELEASE-111bbcf87621'
+      bios_url: 'http://storage.kernelci.org/images/uefi/111bbcf87621/QEMU_EFI.fd-AARCH64-RELEASE-111bbcf87621'
 
   baseline-uefi_x86_64:
     base_name: baseline-uefi
     rootfs: buildroot_baseline_ramdisk
     pattern: 'baseline/generic-qemu-baseline-template.jinja2'
     params:
-      bios_url: 'https://storage.kernelci.org/images/uefi/111bbcf87621/OVMF.fd-X64-RELEASE-111bbcf87621'
+      bios_url: 'http://storage.kernelci.org/images/uefi/111bbcf87621/OVMF.fd-X64-RELEASE-111bbcf87621'
 
   baseline-uefi_i386:
     base_name: baseline-uefi
     rootfs: buildroot_baseline_ramdisk
     pattern: 'baseline/generic-qemu-baseline-template.jinja2'
     params:
-      bios_url: 'https://storage.kernelci.org/images/uefi/111bbcf87621/OVMF.fd-IA32-RELEASE-111bbcf87621'
+      bios_url: 'http://storage.kernelci.org/images/uefi/111bbcf87621/OVMF.fd-IA32-RELEASE-111bbcf87621'
 
   baseline-uefi_x86-mixed:
     base_name: baseline-uefi
     rootfs: buildroot_baseline_ramdisk
     pattern: 'baseline/generic-qemu-baseline-template.jinja2'
     params:
-      bios_url: 'https://storage.kernelci.org/images/uefi/111bbcf87621/OVMF.fd-IA32X64-RELEASE-111bbcf87621'
+      bios_url: 'http://storage.kernelci.org/images/uefi/111bbcf87621/OVMF.fd-IA32X64-RELEASE-111bbcf87621'
 
   boot:
     rootfs: buildroot_ramdisk


### PR DESCRIPTION
Some URLs were using HTTPS while others HTTP, align them all to use
HTTP instead.  In particular, this makes it possible to have file
caching in test labs with Squid.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>