### PR TITLE
dockerfiles: Add container for DT validation

### DIFF
--- a/jenkins/dockerfiles/build-and-push.sh
+++ b/jenkins/dockerfiles/build-and-push.sh
@@ -23,13 +23,14 @@
 # -p = push to dockerhub
 # -b = also rebuild build-base
 # -d = also rebuild debos
+# -i = also rebuild dt-validation
 # -q = make the builds quiet
 # -t = the prefix to use in docker tags (default is kernelci/)
 
 set -e
 tag_px='kernelci/'
 
-options='npbdqt:'
+options='npbdiqt:'
 while getopts $options option
 do
   case $option in
@@ -37,6 +38,7 @@ do
     p )  push=true;;
     b )  base=true;;
     d )  debos=true;;
+    i )  dt_validation=true;;
     q )  quiet="--quiet";;
     t )  tag_px=$OPTARG;;
     \? )
@@ -89,6 +91,18 @@ then
   tag=${tag_px}debos
   echo_build $tag
   docker build ${quiet} ${cache_args} debos -t $tag
+  if [ "x${push}" == "xtrue" ]
+  then
+    echo_push $tag
+    docker push $tag
+  fi
+fi
+
+if [ "x${dt_validation}" == "xtrue" ]
+then
+  tag=${tag_px}dt-validation
+  echo_build $tag
+  docker build ${quiet} ${cache_args} dt-validation -t $tag
   if [ "x${push}" == "xtrue" ]
   then
     echo_push $tag

--- a/jenkins/dockerfiles/dt-validation/Dockerfile
+++ b/jenkins/dockerfiles/dt-validation/Dockerfile
@@ -1,0 +1,12 @@
+FROM kernelci/build-base
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    gcc-8 \
+    gcc-8-plugin-dev \
+    python3-pip \
+    python3-setuptools \
+    python3-wheel
+
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 500
+
+RUN pip3 install git+https://github.com/devicetree-org/dt-schema.git@master


### PR DESCRIPTION
The kernel has started moving devicetree schemas to a format which
allows for automatic validation.  This requires a separate build target
and a toolset (currently not packaged for any distro) so create a new
docker container with the toolset installed that we can use to run these
tests.

Signed-off-by: Mark Brown <broonie@kernel.org>