### PR TITLE
T22500 grunt

### DIFF
--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -534,6 +534,13 @@ device_types:
           defconfig: ['tinyconfig']
           kernel: ['v4.', 'v5.1', 'v5.2']
 
+  hp-11A-G6-EE-grunt:
+    mach: x86
+    arch: x86_64
+    boot_method: depthcharge
+    filters:
+      - passlist: {defconfig: ['x86-chromebook']}
+
   hsdk:
     mach: arc
     class: arc-dtb
@@ -1685,6 +1692,13 @@ test_configs:
   - device_type: hifive-unleashed-a00
     test_plans:
       - baseline
+
+  - device_type: hp-11A-G6-EE-grunt
+    test_plans:
+      - baseline
+      - baseline-nfs
+      - cros-ec
+      - sleep
 
   - device_type: hsdk
     test_plans:


### PR DESCRIPTION
Add x86-chromebook fragment and hp-11A-G6-EE-grunt device type which uses it.

This is pending Depthchage changes to be merged upstream for loading a ramdisk over TFTP on x86 platforms, and the device type to be added to LAVA upstream.

LAVA prerequisite changes for x86 Depthcharge: https://git.lavasoftware.org/lava/lava/-/merge_requests/1283
LAVA device type: https://git.lavasoftware.org/lava/lava/-/merge_requests/1395
Depends on #560 and #561 to be merged first.