### PR TITLE
test-configs: blacklist stm32_defconfig for stm32mp157c-dk

### DIFF
--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -1084,6 +1084,8 @@ device_types:
     mach: stm32
     class: arm-dtb
     boot_method: uboot
+    filters:
+      - blacklist: {defconfig: ['stm32_defconfig']}
 
   sun4i-a10-olinuxino-lime:
     mach: allwinner


### PR DESCRIPTION
The stm32mp157c-dk does not boot with kernel produced by stm32_defconfig.
More generaly (quoting Alexandre Torgue):
For mpu boards you have to use multi_v7_defconfig.
The stm32_defconfig has to be used for MCU boards (f4/f7/h7) only.