### PR TITLE
dockerfiles: Add lld and llvm to the clang Docker images

### DIFF
--- a/jenkins/dockerfiles/clang-10/Dockerfile
+++ b/jenkins/dockerfiles/clang-10/Dockerfile
@@ -11,8 +11,8 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     binutils-aarch64-linux-gnu \
     binutils-arm-linux-gnueabihf \
     binutils \
-    clang-10
+    clang-10 lld-10 llvm-10
 
-RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-10 500
+ENV PATH=/usr/lib/llvm-10/bin:${PATH}
 
 RUN apt-get autoremove -y gcc

--- a/jenkins/dockerfiles/clang-9/Dockerfile
+++ b/jenkins/dockerfiles/clang-9/Dockerfile
@@ -11,8 +11,8 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     binutils-aarch64-linux-gnu \
     binutils-arm-linux-gnueabihf \
     binutils \
-    clang-9
+    clang-9 lld-9 llvm-9
 
-RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-9 500
+ENV PATH=/usr/lib/llvm-9/bin:${PATH}
 
 RUN apt-get autoremove -y gcc


### PR DESCRIPTION
In order to support testing of LLVM=1 builds include lld and llvm in the
images for the existing versions of clang.

Signed-off-by: Mark Brown <broonie@kernel.org>