### PR TITLE
test-configs: Add ThunderX

### DIFF
--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -2141,6 +2141,10 @@ test_configs:
       - sleep
       - usb
 
+  - device_type: thunderx
+    test_plans:
+      - baseline
+
   - device_type: x86-atom330
     test_plans:
       - baseline

--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -1316,6 +1316,14 @@ device_types:
     boot_method: depthcharge
     flags: ['lpae']
 
+  thunderx:
+    mach: sbsa
+    arch: arm64
+    boot_method: grub
+    filters:
+      - passlist: {defconfig: ['defconfig']}
+      - blocklist: {kernel: ['v3.']}
+
   x86-atom330:
     mach: x86
     arch: x86


### PR DESCRIPTION
The Cavium ThunderX is an arm64 server class system, generally booting
using ACPI based firmware.

Signed-off-by: Mark Brown <broonie@kernel.org>