### PR TITLE
rootfs-config: buster: add DHCP client to full rootfs

### DIFF
--- a/jenkins/debian/debos/scripts/setup-networking.sh
+++ b/jenkins/debian/debos/scripts/setup-networking.sh
@@ -10,3 +10,7 @@ systemctl enable systemd-resolved
 systemctl enable systemd-timesyncd
 
 ln -sf /lib/systemd/resolv.conf /etc/resolv.conf
+
+# Setup some static DNS defaults (Google Public)
+echo "nameserver 8.8.8.8" >> /etc/resolv.conf
+echo "nameserver 8.8.4.4" >> /etc/resolv.conf

--- a/rootfs-configs.yaml
+++ b/rootfs-configs.yaml
@@ -11,6 +11,8 @@ rootfs_configs:
       - mips
       - mipsel
       - mips64el
+    extra_packages:
+      - isc-dhcp-client
     extra_packages_remove: &extra_packages_remove_buster
       - bash
       - e2fslibs


### PR DESCRIPTION
Add a DHCP client to the full rootfs (removed for the minimal rootfs).

This is required for proper network setup in a NFSroot setup, since
debian systemd does not properly setup DNS when the kernel has been
booted with kernel IP autoconfig (e.g. booting the kernel with
"ip=dhcp" on the command-line.)

The solution is to run "dhclient" immediately after login
to (re)configure networking before DNS is usable.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>