### PR TITLE
RFC v2: demonstrate k8s builders

### DIFF
--- a/templates/k8s/gen.py
+++ b/templates/k8s/gen.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+import os
+from jinja2 import Environment, FileSystemLoader
+import re
+
+
+def env_override(value, key):
+    return os.getenv(key, value)
+
+
+d = os.getenv('DEFCONFIG').split('+')
+defconfig = d[0]
+frag = None
+if len(d) > 1:
+    frag = d[1]
+
+job_name = 'build-j{}-{}-{}-{}'.format(
+    os.getenv('BUILD_ID'),
+    os.getenv('ARCH'),
+    os.getenv('BUILD_ENVIRONMENT'),
+    defconfig,
+)
+
+if frag:
+    frag = os.path.splitext(os.path.basename(frag))[0]
+    job_name += "-{}".format(frag)
+
+# job name can only have '-'
+job_name = re.sub('[\./_+=]', '-', job_name).lower()
+
+# k8s limits job-name to max 63 chars (and be sure it doesn't end with '-')
+job_name = job_name[0:63].rstrip('-')
+
+# FIXME: needs to be tweaked according to k8s cluster VMs
+cpu_limit = int(os.getenv('K8S_CPU_LIMIT', 8))
+parallel_builds = os.getenv('PARALLEL_BUILDS')
+if parallel_builds:
+    parallel_builds = int(parallel_builds)
+    cpu_limit = min(cpu_limit, parallel_builds)
+    os.environ['PARALLEL_JOPT'] = "-j{}".format(parallel_builds)
+
+if (cpu_limit < 8):
+    cpu_request = cpu_limit * 0.875
+else:
+    cpu_request = cpu_limit - 0.9
+
+# VMs are generous, let's be greedy and ask for 1Gb per core :)
+mem_request = cpu_limit
+
+params = {
+    'job_name': job_name,
+    'cpu_limit': cpu_limit,
+    'cpu_request': cpu_request,
+    'mem_request': "{}Gi".format(mem_request)
+}
+env = Environment(loader=FileSystemLoader(['.', 'templates', 'templates/k8s']),
+                  extensions=["jinja2.ext.do"])
+env.filters['env_override'] = env_override
+template = env.get_template("job-build.jinja2")
+job_yaml = template.render(params)
+f = job_name + ".yaml"
+fp = open(f, "w")
+fp.write(job_yaml)
+fp.close()
+print(job_name)

--- a/templates/k8s/job-build.jinja2
+++ b/templates/k8s/job-build.jinja2
@@ -1,0 +1,100 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ job_name }}
+spec:
+  completions: 1
+  template:
+    spec:
+      restartPolicy: OnFailure
+
+      # in-memory tmpfs
+      volumes:
+      - name: scratch-volume
+        emptyDir: { medium: "Memory" }
+
+      # only run on preemptible nods
+      #nodeSelector:
+      #  cloud.google.com/gke-preemptible: "true"
+
+      # tolerate Azure spot instances
+      tolerations:
+      - key: "kubernetes.azure.com/scalesetpriority"
+        operator: "Equal"
+        value: "spot"
+        effect: "NoSchedule"
+
+      initContainers:
+      - name: kernelci-core-setup
+        image: {{ "FIXME" | env_override('DOCKER_BASE') }}build-{{ "FIXME" | env_override('DOCKER_IMAGE') }}
+
+        volumeMounts:
+        - mountPath: "/scratch"
+          name: scratch-volume
+
+        command: ["/bin/bash", "-x", "-c"]
+        args: ["cd /scratch && git clone --depth=1 --branch ${KCI_CORE_BRANCH} ${KCI_CORE_URL}"]
+
+        env:
+        - name: KCI_CORE_URL
+          value: "{{ "FIXME" | env_override('KCI_CORE_URL') }}"
+        - name: KCI_CORE_BRANCH
+          value: "{{ "FIXME" | env_override('KCI_CORE_BRANCH') }}"
+
+      containers:
+      - name: kci-build
+        image: {{ "FIXME" | env_override('DOCKER_BASE') }}build-{{ "FIXME" | env_override('DOCKER_IMAGE') }}
+
+        volumeMounts:
+        - mountPath: "/scratch"
+          name: scratch-volume
+
+        command: ["/bin/bash", "-x", "-c"]
+        args: ["echo nproc=$(nproc); df; free; \
+export KDIR=/scratch/linux && export OUTPUT=$HOME/build && export CCACHE_DISABLE=true && \
+cd /scratch/kernelci-core &&  \
+./kci_build pull_tarball --kdir ${KDIR} --url ${SRC_TARBALL} --retries 3 --delete && \
+./kci_build build_kernel --kdir ${KDIR} --output ${OUTPUT} --defconfig=${DEFCONFIG} --arch=${ARCH} --build-env=${BUILD_ENVIRONMENT} --verbose ${PARALLEL_JOPT}; export KERNEL_BUILD_RESULT=$?; \
+./kci_build install_kernel --kdir ${KDIR} --output ${OUTPUT} --config ${BUILD_CONFIG} --describe=${GIT_DESCRIBE} --describe-verbose=${GIT_DESCRIBE_VERBOSE} --commit=${COMMIT_ID}; \
+./kci_build push_kernel --kdir ${KDIR} --token=${KCI_API_TOKEN} --api=${KCI_API_URL}; \
+./kci_build publish_kernel --kdir ${KDIR} --token=${KCI_API_TOKEN} --api=${KCI_API_URL}; \
+echo KERNEL_BUILD_RESULT=$KERNEL_BUILD_RESULT; \
+exit 0; \
+"]
+
+        env:
+        - name: ARCH
+          value: "{{ "FIXME" | env_override('ARCH') }}"
+        - name: BUILD_ENVIRONMENT
+          value: "{{ "FIXME" | env_override('BUILD_ENVIRONMENT') }}"
+        - name: DEFCONFIG
+          value: "{{ "FIXME" | env_override('DEFCONFIG') }}"
+        - name: SRC_TARBALL
+          value: "{{ "FIXME" | env_override('SRC_TARBALL') }}"
+        - name: GIT_DESCRIBE
+          value: "{{ "FIXME" | env_override('GIT_DESCRIBE') }}"
+        - name: GIT_DESCRIBE_VERBOSE
+          value: "{{ "FIXME" | env_override('GIT_DESCRIBE_VERBOSE') }}"
+        - name: COMMIT_ID
+          value: "{{ "FIXME" | env_override('COMMIT_ID') }}"
+        - name: BUILD_CONFIG
+          value: "{{ "FIXME" | env_override('BUILD_CONFIG') }}"
+        - name: KCI_API_URL
+          value: "{{ "FIXME" | env_override('KCI_API_URL') }}"
+        - name: KCI_API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: kci-api-token-staging
+              key: token
+
+        # optional env
+        - name: PARALLEL_JOPT
+          value: "{{ "" | env_override('PARALLEL_JOPT') }}"
+
+        resources:
+          limits:
+            cpu: {{ cpu_limit }}
+          requests:
+            cpu: {{ cpu_request }}
+            memory: {{ mem_request }}
+

--- a/templates/k8s/wait.py
+++ b/templates/k8s/wait.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env -S python3 -u
+
+import sys
+import time
+import argparse
+from kubernetes import client, config
+from pprint import pprint
+
+
+def job_show(job):
+    print("Succeeded:", job.status.succeeded)
+    print("Failed:", job.status.failed)
+    if job.status.conditions:
+        for cond in job.status.conditions:
+            print("condition.type:", cond.type)
+
+
+def job_succeeded(job):
+    return job.status.succeeded == True
+
+
+def context_valid(c):
+    valid = False
+
+    print("Available contexts:")
+    contexts, active_context = config.list_kube_config_contexts()
+    for ctx in contexts:
+        print("   {}".format(ctx['name']))
+        if c == ctx['name']:
+            valid = True
+
+    return valid
+
+
+def main(args):
+    build_success = True
+    k8s_success = True
+    job_found = False
+    sleep_secs = args.sleep
+
+    if not context_valid(args.context):
+        print("ERROR: unknown context", args.context)
+        sys.exit(1)
+
+    retries = 3
+    print("Using context:", args.context)
+    while retries:
+        try:
+            config.load_kube_config(context=args.context)
+            break
+        except (TypeError, config.ConfigException) as e:
+            print("WARNING: unable to load context {}: {}.  Retrying.".format(args.context, e))
+            time.sleep(sleep_secs)
+            retries = retries - 1
+    if retries == 0:
+        print("ERROR: unable to load context {}.  Giving up.".format(args.context))
+        sys.exit(1)
+  
+    print("Waiting for job completion. (recheck every {} sec) ".format(sleep_secs))
+
+    #
+    # wait for job to finish
+    #
+    retries = 3  # max API failure retries
+    batch = client.BatchV1Api()
+    while retries:
+        job_found = False
+        try:
+            job = batch.read_namespaced_job(name=args.job_name,
+                                            namespace=args.namespace)
+        except client.rest.ApiException as e:
+            print("x:", e)
+            time.sleep(sleep_secs)
+            retries = retries - 1
+            sleep_secs = sleep_secs * 2
+            continue
+
+        job_found = True
+        if job.status.active or not job.status.conditions:
+            print(".")
+            time.sleep(sleep_secs)
+            continue
+
+        build_success = job_succeeded(job)
+        if build_success:
+            print("PASS")
+        else:
+            print("FAIL")
+            if job.status.conditions:
+                print("Reason:", job.status.conditions[0].reason)
+            else:
+                print("Reason: Unknown: job status:")
+                pprint(job.status)
+
+        break
+
+    if not job_found:
+        print("ERROR: unable to find job {}".format(args.job_name))
+        sys.exit(1)
+
+    #
+    # Find pod where job ran
+    #
+    core = client.CoreV1Api()
+    pod = core.list_namespaced_pod(namespace=args.namespace, watch=False,
+                                   label_selector="job-name={}".format(args.job_name))
+    if len(pod.items) < 1:
+        print("WARNING: no pods found with job name {}".format(args.job_name))
+        sys.exit(0)
+    if len(pod.items) > 1:
+        print("WARNING: >1 pod found with job name {}".format(args.job_name))
+        sys.exit(0)
+    pod_name = pod.items[0].metadata.name
+    print("Found job on pod {}".format(pod_name))
+
+    #
+    # Get logs (from pod)
+    #
+
+    # default: check the main container logs
+    cont_name = pod.items[0].spec.containers[0].name
+
+    # unless the initContainer failed, get that log, because if the
+    # initContainer failed, the main container will not have run
+    if (pod.items[0].spec.init_containers):
+        init_cont_name = pod.items[0].spec.init_containers[0].name
+        if not pod.items[0].status.init_container_statuses[0].ready:
+            print("ERROR: initContainer {} not ready / failed.".format(init_cont_name))
+            cont_name = init_cont_name
+            k8s_success = False
+    try:
+        log = core.read_namespaced_pod_log(name=pod_name,
+                                           namespace=args.namespace,
+                                           container=cont_name)
+        print("Container Log:")
+        print(log)
+    except client.rest.ApiException as e:
+        print("Exception: Unable to get pod log", e)
+        k8s_success = False
+
+    #
+    # Delete job
+    #
+    if args.delete and k8s_success:
+        # important: propagation_policy is important so any pods
+        # created for a job deleted
+        body = client.V1DeleteOptions(propagation_policy="Foreground")
+        ret = batch.delete_namespaced_job(name=args.job_name,
+                                          namespace=args.namespace,
+                                          body=body)
+        print("job {} deleted.  job.status:".format(args.job_name))
+        pprint(ret.status)
+
+    # Make jenkins fail only if k8s fails.  Kernel build fails will
+    # be reported to the backend/
+    sys.exit(not k8s_success)
+ 
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--context')
+    parser.add_argument('--job-name')
+    parser.add_argument('--namespace', default='default')
+    parser.add_argument('--sleep', type=int, default=60)
+    parser.add_argument('--no-delete', dest='delete', default=True, action='store_false')
+    args = parser.parse_args()
+    main(args)


### PR DESCRIPTION
Updates from v1:
- rebase onto master branch

updated from last time
- CPU limit/request paramterized based on PARALLEL_BUILDS
- KCI_API_TOKEN stored as k8s secret
- new docker image (khilman/build-k8s) for driving k8s.  Based on build-base w/gcloud-sdk installed
- jenkins "k8s" nodes now have env variables to configure
  all gcloud secrets and environment

Issues
- kci_build needs a way to pass secrets (e.g tokens) not on the cmdline (otherwise they show on stdout from k8s)

