### PR TITLE
kernelci.cli: replace --token with --db-token and --lab-token

### DIFF
--- a/doc/kci_build.md
+++ b/doc/kci_build.md
@@ -110,10 +110,10 @@ binaries and also the meta-data with these commands:
 
 ```
 ./kci_build push_kernel \
-  --kdir=linux --api=https://localhost:12345 --token=1234-5678
+  --kdir=linux --api=https://localhost:12345 --db-token=1234-5678
 
 ./kci_build publish_kernel \
-  --kdir=linux --api=https://localhost:12345 --token=1234-5678
+  --kdir=linux --api=https://localhost:12345 --db-token=1234-5678
 ```
 
 Alternatively, to store the meta-data locally in a JSON file:

--- a/doc/kci_test.md
+++ b/doc/kci_test.md
@@ -45,7 +45,7 @@ Here's a sample command to get the data from a lab and store it in a JSON file:
   --lab=lab-name \
   --lab-json=lab-name.json \
   --user=kernelci-user-name \
-  --token=abcd-7890
+  --lab-token=abcd-7890
 ```
 
 ### 2. Generate test definitions
@@ -71,7 +71,7 @@ To generate the definitions of all the jobs that can be run in a lab:
   --storage=https://some-storage-place.com/ \
   --lab=lab-name \
   --user=kernelci-user-name \
-  --token=abcd-7890 \
+  --lab-token=abcd-7890 \
   --output=jobs \
   --callback-id=kernelci-callback \
   --callback-url=https://callback-recipient.com/handler/
@@ -103,7 +103,7 @@ and target, even if it is not listed in any `test_config` entry:
   --target=qemu_arm64-virt-gicv3 \
   --lab=lab-name \
   --user=kernelci-user-name \
-  --token=abcd-7890 \
+  --lab-token=abcd-7890 \
   --lab-json=lab-name.json \
   --storage=https://some-storage-place.com/ \
   --callback-id=kernelci-callback-local \
@@ -120,7 +120,7 @@ they can be submitted to the test lab with the `kci_test submit` command:
 ./kci_test submit \
   --lab=lab-name \
   --user=kernelci-user-name \
-  --token=abcd-7890 \
+  --lab-token=abcd-7890 \
   --jobs=jobs/*
 ```
 

--- a/kci_build
+++ b/kci_build
@@ -57,11 +57,12 @@ class cmd_check_new_commit(Command):
 
 class cmd_update_last_commit(Command):
     help = "Update the last commit file on the remote storage server"
-    args = [Args.config, Args.api, Args.token, Args.commit]
+    args = [Args.config, Args.api, Args.db_token, Args.commit]
 
     def __call__(self, configs, args):
         conf = configs['build_configs'][args.config]
-        kernelci.build.set_last_commit(conf, args.api, args.token, args.commit)
+        kernelci.build.set_last_commit(
+            conf, args.api, args.db_token, args.commit)
         return True
 
 
@@ -158,11 +159,11 @@ class cmd_expand_fragments(Command):
 
 class cmd_push_tarball(Command):
     help = "Create and up a source tarball to the remote storage server"
-    args = [Args.config, Args.kdir, Args.storage, Args.api, Args.token]
+    args = [Args.config, Args.kdir, Args.storage, Args.api, Args.db_token]
 
     def __call__(self, configs, args):
         conf = configs['build_configs'][args.config]
-        func_args = (conf, args.kdir, args.storage, args.api, args.token)
+        func_args = (conf, args.kdir, args.storage, args.api, args.db_token)
         if not all(func_args):
             print("Invalid arguments")
             return False
@@ -305,29 +306,30 @@ or
 
 class cmd_push_kernel(Command):
     help = "Push the kernel binaries"
-    args = [Args.kdir, Args.api, Args.token]
+    args = [Args.kdir, Args.api, Args.db_token]
     opt_args = [Args.install_path]
 
     def __call__(self, configs, args):
-        return kernelci.build.push_kernel(args.kdir, args.api, args.token,
+        return kernelci.build.push_kernel(args.kdir, args.api, args.db_token,
                                           args.install_path)
 
 
 class cmd_publish_kernel(Command):
     help = "Publish the kernel meta-data"
     args = [Args.kdir]
-    opt_args = [Args.api, Args.token, Args.json_path, Args.install_path]
+    opt_args = [Args.api, Args.db_token, Args.json_path, Args.install_path]
 
     def __call__(self, configs, args):
-        if not ((args.api and args.token) or args.json_path):
+        if not ((args.api and args.db_token) or args.json_path):
             print("""\
 Invalid arguments, please provide at least one of these sets of options:
-    --token, --api to publish to the backend server
+    --db-token, --api to publish to the backend server
     --json-path to save the data in a local JSON file\
 """)
             return False
         return kernelci.build.publish_kernel(
-            args.kdir, args.install_path, args.api, args.token, args.json_path)
+            args.kdir, args.install_path, args.api, args.db_token,
+            args.json_path)
 
 
 class cmd_pull_tarball(Command):

--- a/kci_data
+++ b/kci_data
@@ -47,7 +47,7 @@ class cmd_list_configs(Command):
 class cmd_submit(Command):
     help = "Submit data to the specified database"
     args = [Args.config, Args.data_file]
-    opt_args = [Args.token, Args.verbose]
+    opt_args = [Args.db_token, Args.verbose]
 
     def __call__(self, config_data, args):
         config = config_data['db_configs'][args.config]
@@ -56,7 +56,7 @@ class cmd_submit(Command):
         else:
             with open(args.data_file, 'r') as f:
                 data = f.read()
-        db = kernelci.data.get_db(config, args.token)
+        db = kernelci.data.get_db(config, args.db_token)
         return db.submit(data, args.verbose)
 
 

--- a/kci_rootfs
+++ b/kci_rootfs
@@ -104,10 +104,10 @@ class cmd_build(Command):
 
 class cmd_upload(Command):
     help = "Upload a rootfs image"
-    args = [Args.rootfs_dir, Args.upload_path, Args.api, Args.token]
+    args = [Args.rootfs_dir, Args.upload_path, Args.api, Args.db_token]
 
     def __call__(self, config_data, args):
-        kernelci.rootfs.upload(args.api, args.token, args.upload_path,
+        kernelci.rootfs.upload(args.api, args.db_token, args.upload_path,
                                args.rootfs_dir)
         return True
 

--- a/kci_test
+++ b/kci_test
@@ -47,7 +47,7 @@ class cmd_validate(Command):
 class cmd_list_jobs(Command):
     help = "List all the jobs that need to be run for a given build and lab"
     args = [Args.bmeta_json, Args.dtbs_json, Args.lab]
-    opt_args = [Args.user, Args.token, Args.lab_json]
+    opt_args = [Args.user, Args.lab_token, Args.lab_json]
 
     def __call__(self, test_configs, lab_configs, args):
         bmeta, dtbs = kernelci.build.load_json(args.bmeta_json, args.dtbs_json)
@@ -56,7 +56,8 @@ class cmd_list_jobs(Command):
             return True
 
         lab = lab_configs['labs'][args.lab]
-        api = kernelci.lab.get_api(lab, args.user, args.token, args.lab_json)
+        api = kernelci.lab.get_api(
+            lab, args.user, args.lab_token, args.lab_json)
 
         configs = kernelci.test.match_configs(
             test_configs['test_configs'], bmeta, dtbs, lab)
@@ -91,11 +92,11 @@ class cmd_list_labs(Command):
 class cmd_get_lab_info(Command):
     help = "Get the information about a lab into a JSON file"
     args = [Args.lab, Args.lab_json]
-    opt_args = [Args.user, Args.token]
+    opt_args = [Args.user, Args.lab_token]
 
     def __call__(self, test_configs, lab_configs, args):
         lab = lab_configs['labs'][args.lab]
-        lab_api = kernelci.lab.get_api(lab, args.user, args.token)
+        lab_api = kernelci.lab.get_api(lab, args.user, args.lab_token)
         data = {
             'lab': lab.name,
             'lab_type': lab.lab_type,
@@ -114,7 +115,7 @@ class cmd_generate(Command):
     help = "Generate the job definition for a given build"
     args = [Args.bmeta_json, Args.dtbs_json, Args.storage, Args.lab]
     opt_args = [Args.plan, Args.target, Args.output,
-                Args.lab_json, Args.user, Args.token,
+                Args.lab_json, Args.user, Args.lab_token,
                 Args.callback_id, Args.callback_dataset,
                 Args.callback_type, Args.callback_url, Args.mach]
 
@@ -129,7 +130,8 @@ class cmd_generate(Command):
             return True
 
         lab = lab_configs['labs'][args.lab]
-        api = kernelci.lab.get_api(lab, args.user, args.token, args.lab_json)
+        api = kernelci.lab.get_api(
+            lab, args.user, args.lab_token, args.lab_json)
 
         if args.target and args.plan:
             target = test_configs['device_types'][args.target]
@@ -183,11 +185,11 @@ class cmd_generate(Command):
 
 class cmd_submit(Command):
     help = "Submit job definitions to a lab"
-    args = [Args.lab, Args.user, Args.token, Args.jobs]
+    args = [Args.lab, Args.user, Args.lab_token, Args.jobs]
 
     def __call__(self, test_configs, lab_configs, args):
         lab = lab_configs['labs'][args.lab]
-        lab_api = kernelci.lab.get_api(lab, args.user, args.token)
+        lab_api = kernelci.lab.get_api(lab, args.user, args.lab_token)
         job_paths = glob.glob(args.jobs)
         res = True
         for path in job_paths:

--- a/kernelci/cli.py
+++ b/kernelci/cli.py
@@ -101,6 +101,11 @@ class Args:
         'help': "Path to the debos files",
     }
 
+    db_token = {
+        'name': '--db-token',
+        'help': "Database token",
+    }
+
     defconfig = {
         'name': '--defconfig',
         'help': "Kernel defconfig name",
@@ -170,6 +175,11 @@ class Args:
         'help': "Path to a JSON file with lab-specific info",
     }
 
+    lab_token = {
+        'name': '--lab-token',
+        'help': "Test lab token",
+    }
+
     mach = {
         'name': '--mach',
         'help': "Mach name (aka SoC family)",
@@ -224,11 +234,6 @@ class Args:
     target = {
         'name': '--target',
         'help': "Name of a target platform",
-    }
-
-    token = {
-        'name': '--token',
-        'help': "Backend API token",
     }
 
     tree_name = {

--- a/templates/k8s/job-build.jinja2
+++ b/templates/k8s/job-build.jinja2
@@ -56,8 +56,8 @@ cd /scratch/kernelci-core &&  \
 ./kci_build pull_tarball --kdir ${KDIR} --url ${SRC_TARBALL} --retries 3 --delete && \
 ./kci_build build_kernel --kdir ${KDIR} --output ${OUTPUT} --defconfig=${DEFCONFIG} --arch=${ARCH} --build-env=${BUILD_ENVIRONMENT} --verbose ${PARALLEL_JOPT}; export KERNEL_BUILD_RESULT=$?; \
 ./kci_build install_kernel --kdir ${KDIR} --output ${OUTPUT} --config ${BUILD_CONFIG} --describe=${GIT_DESCRIBE} --describe-verbose=${GIT_DESCRIBE_VERBOSE} --commit=${COMMIT_ID}; \
-./kci_build push_kernel --kdir ${KDIR} --token=${KCI_API_TOKEN} --api=${KCI_API_URL}; \
-./kci_build publish_kernel --kdir ${KDIR} --token=${KCI_API_TOKEN} --api=${KCI_API_URL}; \
+./kci_build push_kernel --kdir ${KDIR} --db-token=${KCI_API_TOKEN} --api=${KCI_API_URL}; \
+./kci_build publish_kernel --kdir ${KDIR} --db-token=${KCI_API_TOKEN} --api=${KCI_API_URL}; \
 echo KERNEL_BUILD_RESULT=$KERNEL_BUILD_RESULT; \
 exit 0; \
 "]


### PR DESCRIPTION
Replace Args.token with Args.db_token and Args.lab_token, with
argument names --db-token and --lab-token to avoid any ambiguity.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>