### PR TITLE
update kselftest, use Linaro test-defintions

### DIFF
--- a/kernelci/test.py
+++ b/kernelci/test.py
@@ -102,6 +102,11 @@ def get_params(bmeta, target, plan_config, storage):
     defconfig = ''.join(defconfig_full.split('+')[:1])
     endian = 'big' if 'BIG_ENDIAN' in defconfig_full else 'little'
     describe = bmeta['git_describe']
+    kselftests = bmeta.get('kselftests')
+    kselftests_url = (
+        urllib.parse.urljoin(storage, '/'.join([url_px, kselftests]))
+        if kselftests else None
+    )
 
     params = {
         'name': job_name,
@@ -136,6 +141,7 @@ def get_params(bmeta, target, plan_config, storage):
         'rootfs_prompt': rootfs.prompt,
         'file_server_resource': file_server_resource,
         'build_environment': bmeta['build_environment'],
+        'kselftests_url': kselftests_url,
     }
 
     params.update(plan_config.params)

--- a/lab-configs.yaml
+++ b/lab-configs.yaml
@@ -10,6 +10,7 @@ labs:
           plan:
             - baseline
             - baseline-fastboot
+            - kselftest
 
   lab-broonie:
     lab_type: lava

--- a/templates/kselftest/generic-uboot-tftp-nfs-kselftest-template.jinja2
+++ b/templates/kselftest/generic-uboot-tftp-nfs-kselftest-template.jinja2
@@ -1,4 +1,5 @@
-{% extends 'boot/generic-uboot-tftp-ramdisk-boot-template.jinja2' %}
+{% extends 'boot-nfs/generic-uboot-tftp-nfs-template.jinja2' %}
+
 {% block actions %}
 {{ super () }}
 

--- a/templates/kselftest/kselftest.jinja2
+++ b/templates/kselftest/kselftest.jinja2
@@ -1,0 +1,25 @@
+- test:
+    timeout:
+      minutes: 55
+
+    definitions:
+    - from: inline
+      repository:
+        metadata:
+          format: Lava-Test Test Definition 1.0
+          name: timesync-off
+          description: Disable systemd time sync services
+        run:
+          steps:
+          - systemctl stop systemd-timesyncd || true
+      name: timesync-off
+      path: inline/timesync-off.yaml
+
+    - repository: https://github.com/Linaro/test-definitions.git
+      from: git
+      revision: master
+      path: automated/linux/kselftest/kselftest.yaml
+      name: kselftest
+      parameters:
+        TESTPROG_URL: {{ kselftests_url }}
+        SKIPFILE: skipfile-lkft.yaml

--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -161,9 +161,12 @@ test_plans:
         panfrost_submit
 
   kselftest:
-    rootfs: buildroot_kselftest_ramdisk
+    rootfs: debian_buster_nfs
+    pattern: 'kselftest/{category}-{method}-{protocol}-nfs-kselftest-template.jinja2'
     filters:
       - passlist: {defconfig: ['kselftest']}
+    params:
+      job_timeout: '60'
 
   sleep:
     rootfs: debian_buster_ramdisk

--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -1731,6 +1731,7 @@ test_configs:
   - device_type: meson-g12b-odroid-n2
     test_plans:
       - baseline
+      - kselftest
 
   - device_type: meson-g12b-a311d-khadas-vim3
     test_plans:

--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -1421,13 +1421,11 @@ test_configs:
   - device_type: apq8016-sbc
     test_plans:
       - baseline
-      - kselftest
 
   - device_type: ar9331-dpt-module
     test_plans:
       - baseline
       - baseline-nfs
-      - kselftest
       - sleep
 
   - device_type: armada-370-db
@@ -1490,7 +1488,6 @@ test_configs:
   - device_type: arndale
     test_plans:
       - baseline
-      - kselftest
 
   - device_type: at91-sama5d2_xplained
     test_plans:
@@ -1513,24 +1510,20 @@ test_configs:
   - device_type: bcm2837-rpi-3-b
     test_plans:
       - baseline
-      - kselftest
       - usb
 
   - device_type: bcm2837-rpi-3-b-32
     test_plans:
       - baseline
-      - kselftest
 
   - device_type: beaglebone-black
     test_plans:
       - baseline
       - baseline-nfs
-      - kselftest
 
   - device_type: beagle-xm
     test_plans:
       - baseline
-      - kselftest
 
   - device_type: cubietruck
     test_plans:
@@ -1553,54 +1546,44 @@ test_configs:
     test_plans:
       - baseline
       - baseline-nfs
-      - kselftest
       - sleep
 
   - device_type: dra7-evm
     test_plans:
       - baseline
-      - kselftest
 
   - device_type: fsl-ls1012a-rdb
     test_plans:
       - baseline
-      - kselftest
 
   - device_type: fsl-ls1028a-rdb
     test_plans:
       - baseline
-      - kselftest
 
   - device_type: fsl-ls1043a-rdb
     test_plans:
       - baseline
-      - kselftest
 
   - device_type: fsl-ls1046a-rdb
     test_plans:
       - baseline
-      - kselftest
 
   - device_type: fsl-ls1088a-rdb
     test_plans:
       - baseline
-      - kselftest
 
   - device_type: fsl-ls2088a-rdb
     test_plans:
       - baseline
-      - kselftest
 
   - device_type: fsl-lx2160a-rdb
     test_plans:
       - baseline
-      - kselftest
 
   - device_type: hi6220-hikey
     test_plans:
       - baseline
       - baseline-nfs
-      - kselftest
 
   - device_type: hip07-d05
     test_plans:
@@ -1619,35 +1602,30 @@ test_configs:
     test_plans:
       - baseline
       - baseline-nfs
-      - kselftest
       - sleep
 
   - device_type: imx27-phytec-phycard-s-rdk
     test_plans:
       - baseline
       - baseline-nfs
-      - kselftest
       - sleep
 
   - device_type: imx28-duckbill
     test_plans:
       - baseline
       - baseline-nfs
-      - kselftest
       - sleep
 
   - device_type: imx53-qsrb
     test_plans:
       - baseline
       - baseline-nfs
-      - kselftest
       - sleep
 
   - device_type: imx6dl-riotboard
     test_plans:
       - baseline
       - baseline-nfs
-      - kselftest
       - sleep
 
   - device_type: imx6q-nitrogen6x
@@ -1662,14 +1640,12 @@ test_configs:
     test_plans:
       - baseline
       - baseline-nfs
-      - kselftest
       - sleep
 
   - device_type: imx6q-sabrelite
     test_plans:
       - baseline
       - baseline-nfs
-      - kselftest
       - sleep
       - usb
 
@@ -1721,7 +1697,6 @@ test_configs:
     test_plans:
       - baseline
       - baseline-nfs
-      - kselftest
 
   - device_type: kirkwood-db-88f6282
     test_plans:
@@ -1736,7 +1711,6 @@ test_configs:
   - device_type: meson8b-odroidc1
     test_plans:
       - baseline
-      - kselftest
 
   - device_type: meson-g12a-sei510
     test_plans:
@@ -1759,59 +1733,48 @@ test_configs:
     test_plans:
       - baseline
       - baseline-nfs
-      - kselftest
 
   - device_type: meson-gxbb-nanopi-k2
     test_plans:
       - baseline
-      - kselftest
 
   - device_type: meson-gxbb-odroidc2
     test_plans:
       - baseline
-      - kselftest
 
   - device_type: meson-gxbb-p200
     test_plans:
       - baseline
-      - kselftest
 
   - device_type: meson-gxl-s805x-libretech-ac
     test_plans:
       - baseline
-      - kselftest
 
   - device_type: meson-gxl-s905d-p230
     test_plans:
       - baseline
-      - kselftest
 
   - device_type: meson-gxl-s805x-p241
     test_plans:
       - baseline
-      - kselftest
 
   - device_type: meson-gxl-s905x-khadas-vim
     test_plans:
       - baseline
-      - kselftest
 
   - device_type: meson-gxl-s905x-libretech-cc
     test_plans:
       - baseline
-      - kselftest
 
   - device_type: meson-gxm-khadas-vim2
     test_plans:
       - baseline
       - baseline-nfs
-      - kselftest
 
   - device_type: meson-gxm-q200
     test_plans:
       - baseline
       - baseline-nfs
-      - kselftest
 
   - device_type: meson-sm1-khadas-vim3l
     test_plans:
@@ -1837,19 +1800,16 @@ test_configs:
     test_plans:
       - baseline
       - baseline-nfs
-      - kselftest
 
   - device_type: odroid-x2
     test_plans:
       - baseline
-      - kselftest
 
   - device_type: odroid-xu3
     test_plans:
       - baseline
       - baseline-nfs
       - igt-kms-exynos
-      - kselftest
       - sleep
       - usb
 
@@ -1866,18 +1826,15 @@ test_configs:
   - device_type: panda
     test_plans:
       - baseline
-      - kselftest
 
   - device_type: panda-es
     test_plans:
       - baseline
-      - kselftest
 
   - device_type: peach-pi
     test_plans:
       - baseline
       - cros-ec
-      - kselftest
       - sleep
       - usb
 
@@ -1972,7 +1929,6 @@ test_configs:
     test_plans: &r8a7795-salvator-x_test-plans
       - baseline
       - baseline-nfs
-      - kselftest
 
 # this is the same device than r8a7795-salvator-x
   - device_type: r8a77950-salvator-x
@@ -2002,13 +1958,11 @@ test_configs:
   - device_type: rk3399-puma-haikou
     test_plans:
       - baseline
-      - kselftest
 
   - device_type: rk3288-rock2-square
     test_plans:
       - baseline
       - baseline-nfs
-      - kselftest
       - sleep
       - usb
 
@@ -2031,25 +1985,21 @@ test_configs:
     test_plans:
       - baseline
       - baseline-nfs
-      - kselftest
       - sleep
 
   - device_type: snow
     test_plans:
       - baseline
       - baseline-nfs
-      - kselftest
 
   - device_type: stm32mp157c-dk2
     test_plans:
       - baseline
-      - kselftest
 
   - device_type: sun4i-a10-olinuxino-lime
     test_plans:
       - baseline
       - baseline-nfs
-      - kselftest
 
   - device_type: sun50i-a64-bananapi-m64
     test_plans:
@@ -2107,7 +2057,6 @@ test_configs:
     test_plans:
       - baseline
       - baseline-nfs
-      - kselftest
 
   - device_type: sun8i-a23-evb
     test_plans:
@@ -2181,7 +2130,6 @@ test_configs:
     test_plans:
       - baseline
       - baseline-nfs
-      - kselftest
 
   - device_type: x86-celeron
     test_plans:


### PR DESCRIPTION
Update the kselftest test-plan:

1) use the kselftest tarball that is now part of kernelci builds.
2) use debian NFS root (ramdisk + modules, then pivot-root to NFS)
3) use Linaro test-definitions repo for running kselftests

Sharing test-defintions with LInaro/LKFT will allow better collaboration on keeping kselftests running/reliable.

NOTE: this draft PR is based on staging due to dependencies on existing PRs not yet merged into master.