### PR TITLE
test-configs.yaml: add -smp 2 option on QEMU vexpress-a15

### DIFF
--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -954,7 +954,9 @@ device_types:
       cpu: 'cortex-a15'
       model: 'model=lan9118'
       guestfs_interface: 'none'
-      extra_options: ['-device virtio-blk-device,drive=lavatest']
+      extra_options:
+        - '-device virtio-blk-device,drive=lavatest'
+        - '-smp 2'
     dtb: 'vexpress-v2p-ca15-tc1.dtb'
     boot_method: qemu
     filters:


### PR DESCRIPTION
The qemu_arm-vexpress-a15 jobs have been showing some GIC kernel
errors such as this one:

  GIC CPU mask not found - kernel will fail to boot.

This can be fixed by enabling 2 CPU cores using the "-smp 2" QEMU
parameter.  Add it to the extra options accordingly.

Reported-by: "André Przywara" <andre.przywara@arm.com>
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>