### PR TITLE
T23120 config args

### DIFF
--- a/doc/kci_build.md
+++ b/doc/kci_build.md
@@ -28,7 +28,7 @@ To create or update an existing mirror and fetch the git history for the `next`
 build configuration:
 
 ```
-./kci_build update_mirror --config=next --mirror=linux-mirror.git
+./kci_build update_mirror --build-config=next --mirror=linux-mirror.git
 ```
 
 Tip: it's quicker to create a mainline mirror first if you already have a Linux
@@ -50,14 +50,14 @@ locally.  This is typically done using git but any source form will work
 repo, with the `--mirror` optional argument:
 
 ```
-./kci_build update_repo --config=next --kdir=linux --mirror=linux-mirror.git
+./kci_build update_repo --build-config=next --kdir=linux --mirror=linux-mirror.git
 ```
 
 Optionally, to generate additional config fragments to then be able to build
 `defconfig+kselftest` or other KernelCI specific configurations:
 
 ```
-./kci_build generate_fragments --config=next --kdir=linux
+./kci_build generate_fragments --build-config=next --kdir=linux
 ```
 
 ### 3. Build the kernel
@@ -98,7 +98,7 @@ later on using [`kci_test`](kci_test.md).  It's also an intermediate step
 before publishing a kernel build to KernelCI.
 
 ```
-./kci_build install_kernel --config=next --kdir=linux
+./kci_build install_kernel --build-config=next --kdir=linux
 ```
 
 See the output in `linux/_install_`.

--- a/doc/kci_rootfs.md
+++ b/doc/kci_rootfs.md
@@ -53,13 +53,14 @@ rootfs name along with its architecture.
     buster arm64
     ```
 
-    It also comes with couple of options `--config` and `--arch` to filter the results based on config name or arch type.
+    It also comes with couple of options `--rootfs-config` and `--arch` to
+    filter the results based on config name or arch type.
 
     ```
-    $ ./kci_rootfs list_variants --config buster --arch i386
+    $ ./kci_rootfs list_variants --rootfs-config buster --arch i386
     buster i386
 
-    $ ./kci_rootfs list_variants --config buster
+    $ ./kci_rootfs list_variants --rootfs-config buster
     buster amd64
     buster arm64
 
@@ -68,13 +69,18 @@ rootfs name along with its architecture.
     buster-v4l2 amd64
     buster-igt amd64
     ```
-7. Now it's time to re-build existing rootfs image using `kci_rootfs build`. It takes three arguments,
-`--config` refers to rootfs name which you want to build. `--data-path` points to debos files location.
-`--arch` refers to CPU arch you want to build. For example, to build a buster rootfs image for i386,
-you can run
+7. Now it's time to re-build existing rootfs image using `kci_rootfs build`. It
+   takes three arguments:
+    * `--rootfs-config` refers to rootfs name which you want to build
+    * `--data-path` points to debos files location
+    * `--arch` refers to CPU arch you want to build
 
+    For example, to build a buster rootfs image for i386, you can run
     ```
-    ./kci_rootfs build --config buster --data-path jenkins/debian/debos --arch i386
+    ./kci_rootfs build \
+        --rootfs-config buster \
+        --data-path jenkins/debian/debos \
+        --arch i386
     ```
 
    depending on your network speed, this will take some time to complete.
@@ -133,9 +139,14 @@ Now you know how to build default `kci_rootfs` images. Let's look at how to add 
 3. If no issues reported during validation, start the build process using,
 
     ```
-    ./kci_rootfs build --config buster-example --data-path jenkins/debian/debos --arch amd64
+    ./kci_rootfs build \
+        --rootfs-config buster-example \
+        --data-path jenkins/debian/debos \
+        --arch amd64
     ```
-    and wait for its completion. If everything went fine you should see something like below under `jenkins/debian/debos/buster-example/amd64/` directory.
+    and wait for its completion. If everything went fine you should see
+    something like below under `jenkins/debian/debos/buster-example/amd64/`
+    directory.
 
     ```
     ls jenkins/debian/debos/buster-example/amd64/

--- a/doc/kci_test.md
+++ b/doc/kci_test.md
@@ -42,10 +42,10 @@ Here's a sample command to get the data from a lab and store it in a JSON file:
 
 ```
 ./kci_test get_lab_info \
-  --lab=lab-name \
-  --lab-json=lab-name.json \
   --user=kernelci-user-name \
-  --lab-token=abcd-7890
+  --lab-config=lab-name \
+  --lab-token=abcd-7890 \
+  --lab-json=lab-name.json
 ```
 
 ### 2. Generate test definitions
@@ -69,8 +69,8 @@ To generate the definitions of all the jobs that can be run in a lab:
   --dtbs-json=linux/_install_/dtbs.json \
   --lab-json=lab-name.json \
   --storage=https://some-storage-place.com/ \
-  --lab=lab-name \
   --user=kernelci-user-name \
+  --lab-config=lab-name \
   --lab-token=abcd-7890 \
   --output=jobs \
   --callback-id=kernelci-callback \
@@ -101,8 +101,8 @@ and target, even if it is not listed in any `test_config` entry:
   --dtbs-json=linux/_install_/dtbs.json \
   --plan=baseline_qemu \
   --target=qemu_arm64-virt-gicv3 \
-  --lab=lab-name \
   --user=kernelci-user-name \
+  --lab-config=lab-name \
   --lab-token=abcd-7890 \
   --lab-json=lab-name.json \
   --storage=https://some-storage-place.com/ \
@@ -118,8 +118,8 @@ they can be submitted to the test lab with the `kci_test submit` command:
 
 ```
 ./kci_test submit \
-  --lab=lab-name \
   --user=kernelci-user-name \
+  --lab-config=lab-name \
   --lab-token=abcd-7890 \
   --jobs=jobs/*
 ```

--- a/kci_build
+++ b/kci_build
@@ -44,10 +44,10 @@ class cmd_list_configs(Command):
 
 class cmd_check_new_commit(Command):
     help = "Check if a new commit is available on a branch"
-    args = [Args.config, Args.storage]
+    args = [Args.build_config, Args.storage]
 
     def __call__(self, configs, args):
-        conf = configs['build_configs'][args.config]
+        conf = configs['build_configs'][args.build_config]
         update = kernelci.build.check_new_commit(conf, args.storage)
         if update is False or update is True:
             return update
@@ -57,10 +57,10 @@ class cmd_check_new_commit(Command):
 
 class cmd_update_last_commit(Command):
     help = "Update the last commit file on the remote storage server"
-    args = [Args.config, Args.api, Args.db_token, Args.commit]
+    args = [Args.build_config, Args.api, Args.db_token, Args.commit]
 
     def __call__(self, configs, args):
-        conf = configs['build_configs'][args.config]
+        conf = configs['build_configs'][args.build_config]
         kernelci.build.set_last_commit(
             conf, args.api, args.db_token, args.commit)
         return True
@@ -68,10 +68,10 @@ class cmd_update_last_commit(Command):
 
 class cmd_tree_branch(Command):
     help = "Print the name of the tree and branch for a given build config"
-    args = [Args.config]
+    args = [Args.build_config]
 
     def __call__(self, configs, args):
-        conf = configs['build_configs'][args.config]
+        conf = configs['build_configs'][args.build_config]
         print(conf.tree.name)
         print(conf.tree.url)
         print(conf.branch)
@@ -80,31 +80,31 @@ class cmd_tree_branch(Command):
 
 class cmd_update_mirror(Command):
     help = "Update the local kernel git mirror"
-    args = [Args.config, Args.mirror]
+    args = [Args.build_config, Args.mirror]
 
     def __call__(self, configs, args):
-        conf = configs['build_configs'][args.config]
+        conf = configs['build_configs'][args.build_config]
         kernelci.build.update_mirror(conf, args.mirror)
         return True
 
 
 class cmd_update_repo(Command):
     help = "Update the local kernel repository checkout"
-    args = [Args.config, Args.kdir]
+    args = [Args.build_config, Args.kdir]
     opt_args = [Args.mirror]
 
     def __call__(self, configs, args):
-        conf = configs['build_configs'][args.config]
+        conf = configs['build_configs'][args.build_config]
         kernelci.build.update_repo(conf, args.kdir, args.mirror)
         return True
 
 
 class cmd_describe(Command):
     help = "Print the git commit, describe and verbose describe from kdir"
-    args = [Args.config, Args.kdir]
+    args = [Args.build_config, Args.kdir]
 
     def __call__(self, configs, args):
-        conf = configs['build_configs'][args.config]
+        conf = configs['build_configs'][args.build_config]
         commit = kernelci.build.head_commit(args.kdir)
         describe = kernelci.build.git_describe(conf.tree.name, args.kdir)
         verbose = kernelci.build.git_describe_verbose(args.kdir)
@@ -116,10 +116,10 @@ class cmd_describe(Command):
 
 class cmd_generate_fragments(Command):
     help = "Generate the config fragment files in kdir"
-    args = [Args.config, Args.kdir]
+    args = [Args.build_config, Args.kdir]
 
     def __call__(self, configs, args):
-        conf = configs['build_configs'][args.config]
+        conf = configs['build_configs'][args.build_config]
         kernelci.build.generate_fragments(conf, args.kdir)
         return True
 
@@ -159,10 +159,11 @@ class cmd_expand_fragments(Command):
 
 class cmd_push_tarball(Command):
     help = "Create and up a source tarball to the remote storage server"
-    args = [Args.config, Args.kdir, Args.storage, Args.api, Args.db_token]
+    args = [Args.build_config, Args.kdir, Args.storage,
+            Args.api, Args.db_token]
 
     def __call__(self, configs, args):
-        conf = configs['build_configs'][args.config]
+        conf = configs['build_configs'][args.build_config]
         func_args = (conf, args.kdir, args.storage, args.api, args.db_token)
         if not all(func_args):
             print("Invalid arguments")
@@ -176,10 +177,10 @@ class cmd_push_tarball(Command):
 
 class cmd_list_variants(Command):
     help = "Print the list of build variants for a given build configuration"
-    args = [Args.config]
+    args = [Args.build_config]
 
     def __call__(self, configs, args):
-        conf = configs['build_configs'][args.config]
+        conf = configs['build_configs'][args.build_config]
         for variant in conf.variants:
             print(variant.name)
         return True
@@ -187,10 +188,10 @@ class cmd_list_variants(Command):
 
 class cmd_arch_list(Command):
     help = "Print the list of CPU architecture names for a given build variant"
-    args = [Args.config, Args.variant]
+    args = [Args.build_config, Args.variant]
 
     def __call__(self, configs, args):
-        conf = configs['build_configs'][args.config]
+        conf = configs['build_configs'][args.build_config]
         variant = conf.get_variant(args.variant)
         for arch in variant.arch_list:
             print(arch)
@@ -209,11 +210,11 @@ def _show_build_env(build_env, arch=None):
 
 class cmd_get_build_env(Command):
     help = "Print the build environment parameters for a given build variant"
-    args = [Args.config, Args.variant]
+    args = [Args.build_config, Args.variant]
     opt_args = [Args.arch]
 
     def __call__(self, configs, args):
-        conf = configs['build_configs'][args.config]
+        conf = configs['build_configs'][args.build_config]
         variant = conf.get_variant(args.variant)
         _show_build_env(variant.build_environment, args.arch)
         return True
@@ -247,11 +248,11 @@ class cmd_show_build_env(Command):
 
 class cmd_list_kernel_configs(Command):
     help = "List the kernel configs to build for a given build configuration"
-    args = [Args.config, Args.kdir]
+    args = [Args.build_config, Args.kdir]
     opt_args = [Args.variant, Args.arch]
 
     def __call__(self, configs, args):
-        conf = configs['build_configs'][args.config]
+        conf = configs['build_configs'][args.build_config]
         configs = kernelci.build.list_kernel_configs(
             conf, args.kdir, args.variant, args.arch)
         for item in configs:
@@ -275,14 +276,14 @@ class cmd_build_kernel(Command):
 class cmd_install_kernel(Command):
     help = "Install the kernel binaries and bmeta.json locally"
     args = [Args.kdir]
-    opt_args = [Args.config, Args.tree_name, Args.tree_url, Args.branch,
+    opt_args = [Args.build_config, Args.tree_name, Args.tree_url, Args.branch,
                 Args.commit, Args.describe, Args.describe_verbose,
                 Args.output, Args.publish_path, Args.install_path,
                 Args.mod_path]
 
     def __call__(self, configs, args):
-        if args.config:
-            conf = configs['build_configs'][args.config]
+        if args.build_config:
+            conf = configs['build_configs'][args.build_config]
             tree_name = conf.tree.name
             tree_url = conf.tree.url
             branch = conf.branch

--- a/kci_data
+++ b/kci_data
@@ -46,11 +46,11 @@ class cmd_list_configs(Command):
 
 class cmd_submit(Command):
     help = "Submit data to the specified database"
-    args = [Args.config, Args.data_file]
+    args = [Args.db_config, Args.data_file]
     opt_args = [Args.db_token, Args.verbose]
 
     def __call__(self, config_data, args):
-        config = config_data['db_configs'][args.config]
+        config = config_data['db_configs'][args.db_config]
         if args.data_file == '-':
             data = sys.stdin.read()
         else:

--- a/kci_rootfs
+++ b/kci_rootfs
@@ -64,11 +64,11 @@ class cmd_list_configs(Command):
 
 class cmd_list_variants(Command):
     help = "List all rootfs variants"
-    opt_args = [Args.config, Args.arch]
+    opt_args = [Args.rootfs_config, Args.arch]
 
     def __call__(self, config_data, args, **kwargs):
         rootfs_configs = config_data['rootfs_configs']
-        config_name = args.config
+        config_name = args.rootfs_config
         arch = args.arch
 
         if config_name and config_name not in rootfs_configs:
@@ -91,18 +91,17 @@ class cmd_list_variants(Command):
 
 class cmd_build(Command):
     help = "Build a rootfs image"
-    args = [Args.config, Args.data_path, Args.arch]
+    args = [Args.rootfs_config, Args.data_path, Args.arch]
 
     def __call__(self, config_data, args, **kwargs):
-        data_path = args.data_path
-        config_name = args.config
-        arch = args.arch
-        if config_name not in config_data['rootfs_configs']:
+        config_name = args.rootfs_config
+        config = config_data['rootfs_configs'].get(config_name)
+        if not config:
             print("{} invalid. Check 'kci_rootfs list_configs' for valid \
                     entries".format(config_name))
             return False
-        config = config_data['rootfs_configs'][args.config]
-        return kernelci.rootfs.build(config_name, config, data_path, arch)
+        return kernelci.rootfs.build(config_name, config,
+                                     args.data_path, args.arch)
 
 
 class cmd_upload(Command):

--- a/kci_test
+++ b/kci_test
@@ -46,7 +46,7 @@ class cmd_validate(Command):
 
 class cmd_list_jobs(Command):
     help = "List all the jobs that need to be run for a given build and lab"
-    args = [Args.bmeta_json, Args.dtbs_json, Args.lab]
+    args = [Args.bmeta_json, Args.dtbs_json, Args.lab_config]
     opt_args = [Args.user, Args.lab_token, Args.lab_json]
 
     def __call__(self, test_configs, lab_configs, args):
@@ -55,7 +55,7 @@ class cmd_list_jobs(Command):
         if bmeta['status'] != "PASS":
             return True
 
-        lab = lab_configs['labs'][args.lab]
+        lab = lab_configs['labs'][args.lab_config]
         api = kernelci.lab.get_api(
             lab, args.user, args.lab_token, args.lab_json)
 
@@ -91,11 +91,11 @@ class cmd_list_labs(Command):
 
 class cmd_get_lab_info(Command):
     help = "Get the information about a lab into a JSON file"
-    args = [Args.lab, Args.lab_json]
+    args = [Args.lab_config, Args.lab_json]
     opt_args = [Args.user, Args.lab_token]
 
     def __call__(self, test_configs, lab_configs, args):
-        lab = lab_configs['labs'][args.lab]
+        lab = lab_configs['labs'][args.lab_config]
         lab_api = kernelci.lab.get_api(lab, args.user, args.lab_token)
         data = {
             'lab': lab.name,
@@ -113,7 +113,7 @@ class cmd_get_lab_info(Command):
 
 class cmd_generate(Command):
     help = "Generate the job definition for a given build"
-    args = [Args.bmeta_json, Args.dtbs_json, Args.storage, Args.lab]
+    args = [Args.bmeta_json, Args.dtbs_json, Args.storage, Args.lab_config]
     opt_args = [Args.plan, Args.target, Args.output,
                 Args.lab_json, Args.user, Args.lab_token,
                 Args.callback_id, Args.callback_dataset,
@@ -129,7 +129,7 @@ class cmd_generate(Command):
         if bmeta['status'] != "PASS":
             return True
 
-        lab = lab_configs['labs'][args.lab]
+        lab = lab_configs['labs'][args.lab_config]
         api = kernelci.lab.get_api(
             lab, args.user, args.lab_token, args.lab_json)
 
@@ -185,10 +185,10 @@ class cmd_generate(Command):
 
 class cmd_submit(Command):
     help = "Submit job definitions to a lab"
-    args = [Args.lab, Args.user, Args.lab_token, Args.jobs]
+    args = [Args.lab_config, Args.user, Args.lab_token, Args.jobs]
 
     def __call__(self, test_configs, lab_configs, args):
-        lab = lab_configs['labs'][args.lab]
+        lab = lab_configs['labs'][args.lab_config]
         lab_api = kernelci.lab.get_api(lab, args.user, args.lab_token)
         job_paths = glob.glob(args.jobs)
         res = True

--- a/kernelci/cli.py
+++ b/kernelci/cli.py
@@ -170,9 +170,9 @@ class Args:
         'help': "Path to the kernel checkout directory",
     }
 
-    lab = {
-        'name': '--lab',
-        'help': "Name of a test lab",
+    lab_config = {
+        'name': '--lab-config',
+        'help': 'Test lab config name',
     }
 
     lab_json = {

--- a/kernelci/cli.py
+++ b/kernelci/cli.py
@@ -54,6 +54,11 @@ class Args:
         'help': "Name of a kernel branch in a tree",
     }
 
+    build_config = {
+        'name': '--build-config',
+        'help': "Build config name",
+    }
+
     build_env = {
         'name': '--build-env',
         'help': "Build environment name",

--- a/kernelci/cli.py
+++ b/kernelci/cli.py
@@ -224,6 +224,11 @@ class Args:
         'type': int,
     }
 
+    rootfs_config = {
+        'name': '--rootfs-config',
+        'help': "Root file system config name",
+    }
+
     rootfs_dir = {
         'name': '--rootfs-dir',
         'help': "Path to the rootfs images directory",

--- a/kernelci/cli.py
+++ b/kernelci/cli.py
@@ -91,11 +91,6 @@ class Args:
         'help': "Git commit checksum",
     }
 
-    config = {
-        'name': '--config',
-        'help': "Build config name",
-    }
-
     data_file = {
         'name': '--data-file',
         'help': "Path to the file with data to be submitted to storage",
@@ -104,6 +99,11 @@ class Args:
     data_path = {
         'name': '--data-path',
         'help': "Path to the debos files",
+    }
+
+    db_config = {
+        'name': '--db-config',
+        'help': 'Database config name',
     }
 
     db_token = {

--- a/templates/k8s/job-build.jinja2
+++ b/templates/k8s/job-build.jinja2
@@ -55,7 +55,7 @@ export KDIR=/scratch/linux && export OUTPUT=$HOME/build && export CCACHE_DISABLE
 cd /scratch/kernelci-core &&  \
 ./kci_build pull_tarball --kdir ${KDIR} --url ${SRC_TARBALL} --retries 3 --delete && \
 ./kci_build build_kernel --kdir ${KDIR} --output ${OUTPUT} --defconfig=${DEFCONFIG} --arch=${ARCH} --build-env=${BUILD_ENVIRONMENT} --verbose ${PARALLEL_JOPT}; export KERNEL_BUILD_RESULT=$?; \
-./kci_build install_kernel --kdir ${KDIR} --output ${OUTPUT} --config ${BUILD_CONFIG} --describe=${GIT_DESCRIBE} --describe-verbose=${GIT_DESCRIBE_VERBOSE} --commit=${COMMIT_ID}; \
+./kci_build install_kernel --kdir ${KDIR} --output ${OUTPUT} --build-config ${BUILD_CONFIG} --describe=${GIT_DESCRIBE} --describe-verbose=${GIT_DESCRIBE_VERBOSE} --commit=${COMMIT_ID}; \
 ./kci_build push_kernel --kdir ${KDIR} --db-token=${KCI_API_TOKEN} --api=${KCI_API_URL}; \
 ./kci_build publish_kernel --kdir ${KDIR} --db-token=${KCI_API_TOKEN} --api=${KCI_API_URL}; \
 echo KERNEL_BUILD_RESULT=$KERNEL_BUILD_RESULT; \


### PR DESCRIPTION
This is in preparation for adding support for settings files.  Some commands may be using multiple configurations, such as a database and a build configuration or a test lab.  For this reason, it's necessary to be able to distinguish between them so each config argument should be specific i.e. `--build-config`, `--lab-config`, `--db-config` rather than a generic `--config`.