### PR TITLE
Revert "bisect.jpl: disable automatic email recipients"

### DIFF
--- a/jenkins/bisect.jpl
+++ b/jenkins/bisect.jpl
@@ -531,7 +531,6 @@ PYTHON_EGG_CACHE=${egg_cache} \
 --kdir=${kdir} \
 --subject=\"${subject}\" \
 --to=\"${params.EMAIL_RECIPIENTS}\" \
---no-auto-recipients \
 """)
         }
     }


### PR DESCRIPTION
It has been 6 months since automated bisections were enabled on all
test cases, and this is proving to be working well.  We can now have
the email reports sent automatically to all the recipients.

This reverts commit 0df55b7061b0520b3b36323fd21bd943e7b71ebb.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>