### PR TITLE
lab-configs: Accept all stable trees on LKFT lab

### DIFF
--- a/lab-configs.yaml
+++ b/lab-configs.yaml
@@ -64,23 +64,15 @@ labs:
     url: 'https://lkft.validation.linaro.org/RPC2/'
     priority: low
     filters:
-      - combination:
-          keys: ['tree', 'branch']
-          values:
-            - ['stable', 'linux-4.4.y']
-            - ['stable', 'linux-4.9.y']
-            - ['stable', 'linux-4.14.y']
-            - ['stable-rc', 'linux-4.4.y']
-            - ['stable-rc', 'linux-4.9.y']
-            - ['stable-rc', 'linux-4.14.y']
-            - ['next', 'master']
-            - ['next', 'pending-fixes']
-            - ['kernelci', 'kernelci.org']
-            - ['kernelci', 'staging.kernelci.org']
       - passlist:
           plan:
             - baseline
             - baseline-uefi
+          tree:
+            - kernelci
+            - next
+            - stable-rc
+            - stable
 
   lab-mhart:
     lab_type: lava


### PR DESCRIPTION
Currently the LKFT lab has a specific list of branches that are accepted,
mainly used to filter exactly which stable trees are covered. Since there
have been issues with submitting jobs for a considerable time this now
only covers very old stable branches so let's update to include newer ones.

Do this by replacing the explicit list of branches with just accepting
trees as a whole, comparing the list of stable trees that KernelCI covers
with those covered in LKFT's native testing they look to be the same at
the minute. For the other trees covered, -next and kernelci, all the
branches in those trees are included in the explicit list already so there
should be no change. Doing things by tree will reduce the maintenance
overhead going forwards.

Signed-off-by: Mark Brown <broonie@kernel.org>