### PR TITLE
rootfs_configs: fix baseline overlay path

### DIFF
--- a/rootfs-configs.yaml
+++ b/rootfs-configs.yaml
@@ -34,7 +34,7 @@ rootfs_configs:
       - partx
       - find
     script: "scripts/install-bootrr.sh"
-    test_overlay: "overlay/baseline"
+    test_overlay: "overlays/baseline"
 
   buster-v4l2:
     rootfs_type: debos


### PR DESCRIPTION
Fix typo in path to baseline overlay.

Fixes: 9b69ba3c84f7 (rootfs-configs: add baseline overlay to default buster)
Signed-off-by: Kevin Hilman <khilman@baylibre.com>