### PR TITLE
dockerfiles: add clang-latest

### DIFF
--- a/jenkins/dockerfiles/clang-latest/Dockerfile
+++ b/jenkins/dockerfiles/clang-latest/Dockerfile
@@ -1,0 +1,16 @@
+FROM kernelci/build-base
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    software-properties-common \
+    gnupg2
+
+RUN wget -q -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+RUN apt-add-repository 'deb http://apt.llvm.org/buster/ llvm-toolchain-buster main'
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    binutils-aarch64-linux-gnu \
+    binutils-arm-linux-gnueabihf \
+    binutils \
+    clang lld llvm
+
+RUN apt-get autoremove -y gcc


### PR DESCRIPTION
Rather than keep versioning this file for clang versions, just build
the latest version from the apt.llvm.org repo.

This can then be pushed to the docker hub as a specific version.

For example, as of today, latest version is 12, so this an be built
with the version in the image name:

   docker build -t kernelci/build-clang-12 .

Signed-off-by: Kevin Hilman <khilman@baylibre.com>