### PR TITLE
test-configs: add qemu malta

### DIFF
--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -1015,6 +1015,21 @@ device_types:
     filters:
       - whitelist: {defconfig: ['i386_defconfig']}
 
+  qemu_mips-malta:
+    base_name: qemu
+    mach: qemu
+    arch: mips
+    boot_method: qemu
+    context:
+      arch: mipsel
+      guestfs_interface: 'ide'
+      machine: 'malta'
+      memory: 256
+      model: 'model=pcnet'
+      no_kvm: True
+    filters:
+      - whitelist: {defconfig: ['malta_kvm_guest_defconfig']}
+
   qemu_x86_64:
     base_name: qemu
     mach: qemu
@@ -1815,6 +1830,10 @@ test_configs:
     test_plans:
       - baseline_qemu
       - baseline-uefi_i386
+
+  - device_type: qemu_mips-malta
+    test_plans:
+      - baseline_qemu
 
   - device_type: qemu_x86_64
     test_plans:


### PR DESCRIPTION
Since kernelCI builds all MIPS defconfig, we could now boot some MIPS qemu.
From all MIPS qemu, only malta are working.

Signed-off-by: Corentin LABBE <clabbe@baylibre.com>