### PR TITLE
test-configs.yaml: move all i.MX* boards to imx mach type

### DIFF
--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -636,17 +636,17 @@ device_types:
           kernel: ['v3.18']
 
   imx6q-sabresd:
-    mach: freescale
+    mach: imx
     class: arm-dtb
     boot_method: uboot
 
   imx7d-sdb:
-    mach: freescale
+    mach: imx
     class: arm-dtb
     boot_method: uboot
 
   imx8mn-ddr4-evk:
-    mach: freescale
+    mach: imx
     class: arm64-dtb
     boot_method: uboot
 


### PR DESCRIPTION
Some i.MX* boards were imx, others freescale.  Align them all on imx
which is also the mach name in the kernel source tree.

Fixes: 253bc4591c07 ("adding imx6q-sabresd and imx7d-sdb to kernelci.org")
Fixes: 06c33cb4532b ("test-configs.yaml: add support for imx8mn-ddr4-evk")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>