### PR TITLE
lab-configs.yaml: drop lab-free-electrons as confirmed with Bootlin

### DIFF
--- a/lab-configs.yaml
+++ b/lab-configs.yaml
@@ -47,16 +47,6 @@ labs:
             - v4l2-compliance-uvc
             - v4l2-compliance-vivid
 
-  lab-free-electrons:
-    lab_type: lava
-    url: 'https://lab.free-electrons.com/RPC2/'
-    filters:
-      - blacklist: {tree: [drm-tip, linaro-android]}
-      - whitelist:
-          plan:
-            - baseline
-            - baseline-nfs
-
   lab-linaro-lkft:
     lab_type: lava
     url: 'https://lkft.validation.linaro.org/RPC2/'


### PR DESCRIPTION
The lab-free-electrons, which would now have to become lab-bootlin, is
offline with no plans to bring it back online in the near future.  As
aggreed with Bootlin contacts, remove it from the kernelci.org
configuration.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>