### PR TITLE
add build config and test-plan for PREEMPT_RT

### DIFF
--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -142,6 +142,13 @@ fragments:
   kselftest:
     path: "kernel/configs/kselftest.config"
 
+  preempt_rt:
+    path: "kernel/configs/preempt_rt.config"
+    configs:
+      - 'CONFIG_EXPERT=y'
+      - 'CONFIG_PREEMPT_RT=y'
+      - 'CONFIG_PREEMPT_RT_FULL=y' # <= v4.19
+
   tinyconfig:
     path: "kernel/configs/tiny.config"
     defconfig: 'tinyconfig'
@@ -292,7 +299,7 @@ arch_defconfigs: &arch_defconfigs
 
 
 minimal_variants: &minimal_variants
-  gcc-8:
+  gcc-8: &gcc_8_minimal
     build_environment: gcc-8
     architectures: *arch_defconfigs
 
@@ -324,6 +331,12 @@ stable_variants: &stable_variants
       x86_64:
         base_defconfig: 'x86_64_defconfig'
         extra_configs: ['allnoconfig']
+
+preempt_rt_variants: &preempt_rt_variants
+  <<: *minimal_variants
+  gcc-8:
+    <<: *gcc_8_minimal
+    fragments: [preempt_rt]
 
 android_variants: &android_variants
   gcc-8:
@@ -807,22 +820,37 @@ build_configs:
   rt-stable_v3.18-rt:
     tree: rt-stable
     branch: 'v3.18-rt'
+    variants: *preempt_rt_variants
 
   rt-stable_v4.1-rt:
     tree: rt-stable
     branch: 'v4.1-rt'
+    variants: *preempt_rt_variants
 
   rt-stable_v4.4-rt:
     tree: rt-stable
     branch: 'v4.4-rt'
+    variants: *preempt_rt_variants
 
   rt-stable_v4.9-rt:
     tree: rt-stable
     branch: 'v4.9-rt'
+    variants: *preempt_rt_variants
 
   rt-stable_v4.14-rt:
     tree: rt-stable
     branch: 'v4.14-rt'
+    variants: *preempt_rt_variants
+
+  rt-stable_v4.19-rt:
+    tree: rt-stable
+    branch: 'v4.19-rt'
+    variants: *preempt_rt_variants
+
+  rt-stable_v5.4-rt:
+    tree: rt-stable
+    branch: 'v5.4-rt'
+    variants: *preempt_rt_variants
 
   samsung:
     tree: samsung

--- a/lab-configs.yaml
+++ b/lab-configs.yaml
@@ -11,6 +11,7 @@ labs:
             - baseline
             - baseline-fastboot
             - kselftest
+            - preempt-rt
 
   lab-broonie:
     lab_type: lava

--- a/templates/preempt-rt/generic-uboot-tftp-nfs-preempt-rt-template.jinja2
+++ b/templates/preempt-rt/generic-uboot-tftp-nfs-preempt-rt-template.jinja2
@@ -1,0 +1,8 @@
+{% extends 'boot-nfs/generic-uboot-tftp-nfs-template.jinja2' %}
+
+{% block actions %}
+{{ super () }}
+
+{% include 'preempt-rt/preempt-rt.jinja2' %}
+
+{% endblock %}

--- a/templates/preempt-rt/preempt-rt.jinja2
+++ b/templates/preempt-rt/preempt-rt.jinja2
@@ -1,0 +1,30 @@
+- test:
+    timeout:
+      minutes: 10
+
+    definitions:
+    - from: inline
+      repository:
+        metadata:
+          format: Lava-Test Test Definition 1.0
+          name: preempt-rt-prereq
+          description: Pre-requisites for PREEMPT_RT
+        run:
+          steps:
+          - apt-get update && apt-get install -y procps rt-tests
+      name: preempt-rt-prereq
+      path: inline/preempt-rt-prereq.yaml
+
+    - repository: https://github.com/kernelci/test-definitions.git
+      from: git
+      revision: kernelci.org
+      path: automated/linux/cyclictest/cyclictest.yaml
+      name: cyclictest
+      parameters:
+        AFFINTIY: 0-1
+        BACKGROUND_CMD: hackbench
+        DURATION: 300s
+        INTERVAL: 1000
+        MAX_LATENCY: 35
+        PRIORITY: 98
+        THREADS: 2

--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -175,6 +175,11 @@ test_plans:
     filters:
       - blocklist: *kselftest_defconfig_filter
 
+  preempt-rt:
+    rootfs: debian_buster_nfs
+    filters:
+      - passlist: {defconfig: ['preempt_rt']}
+
   sleep:
     rootfs: debian_buster_ramdisk
 

--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -1796,6 +1796,7 @@ test_configs:
   - device_type: meson-sm1-khadas-vim3l
     test_plans:
       - baseline
+      - preempt-rt
 
   - device_type: meson-sm1-sei610
     test_plans:


### PR DESCRIPTION
Add minimal set of build configurations, including PREEMPT_RT=y config for the rt-stable branches.
Also add a test-plan based on LAVA test-definition from Daniel Wagner's fork of LInaro test-definition repo.

NOTE: PR currently based on the kselftest PR #445 due to conflicts in adding test-plan to test-configs and lab-configs.

Things to fix
- [ ] move parameters to device-specific part of test-configs (e.g. num threads will be SoC specific)