### PR TITLE
kernelci.test: Allow filtering on branches

### DIFF
--- a/kernelci/test.py
+++ b/kernelci/test.py
@@ -39,6 +39,7 @@ def match_configs(configs, bmeta, dtbs, lab):
         'kernel': bmeta['git_describe'],
         'build_environment': bmeta['build_environment'],
         'tree': bmeta['job'],
+        'branch': bmeta['git_branch']
     }
 
     flags = {

--- a/kernelci/test.py
+++ b/kernelci/test.py
@@ -39,7 +39,7 @@ def match_configs(configs, bmeta, dtbs, lab):
         'kernel': bmeta['git_describe'],
         'build_environment': bmeta['build_environment'],
         'tree': bmeta['job'],
-        'branch': bmeta['git_branch']
+        'branch': bmeta['git_branch'],
     }
 
     flags = {


### PR DESCRIPTION
Currently we do not supply the branch name in the filter set we use to
determine which tests to run on a given lab. This is useful for trees
like stable with many branches and currently causes the filters set up
for the LKFT lab which include the branches to not match anything
resulting in no jobs being scheduled there. Add the branch name.

Signed-off-by: Mark Brown <broonie@kernel.org>