### PR TITLE
WIP get baseline dmesg definition from git repo with dmesg.sh

### DIFF
--- a/templates/baseline/baseline.jinja2
+++ b/templates/baseline/baseline.jinja2
@@ -5,37 +5,11 @@
     timeout:
       minutes: 1
     definitions:
-    - repository:
-        metadata:
-          format: Lava-Test Test Definition 1.0
-          name: baseline
-          description: "baseline test plan"
-          os:
-            - debian
-          scope:
-            - functional
-          environment:
-            - lava-test-shell
-        run:
-          steps:
-            - >
-                for level in warn err; do
-                  dmesg --level=$level --notime -x -k > dmesg.$level
-                done
-            - >
-                for level in crit alert emerg; do
-                  dmesg --level=$level --notime -x -k > dmesg.$level
-                  test -s dmesg.$level && res=fail || res=pass
-                  count=$(cat dmesg.$level | wc -l)
-                  lava-test-case $level \
-                    --result $res \
-                    --measurement $count \
-                    --units lines
-                done
-            - cat dmesg.emerg dmesg.alert dmesg.crit dmesg.err dmesg.warn
-      from: inline
-      name: dmesg
-      path: inline/dmesg.yaml
+      - repository: https://gitlab.collabora.com/gtucker/lava-test-definitions.git
+        revision: dmesg
+        from: git
+        path: dmesg.yaml
+        name: dmesg
 
 - test:
 {%- if test_namespace %}


### PR DESCRIPTION
ToDo: create kernelci/test-definitions if we want to do that

Rather than defining the dmesg test inline, use a separate repository
with dmesg.yaml as well as a script dmesg.sh to control what is being
output in the LAVA log.  This way, commands inside the shell script
are not visible in the log and reduce noise.  It also helps to be able
to separate test definitions from kernelci-core which is aiming to be
a pure Python package.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>