### PR TITLE
kernelci: use Python 3 class and super()

### DIFF
--- a/kernelci/cli.py
+++ b/kernelci/cli.py
@@ -22,7 +22,7 @@ import argparse
 # Standard arguments that can be used in sub-commands
 #
 
-class Args(object):
+class Args:
     """A list of all the common command line argument options
 
     All the members of this class are arguments that can be reused in various
@@ -268,7 +268,7 @@ class Args(object):
     }
 
 
-class Command(object):
+class Command:
     """A command helper class.
 
     It contains several class attributes:

--- a/kernelci/config/__init__.py
+++ b/kernelci/config/__init__.py
@@ -23,7 +23,7 @@ import yaml
 # Common classes for all config types
 #
 
-class YAMLObject(object):
+class YAMLObject:
     """Base class with helper methods to initialise objects from YAML data."""
 
     @classmethod
@@ -42,7 +42,7 @@ class YAMLObject(object):
         } if data else dict()
 
 
-class Filter(object):
+class Filter:
     """Base class to implement arbitrary configuration filters."""
 
     def __init__(self, items):
@@ -102,7 +102,7 @@ class Regex(Filter):
     """
 
     def __init__(self, *args, **kw):
-        super(Regex, self).__init__(*args, **kw)
+        super().__init__(*args, **kw)
         self._re_items = {k: re.compile(v) for k, v in self._items.items()}
 
     def match(self, **kw):

--- a/kernelci/config/lab.py
+++ b/kernelci/config/lab.py
@@ -60,7 +60,7 @@ class Lab(YAMLObject):
 class Lab_LAVA(Lab):
 
     def __init__(self, priority='medium', *args, **kwargs):
-        super(Lab_LAVA, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._priority = priority
 
     @property

--- a/kernelci/config/rootfs.py
+++ b/kernelci/config/rootfs.py
@@ -46,7 +46,7 @@ class RootFS_Debos(RootFS):
                  extra_files_remove=None, script="",
                  test_overlay="", crush_image_options=None):
 
-        super(RootFS_Debos, self).__init__(name, rootfs_type)
+        super().__init__(name, rootfs_type)
         self._debian_release = debian_release
         self._arch_list = arch_list or list()
         self._extra_packages = extra_packages or list()

--- a/kernelci/config/test.py
+++ b/kernelci/config/test.py
@@ -101,7 +101,7 @@ class DeviceType_arc(DeviceType):
     def __init__(self, name, mach, arch='arc', *args, **kw):
         """arc device type with a device tree."""
         kw.setdefault('dtb', '{}.dtb'.format(name))
-        super(DeviceType_arc, self).__init__(name, mach, arch, *args, **kw)
+        super().__init__(name, mach, arch, *args, **kw)
 
 
 class DeviceType_arm(DeviceType):
@@ -109,7 +109,7 @@ class DeviceType_arm(DeviceType):
     def __init__(self, name, mach, arch='arm', *args, **kw):
         """arm device type with a device tree."""
         kw.setdefault('dtb', '{}.dtb'.format(name))
-        super(DeviceType_arm, self).__init__(name, mach, arch, *args, **kw)
+        super().__init__(name, mach, arch, *args, **kw)
 
 
 class DeviceType_mips(DeviceType):
@@ -117,7 +117,7 @@ class DeviceType_mips(DeviceType):
     def __init__(self, name, mach, arch='mips', *args, **kw):
         """mips device type with a device tree."""
         kw.setdefault('dtb', '{}.dtb'.format(name))
-        super(DeviceType_mips, self).__init__(name, mach, arch, *args, **kw)
+        super().__init__(name, mach, arch, *args, **kw)
 
 
 class DeviceType_arm64(DeviceType):
@@ -125,7 +125,7 @@ class DeviceType_arm64(DeviceType):
     def __init__(self, name, mach, arch='arm64', *args, **kw):
         """arm64 device type with a device tree."""
         kw.setdefault('dtb', '{}/{}.dtb'.format(mach, name))
-        super(DeviceType_arm64, self).__init__(name, mach, arch, *args, **kw)
+        super().__init__(name, mach, arch, *args, **kw)
 
 
 class DeviceType_riscv(DeviceType):
@@ -133,7 +133,7 @@ class DeviceType_riscv(DeviceType):
     def __init__(self, name, mach, arch='riscv', *args, **kw):
         """RISCV device type with a device tree."""
         kw.setdefault('dtb', '{}/{}.dtb'.format(mach, name))
-        super(DeviceType_riscv, self).__init__(name, mach, arch, *args, **kw)
+        super().__init__(name, mach, arch, *args, **kw)
 
 
 class DeviceTypeFactory(YAMLObject):

--- a/kernelci/lab/__init__.py
+++ b/kernelci/lab/__init__.py
@@ -21,7 +21,7 @@ import urllib.parse
 import xmlrpc.client
 
 
-class LabAPI(object):
+class LabAPI:
     """Remote API to a test lab"""
 
     def __init__(self, config):


### PR DESCRIPTION
Use the Python 3 class definition style without (object) for base
classes, and plain super() for calling direct parent method.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>