### PR TITLE
Add various NXP i.mx boards to kernelci

### DIFF
--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -625,9 +625,44 @@ device_types:
     class: arm-dtb
     boot_method: uboot
 
+  imx6qp-sabresd:
+    mach: imx
+    class: arm-dtb
+    boot_method: uboot
+
+  imx6sll-evk:
+    mach: imx
+    class: arm-dtb
+    boot_method: uboot
+
+  imx6sx-sdb:
+    mach: imx
+    class: arm-dtb
+    boot_method: uboot
+
+  imx6ul-14x14-evk:
+    mach: imx
+    class: arm-dtb
+    boot_method: uboot
+
+  imx6ull-14x14-evk:
+    mach: imx
+    class: arm-dtb
+    boot_method: uboot
+
   imx7d-sdb:
     mach: imx
     class: arm-dtb
+    boot_method: uboot
+
+  imx7ulp-evk:
+    mach: imx
+    class: arm-dtb
+    boot_method: uboot
+
+  imx8mm-ddr4-evk:
+    mach: imx
+    class: arm64-dtb
     boot_method: uboot
 
   imx8mn-ddr4-evk:
@@ -1635,7 +1670,42 @@ test_configs:
       - baseline
       - kselftest
 
+  - device_type: imx6qp-sabresd
+    test_plans:
+      - baseline
+      - kselftest
+
+  - device_type: imx6sll-evk
+    test_plans:
+      - baseline
+      - kselftest
+
+  - device_type: imx6sx-sdb
+    test_plans:
+      - baseline
+      - kselftest
+
+  - device_type: imx6ul-14x14-evk
+    test_plans:
+      - baseline
+      - kselftest
+
+  - device_type: imx6ull-14x14-evk
+    test_plans:
+      - baseline
+      - kselftest
+
   - device_type: imx7d-sdb
+    test_plans:
+      - baseline
+      - kselftest
+
+  - device_type: imx7ulp-evk
+    test_plans:
+      - baseline
+      - kselftest
+
+  - device_type: imx8mm-ddr4-evk
     test_plans:
       - baseline
       - kselftest

--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -630,11 +630,6 @@ device_types:
     class: arm-dtb
     boot_method: uboot
 
-  imx6sll-evk:
-    mach: imx
-    class: arm-dtb
-    boot_method: uboot
-
   imx6sx-sdb:
     mach: imx
     class: arm-dtb
@@ -653,16 +648,6 @@ device_types:
   imx7d-sdb:
     mach: imx
     class: arm-dtb
-    boot_method: uboot
-
-  imx7ulp-evk:
-    mach: imx
-    class: arm-dtb
-    boot_method: uboot
-
-  imx8mm-ddr4-evk:
-    mach: imx
-    class: arm64-dtb
     boot_method: uboot
 
   imx8mn-ddr4-evk:
@@ -1675,11 +1660,6 @@ test_configs:
       - baseline
       - kselftest
 
-  - device_type: imx6sll-evk
-    test_plans:
-      - baseline
-      - kselftest
-
   - device_type: imx6sx-sdb
     test_plans:
       - baseline
@@ -1696,16 +1676,6 @@ test_configs:
       - kselftest
 
   - device_type: imx7d-sdb
-    test_plans:
-      - baseline
-      - kselftest
-
-  - device_type: imx7ulp-evk
-    test_plans:
-      - baseline
-      - kselftest
-
-  - device_type: imx8mm-ddr4-evk
     test_plans:
       - baseline
       - kselftest


### PR DESCRIPTION
Add imx6qp-sabresd, imx6sll-evk, imx6sx-sdb, imx6ul-14x14-evk, imx6ull-14x14-evk, imx7ulp-evk, imx8mm-ddr4-evk, imx8mp-evk to kernelci tests
Following are the jobs verified
imx8mp-evk
baseline: https://lavalab.nxp.com/scheduler/job/23466

imx6sx-sdb
baseline - https://lavalab.nxp.com/scheduler/job/21321

imx6ul-14x14-evk
baseline - https://lavalab.nxp.com/scheduler/job/21311

imx6ull-14x14-evk
baseline - https://lavalab.nxp.com/scheduler/job/21313

imx6sll-evk
baseline - https://lavalab.nxp.com/scheduler/job/21307

imx6qp-sabresd
baseline - https://lavalab.nxp.com/scheduler/job/21308

imx7ulp-evk
baseline - https://lavalab.nxp.com/scheduler/job/22625 
