### PR TITLE
jenkins/dockerfiles: build-base: add rsync

### DIFF
--- a/jenkins/dockerfiles/build-base/Dockerfile
+++ b/jenkins/dockerfiles/build-base/Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     libelf-dev \
     lzop \
     make \
+    rsync \
     tar \
     u-boot-tools \
     wget \


### PR DESCRIPTION
kselftest build/install has (unexplained) dependency on rsync.  While
this may be removed eventually, let's add so we can build/install
current (and older) kselftest.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>