### PR TITLE
Fix lab-configs.yaml by removing simple and kselftest from filters

### DIFF
--- a/lab-configs.yaml
+++ b/lab-configs.yaml
@@ -28,7 +28,6 @@ labs:
           plan:
             - baseline
             - baseline-nfs
-            - simple
             - sleep
           tree:
             - kernelci
@@ -88,7 +87,6 @@ labs:
           plan:
             - baseline
             - baseline-nfs
-            - simple
 
   lab-nxp:
     lab_type: lava

--- a/lab-configs.yaml
+++ b/lab-configs.yaml
@@ -91,6 +91,10 @@ labs:
   lab-nxp:
     lab_type: lava
     url: 'https://lavalab.nxp.com/RPC2'
+    filters:
+      - passlist:
+          plan:
+            - baseline
 
   lab-pengutronix:
     lab_type: lava
@@ -107,4 +111,3 @@ labs:
       - passlist:
           plan:
             - baseline
-            - kselftest


### PR DESCRIPTION
The "simple" test plan has been dropped, and "kselftest" is not ready to be run yet.  Drop both from filters in lab-configs.yaml to only  run baseline in lab-nxp and lab-theobrama-systems.