### PR TITLE
build-configs: Enable coverage of 64K pages on arm64

### DIFF
--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -696,6 +696,7 @@ build_configs:
           arm64:
             extra_configs:
               - 'allmodconfig'
+              - 'defconfig+CONFIG_ARM64_64K_PAGES'
               - 'allnoconfig'
           arm:
             base_defconfig: 'multi_v7_defconfig'

--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -704,7 +704,7 @@ build_configs:
             extra_configs:
               - 'allmodconfig'
               - 'allnoconfig'
-              - 'defconfig+CONFIG_ARM64_64K_PAGES'
+              - 'defconfig+CONFIG_ARM64_64K_PAGES=y'
           arm:
             base_defconfig: 'multi_v7_defconfig'
             filters:

--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -685,7 +685,7 @@ build_configs:
             extra_configs:
               - 'allmodconfig'
               - 'allnoconfig'
-              - 'defconfig+CONFIG_ARM64_64K_PAGES'
+              - 'defconfig+CONFIG_ARM64_64K_PAGES=y'
               - 'defconfig+CONFIG_CPU_BIG_ENDIAN=y'
               - 'defconfig+CONFIG_RANDOMIZE_BASE=y'
           arm:

--- a/lab-configs.yaml
+++ b/lab-configs.yaml
@@ -11,6 +11,10 @@ labs:
             - baseline
             - baseline-fastboot
 
+  lab-broonie:
+    lab_type: lava
+    url: 'https://lava.sirena.org.uk/RPC2/'
+
   lab-cip:
     lab_type: lava
     url: 'https://lava.ciplatform.org/RPC2'


### PR DESCRIPTION
arm64 supports a range of page sizes, including 64K. In testing on other
systems we seem to turn up a small but interesting stream of bugs on 64K
pages which it'd be good to keep an eye on so let's enable a build with
that config option enabled.

This is added for clang-9 simply because we're not really focused on which
compiler is used for the coverage but clang-9 is the only compiler which
has a list of configs already specified so it's the least invasive change.

Signed-off-by: Mark Brown <broonie@kernel.org>