### PR TITLE
T23210 settings file

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,9 @@ All the steps of the KernelCI pipeline are implemented with portable command
 line tools.  They are used in [Jenkins pipeline
 jobs](https://github.com/kernelci/kernelci-core/tree/master/jenkins) for
 kernelci.org, but can also be run by hand in a shell or integrated with any CI
-environment.  The `kernelci/build-base` Docker image comes with all the
-dependencies needed.
+environment.  The
+[`kernelci/build-base`](https://hub.docker.com/r/kernelci/build-base) Docker
+image comes with all the dependencies needed.
 
 **The available command line tools are:**
 
@@ -62,7 +63,19 @@ implementation which is still tied to Jenkins or hard-coded in shell scripts:
 * **`kci_email` (WIP)** to generate an email report with test results.
 
 
-## Configuration files
+## [User Settings file](doc/settings.md)
+
+The command line tools can make use of an optional settings file with
+user-specific options.  These settings provide default values for any of the
+command line arguments, as a convenience but also to avoid providing secrets
+such as API tokens in clear.  The file uses sections for each command line tool
+and also for each component (i.e. each lab, backend...).
+
+See the [`kernelci.conf.sample`](kernelci.conf.sample) sample config file and
+the [user settings file](doc/settings.md) section for more details about how
+this works.
+
+## YAML Configuration files
 
 All the builds are configured in
 [`build-configs.yaml`](https://github.com/kernelci/kernelci-core/blob/master/build-configs.yaml),

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -1,0 +1,165 @@
+## User Settings File
+
+The user settings file is intended to be created by end-users with options
+specific to their local setup.  It can also be used by automated CI systems, in
+particular to hide secret API tokens.  The format is similar to
+[INI](https://en.wikipedia.org/wiki/INI_file) although it is parsed by the
+Python 3 [`configparser`](https://docs.python.org/3/library/configparser.html)
+package.
+
+The default name for the file is `kernelci.conf` and it has several standard
+potential locations:
+
+* `kernelci.conf` in the current working directory,
+* `~/.config/kernelci/kernelci.conf` for per-user settings,
+* `/etc/kernelci/kernelci.conf` for system-wide settings.
+
+Unless directly specified on the command line with the `--settings` argument,
+each of the default locations above will be visited in that order until one is
+found to exist.  Only one settings file will be loaded, the first one found.
+
+Settings are defined in separate sections within the file, as described in
+detail below.  Regardless of what is set in the file, each option can always be
+overridden on the command line.  So if you set `kdir: linux` in the settings
+file as the default path to the Linux kernel source directory, you can always
+override it with `--kdir=/some/other/path` on the command line (say, if you
+want to occasionally use a different source tree).  This applies to all the
+options as they are derived from the list of arguments supported by each
+command.
+
+There is a convention to convert the command line argument names to settings
+names, with the `--` being dropped and single dashes `-` replaced with
+underscores `_`.  This is identical to what the Python 3
+[`argparse`](https://docs.python.org/3/howto/argparse.html) module does to
+convert command line argument names to Python object attributes.  A few
+examples:
+
+* `--kdir` becomes `kdir`
+* `--lab-config` becomes `lab_config`
+
+To get started quickly, see the [kernelci.conf.sample](../kernelci.conf.sample)
+file.  You can copy it as `kernelci.conf` into a suitable location as described
+above and edit it to suit your particular needs.
+
+### Command sections
+
+Each command line tool will be looking for a section with a matching name in
+the settings file, such as `[kci_build]`, `[kci_test]` or `[kci_data]`.  These
+are not required to be in the file, but can be used to provide default values
+for command line arguments.  For example:
+
+```ini
+[kci_build]
+
+mirror: linux-mirror.git
+kdir: linux
+build_env: gcc-8
+j: 3
+```
+
+With the values set above, instead of running this:
+```
+kci_build update_mirror --build-config=mainline --mirror=linux-mirror.git
+```
+you can now omit the `--mirror` argument:
+```
+kci_build update_mirror --build-config=mainline
+```
+
+### Component sections
+
+Other sections are specific to a component, such as a test lab or a database
+backend.  This is to allow different values to be set for a same option
+depending on the component being used, and also to allow these values to be
+used by all the command line tools.
+
+The component names are derived from entries defined in the YAML configuration
+files, such as `lab-configs.yaml` or `db-configs.yaml`.  However, the settings
+file can be used to keep values that don't belong in the YAML configuration
+such as secret API tokens or arbitrary user-specific choices.
+
+Each component section name in the settings file will be composed of two parts,
+separated by a colon `:` character:
+
+* a prefix with the type of component such as `lab` or `db`
+* the name of the component
+
+For example, if you define a lab called `my-lava-lab` in `lab-configs.yaml`,
+you can create a section called `[lab:my-lava-lab]` in the settings file.  You
+can refer to it with `--lab-config=my-lava-lab` on the command line, or even
+set `lab_config: my-lava-lab` in the `[DEFAULT]` section to always pick this
+one by default.  Here's an example:
+
+```ini
+[DEFAULT]
+
+lab_config: my-lava-lab
+
+[lab:my-lava-lab]
+
+user: user-name
+lab_token: 1234-5678
+```
+
+### `[DEFAULT]` section
+
+As per the INI file standard specifications, the `[DEFAULT]` section is where
+catch-all default values can be set regardless of the settings section being
+looked up.  The example above shows how this can be used, for a default
+`lab_config` value across all the command line tools.  But values in the
+`[DEFAULT]` section also apply to component sections.  Say, if you have set up
+several labs but they all need the same user name to access their API, you can
+set `user` in the `[DEFAULT]` section and not have to repeat it in each
+`[lab:lab-name]` section.
+
+### A more complete example
+
+It's worth noting that for a same command, some settings values will be found
+in a tool section such as `[kci_test]` while others will be found in a
+component section such as `[lab:lab-name]`.  Others may be found in the
+`[DEFAULT]` section, and finally any option can always be provided or
+overridden on the command line.
+
+For example, if you have these values in your `kernelci.conf` settings file:
+
+```ini
+
+[DEFAULT]
+
+db_config: localhost
+
+[db:localhost]
+
+db_token: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+callback_id: kernelci-callback-local
+callback_url: http://localhost:5001
+
+[kci_build]
+
+kdir: linux
+build_env: gcc-8
+```
+
+you can then run these commands:
+
+```
+kci_build build_kernel --arch=arm64 --defconfig=defconfig
+kci_build install_kernel --build-config=mainline
+```
+
+The `kci_build build_kernel` command normally requires `--kdir` and
+`--build-env`, they are both defined in the `[kci_build]` section so they can
+be dropped on the command line.  The `--arch` and `--defconfig` options are
+still passed on the command line here, because they're more likely to change
+between kernel builds.  If you build the same architecture and defconfig most
+of the time, you can still set some default values for them under the
+`[kci_build]` section and drop them from the command line too until you need to
+build a different one.  Say if you mostly build `arm64`, you can set it in the
+settings file, but if you need to build `x86_64` one day you can pass
+`--arch=x86_64` on the command line without having to edit the settings file.
+
+Then the `kci_build install_kernel` command normally requires `--kdir`,
+`--db-token` and `--db-config`.  These can all be found in the settings file,
+so they don't need to be provided on the command line: `db_config` is in the
+`[DEFAULT]` section, `db_token` in the `[db:localhost]` section and `kdir` in
+the `[kci_build]` section.

--- a/kci_build
+++ b/kci_build
@@ -19,7 +19,7 @@
 
 import sys
 
-from kernelci.cli import Args, Command, parse_args
+from kernelci.cli import Args, Command, parse_opts
 import kernelci.build
 import kernelci.config.build
 
@@ -346,7 +346,7 @@ class cmd_pull_tarball(Command):
 
 
 if __name__ == '__main__':
-    args = parse_args("kci_build", "build-configs.yaml", globals())
-    configs = kernelci.config.build.from_yaml(args.yaml_configs)
-    status = args.func(configs, args)
+    opts = parse_opts("kci_build", "build-configs.yaml", globals())
+    configs = kernelci.config.build.from_yaml(opts.yaml_configs)
+    status = opts.command(configs, opts)
     sys.exit(0 if status is True else 1)

--- a/kci_build
+++ b/kci_build
@@ -161,6 +161,7 @@ class cmd_push_tarball(Command):
     help = "Create and up a source tarball to the remote storage server"
     args = [Args.build_config, Args.kdir, Args.storage,
             Args.api, Args.db_token]
+    opt_args = [Args.db_config]  # This should become mandatory
 
     def __call__(self, configs, args):
         conf = configs['build_configs'][args.build_config]
@@ -308,7 +309,7 @@ or
 class cmd_push_kernel(Command):
     help = "Push the kernel binaries"
     args = [Args.kdir, Args.api, Args.db_token]
-    opt_args = [Args.install_path]
+    opt_args = [Args.install_path, Args.db_config]
 
     def __call__(self, configs, args):
         return kernelci.build.push_kernel(args.kdir, args.api, args.db_token,
@@ -318,13 +319,14 @@ class cmd_push_kernel(Command):
 class cmd_publish_kernel(Command):
     help = "Publish the kernel meta-data"
     args = [Args.kdir]
-    opt_args = [Args.api, Args.db_token, Args.json_path, Args.install_path]
+    opt_args = [Args.db_config, Args.api, Args.db_token,
+                Args.json_path, Args.install_path]
 
     def __call__(self, configs, args):
         if not ((args.api and args.db_token) or args.json_path):
             print("""\
 Invalid arguments, please provide at least one of these sets of options:
-    --db-token, --api to publish to the backend server
+    --db-config, --db-token, --api to publish to the backend server
     --json-path to save the data in a local JSON file\
 """)
             return False

--- a/kci_build
+++ b/kci_build
@@ -336,11 +336,11 @@ Invalid arguments, please provide at least one of these sets of options:
 class cmd_pull_tarball(Command):
     help = "Downloads and untars kernel sources"
     args = [Args.kdir, Args.url]
-    opt_args = [Args.filename, Args.retries, Args.delete]
+    opt_args = [Args.kernel_tarball, Args.retries, Args.delete]
 
     def __call__(self, configs, args):
         retries = args.retries or 1
-        tarball = args.filename or 'linux-src.tar.gz'
+        tarball = args.kernel_tarball or 'linux-src.tar.gz'
         return kernelci.build.pull_tarball(
             args.kdir, args.url, tarball, retries, args.delete)
 

--- a/kci_build
+++ b/kci_build
@@ -339,9 +339,10 @@ class cmd_pull_tarball(Command):
     opt_args = [Args.filename, Args.retries, Args.delete]
 
     def __call__(self, configs, args):
-        return kernelci.build.pull_tarball(args.kdir, args.url,
-                                           args.filename, args.retries,
-                                           args.delete)
+        retries = args.retries or 1
+        tarball = args.filename or 'linux-src.tar.gz'
+        return kernelci.build.pull_tarball(
+            args.kdir, args.url, tarball, retries, args.delete)
 
 
 if __name__ == '__main__':

--- a/kci_data
+++ b/kci_data
@@ -20,7 +20,7 @@
 
 import sys
 
-from kernelci.cli import Args, Command, parse_args
+from kernelci.cli import Args, Command, parse_opts
 import kernelci.config.data
 import kernelci.data
 
@@ -61,7 +61,7 @@ class cmd_submit(Command):
 
 
 if __name__ == '__main__':
-    args = parse_args("kci_data", "db-configs.yaml", globals())
-    configs = kernelci.config.data.from_yaml(args.yaml_configs)
-    status = args.func(configs, args)
+    opts = parse_opts("kci_data", "db-configs.yaml", globals())
+    configs = kernelci.config.data.from_yaml(opts.yaml_configs)
+    status = opts.command(configs, opts)
     sys.exit(0 if status is True else 1)

--- a/kci_rootfs
+++ b/kci_rootfs
@@ -19,7 +19,7 @@
 
 import sys
 
-from kernelci.cli import Args, Command, parse_args
+from kernelci.cli import Args, Command, parse_opts
 import kernelci.rootfs
 import kernelci.config.rootfs
 
@@ -123,7 +123,7 @@ class cmd_upload(Command):
 #
 
 if __name__ == '__main__':
-    args = parse_args("kci_rootfs", "rootfs-configs.yaml", globals())
-    configs = kernelci.config.rootfs.from_yaml(args.yaml_configs)
-    status = args.func(configs, args)
+    opts = parse_opts("kci_rootfs", "rootfs-configs.yaml", globals())
+    configs = kernelci.config.rootfs.from_yaml(opts.yaml_configs)
+    status = opts.command(configs, opts)
     sys.exit(0 if status is True else 1)

--- a/kci_test
+++ b/kci_test
@@ -158,8 +158,8 @@ class cmd_generate(Command):
         # from the backend API.
         callback_opts = {
             'id': args.callback_id,
-            'dataset': args.callback_dataset,
-            'type': args.callback_type,
+            'dataset': args.callback_dataset or 'all',
+            'type': args.callback_type or 'kernelci',
             'url': args.callback_url,
         }
         if args.output and not os.path.exists(args.output):

--- a/kci_test
+++ b/kci_test
@@ -115,7 +115,7 @@ class cmd_generate(Command):
     help = "Generate the job definition for a given build"
     args = [Args.bmeta_json, Args.dtbs_json, Args.storage, Args.lab_config]
     opt_args = [Args.plan, Args.target, Args.output,
-                Args.lab_json, Args.user, Args.lab_token,
+                Args.lab_json, Args.user, Args.lab_token, Args.db_config,
                 Args.callback_id, Args.callback_dataset,
                 Args.callback_type, Args.callback_url, Args.mach]
 

--- a/kci_test
+++ b/kci_test
@@ -23,7 +23,7 @@ import json
 import os
 import sys
 
-from kernelci.cli import Args, Command, parse_args_with_parser
+from kernelci.cli import Args, Command
 import kernelci.config.lab
 import kernelci.config.test
 import kernelci.build
@@ -216,8 +216,11 @@ if __name__ == '__main__':
                         help="Path to the YAML test configs file")
     parser.add_argument("--yaml-lab-configs", default="lab-configs.yaml",
                         help="Path to the YAML lab configs file")
-    args = parse_args_with_parser(parser, globals())
-    test_configs = kernelci.config.test.from_yaml(args.yaml_test_configs)
-    lab_configs = kernelci.config.lab.from_yaml(args.yaml_lab_configs)
-    status = args.func(test_configs, lab_configs, args)
+    parser.add_argument("--settings",
+                        help="Path to the settings file")
+    args = kernelci.cli.parse_args_with_parser(parser, globals())
+    opts = kernelci.cli.make_options(args, parser.prog)
+    test_configs = kernelci.config.test.from_yaml(opts.yaml_test_configs)
+    lab_configs = kernelci.config.lab.from_yaml(opts.yaml_lab_configs)
+    status = opts.command(test_configs, lab_configs, opts)
     sys.exit(0 if status is True else 1)

--- a/kernelci.conf.sample
+++ b/kernelci.conf.sample
@@ -1,0 +1,57 @@
+# Sample kernelci.conf settings file with arbitrary values.
+#
+# These value are only for illustration purposes, they should be manually set
+# by any user to mach a particular installation.  The options mentioned here
+# are typical ones that shouldn't change in every command line call when used
+# manually for local development purposes.  Any command line argument can have
+# a default value stored in this file.  Components such as databases and labs
+# have their own section too, with a naming convention of the form [db:db-name]
+# or [lab:lab-name].
+
+[DEFAULT]
+
+# -- Sample global defaults ---
+#
+# storage: http://localhost:5002
+# db_config: localhost
+
+# -- Sample test lab --
+#
+# [lab:my-lava-lab]
+#
+# user: user-name
+# lab_token: 1234-5678
+
+# -- Sample database --
+#
+# [db:localhost]
+#
+# db_token: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+# api: http://192.168.122.1:5001
+# callback_id: kernelci-callback-local
+# callback_url: http://localhost:5001
+
+
+# -- Sample command line defaults --
+
+[kci_build]
+
+# mirror: linux-mirror.git
+# kdir: linux
+# build_env: gcc-8
+# j: 3
+
+[kci_test]
+
+# lab_config: localhost
+# bmeta_json: linux/_install_/bmeta.json
+# dtbs_json: linux/_install_/dtbs.json
+
+[kci_data]
+
+# db_config: localhost
+# verbose: True
+
+[kci_rootfs]
+
+# arch: arm64

--- a/kernelci/cli.py
+++ b/kernelci/cli.py
@@ -31,6 +31,8 @@ class Args:
     add_argument() method of the parser object from argparse.  There should
     also always be a `help` attribute, as this is needed by the Command class.
     """
+    SECTION_DB = ('db', 'db_config')
+    SECTION_LAB = ('lab', 'lab_config')
 
     arch = {
         'name': '--arch',
@@ -41,6 +43,7 @@ class Args:
         'name': '--api',
         'help': "Backend API URL",
         'default': "https://api.kernelci.org",
+        'section': SECTION_DB,
     }
 
     bmeta_json = {
@@ -67,22 +70,26 @@ class Args:
         'name': '--callback-dataset',
         'help': "Dataset to include in a lab callback",
         'default': 'all',
+        'section': SECTION_DB,
     }
 
     callback_id = {
         'name': '--callback-id',
         'help': "Callback identifier used to look up an authentication token",
+        'section': SECTION_DB,
     }
 
     callback_type = {
         'name': '--callback-type',
         'help': "Type of callback URL",
         'default': 'kernelci',
+        'section': SECTION_DB,
     }
 
     callback_url = {
         'name': '--callback-url',
         'help': "Base URL for the callback",
+        'section': SECTION_DB,
     }
 
     commit = {
@@ -108,6 +115,7 @@ class Args:
     db_token = {
         'name': '--db-token',
         'help': "Database token",
+        'section': SECTION_DB,
     }
 
     defconfig = {
@@ -181,6 +189,7 @@ class Args:
     lab_token = {
         'name': '--lab-token',
         'help': "Test lab token",
+        'section': SECTION_LAB,
     }
 
     mach = {
@@ -264,7 +273,8 @@ class Args:
 
     user = {
         'name': '--user',
-        'help': "User name",
+        'help': "Test lab user name",
+        'section': SECTION_LAB,
     }
 
     variant = {
@@ -322,6 +332,7 @@ class Command:
     def _add_arg(self, arg, required=True):
         kw = dict(arg)
         arg_name = kw.pop('name')
+        kw.pop('section', None)
         if required:
             kw.setdefault('required', True)
         self._parser.add_argument(arg_name, **kw)

--- a/kernelci/cli.py
+++ b/kernelci/cli.py
@@ -319,6 +319,13 @@ class Command:
             for arg in self.opt_args:
                 self._add_arg(arg, False)
         self._parser.set_defaults(func=self)
+        self._args_dict = dict()
+        for arg_list in [self.args, self.opt_args]:
+            if arg_list:
+                self._args_dict.update({
+                    self.to_opt_name(arg['name']): arg
+                    for arg in arg_list
+                })
 
     def __call__(self, *args, **kw):
         raise NotImplementedError("Command not implemented")
@@ -330,6 +337,26 @@ class Command:
         if required:
             kw.setdefault('required', True)
         self._parser.add_argument(arg_name, **kw)
+
+    def get_arg_data(self, arg_name):
+        """Get the data associated with an argument definition
+
+        Get the dictionary with the data associated with an argument using the
+        option form of the name.  For example, to get the data associated with
+        `--db-token` argument, use `db_token` per the translation implemented
+        by the `Command.to_opt_name()` method.
+        """
+        return self._args_dict.get(arg_name)
+
+    @classmethod
+    def to_opt_name(cls, arg_name):
+        """Convert a command line argument name to the option name convention
+
+        Convert a command line argument to an option name which can be used as
+        a Python attribute in the same way as `argparse` adds options to a
+        namespace.  For example, `--db-token` gets convereted to `db_token`.
+        """
+        return arg_name.strip('-').replace('-', '_')
 
 
 def make_parser(title, default_yaml):

--- a/kernelci/cli.py
+++ b/kernelci/cli.py
@@ -42,7 +42,6 @@ class Args:
     api = {
         'name': '--api',
         'help': "Backend API URL",
-        'default': "https://api.kernelci.org",
         'section': SECTION_DB,
     }
 
@@ -147,7 +146,6 @@ class Args:
     filename = {
         'name': '--filename',
         'help': "Kernel sources destination filename",
-        'default': 'linux-src.tar.gz',
     }
 
     install_path = {
@@ -226,7 +224,6 @@ class Args:
     retries = {
         'name': '--retries',
         'help': 'Number of retries before download fails',
-        'default': 1,
         'type': int,
     }
 

--- a/kernelci/cli.py
+++ b/kernelci/cli.py
@@ -41,7 +41,6 @@ class Args:
         'name': '--api',
         'help': "Backend API URL",
         'default': "https://api.kernelci.org",
-        'required': False,
     }
 
     bmeta_json = {
@@ -140,7 +139,6 @@ class Args:
     filename = {
         'name': '--filename',
         'help': "Kernel sources destination filename",
-        'required': False,
         'default': 'linux-src.tar.gz',
     }
 
@@ -219,7 +217,6 @@ class Args:
     retries = {
         'name': '--retries',
         'help': 'Number of retries before download fails',
-        'required': False,
         'default': 1,
         'type': int,
     }
@@ -238,7 +235,6 @@ class Args:
         'name': '--storage',
         'help': "Storage URL",
         'default': "https://storage.kernelci.org",
-        'required': False,
     }
 
     target = {

--- a/kernelci/cli.py
+++ b/kernelci/cli.py
@@ -68,7 +68,6 @@ class Args:
     callback_dataset = {
         'name': '--callback-dataset',
         'help': "Dataset to include in a lab callback",
-        'default': 'all',
         'section': SECTION_DB,
     }
 
@@ -81,7 +80,6 @@ class Args:
     callback_type = {
         'name': '--callback-type',
         'help': "Type of callback URL",
-        'default': 'kernelci',
         'section': SECTION_DB,
     }
 

--- a/kernelci/cli.py
+++ b/kernelci/cli.py
@@ -238,7 +238,6 @@ class Args:
     storage = {
         'name': '--storage',
         'help': "Storage URL",
-        'default': "https://storage.kernelci.org",
     }
 
     target = {

--- a/kernelci/cli.py
+++ b/kernelci/cli.py
@@ -143,11 +143,6 @@ class Args:
         'help': "Path to the dtbs.json file",
     }
 
-    filename = {
-        'name': '--filename',
-        'help': "Kernel sources destination filename",
-    }
-
     install_path = {
         'name': '--install-path',
         'help':
@@ -172,6 +167,11 @@ class Args:
     kdir = {
         'name': '--kdir',
         'help': "Path to the kernel checkout directory",
+    }
+
+    kernel_tarball = {
+        'name': '--kernel-tarball',
+        'help': "Kernel source tarball destination filename",
     }
 
     lab_config = {


### PR DESCRIPTION
Add support for a settings file with sections per component and per command line utility, with the possibility to override any of these values with command line arguments to keep compatibility with current use-cases.