### PR TITLE
EFI tree updates

### DIFF
--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -567,10 +567,26 @@ build_configs:
   efi:
     tree: efi
     branch: 'next'
+    variants:
+      gcc-8:
+        build_environment: gcc-8
+        architectures:
+          arm: *arm_defconfig
+          arm64: *arm64_defconfig
+          i386: *i386_defconfig
+          x86_64: *x86_64_defconfig
 
   efi_urgent:
     tree: efi
     branch: 'urgent'
+    variants:
+      gcc-8:
+        build_environment: gcc-8
+        architectures:
+          arm: *arm_defconfig
+          arm64: *arm64_defconfig
+          i386: *i386_defconfig
+          x86_64: *x86_64_defconfig
 
   evalenti:
     tree: evalenti

--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -568,6 +568,10 @@ build_configs:
     tree: efi
     branch: 'next'
 
+  efi_urgent:
+    tree: efi
+    branch: 'urgent'
+
   evalenti:
     tree: evalenti
     branch: 'for-kernelci'

--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -273,6 +273,10 @@ arch_defconfigs: &arch_defconfigs
     base_defconfig: 'defconfig'
     filters:
       - regex: { defconfig: 'defconfig' }
+  i386: &i386_defconfig
+    base_defconfig: 'i386_defconfig'
+    filters:
+      - regex: { defconfig: 'i386_defconfig' }
   mips: &mips_defconfig
     base_defconfig: '32r2el_defconfig'
     filters:


### PR DESCRIPTION
A couple of tweaks to the configuration for the EFI tree configuration - add the urgent branch for testing fixes and restrict the configurations built to a subset since the main goal for EFI testing is boot rather than build coverage.

@ardbiesheuvel - does this look OK to you?