### PR TITLE
kci_build: fix show_build_env and use it for Docker image names

### DIFF
--- a/kci_build
+++ b/kci_build
@@ -192,8 +192,8 @@ def _show_build_env(build_env, arch=None):
     print(build_env.cc)
     print(build_env.cc_version)
     if arch:
-        print(build_env.get_arch_name(args.arch))
-        xc = build_env.get_cross_compile(args.arch)
+        print(build_env.get_arch_name(arch) or '')
+        xc = build_env.get_cross_compile(arch)
         if xc:
             print(xc)
 

--- a/src/org/kernelci/util/Job.groovy
+++ b/src/org/kernelci/util/Job.groovy
@@ -45,26 +45,20 @@ def cloneKciCore(path, url, branch) {
 
 def dockerImageName(kci_core, build_env, kernel_arch) {
     def image_name = build_env
-    def cc = null
 
     dir(kci_core) {
         def build_env_raw = sh(
-            script: "./kci_build show_build_env --build-env=${build_env}",
-            returnStdout: true).trim()
-        cc = build_env_raw.tokenize('\n')[1]
-    }
+            script: """
+./kci_build \
+  show_build_env \
+  --build-env=${build_env} \
+  --arch=${kernel_arch} \
+""", returnStdout: true).trim()
+        def build_env_data = build_env_raw.split('\n').toList()
+        def cc_arch = build_env_data[3]
 
-    if (cc == "gcc") {
-        def docker_arch
-
-        if (kernel_arch == "riscv")
-            docker_arch = "riscv64"
-        else if ((kernel_arch == "i386") || (kernel_arch == "x86_64"))
-            docker_arch = "x86"
-        else
-            docker_arch = kernel_arch
-
-	image_name = "${image_name}_${docker_arch}"
+        if (cc_arch)
+            image_name = "${build_env}_${cc_arch}"
     }
 
     return image_name


### PR DESCRIPTION
Fix the output of `kci_build show_build_environment` and update the Jenkins library to use it rather than hard-coding the mapping between architecture names for the kernel and compilers.