### PR TITLE
kernelci.build: make dtbs.json optional in .load_json()

### DIFF
--- a/kci_test
+++ b/kci_test
@@ -46,8 +46,8 @@ class cmd_validate(Command):
 
 class cmd_list_jobs(Command):
     help = "List all the jobs that need to be run for a given build and lab"
-    args = [Args.bmeta_json, Args.dtbs_json, Args.lab_config]
-    opt_args = [Args.user, Args.lab_token, Args.lab_json]
+    args = [Args.bmeta_json, Args.lab_config]
+    opt_args = [Args.dtbs_json, Args.user, Args.lab_token, Args.lab_json]
 
     def __call__(self, test_configs, lab_configs, args):
         bmeta, dtbs = kernelci.build.load_json(args.bmeta_json, args.dtbs_json)
@@ -113,8 +113,8 @@ class cmd_get_lab_info(Command):
 
 class cmd_generate(Command):
     help = "Generate the job definition for a given build"
-    args = [Args.bmeta_json, Args.dtbs_json, Args.storage, Args.lab_config]
-    opt_args = [Args.plan, Args.target, Args.output,
+    args = [Args.bmeta_json, Args.storage, Args.lab_config]
+    opt_args = [Args.plan, Args.target, Args.output, Args.dtbs_json,
                 Args.lab_json, Args.user, Args.lab_token, Args.db_config,
                 Args.callback_id, Args.callback_dataset,
                 Args.callback_type, Args.callback_url, Args.mach]

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -949,16 +949,19 @@ def publish_kernel(kdir, install_path=None, api=None, token=None,
     return True
 
 
-def load_json(bmeta_json, dtbs_json):
+def load_json(bmeta_json, dtbs_json=None):
     """Load the build meta-data from JSON files and return dictionaries
 
     *bmeta_json* is the path to a kernel build meta-data JSON file
-    *dtbs_json* is the path to a kernel dtbs JSON file
+    *dtbs_json* is the path to an optional kernel dtbs JSON file
 
     The returned value is a 2-tuple with the bmeta and dtbs data.
     """
     with open(bmeta_json) as json_file:
         bmeta = json.load(json_file)
-    with open(dtbs_json) as json_file:
-        dtbs = json.load(json_file)['dtbs']
+    if dtbs_json:
+        with open(dtbs_json) as json_file:
+            dtbs = json.load(json_file)['dtbs']
+    else:
+        dtbs = {'dtbs': []}
     return bmeta, dtbs


### PR DESCRIPTION
Some platforms don't use any dtb file, and while the dtbs.json file is
normally always generated by the build_kernel() command, it's not
strictly required to keep it and use it again for platforms that don't
need it.  So make dtbs_json an optional argument in .load_json() and
update kci_test accordingly when generating test jobs.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>