### PR TITLE
kci_build: clang builds use LLVM=1

### DIFF
--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -456,7 +456,10 @@ def _run_make(kdir, arch, target=None, jopt=None, silent=True, cc='gcc',
     if cross_compile_compat:
         args.append('CROSS_COMPILE_COMPAT={}'.format(cross_compile_compat))
 
-    args.append('HOSTCC={}'.format(cc))
+    if cc.startswith('clang'):
+        args.append('LLVM=1')
+    else:
+        args.append('HOSTCC={}'.format(cc))
 
     if use_ccache:
         px = cross_compile if cc == 'gcc' and cross_compile else ''


### PR DESCRIPTION
If building with clang, also set LLVM=1 which will enable all the
other LLVM tools as well, including linker.  When doing so, do not set
HOSTCC since that is already handled by LLVM=1

Also note that 'make LLVM=1' only works in v5.4+, but currently, we're
only doing clang builds in linux-next, so enabling this as the default
should be fine.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>