### PR TITLE
dockerfiles: add k8s build node

### DIFF
--- a/jenkins/dockerfiles/build-k8s/Dockerfile
+++ b/jenkins/dockerfiles/build-k8s/Dockerfile
@@ -1,0 +1,31 @@
+#
+# Container to drive Kubernetes cluster from KernelCI
+#
+FROM kernelci/build-base
+MAINTAINER "Kevin Hilman <khilmnan@baylibre.com>"
+
+#
+# Install gcloud-sdk
+# From: https://cloud.google.com/sdk/docs/downloads-apt-get
+#
+RUN apt-get update && apt-get install -y apt-transport-https ca-certificates gnupg curl
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
+RUN apt-get update && apt-get install -y google-cloud-sdk kubectl
+
+#
+# Azure CLI
+# From: https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-apt?view=azure-cli-latest
+#
+RUN curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor |  tee /etc/apt/trusted.gpg.d/microsoft.asc.gpg > /dev/null
+RUN AZ_REPO=buster && echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" | tee /etc/apt/sources.list.d/azure-cli.list
+RUN apt-get update && apt-get install -y azure-cli
+
+#
+# Kubernetes python lib (need latest from pip)
+# - remove existing deps (urllib3, requests) to be sure
+#   latest are installed from pip
+#
+RUN apt-get update && apt-get install -y python3-pip python3-setuptools
+RUN apt-get remove -y python3-urllib3 python3-requests && apt-get autoremove -y
+RUN python3 -m pip install --upgrade kubernetes


### PR DESCRIPTION
Add new container capable of submitting build jobs to a k8s cluster.

The service-account key must be mounted at docker-run time for
'gcloud auth` to work correctly.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>