### PR TITLE
test-configs.yaml: add mt8173-elm-hana arm64 Chromebook

### DIFF
--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -810,6 +810,11 @@ device_types:
             - 'tinyconfig'
             - 'kvm_guest.config'
 
+  mt8173-elm-hana:
+    mach: mediatek
+    class: arm64-dtb
+    boot_method: depthcharge
+
   mustang:
     mach: apm
     class: arm64-dtb
@@ -1737,6 +1742,14 @@ test_configs:
       - baseline
       - boot
       - simple
+
+  - device_type: mt8173-elm-hana
+    test_plans:
+      - baseline
+      - boot
+      - cros-ec
+      - sleep
+      - v4l2-compliance-uvc
 
   - device_type: mustang
     test_plans:


### PR DESCRIPTION
Add definition for the mt8173-elm-hana arm64 Chromebook device and
enable some relevant test plans to run on it.

- [x] device support available in `linux-next` [arm64: dts: mediatek: add mt8173 elm and hana board](https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/arch/arm64/boot/dts/mediatek/mt8173-elm-hana.dts?h=next-20200417&id=689b937beddebf2d7c57249206428b8eecf4646b)
- [x] device type merged in LAVA upstream [MR 1129](https://git.lavasoftware.org/lava/lava/-/merge_requests/1129)