### PR TITLE
lab-configs: enable stable and mainline in lab-clabbe

### DIFF
--- a/lab-configs.yaml
+++ b/lab-configs.yaml
@@ -25,8 +25,10 @@ labs:
             - sleep
           tree:
             - kernelci
+            - mainline
             - next
             - stable-rc
+            - stable
 
   lab-collabora:
     lab_type: lava


### PR DESCRIPTION
My internet line got upgraded to fiber and I increased the throughput of
my lab.
So it can handle more tree job.