### PR TITLE
kunit: kunit_tool integration in kci_test

### DIFF
--- a/config/core/lab-configs.yaml
+++ b/config/core/lab-configs.yaml
@@ -67,14 +67,15 @@ labs:
             - v4l2-compliance-uvc
             - v4l2-compliance-vivid
 
-  lab-kontron:
-    lab_type: lava
-    url: 'https://lavalab.kontron.com/RPC2/'
+  lab-kunit:
+    lab_type: shell
+    url: '#'
     filters:
       - passlist:
           plan:
-            - baseline
-            - baseline-nfs
+            - kunit-alltests
+            - kunit-defconfig
+            - kunit-kunitconfig
 
   lab-linaro-lkft:
     lab_type: lava

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -225,6 +225,30 @@ test_plans:
     filters:
       - passlist: {defconfig: ['preempt_rt']}
 
+  kunit-alltests:
+    base_name: kunit
+    rootfs: buildroot_ramdisk
+    params:
+      config: "--alltests"
+      kunit_json: "kunit_alltests.json"
+      run_path: "tools/testing/kunit/kunit.py"
+
+  kunit-defconfig:
+    base_name: kunit
+    rootfs: buildroot_ramdisk
+    params:
+      config: ""
+      kunit_json: "kunit_defconfig.json"
+      run_path: "tools/testing/kunit/kunit.py"
+
+  kunit-kunitconfig:
+    base_name: kunit
+    rootfs: buildroot_ramdisk
+    params:
+      config: ""
+      kunit_json: "kunit_kunitconfig.json"
+      run_path: "tools/testing/kunit/kunit.py"
+
   sleep:
     rootfs: debian_buster_ramdisk
     params:

--- a/kci_test
+++ b/kci_test
@@ -164,6 +164,23 @@ class cmd_generate(Command):
         api = kernelci.lab.get_api(
             lab, args.user, args.lab_token, args.lab_json)
 
+        if lab.lab_type == 'shell':
+            if not args.plan:
+                print("--plan is required with a SHELL lab")
+                return False
+            plan = test_configs['test_plans'][args.plan]
+            params = plan.params
+            target = args.bmeta_json.split('_install_/')[0]
+            # target here will be set to the linux checkout that we will run
+            # the KUnit shell command through this is fetched using the
+            # bmeta_json for now
+            job = api.generate(params=params,
+                               target=target,
+                               plan=plan,
+                               callback_opts=None,
+                               args=args)
+            return True
+
         if args.target and args.plan:
             target = test_configs['device_types'][args.target]
             plan = test_configs['test_plans'][args.plan]

--- a/kernelci/config/lab.py
+++ b/kernelci/config/lab.py
@@ -53,6 +53,10 @@ class Lab(YAMLObject):
     def url(self):
         return self._url
 
+    @property
+    def filters(self):
+        return self._filters
+
     def match(self, data):
         return all(f.match(**data) for f in self._filters)
 
@@ -75,11 +79,18 @@ class Lab_LAVA(Lab):
         return cls(**kw)
 
 
+class Lab_SHELL(Lab):
+
+    def __init__(self, priority='medium', *args, **kwargs):
+        super(Lab_SHELL, self).__init__(*args, **kwargs)
+
+
 class LabFactory(YAMLObject):
     """Factory to create lab objects from YAML data."""
 
     _lab_types = {
         'lava': Lab_LAVA,
+        'shell': Lab_SHELL,
     }
 
     @classmethod

--- a/kernelci/lab/shell.py
+++ b/kernelci/lab/shell.py
@@ -1,0 +1,58 @@
+# Copyright (C) 2020 Google LLC
+# Author: Heidi Fahim <heidifahim@google.com>
+#
+# This module is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+from jinja2 import Environment, FileSystemLoader
+import os
+import subprocess
+
+from kernelci.lab import LabAPI
+
+
+class SHELL(LabAPI):
+
+    shell_script = 'shell_lab.sh'
+
+    def connect(self, user=None, token=None):
+        print('User and Token not required for a SHELL lab. '
+              'Skipping connection step.')
+
+    def generate(self, params, target, plan, callback_opts, args=None):
+        # shell command variable that will be modified depending on the
+        # test_plan
+        shell_command = ''
+        if plan.base_name == 'kunit':
+            run_path = os.path.realpath(os.path.join(target,
+                                                     params['run_path']))
+            out_json = (os.path.realpath(args.output) if args and args.output
+                        else 'stdout')
+            config = params['config']
+            shell_command = '%s run --json=%s %s' % (run_path,
+                                                     out_json,
+                                                     config)
+            with open(self.shell_script, 'w') as file:
+                file.write(shell_command)
+        print('Shell commands generated and saved to %s' %
+              os.path.realpath(file.name))
+        return file.name
+
+    def submit(self, job):
+        return subprocess.call([job], shell=True)
+
+
+def get_api(lab):
+    """Get a SHELL lab API object"""
+    return SHELL(lab)


### PR DESCRIPTION
This is a follow-up to the work Heidi did earlier this year. In particular, this change attempts to integrate KUnit in the manner discussed in the design doc that Heidi wrote:

https://docs.google.com/document/d/1ntU5SzDk1XWTVBMqoqBJ1vCHHdKcqyWQm616fe4unhc/edit

This provides a rough but functional first revision of an alternate
implementation design for kunit_tool integration in kernelci_core. This
integration involves both 'kci_test generate' and 'kci_test submit'
steps, where the shell command is generated in the former and run in the
latter. There have been three new test_plan variants added to test_configs.yaml: kunit-alltests,
kunit-defconfig and kunit-kunitconfig.

After running kci_build and having the bmeta.json and dtbs.json files
generated, one can then run this through kci_test generate and submit:

./kci_test generate --lab=lab-kunit --user=heidi --token=jhfgd
--bmeta-json=$HOME/workspace1/linux/_install_/bmeta.json
--dtbs-json=$HOME/workspace1/linux/_install_/dtbs.json
--plan=kunit-kunitconfig

./kci_test submit --lab=lab-kunit --user=heidi --token=jhfgd
--jobs=shell_lab.sh

Currently, --user and --token are required but for a shell lab_type they
aren't used so dummy values have been used here. Also the --plan value
corresponds to one of the three test_plan variants previously mentioned.

Finally, here for a lab with 'shell' lab_type, --jobs corresponds to the
shell_script generated by kci_test generate. This is currently saved at
kernelci-core/shell_lab.sh.

Signed-off-by: Heidi Fahim <heidifahim@google.com>
Signed-off-by: Brendan Higgins <brendanhiggins@google.com>