### PR TITLE
test-configs: add support for qemu RISCV

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1197,6 +1197,22 @@ device_types:
     params: &uefi_i386
       bios_url: 'http://storage.kernelci.org/images/uefi/edk2-stable202005/i386/OVMF.fd'
 
+  qemu_riscv64:
+    base_name: qemu
+    mach: qemu
+    arch: riscv
+    boot_method: qemu
+    context:
+      arch: riscv64
+      cpu: 'rv64'
+      guestfs_interface: 'virtio'
+      machine: 'virt'
+      no_kvm: True
+      memory: 1024
+      extra_options: ['-bios default']
+    filters:
+      - passlist: {defconfig: ['defconfig']}
+
   qemu_x86_64: &qemu_x86_64
     base_name: qemu
     mach: qemu
@@ -2151,6 +2167,10 @@ test_configs:
   - device_type: qemu_i386-uefi
     test_plans:
       - baseline_qemu
+
+  - device_type: qemu_riscv64
+    test_plans:
+      - baseline-qemu-docker
 
   - device_type: qemu_x86_64
     test_plans:

--- a/config/lava/boot/generic-qemu-boot-template.jinja2
+++ b/config/lava/boot/generic-qemu-boot-template.jinja2
@@ -7,6 +7,10 @@
 {% set console_dev = console_dev|default('ttyAMA0') %}
 {% set qemu_binary = 'qemu-system-aarch64' %}
 {% endif %}
+{% if arch == 'riscv' %}
+{% set console_dev = console_dev|default('ttyS0') %}
+{% set qemu_binary = 'qemu-system-riscv64' %}
+{% endif %}
 {% if arch == 'x86_64' %}
 {% set console_dev = console_dev|default('ttyS0') %}
 {% set qemu_binary = 'qemu-system-x86_64' %}


### PR DESCRIPTION
This patch adds suppport for RISCV qemu virt machine.

The device type is LAVA upstreamed:
https://git.lavasoftware.org/lava/lava/-/merge_requests/1255

But probably only my personal lab (LAVA patched with RISCV patch and recent qemu with riscV support installed) could ran it.
So I have set a flags qemu-riscv64 since qemu docker images are not yet ready.

Signed-off-by: Corentin LABBE <clabbe@baylibre.com>