### PR TITLE
setup: add all dependencies to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,11 @@ setuptools.setup(
     ],
     python_requires='>=3.6',
     install_requires=[
-        "pyyaml",
         "jinja2",
+        "keyring",
+        "pyelftools",
+        "pytest",
+        "pyyaml",
+        "requests",
     ]
 )


### PR DESCRIPTION
When installing kernelci via pip, all the dependencies are
not properly installed:
```
~ ϟ kci_build --help
Traceback (most recent call last):
  File "/home/mkorpershoek/.local/bin/kci_build", line 23, in <module>
    import kernelci.build
  File "/home/mkorpershoek/.local/lib/python3.8/site-packages/kernelci/build.py", line 32, in <module>
    import kernelci.elf
  File "/home/mkorpershoek/.local/lib/python3.8/site-packages/kernelci/elf.py", line 24, in <module>
    import elftools.elf.constants as elfconst
ModuleNotFoundError: No module named 'elftools'
```

```
~ ϟ pip3 show kernelci
Name: kernelci
Version: 1.0
Summary: KernelCI core functions
Home-page: https://github.com/kernelci/kernelci-core
Author: kernelci.org
Author-email: kernelci@groups.io
License: UNKNOWN
Location: /home/mkorpershoek/.local/lib/python3.8/site-packages
Requires: pyyaml, jinja2
Required-by:
```

To fix this, sync back all the dependencies from requirements.txt
into setup.py

Signed-off-by: Mattijs Korpershoek <mkorpershoek@baylibre.com>


Note: for users re-installing via pip, you should consider bumping up the minor version `version='1.1'`, as well, otherwise the package won't be upgraded.

Since I did not know how you release on pip I left that part up to the maintainers.