### PR TITLE
kci_rootfs: add debian riscv64 support for sid / debian-ports

### DIFF
--- a/jenkins/debian/debos/rootfs.yaml
+++ b/jenkins/debian/debos/rootfs.yaml
@@ -7,6 +7,9 @@
 {{- $extra_packages_remove := or .extra_packages_remove -}}
 {{- $extra_files_remove := or .extra_files_remove -}}
 {{- $crush_image_options := or .crush_image_options "" -}}
+{{- $debian_mirror := or .debian_mirror "http://deb.debian.org/debian" -}}
+{{- $keyring_package := or .keyring_package "" -}}
+{{- $keyring_file := or .keyring_file "" -}}
 
 architecture: {{ $architecture }}
 
@@ -15,8 +18,10 @@ actions:
     suite: {{ $suite }}
     components:
       - main
-    mirror: http://deb.debian.org/debian
+    mirror: {{ $debian_mirror }}
     variant: minbase
+    keyring-package: {{ $keyring_package }}
+    keyring-file: {{ $keyring_file }}
 
   - action: apt
     recommends: false

--- a/kci_rootfs
+++ b/kci_rootfs
@@ -46,6 +46,9 @@ class cmd_validate(Command):
             print('\ttest_overlay: {}'.format(config.test_overlay))
             print('\tcrush_image_options: {}'
                   .format(config.crush_image_options))
+            print('\tdebian_mirror: {}'.format(config.debian_mirror))
+            print('\tkeyring_package: {}'.format(config.keyring_package))
+            print('\tkeyring_file: {}'.format(config.keyring_file))
         return True
 
 

--- a/kernelci/config/rootfs.py
+++ b/kernelci/config/rootfs.py
@@ -44,8 +44,8 @@ class RootFS_Debos(RootFS):
                  arch_list=None, extra_packages=None,
                  extra_packages_remove=None,
                  extra_files_remove=None, script="",
-                 test_overlay="", crush_image_options=None):
-
+                 test_overlay="", crush_image_options=None, debian_mirror="",
+                 keyring_package="", keyring_file=""):
         super().__init__(name, rootfs_type)
         self._debian_release = debian_release
         self._arch_list = arch_list or list()
@@ -55,6 +55,9 @@ class RootFS_Debos(RootFS):
         self._script = script
         self._test_overlay = test_overlay
         self._crush_image_options = crush_image_options or list()
+        self._debian_mirror = debian_mirror
+        self._keyring_package = keyring_package
+        self._keyring_file = keyring_file
 
     @classmethod
     def from_yaml(cls, config, name):
@@ -63,7 +66,8 @@ class RootFS_Debos(RootFS):
             config, ['name', 'debian_release', 'arch_list',
                      'extra_packages', 'extra_packages_remove',
                      'extra_files_remove', 'script', 'test_overlay',
-                     'crush_image_options']))
+                     'crush_image_options', 'debian_mirror',
+                     'keyring_package', 'keyring_file']))
         return cls(**kw)
 
     @property
@@ -97,6 +101,18 @@ class RootFS_Debos(RootFS):
     @property
     def crush_image_options(self):
         return list(self._crush_image_options)
+
+    @property
+    def debian_mirror(self):
+        return self._debian_mirror
+
+    @property
+    def keyring_package(self):
+        return self._keyring_package
+
+    @property
+    def keyring_file(self):
+        return self._keyring_file
 
 
 class RootFSFactory(YAMLObject):

--- a/kernelci/rootfs.py
+++ b/kernelci/rootfs.py
@@ -31,6 +31,9 @@ def _build_debos(name, config, data_path, arch):
 -t script:"{script}" \
 -t test_overlay:"{test_overlay}" \
 -t crush_image_options:"{crush_image_options}" \
+-t debian_mirror:"{debian_mirror}" \
+-t keyring_package:"{keyring_package}" \
+-t keyring_file:"{keyring_file}" \
 rootfs.yaml'.format(
             name=name,
             data_path=data_path,
@@ -41,7 +44,10 @@ rootfs.yaml'.format(
             extra_files_remove=" ".join(config.extra_files_remove),
             script=config.script,
             test_overlay=config.test_overlay,
-            crush_image_options=" ".join(config.crush_image_options)
+            crush_image_options=" ".join(config.crush_image_options),
+            debian_mirror=config.debian_mirror,
+            keyring_package=config.keyring_package,
+            keyring_file=config.keyring_file,
     )
     return shell_cmd(cmd, True)
 

--- a/rootfs-configs.yaml
+++ b/rootfs-configs.yaml
@@ -11,7 +11,7 @@ rootfs_configs:
       - mips
       - mipsel
       - mips64el
-    extra_packages_remove:
+    extra_packages_remove: &extra_packages_remove_buster
       - bash
       - e2fslibs
       - e2fsprogs
@@ -23,7 +23,7 @@ rootfs_configs:
       - libp11-kit0
       - libunistring2
       - sensible-utils
-    extra_files_remove:
+    extra_files_remove: &extra_files_remove_buster
       - '*networkd*'
       - '*resolved*'
       - tar
@@ -107,3 +107,24 @@ rootfs_configs:
       - libext2fs2
     script: "scripts/buster-cros-ec-tests.sh"
     test_overlay: ""
+
+  sid:
+    rootfs_type: debos
+    debian_release: sid
+    debian_mirror: http://deb.debian.org/debian-ports
+    keyring_package: debian-ports-archive-keyring
+    keyring_file: /usr/share/keyrings/debian-ports-archive-keyring.gpg
+    arch_list:
+      - riscv64
+    extra_packages_remove: &extra_packages_remove_sid
+      - bash
+      - e2fslibs
+      - e2fsprogs
+      - klibc-utils
+      - libext2fs2
+      - libgnutls30
+      - libklibc
+      - libncursesw6
+      - libp11-kit0
+      - sensible-utils
+    extra_files_remove: *extra_files_remove_buster


### PR DESCRIPTION
riscv64 support is available in debian, but only in unstable/sid.  It
also requires using debian-ports.

In order to use debian-ports, the debian mirror needs to be a config
parameter.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>