### PR TITLE
dockerfiles: Include arm toolchain in the arm64 GCC container

### DIFF
--- a/jenkins/dockerfiles/gcc-8_arm64/Dockerfile
+++ b/jenkins/dockerfiles/gcc-8_arm64/Dockerfile
@@ -2,7 +2,9 @@ FROM kernelci/build-base
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
     gcc-8-aarch64-linux-gnu \
-    gcc-8-plugin-dev-aarch64-linux-gnu
+    gcc-8-plugin-dev-aarch64-linux-gnu \
+    gcc-8-arm-linux-gnueabihf \
+    gcc-8-plugin-dev-arm-linux-gnueabihf
 
 RUN update-alternatives \
     --install /usr/bin/aarch64-linux-gnu-gcc aarch64-linux-gnu-gcc /usr/bin/aarch64-linux-gnu-gcc-8 500 \
@@ -12,3 +14,12 @@ RUN update-alternatives \
     --slave /usr/bin/aarch64-linux-gnu-gcc-gcov aarch64-linux-gnu-gcov /usr/bin/aarch64-linux-gnu-gcov-8 \
     --slave /usr/bin/aarch64-linux-gnu-gcov-gcc-dump aarch64-linux-gnu-gcov-dump /usr/bin/aarch64-linux-gnu-gcov-dump-8 \
     --slave /usr/bin/aarch64-linux-gnu-gcov-gcc-tool aarch64-linux-gnu-gcov-tool /usr/bin/aarch64-linux-gnu-gcov-tool-8
+
+RUN update-alternatives \
+    --install /usr/bin/arm-linux-gnueabihf-gcc arm-linux-gnueabihf-gcc /usr/bin/arm-linux-gnueabihf-gcc-8 500 \
+    --slave /usr/bin/arm-linux-gnueabihf-gcc-ar arm-linux-gnueabihf-gcc-ar /usr/bin/arm-linux-gnueabihf-gcc-ar-8 \
+    --slave /usr/bin/arm-linux-gnueabihf-gcc-nm arm-linux-gnueabihf-gcc-nm /usr/bin/arm-linux-gnueabihf-gcc-nm-8 \
+    --slave /usr/bin/arm-linux-gnueabihf-gcc-ranlib arm-linux-gnueabihf-gcc-ranlib /usr/bin/arm-linux-gnueabihf-gcc-ranlib-8 \
+    --slave /usr/bin/arm-linux-gnueabihf-gcc-gcov arm-linux-gnueabihf-gcov /usr/bin/arm-linux-gnueabihf-gcov-8 \
+    --slave /usr/bin/arm-linux-gnueabihf-gcc-gcov-dump arm-linux-gnueabihf-gcov-dump /usr/bin/arm-linux-gnueabihf-gcov-dump-8 \
+    --slave /usr/bin/arm-linux-gnueabihf-gcc-gcov-tool arm-linux-gnueabihf-gcov-tool /usr/bin/arm-linux-gnueabihf-gcov-tool-8


### PR DESCRIPTION
arm64 supports 32 bit arm userspace, including a VDSO for that userspace
which needs a 32 bit toolchain to build, so add the arm toolchain so we
can provide coverage for it.

Signed-off-by: Mark Brown <broonie@kernel.org>