### PR TITLE
test-configs: Enable clang boot testing

### DIFF
--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -66,29 +66,22 @@ test_plan_default_filters:
         - ['i386', 'i386_defconfig']
         - ['x86_64', 'x86_64_defconfig']
 
-  - blacklist: &clang_environment_filter
-      build_environment: ['clang']
-
   - blacklist: &kselftest_defconfig_filter
       defconfig: ['kselftest']
-
-  - blacklist: &kselftest_defconfig_clang_environment_filter
-      <<: *kselftest_defconfig_filter
-      <<: *clang_environment_filter
 
 test_plans:
 
   baseline:
     rootfs: buildroot_baseline_ramdisk
     filters:
-      - blacklist: *kselftest_defconfig_clang_environment_filter
+      - blacklist: *kselftest_defconfig_filter
 
   baseline_qemu:
     base_name: baseline
     rootfs: buildroot_baseline_ramdisk
     pattern: 'baseline/generic-qemu-baseline-template.jinja2'
     filters:
-      - blacklist: *kselftest_defconfig_clang_environment_filter
+      - blacklist: *kselftest_defconfig_filter
 
   baseline-fastboot:
     rootfs: buildroot_baseline_ramdisk
@@ -116,7 +109,6 @@ test_plans:
             - ['arm', 'at91_dt_defconfig']
             - ['arm', 'davinci_all_defconfig']
             - ['arm64', 'defconfig']
-      - blacklist: *clang_environment_filter
 
   baseline-uefi_arm:
     base_name: baseline-uefi


### PR DESCRIPTION
Currently we only build test with clang, we don't boot the resulting
binaries as there were some issue with the boot-specific reporting.  As
that is being phased out there is now no reason not to include clang
binaries in testing so do so, existing use of clang by developers and
results on staging do not suggest this is likely to result in many
additional failures.

Signed-off-by: Mark Brown <broonie@kernel.org>