### PR TITLE
lab-configs.yaml: drop lab-drue as it's permanently offline

### DIFF
--- a/lab-configs.yaml
+++ b/lab-configs.yaml
@@ -49,18 +49,6 @@ labs:
             - v4l2-compliance-uvc
             - v4l2-compliance-vivid
 
-  lab-drue:
-    lab_type: lava
-    url: 'https://lava.therub.org/RPC2/'
-    filters:
-      - whitelist:
-          plan:
-            - baseline
-            - boot
-            - boot-nfs
-            - simple
-            - sleep
-
   lab-free-electrons:
     lab_type: lava
     url: 'https://lab.free-electrons.com/RPC2/'


### PR DESCRIPTION
As discussed with Dan, lab-drue is now going to be offline until
further notice so remove it from the YAML config.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>