### PR TITLE
templates/k8s/job-build.jinja2: use KCI_API_TOKEN_ID

### DIFF
--- a/templates/k8s/job-build.jinja2
+++ b/templates/k8s/job-build.jinja2
@@ -84,7 +84,7 @@ exit 0; \
         - name: KCI_API_TOKEN
           valueFrom:
             secretKeyRef:
-              name: kci-api-token-staging
+              name: {{ "kci-api-token" | env_override('KCI_API_TOKEN_ID') }}
               key: token
 
         # optional env
@@ -97,4 +97,3 @@ exit 0; \
           requests:
             cpu: {{ cpu_request }}
             memory: {{ mem_request }}
-


### PR DESCRIPTION
Fix mistake with "kci-api-token-staging" being hard-coded in the k8s
job template by using the KCI_API_TOKEN_ID environment variable
instead.  This can be set to whatever is required on each host.

Fixes: 725929c08091 ("templates: support tools/scripts/templates for k8s builds")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>