### PR TITLE
Costomize the sleep test

### DIFF
--- a/templates/sleep/sleep.jinja2
+++ b/templates/sleep/sleep.jinja2
@@ -2,28 +2,11 @@
     timeout:
       minutes: 5
     definitions:
-    - repository:
-        metadata:
-          format: Lava-Test Test Definition 1.0
-          name: sleep
-          description: "sleep test plan"
-          os:
-          - oe
-          scope:
-          - functional
-        run:
-          steps:
-            - >
-              for i in $(seq 1 10); do
-                lava-test-case rtcwake-mem-$i --shell \
-                  rtcwake -d rtc0 -m mem -s 5
-              done
-            - >
-              for i in $(seq 1 10); do
-                lava-test-case rtcwake-freeze-$i --shell \
-                  rtcwake -d rtc0 -m freeze -s 5
-              done
-      lava-signal: kmsg
-      from: inline
+    - repository: https://github.com/kernelci/kernelci-core
+      branch: kernelci.org
+      from: git
+      history: False
+      path: templates/sleep/sleep.yaml
       name: sleep
-      path: inline/sleep.yaml
+      parameters:
+        sleep_params: "{{ sleep_params }}"

--- a/templates/sleep/sleep.sh
+++ b/templates/sleep/sleep.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+modes=$*
+ls -l /dev/rtc0
+if [ $? -eq 0 ];then
+	lava-test-case rtc-exist --result pass
+	for mode in $modes; do
+		for i in $(seq 1 10); do
+			rtcwake -d rtc0 -m $mode -s 5
+        	if [ $? -eq 0 ] && result="pass" || result="fail" ;then
+				lava-test-case rtcwake-$mode-$i --result $result
+			fi 
+		done
+	done
+else
+	lava-test-case rtc-exist --result fail
+	echo "No real time clock found !"
+fi
+

--- a/templates/sleep/sleep.yaml
+++ b/templates/sleep/sleep.yaml
@@ -1,0 +1,16 @@
+metadata:
+    name: sleep
+    format: "Lava-Test Test Definition 1.0"
+    description: "sleep test plan"
+    maintainer:
+        - ktouil@baylibre.com
+    os:
+        - openembedded
+    scope:
+        - functional
+params:
+  test_params: ""
+
+run:
+    steps:
+        - ./templates/sleep/sleep.sh ${sleep_params}

--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -167,6 +167,15 @@ test_plans:
 
   sleep:
     rootfs: debian_buster_ramdisk
+    params:
+      sleep_params: mem freeze
+
+  sleep_mem:
+    base_name: sleep
+    rootfs: debian_buster_ramdisk
+    pattern: 'sleep/{category}-{method}-{protocol}-{rootfs}-sleep-template.jinja2'
+    params:
+      sleep_params: mem
 
   usb:
     rootfs: debian_buster_ramdisk
@@ -506,7 +515,6 @@ device_types:
     boot_method: barebox
     filters:
       - blocklist: *allmodconfig_filter
-
   imx28-duckbill:
     mach: imx
     class: arm-dtb


### PR DESCRIPTION
Costomize the sleep test to use parameters and run the suited tests.
The parameters to be added in the test-config.yaml file to each board
that supports the test.
Add a check for the existence of the rtc otherwise it won't execute
the test.

Signed-off-by: Khouloud Touil <ktouil@baylibre.com>