### PR TITLE
Cross compile compat

### DIFF
--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -171,6 +171,8 @@ build_environments:
       arm64: 'aarch64-linux-gnu-'
       mips: 'mips-linux-gnu-'
       riscv: 'riscv64-linux-gnu-'
+    cross_compile_compat: &default_cross_compile_compat
+      arm64: 'arm-linux-gnueabihf-'
 
   clang-9:
     cc: clang
@@ -184,6 +186,7 @@ build_environments:
       arc:
       riscv:
     cross_compile: *default_cross_compile
+    cross_compile_compat: *default_cross_compile_compat
 
   clang-10:
     cc: clang

--- a/kci_build
+++ b/kci_build
@@ -193,9 +193,8 @@ def _show_build_env(build_env, arch=None):
     print(build_env.cc_version)
     if arch:
         print(build_env.get_arch_name(arch) or '')
-        xc = build_env.get_cross_compile(arch)
-        if xc:
-            print(xc)
+        print(build_env.get_cross_compile(arch) or '')
+        print(build_env.get_cross_compile_compat(arch) or '')
 
 
 class cmd_get_build_env(Command):

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -434,7 +434,7 @@ def _output_to_file(cmd, log_file, rel_dir=None):
 
 def _run_make(kdir, arch, target=None, jopt=None, silent=True, cc='gcc',
               cross_compile=None, use_ccache=None, output=None, log_file=None,
-              opts=None):
+              opts=None, cross_compile_compat=None):
     args = ['make']
 
     if opts:
@@ -452,6 +452,9 @@ def _run_make(kdir, arch, target=None, jopt=None, silent=True, cc='gcc',
 
     if cross_compile:
         args.append('CROSS_COMPILE={}'.format(cross_compile))
+
+    if cross_compile_compat:
+        args.append('CROSS_COMPILE_COMPAT={}'.format(cross_compile_compat))
 
     args.append('HOSTCC={}'.format(cc))
 
@@ -565,6 +568,7 @@ def build_kernel(build_env, kdir, arch, defconfig=None, jopt=None,
     """
     cc = build_env.cc
     cross_compile = build_env.get_cross_compile(arch) or ''
+    cross_compile_compat = build_env.get_cross_compile_compat(arch) or ''
     use_ccache = shell_cmd("which ccache > /dev/null", True)
     if jopt is None:
         jopt = int(shell_cmd("nproc")) + 2
@@ -589,6 +593,7 @@ def build_kernel(build_env, kdir, arch, defconfig=None, jopt=None,
         'arch': arch,
         'cc': cc,
         'cross_compile': cross_compile,
+        'cross_compile_compat': cross_compile_compat,
         'use_ccache': use_ccache,
         'output': output_path,
         'silent': not verbose,

--- a/kernelci/config/build.py
+++ b/kernelci/config/build.py
@@ -193,7 +193,7 @@ class BuildEnvironment(YAMLObject):
     """Kernel build environment model."""
 
     def __init__(self, name, cc, cc_version, arch_map=None,
-                 cross_compile=None):
+                 cross_compile=None, cross_compile_compat=None):
         """A build environment is a compiler and tools to build a kernel.
 
         *name* is the name of the build environment so it can be referred to in
@@ -213,12 +213,17 @@ class BuildEnvironment(YAMLObject):
 
         *cross_compile* is a dictionary mapping kernel CPU architecture names
                         to cross-compiler prefixes.
+
+        *cross_compile_compat* is a dictionary mapping kernel CPU
+                               architecture names to cross-compiler
+                               prefixes for building compat VDSOs.
         """
         self._name = name
         self._cc = cc
         self._cc_version = str(cc_version)
         self._arch_map = arch_map or dict()
         self._cross_compile = cross_compile or dict()
+        self._cross_compile_compat = cross_compile_compat or dict()
 
     @classmethod
     def from_yaml(cls, config, name):
@@ -226,7 +231,8 @@ class BuildEnvironment(YAMLObject):
             'name': name,
         }
         kw.update(cls._kw_from_yaml(
-            config, ['name', 'cc', 'cc_version', 'arch_map', 'cross_compile']))
+            config, ['name', 'cc', 'cc_version', 'arch_map', 'cross_compile',
+                     'cross_compile_compat']))
         return cls(**kw)
 
     @property
@@ -246,6 +252,9 @@ class BuildEnvironment(YAMLObject):
 
     def get_cross_compile(self, kernel_arch):
         return self._cross_compile.get(kernel_arch, '')
+
+    def get_cross_compile_compat(self, kernel_arch):
+        return self._cross_compile_compat.get(kernel_arch, '')
 
 
 class BuildVariant(YAMLObject):


### PR DESCRIPTION
These two patches update kci_build to build the compat VDSO on arm64, giving us coverage of that.

Doing these builds will depend on having a docker container with the Arm compiler added as enabled by the separate pull request https://github.com/kernelci/kernelci-core/pull/353 