### PR TITLE
test-configs: Add imx6qp-wandboard-revd1

### DIFF
--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -589,6 +589,18 @@ device_types:
             - 'multi_v5_defconfig'
             - 'allmodconfig'
 
+  imx6qp-wandboard-revd1:
+    mach: imx
+    class: arm-dtb
+    boot_method: barebox
+    flags: ['fastboot']
+    filters:
+      - blacklist:
+          defconfig:
+            - 'imx_v4_v5_defconfig'
+            - 'multi_v5_defconfig'
+            - 'allmodconfig'
+
   imx6q-var-dt6customboard:
     mach: imx
     class: arm-dtb


### PR DESCRIPTION
This patch adds support for imx6qp-wandboard-revd1
LAVA device-type is upstreamed: https://git.lavasoftware.org/lava/lava/-/merge_requests/1206