### PR TITLE
test-configs.yaml: Use max CPU for arm64 qemu targets

### DIFF
--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -1004,7 +1004,7 @@ device_types:
     boot_method: qemu
     context:
       arch: arm64
-      cpu: 'cortex-a57'
+      cpu: 'max'
       guestfs_interface: 'virtio'
       machine: 'virt,gic-version=2'
     filters:
@@ -1017,7 +1017,7 @@ device_types:
     boot_method: qemu
     context:
       arch: arm64
-      cpu: 'cortex-a57'
+      cpu: 'max'
       guestfs_interface: 'virtio'
       machine: 'virt,gic-version=3'
     filters:


### PR DESCRIPTION
The arm64 emulation in qemu supports architectural features which are not
present in currently shipping CPUs that are emulated by qemu. Many of
these have support in software and it would be good to get coverage for
them so rather than emulating cortex-a57 (which has plenty of physical
implementations) instead specify the CPU as "max" when invoking qemu which
will make the CPU as featureful as possible.

This does mean that the exact feature set of the CPU being emulated will
vary depending on the target system, the qemu version and when the host
is arm64 based the host hardware will control what gets selected. We will
need to pay attention to this going forwards.

Signed-off-by: Mark Brown <broonie@kernel.org>