### PR TITLE
test-configs: d2500cc: block tinyconfig/allnoconfig

### DIFF
--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -410,6 +410,8 @@ device_types:
     mach: x86
     arch: x86_64
     boot_method: grub
+    filters:
+      - blocklist: {defconfig: ['allnoconfig', 'tinyconfig']}
 
   da850-lcdk:
     mach: davinci


### PR DESCRIPTION
tinyconfig/allnoconfig does not work at all on d2500cc, block them.