### PR TITLE
T20434 baseline: use dmesg.sh script from the rootfs

### DIFF
--- a/templates/baseline/baseline.jinja2
+++ b/templates/baseline/baseline.jinja2
@@ -18,21 +18,7 @@
             - lava-test-shell
         run:
           steps:
-            - >
-                for level in warn err; do
-                  dmesg --level=$level --notime -x -k > dmesg.$level
-                done
-            - >
-                for level in crit alert emerg; do
-                  dmesg --level=$level --notime -x -k > dmesg.$level
-                  test -s dmesg.$level && res=fail || res=pass
-                  count=$(cat dmesg.$level | wc -l)
-                  lava-test-case $level \
-                    --result $res \
-                    --measurement $count \
-                    --units lines
-                done
-            - cat dmesg.emerg dmesg.alert dmesg.crit dmesg.err dmesg.warn
+            - KERNELCI_LAVA=y /bin/sh /opt/kernelci/dmesg.sh
       from: inline
       name: dmesg
       path: inline/dmesg.yaml


### PR DESCRIPTION
The baseline rootfs images now have a dmesg.sh script which can be
called to run the dmesg tests and reduce the noise in the LAVA log.
Use it in the baseline job template rather than defining the steps
inline.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>