### PR TITLE
build-configs: android branch renames

### DIFF
--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -471,19 +471,14 @@ build_configs:
     branch: 'android-4.19-stable'
     variants: *android_variants
 
-  android_4.19:
+  android11_5.4:
     tree: android
-    branch: 'android-4.19'
+    branch: 'android11-5.4'
     variants: *android_variants
 
-  android_5.4-stable:
+  android12_5.4:
     tree: android
-    branch: 'android-5.4-stable'
-    variants: *android_variants
-
-  android_5.4:
-    tree: android
-    branch: 'android-5.4'
+    branch: 'android12-5.4'
     variants: *android_variants
 
   android_mainline:


### PR DESCRIPTION
Request from Google (Todd Kjos):

> We renamed a couple of Android kernel branches, so the old names
> should be removed from kernelci and the new ones added (the old names
> still work, but will go away in a few weeks). Also, the android-4.19
> branch is deprecated (other android-4.19-* branches should still be
> tested):
>
> Repo: repo: https://android.googlesource.com/kernel/common
> Remove: android-5.4, android-5.4-stable, android-4.19
> Add: android11-5.4, android12-5.4

Signed-off-by: Kevin Hilman <khilman@baylibre.com>