### PR TITLE
kernelci.build.install_kernel: replace slashes with dashes

### DIFF
--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -787,10 +787,9 @@ def install_kernel(kdir, tree_name, tree_url, git_branch, git_commit=None,
 
     build_env = bmeta['build_environment']
     defconfig_full = bmeta['defconfig_full']
-    defconfig_dir = defconfig_full.replace('/', '-')
     if not publish_path:
-        publish_path = '/'.join([
-            tree_name, git_branch, describe, arch, defconfig_dir, build_env,
+        publish_path = '/'.join(field.replace('/', '-') for field in [
+            tree_name, git_branch, describe, arch, defconfig_full, build_env,
         ])
 
     bmeta.update({


### PR DESCRIPTION
Replace all slashes "/" with dashes "-" in each element of the path
where the build binaries are being uploaded to.  This can be done
because the actual values of each field is store separately in the
meta-data, the important thing is to keep the upload paths unique.

Doing this in particular enables slashes in git branch names.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>