### PR TITLE
build-configs.yaml: add android-{4.14,4.19,5.4}-stable branches

### DIFF
--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -406,6 +406,10 @@ build_configs:
     tree: android
     branch: 'android-4.14-q-release'
 
+  android_4.14-stable:
+    tree: android
+    branch: 'android-4.14-stable'
+
   android_4.14:
     tree: android
     branch: 'android-4.14'
@@ -418,9 +422,17 @@ build_configs:
     tree: android
     branch: 'android-4.19-q-release'
 
+  android_4.19-stable:
+    tree: android
+    branch: 'android-4.19-stable'
+
   android_4.19:
     tree: android
     branch: 'android-4.19'
+
+  android_5.4-stable:
+    tree: android
+    branch: 'android-5.4-stable'
 
   android_5.4:
     tree: android


### PR DESCRIPTION
Add the android stable branches for 4.14, 4.19 and 5.4 as they are
among the most important ones to cover.  For some reason they had
never been built on kernelci.org before.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>