### PR TITLE
build.py: merge_config needs CROSS_COMPILE_COMPAT

### DIFF
--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -530,9 +530,11 @@ export ARCH={arch}
 export HOSTCC={cc}
 export CC={cc}
 export CROSS_COMPILE={cross}
+export CROSS_COMPILE_COMPAT={cross_compat}
 scripts/kconfig/merge_config.sh -O {output} '{base}' '{frag}' {redir}
 """.format(kdir=kdir, arch=kwargs['arch'], cc=kwargs['cc'],
            cross=kwargs['cross_compile'], output=rel_path,
+           cross_compat=kwargs['cross_compile_compat'],
            base=os.path.join(rel_path, '.config'),
            frag=os.path.join(rel_path, kconfig_frag_name),
            redir='> /dev/null' if not verbose else '')


### PR DESCRIPTION
The merge_config.sh script needs CROSS_COMPILE_COMPAT env set in order
to properly merge configs, otherwise some settings that depend on
that (e.g. VDSO-related) will get disabled during the merge.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>