### PR TITLE
kci_rootfs: align implementation of the validate command

### DIFF
--- a/kci_rootfs
+++ b/kci_rootfs
@@ -29,26 +29,30 @@ import kernelci.config.rootfs
 #
 
 class cmd_validate(Command):
-    help = "Validate the rootfs YAML configuration"
+    help = "Validate the YAML configuration"
+    opt_args = [Args.verbose]
 
-    def __call__(self, config_data, *args, **kwargs):
-        rootfs_configs = config_data['rootfs_configs']
-        for config_name, config in rootfs_configs.items():
-            print(config_name)
-            print('\trootfs_type: {}'.format(config.rootfs_type))
-            print('\tarch_list: {}'.format(config.arch_list))
-            print('\tdebian_release: {}'.format(config.debian_release))
-            print('\textra_packages: {}'.format(config.extra_packages))
-            print('\textra_packages_remove: {}'
-                  .format(config.extra_packages_remove))
-            print('\textra_files_remove: {}'.format(config.extra_files_remove))
-            print('\tscript: {}'.format(config.script))
-            print('\ttest_overlay: {}'.format(config.test_overlay))
-            print('\tcrush_image_options: {}'
-                  .format(config.crush_image_options))
-            print('\tdebian_mirror: {}'.format(config.debian_mirror))
-            print('\tkeyring_package: {}'.format(config.keyring_package))
-            print('\tkeyring_file: {}'.format(config.keyring_file))
+    def __call__(self, config_data, args, **kwargs):
+        # ToDo: Use jsonschema
+        if args.verbose:
+            rootfs_configs = config_data['rootfs_configs']
+            for config_name, config in rootfs_configs.items():
+                print(config_name)
+                print('\trootfs_type: {}'.format(config.rootfs_type))
+                print('\tarch_list: {}'.format(config.arch_list))
+                print('\tdebian_release: {}'.format(config.debian_release))
+                print('\textra_packages: {}'.format(config.extra_packages))
+                print('\textra_packages_remove: {}'.format(
+                    config.extra_packages_remove))
+                print('\textra_files_remove: {}'.format(
+                    config.extra_files_remove))
+                print('\tscript: {}'.format(config.script))
+                print('\ttest_overlay: {}'.format(config.test_overlay))
+                print('\tcrush_image_options: {}'.format(
+                    config.crush_image_options))
+                print('\tdebian_mirror: {}'.format(config.debian_mirror))
+                print('\tkeyring_package: {}'.format(config.keyring_package))
+                print('\tkeyring_file: {}'.format(config.keyring_file))
         return True
 
 


### PR DESCRIPTION
Do not print anything by default when running kci_rootfs, only if
--verbose is provided as the main purpose is to validate the YAML
configuration.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>