### PR TITLE
dockerfiles: add clang-latest

### DIFF
--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -199,6 +199,7 @@ build_environments:
     cc_version: 10
     arch_map: *clang_arch_map
     cross_compile: *default_cross_compile
+    cross_compile_compat: *default_cross_compile_compat
 
 
 # Default config with full build coverage

--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -201,6 +201,13 @@ build_environments:
     cross_compile: *default_cross_compile
     cross_compile_compat: *default_cross_compile_compat
 
+  clang-12:
+    cc: clang
+    cc_version: 12
+    arch_map: *clang_arch_map
+    cross_compile: *default_cross_compile
+    cross_compile_compat: *default_cross_compile_compat
+
 
 # Default config with full build coverage
 build_configs_defaults:
@@ -763,6 +770,13 @@ build_configs:
               - 'allnoconfig'
 
       clang-10:
+        build_environment: clang-10
+        architectures:
+          arm: *arm_defconfig
+          arm64: *arm64_defconfig
+          x86_64: *x86_64_defconfig
+
+      clang-12:
         build_environment: clang-10
         architectures:
           arm: *arm_defconfig

--- a/jenkins/dockerfiles/clang-latest/Dockerfile
+++ b/jenkins/dockerfiles/clang-latest/Dockerfile
@@ -1,0 +1,16 @@
+FROM kernelci/build-base
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    software-properties-common \
+    gnupg2
+
+RUN wget -q -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+RUN apt-add-repository 'deb http://apt.llvm.org/buster/ llvm-toolchain-buster main'
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    binutils-aarch64-linux-gnu \
+    binutils-arm-linux-gnueabihf \
+    binutils \
+    clang lld llvm
+
+RUN apt-get autoremove -y gcc


### PR DESCRIPTION
Rather than keep versioning this file for clang versions, just build
the latest version from the apt.llvm.org repo.

In addition, this version also install lld and llvm packages so that
kernel builds can be built using 'make LLVM=1'.

The resulting docker image can then be pushed to the docker hub as a
specific version.

For example, as of today, latest version is 12, so this an be built
with the version in the image name:

   docker build -t kernelci/build-clang-12 .

Signed-off-by: Kevin Hilman <khilman@baylibre.com>