### PR TITLE
debos: sid: systemd-networking fixups

### DIFF
--- a/jenkins/debian/debos/scripts/setup-networking.sh
+++ b/jenkins/debian/debos/scripts/setup-networking.sh
@@ -3,10 +3,16 @@
 set -e
 
 # Network management
-systemctl enable systemd-networkd
+if [ -e /lib/systemd/system/systemd-networkd.service ]; then
+    systemctl enable systemd-networkd
+fi
 # DNS resolving
-systemctl enable systemd-resolved
+if [ -e /lib/systemd/system/systemd-resolved.service ]; then
+    systemctl enable systemd-resolved
+fi
 # NTP client
-systemctl enable systemd-timesyncd
+if [ -e /lib/systemd/system/systemd-timesyncd.service ]; then
+    systemctl enable systemd-timesyncd
+fi
 
 ln -sf /lib/systemd/resolv.conf /etc/resolv.conf


### PR DESCRIPTION
systemd networking appears different on sid and this setup script is
failing.  Add some sanity checks before attempting to start services
that may not be installed on a basic debootstrap'd system.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>