### PR TITLE
Handle vmlinux for MIPS build

### DIFF
--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -49,7 +49,7 @@ KERNEL_IMAGE_NAMES = {
     'arm64': ['Image'],
     'arc': ['uImage'],
     'i386': ['bzImage'],
-    'mips': ['uImage.gz', 'vmlinux.gz.itb'],
+    'mips': ['uImage.gz', 'vmlinux.gz.itb', 'vmlinuz'],
     'riscv': ['Image', 'Image.gz'],
     'x86_64': ['bzImage'],
     'x86': ['bzImage'],
@@ -613,10 +613,12 @@ def build_kernel(build_env, kdir, arch, defconfig=None, jopt=None,
         print_flush("ERROR: Missing kernel config")
         result = False
     if result:
-        target = (
-            'xipImage' if _kernel_config_enabled(dot_config, 'XIP_KERNEL')
-            else MAKE_TARGETS.get(arch)
-        )
+        if _kernel_config_enabled(dot_config, 'XIP_KERNEL'):
+            target = 'xipImage'
+        elif _kernel_config_enabled(dot_config, 'SYS_SUPPORTS_ZBOOT'):
+            target = 'vmlinuz'
+        else:
+            target = MAKE_TARGETS.get(arch)
         result = _run_make(jopt=jopt, target=target, **kwargs)
     mods = _kernel_config_enabled(dot_config, 'MODULES')
     if result and mods:
@@ -753,6 +755,12 @@ def install_kernel(kdir, tree_name, tree_url, git_branch, git_commit=None,
             if name in files:
                 kimages.append(name)
                 image_path = os.path.join(root, name)
+                shutil.copy(image_path, install_path)
+    for files in os.listdir(output_path):
+        for name in kimage_names:
+            if name == files:
+                kimages.append(name)
+                image_path = os.path.join(output_path, name)
                 shutil.copy(image_path, install_path)
     if kimages:
         for name in kimage_names:


### PR DESCRIPTION
Many of MIPS build have no kernel due to the fact they use vmlinux.
The case which I care are all malta defconfig.

So this patch adds vmlinux as valid kernel for MIPS and add the ability
for seek kernel images in the base output directory.

Signed-off-by: Corentin LABBE <clabbe@baylibre.com>