### PR TITLE
T20625 build-configs.yaml: add MEDIA_TEST_SUPPORT=y to virtualvideo

### DIFF
--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -145,6 +145,7 @@ fragments:
     configs:
       - 'CONFIG_MEDIA_SUPPORT=y'
       - 'CONFIG_MEDIA_CAMERA_SUPPORT=y'
+      - 'CONFIG_MEDIA_TEST_SUPPORT=y'
       - 'CONFIG_VIDEO_DEV=y'
       - 'CONFIG_VIDEO_V4L2=y'
       - 'CONFIG_V4L_TEST_DRIVERS=y'


### PR DESCRIPTION
Starting with v5.7, the media test drivers need MEDIA_TEST_SUPPORT=y
to be enabled.  Add this to the virtualvideo config fragment.

Link: https://lore.kernel.org/linux-media/20200415142147.1ed3487e@coco.lan/
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>