### PR TITLE
Add kci_data commandline tool

### DIFF
--- a/db-configs.yaml
+++ b/db-configs.yaml
@@ -1,0 +1,4 @@
+db_configs:
+  staging-kernelci-org:
+    db_type: kernelci_backend
+    url: https://staging.kernelci.org/test

--- a/kci_data
+++ b/kci_data
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2020 Collabora Limited
+# Author: Michal Galka <michal.galka@collabora.com>
+#
+# This module is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+import sys
+
+import kernelci.config.data
+from kernelci.data import submit
+from kernelci.cli import Args, Command, parse_args
+
+
+class cmd_list_configs(Command):
+    help = "List all database configurations"
+
+    def __call__(self, config_data, *args, **kwargs):
+        db_configs = config_data['db_configs']
+        for config_name in db_configs:
+            print(config_name)
+        return True
+
+
+class cmd_submit(Command):
+    help = "Submit data to the specified database"
+    args = [Args.config, Args.data_file]
+    opt_args = [Args.token]
+
+    def __call__(self, config_data, args):
+        config = config_data['db_configs'][args.config]
+        if args.data_file == '-':
+            data = sys.stdin.read()
+        else:
+            with open(args.data_file, 'r') as f:
+                data = f.read()
+        return submit(args.config, config, data, args.token)
+
+
+if __name__ == '__main__':
+    args = parse_args("kci_data", "db-configs.yaml", globals())
+    configs = kernelci.config.data.from_yaml(args.yaml_configs)
+    status = args.func(configs, args)
+    sys.exit(0 if status is True else 1)

--- a/kernelci/cli.py
+++ b/kernelci/cli.py
@@ -262,6 +262,11 @@ class Args(object):
         'action': 'store_true'
     }
 
+    data_file = {
+        'name': '--data-file',
+        'help': "Path to the file with data to be submitted to storage",
+    }
+
 
 class Command(object):
     """A command helper class.

--- a/kernelci/config/data.py
+++ b/kernelci/config/data.py
@@ -1,0 +1,91 @@
+# Copyright (C) 2020 Collabora Limited
+# Author: Michal Galka <michal.galka@collabora.com>
+#
+# This module is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+import yaml
+
+from kernelci.config import YAMLObject
+
+
+class Database(YAMLObject):
+    def __init__(self, name, db_type):
+        self._name = name
+        self._db_type = db_type
+
+    @classmethod
+    def from_yaml(cls, db, kw):
+        return cls(**kw)
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def db_type(self):
+        return self._db_type
+
+
+class Backend(Database):
+    def __init__(self, name, db_type, url):
+        super().__init__(name, db_type)
+        self._url = url
+
+    @classmethod
+    def from_yaml(cls, config, name):
+        kw = name
+        kw.update(cls._kw_from_yaml(
+            config, ['name', 'url']))
+        return cls(**kw)
+
+    @property
+    def url(self):
+        return self._url
+
+
+class DatabaseFactory(YAMLObject):
+    _db_types = {
+        "kernelci_backend": Backend
+    }
+
+    @classmethod
+    def from_yaml(cls, name, db):
+        db_type = db.get('db_type')
+        if db_type is None:
+            raise TypeError("db_type cannot be Empty")
+        elif db_type not in cls._db_types:
+            raise ValueError("Unsupported value {}".format(db_type))
+        else:
+            kw = {
+                'name': name,
+                'db_type': db_type,
+                }
+        db_cls = cls._db_types[db_type] if db_type else Database
+        return db_cls.from_yaml(db, kw)
+
+
+def from_yaml(yaml_path):
+    with open(yaml_path) as f:
+        data = yaml.safe_load(f)
+
+    db_configs = {
+        name: DatabaseFactory.from_yaml(name, db)
+        for name, db in data['db_configs'].items()
+    }
+
+    config_data = {
+        'db_configs': db_configs,
+    }
+    return config_data

--- a/kernelci/data.py
+++ b/kernelci/data.py
@@ -1,0 +1,38 @@
+# Copyright (C) 2020 Collabora Limited
+# Author: Michal Galka <michal.galka@collabora.com>
+#
+# This module is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+import json
+import requests
+
+
+def _submit_backend(name, config, data, token):
+    if token is None:
+        print('API token must be provided')
+        return False
+    resp = requests.post(config.url,
+                         json=json.loads(data),
+                         headers={'Authorization': token})
+    print("Status: {}".format(resp.status_code))
+    print(resp.text)
+    return 200 <= resp.status_code <= 300
+
+
+def submit(name, config, data, token=None):
+    if config.db_type == "kernelci_backend":
+        return _submit_backend(name, config, data, token)
+    else:
+        raise ValueError("db_type not supported: {}".format(config.db_type))


### PR DESCRIPTION
kci_data is a tool to feed test data to different types of result
storages. This commit adds basic functionality of the tool that allows
to submit data to /test API of kernelci-backend.

Signed-off-by: Michal Galka <michal.galka@collabora.com>