### PR TITLE
test-configs: handle rename of renesas boards

### DIFF
--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -678,12 +678,15 @@ device_types:
       - blacklist: {defconfig: ['allmodconfig', 'multi_v5_defconfig']}
       - blacklist: {kernel: ['v3.']}
 
-  r8a7796-m3ulcb:
+  r8a7796-m3ulcb: &r8a7796-m3ulcb
     mach: renesas
     class: arm64-dtb
     boot_method: uboot
     filters:
       - blacklist: {defconfig: ['allnoconfig', 'allmodconfig']}
+
+# this is the same device than r8a7796-m3ulcb
+  r8a77960-ulcb: *r8a7796-m3ulcb
 
   meson8b-odroidc1:
     mach: amlogic
@@ -1085,13 +1088,16 @@ device_types:
     boot_method: depthcharge
     flags: ['lpae']
 
-  r8a7795-salvator-x:
+  r8a7795-salvator-x: &r8a7795-salvator-x
     mach: renesas
     class: arm64-dtb
     boot_method: uboot
     flags: ['big_endian']
     filters:
       - blacklist: {defconfig: ['allnoconfig', 'allmodconfig']}
+
+# this is the same device than r8a7795-salvator-x
+  r8a77950-salvator-x: *r8a7795-salvator-x
 
   sun8i-a33-sinlinx-sina33:
     mach: allwinner
@@ -1974,19 +1980,27 @@ test_configs:
       - boot
 
   - device_type: r8a7795-salvator-x
-    test_plans:
+    test_plans: &r8a7795-salvator-x_test-plans
       - baseline
       - boot
       - boot-nfs
       - kselftest
       - simple
 
+# this is the same device than r8a7795-salvator-x
+  - device_type: r8a77950-salvator-x
+    test_plans: *r8a7795-salvator-x_test-plans
+
   - device_type: r8a7796-m3ulcb
-    test_plans:
+    test_plans: &r8a7796-m3ulcb_test-plans
       - baseline
       - boot
       - simple
       - usb
+
+# this is the same device than r8a7796-m3ulcb
+  - device_type: r8a77960-ulcb
+    test_plans: *r8a7796-m3ulcb_test-plans
 
   - device_type: rk3399-gru-kevin
     test_plans:


### PR DESCRIPTION
The DTB of all renesas board was renamed in v5.6, so renesas boards wont
get new jobs.
The simple fix is to duplicate them in kci and use LAVA aliases.