### PR TITLE
dockerfiles/debos: add keyring for debian-ports

### DIFF
--- a/jenkins/dockerfiles/debos/Dockerfile
+++ b/jenkins/dockerfiles/debos/Dockerfile
@@ -32,6 +32,7 @@ RUN go get github.com/go-debos/debos/cmd/debos && \
 RUN apt-get update && apt-get install --no-install-recommends -y \
     binfmt-support \
     busybox \
+    debian-ports-archive-keyring \
     debootstrap \
     dosfstools \
     e2fsprogs \


### PR DESCRIPTION
In order for debootstrap to work from sid/unstable with debian-ports,
we need the keyring debian-ports.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>