### PR TITLE
dockerfiles: Add clang-11 docker container

### DIFF
--- a/jenkins/dockerfiles/clang-11/Dockerfile
+++ b/jenkins/dockerfiles/clang-11/Dockerfile
@@ -1,0 +1,18 @@
+FROM kernelci/build-base
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    software-properties-common \
+    gnupg2
+
+RUN wget -q -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+RUN apt-add-repository 'deb http://apt.llvm.org/buster/ llvm-toolchain-buster-11 main'
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    binutils-aarch64-linux-gnu \
+    binutils-arm-linux-gnueabihf \
+    binutils \
+    clang-11 lld-11 llvm-11
+
+ENV PATH=/usr/lib/llvm-11/bin:${PATH}
+
+RUN apt-get autoremove -y gcc


### PR DESCRIPTION
The next release of clang is due at the end of August (it's scheduled
for the 26th) so get a docker container ready for it.

Signed-off-by: Mark Brown <broonie@kernel.org>