### PR TITLE
build-configs.yaml: Add a branch in my misc tree

### DIFF
--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -25,6 +25,9 @@ trees:
   arnd:
     url: "https://git.kernel.org/pub/scm/linux/kernel/git/arnd/playground.git"
 
+  broonie-misc:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/broonie/misc.git"
+
   broonie-regmap:
     url: "https://git.kernel.org/pub/scm/linux/kernel/git/broonie/regmap.git"
 
@@ -528,6 +531,10 @@ build_configs:
   arnd:
     tree: arnd
     branch: 'to-build'
+
+  broonie-misc:
+    tree: broonie-misc
+    branch: 'for-kernelci'
 
   broonie-regmap:
     tree: broonie-regmap


### PR DESCRIPTION
Add a for-kernelci branch in my misc tree for testing of changes without
putting them into a production branch - this will be infrequently used,
the intention is to allow me to check changes that I'm worried might be
disruptive on a wide range of hardware without publishing them in my normal
development branches where they can cause trouble in trees like -next.

The goal here is to get runtime testing so ideally the built configurations
could be limited to those that will usefully boot, unfortunately we don't
really have a way of specifying that at present.

Signed-off-by: Mark Brown <broonie@kernel.org>