### PR TITLE
build-trigger: pass-on params to build

### DIFF
--- a/jenkins/build-trigger.jpl
+++ b/jenkins/build-trigger.jpl
@@ -246,6 +246,12 @@ def buildKernelStep(job, arch, defconfig, build_env, opts, labs, kci_core) {
         'BUILD_ENVIRONMENT': build_env,
         'NODE_LABEL': node_label,
         'PARALLEL_BUILDS': parallel_builds,
+        'KCI_CORE_URL': "${params.KCI_CORE_URL}",
+        'KCI_CORE_BRANCH': "${params.KCI_CORE_BRANCH}",
+        'KCI_STORAGE_URL': "${params.KCI_STORAGE_URL}",
+        'KCI_API_URL': "${params.KCI_API_URL}",
+        'KCI_TOKEN_ID': "${params.KCI_TOKEN_ID}",
+        'DOCKER_BASE': "${params.DOCKER_BASE}",
     ]
     def job_params = []
 


### PR DESCRIPTION
The build trigger should pass it's arguments on to the build job, in
particular those that affect kernelci-core repo usage and the kernelci
API.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>