### PR TITLE
test-configs: add D2500CC

### DIFF
--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -448,6 +448,11 @@ device_types:
     filters:
       - blacklist: {defconfig: ['allnoconfig', 'allmodconfig']}
 
+  d2500cc:
+    mach: x86
+    arch: x86_64
+    boot_method: grub
+
   da850-lcdk:
     mach: davinci
     class: arm-dtb
@@ -1461,6 +1466,10 @@ test_configs:
     test_plans:
       - baseline
       - baseline-nfs
+
+  - device_type: d2500cc
+    test_plans:
+      - baseline
 
   - device_type: d03
     test_plans:


### PR DESCRIPTION
D2500CC is an x86_64 board with an "embedded" intel CPU.
This board lacks PXE, so it is booted via a fake GRUB.
It is a bash init script which emulates GRUB commands and then kexec the final kernel.