### PR TITLE
jenkins: remove build- from DOCKER_BASE

### DIFF
--- a/jenkins/bisect.jpl
+++ b/jenkins/bisect.jpl
@@ -69,7 +69,7 @@ KCI_CORE_URL (https://github.com/kernelci/kernelci-core.git)
   URL of the kernelci-core repository
 KCI_CORE_BRANCH (master)
   Name of the branch to use in the kernelci-core repository
-DOCKER_BASE (kernelci/build-)
+DOCKER_BASE (kernelci/)
   Dockerhub base address used for the build images
 LAVA_CALLBACK (kernel-ci-callback)
   Description of the LAVA auth token to look up and use in LAVA callbacks
@@ -733,11 +733,11 @@ ${params_summary}""")
         }
     }
 
-    j.dockerPullWithRetry("${params.DOCKER_BASE}base").inside() {
+    j.dockerPullWithRetry("${params.DOCKER_BASE}build-base").inside() {
         j.cloneKciCore(kci_core, params.KCI_CORE_URL, params.KCI_CORE_BRANCH)
         build_env_docker_image = j.dockerImageName(
             kci_core, params.BUILD_ENVIRONMENT, params.ARCH)
-        docker_image = "${params.DOCKER_BASE}${build_env_docker_image}"
+        docker_image = "${params.DOCKER_BASE}build-${build_env_docker_image}"
     }
 
     j.dockerPullWithRetry(docker_image).inside() {

--- a/jenkins/build-trigger.jpl
+++ b/jenkins/build-trigger.jpl
@@ -40,7 +40,7 @@ KCI_CORE_URL (https://github.com/kernelci/kernelci-core.git)
   URL of the kernelci-core repository
 KCI_CORE_BRANCH (master)
   Name of the branch to use in the kernelci-core repository
-DOCKER_BASE
+DOCKER_BASE (kernelci/)
   Dockerhub base address used for the build images
 ALLOW_REBUILD (false)
   Allow building the same revision again.
@@ -284,7 +284,7 @@ node("docker && build-trigger") {
     def kdir = "${env.WORKSPACE}/configs/${params.BUILD_CONFIG}"
     def mirror = "${env.WORKSPACE}/linux.git"
     def labs_info = "${env.WORKSPACE}/labs"
-    def docker_image = "${params.DOCKER_BASE}base"
+    def docker_image = "${params.DOCKER_BASE}build-base"
     def opts = [:]
     def configs = []
 

--- a/jenkins/build.jpl
+++ b/jenkins/build.jpl
@@ -52,7 +52,7 @@ KCI_CORE_URL (https://github.com/kernelci/kernelci-core.git)
   URL of the kernelci-core repository
 KCI_CORE_BRANCH (master)
   Name of the branch to use in the kernelci-core repository
-DOCKER_BASE
+DOCKER_BASE (kernelci/)
   Dockerhub base address used for the build images
 PARALLEL_BUILDS
   Number of kernel builds to run in parallel
@@ -131,11 +131,11 @@ node("docker" && params.NODE_LABEL) {
     Defconfig: ${params.DEFCONFIG}
     Compiler:  ${params.BUILD_ENVIRONMENT}""")
 
-    j.dockerPullWithRetry("${params.DOCKER_BASE}base").inside() {
+    j.dockerPullWithRetry("${params.DOCKER_BASE}build-base").inside() {
         j.cloneKciCore(kci_core, params.KCI_CORE_URL, params.KCI_CORE_BRANCH)
         build_env_docker_image = j.dockerImageName(
             kci_core, params.BUILD_ENVIRONMENT, params.ARCH)
-        docker_image = "${params.DOCKER_BASE}${build_env_docker_image}"
+        docker_image = "${params.DOCKER_BASE}build-${build_env_docker_image}"
     }
 
     j.dockerPullWithRetry(docker_image).inside() {

--- a/jenkins/monitor.jpl
+++ b/jenkins/monitor.jpl
@@ -37,7 +37,7 @@ KCI_CORE_URL (https://github.com/kernelci/kernelci-core.git)
   URL of the kernelci-core repository
 KCI_CORE_BRANCH (master)
   Name of the branch to use in the kernelci-core repository
-DOCKER_BASE (kernelci/build-)
+DOCKER_BASE (kernelci/)
   Dockerhub base address used for the build images
 
 */
@@ -77,7 +77,7 @@ node("docker && monitor") {
     def j = new Job()
     def kci_core = env.WORKSPACE + '/kernelci-core'
     def trees_dir = "${env.WORKSPACE}/trees"
-    def docker_image = "${params.DOCKER_BASE}base"
+    def docker_image = "${params.DOCKER_BASE}build-base"
 
     print("""\
     Storage:   ${params.KCI_STORAGE_URL}

--- a/jenkins/test-runner.jpl
+++ b/jenkins/test-runner.jpl
@@ -38,7 +38,7 @@ KCI_CORE_BRANCH (master)
   Name of the branch to use in the kernelci-core repository
 KCI_STORAGE_URL (https://storage.kernelci.org/)
   URL of the KernelCI storage server
-DOCKER_BASE (kernelci/build-)
+DOCKER_BASE (kernelci/)
   Dockerhub base address used for the build images
 CALLBACK_ID (kernel-ci-callback)
   Identifier of the callback to look up an authentication token
@@ -113,7 +113,7 @@ node("docker && test-runner") {
     def kci_core = "${env.WORKSPACE}/kernelci-core"
     def jobs_dir = "${env.WORKSPACE}/jobs"
     def artifacts = "${env.WORKSPACE}/artifacts"
-    def docker_image = "${params.DOCKER_BASE}base"
+    def docker_image = "${params.DOCKER_BASE}build-base"
     def labs = params.LABS.tokenize(' ')
     def labs_submit = []
 


### PR DESCRIPTION
Remove the build- part of the DOCKER_BASE strings and add it in each
job that actually requires it.  This is to be able to have the same
DOCKER_BASE for jobs that require other types of Docker images such as
kernelci/debos.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>