### PR TITLE
setup.py: drop keyring from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 jinja2
-keyring
 pyelftools
 pytest
 pyyaml

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,6 @@ setuptools.setup(
     python_requires='>=3.6',
     install_requires=[
         "jinja2",
-        "keyring",
         "pyelftools",
         "pytest",
         "pyyaml",


### PR DESCRIPTION
Drop they "keyring" package from the list of requirements as it's not
used anywhere.  Update requirements.txt accordingly.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>