### PR TITLE
build-trigger: don't pass KCI_STORAGE_URL to build

### DIFF
--- a/jenkins/build-trigger.jpl
+++ b/jenkins/build-trigger.jpl
@@ -248,7 +248,6 @@ def buildKernelStep(job, arch, defconfig, build_env, opts, labs, kci_core) {
         'PARALLEL_BUILDS': parallel_builds,
         'KCI_CORE_URL': "${params.KCI_CORE_URL}",
         'KCI_CORE_BRANCH': "${params.KCI_CORE_BRANCH}",
-        'KCI_STORAGE_URL': "${params.KCI_STORAGE_URL}",
         'KCI_API_URL': "${params.KCI_API_URL}",
         'KCI_TOKEN_ID': "${params.KCI_TOKEN_ID}",
         'DOCKER_BASE': "${params.DOCKER_BASE}",


### PR DESCRIPTION
build.jpl doesn't use KCI_STORAGE_URL, don't pass it.

Fixes: 1a1c57041c61 (build-trigger: pass-on params to build)
Signed-off-by: Kevin Hilman <khilman@baylibre.com>