### PR TITLE
YAML validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,6 @@ script:
   - pycodestyle kernelci
   - pycodestyle kci_*
   - pycodestyle *.py
+  - ./kci_build validate
+  - ./kci_test validate
   - ./kci_rootfs validate

--- a/kci_build
+++ b/kci_build
@@ -24,6 +24,15 @@ import kernelci.build
 import kernelci.config.build
 
 
+class cmd_validate(Command):
+    help = "Validate the YAML configuration"
+    opt_args = [Args.verbose]
+
+    def __call__(self, configs, args):
+        # ToDo: Use jsonschema
+        return True
+
+
 class cmd_list_configs(Command):
     help = "List the build configurations"
 

--- a/kci_test
+++ b/kci_test
@@ -35,6 +35,15 @@ import kernelci.test
 # Commands
 #
 
+class cmd_validate(Command):
+    help = "Validate the YAML configuration"
+    opt_args = [Args.verbose]
+
+    def __call__(self, test_configs, lab_configs, args):
+        # ToDo: Use jsonschema
+        return True
+
+
 class cmd_list_jobs(Command):
     help = "List all the jobs that need to be run for a given build and lab"
     args = [Args.bmeta_json, Args.dtbs_json, Args.lab]


### PR DESCRIPTION
Add basic validation of the YAML config to detect syntax errors and run it in Travis CI.  Proper validation should be added as a follow-up using `jsonschema`.