### PR TITLE
T23119 schema clean up

### DIFF
--- a/kernelci/test.py
+++ b/kernelci/test.py
@@ -98,9 +98,9 @@ def get_params(bmeta, target, plan_config, storage):
         if modules else None
     )
     rootfs = plan_config.rootfs
-    defconfig = bmeta['defconfig_full']
-    defconfig_base = ''.join(defconfig.split('+')[:1])
-    endian = 'big' if 'BIG_ENDIAN' in defconfig else 'little'
+    defconfig_full = bmeta['defconfig_full']
+    defconfig = ''.join(defconfig_full.split('+')[:1])
+    endian = 'big' if 'BIG_ENDIAN' in defconfig_full else 'little'
     describe = bmeta['git_describe']
 
     params = {
@@ -118,6 +118,7 @@ def get_params(bmeta, target, plan_config, storage):
         'kernel': describe,
         'tree': bmeta['job'],
         'defconfig': defconfig,
+        'defconfig_full': defconfig_full,
         'fastboot': str(target.get_flag('fastboot')).lower(),
         'device_type': target.name,
         'base_device_type': target.base_name,
@@ -128,7 +129,6 @@ def get_params(bmeta, target, plan_config, storage):
         'git_commit': bmeta['git_commit'],
         'git_describe': describe,
         'git_url': bmeta['git_url'],
-        'defconfig_base': defconfig_base,
         'initrd_url': rootfs.get_url('ramdisk', arch, endian),
         'kernel_image': kernel_img,
         'nfsrootfs_url': rootfs.get_url('nfs', arch, endian),

--- a/kernelci/test.py
+++ b/kernelci/test.py
@@ -90,10 +90,8 @@ def get_params(bmeta, target, plan_config, storage):
     if dtb_full and dtb_full.endswith('.dtb'):
         dtb_url = urllib.parse.urljoin(
             storage, '/'.join([url_px, dtb_full]))
-        platform = dtb.split('.')[0]
     else:
         dtb_url = None
-        platform = target.name
     modules = bmeta.get('modules')
     modules_url = (
         urllib.parse.urljoin(storage, '/'.join([url_px, modules]))
@@ -110,7 +108,6 @@ def get_params(bmeta, target, plan_config, storage):
         'dtb_url': dtb_url,
         'dtb_short': dtb,
         'dtb_full': dtb_full,
-        'platform': platform,
         'mach': target.mach,
         'kernel_url': kernel_url,
         'image_type': 'kernel-ci',

--- a/kernelci/test.py
+++ b/kernelci/test.py
@@ -118,7 +118,6 @@ def get_params(bmeta, target, plan_config, storage):
         'kernel': describe,
         'tree': bmeta['job'],
         'defconfig': defconfig,
-        'arch_defconfig': '-'.join([arch, defconfig]),
         'fastboot': str(target.get_flag('fastboot')).lower(),
         'device_type': target.name,
         'base_device_type': target.base_name,

--- a/templates/base/kernel-ci-base.jinja2
+++ b/templates/base/kernel-ci-base.jinja2
@@ -13,7 +13,6 @@ metadata:
   platform.dtb: {{ dtb_full }}
   platform.dtb_short: {{ dtb_short }}
   platform.fastboot: {{ fastboot }}
-  platform.name: {{ platform }}
   platform.mach: {{ mach }}
   test.plan: {{ plan }}
   test.plan_variant: {{ plan_variant }}

--- a/templates/base/kernel-ci-base.jinja2
+++ b/templates/base/kernel-ci-base.jinja2
@@ -8,7 +8,7 @@ metadata:
   kernel.version: {{ kernel }}
   kernel.endian: {{ endian }}
   kernel.defconfig: {{ defconfig }}
-  kernel.defconfig_base: {{ defconfig_base }}
+  kernel.defconfig_full: {{ defconfig_full }}
   platform.dtb: {{ dtb_full }}
   platform.dtb_short: {{ dtb_short }}
   platform.fastboot: {{ fastboot }}

--- a/templates/base/kernel-ci-base.jinja2
+++ b/templates/base/kernel-ci-base.jinja2
@@ -2,7 +2,6 @@
 
 {%- block metadata %}
 metadata:
-  image.type: 'kernel-ci'
   image.url: {{ image_url }}
   kernel.tree: {{ tree }}
   kernel.version: {{ kernel }}

--- a/templates/base/kernel-ci-base.jinja2
+++ b/templates/base/kernel-ci-base.jinja2
@@ -9,7 +9,6 @@ metadata:
   kernel.endian: {{ endian }}
   kernel.defconfig: {{ defconfig }}
   kernel.defconfig_base: {{ defconfig_base }}
-  kernel.arch_defconfig: {{ arch_defconfig }}
   platform.dtb: {{ dtb_full }}
   platform.dtb_short: {{ dtb_short }}
   platform.fastboot: {{ fastboot }}


### PR DESCRIPTION
Clean up the meta-data passed in LAVA jobs as part of the more general clean-up of the kernelci-backend schema for non-LAVA labs.

Depends on https://github.com/kernelci/kernelci-backend/pull/249