### PR TITLE
kernelci.cli: put lab_json option in lab section

### DIFF
--- a/kernelci/cli.py
+++ b/kernelci/cli.py
@@ -182,6 +182,7 @@ class Args:
     lab_json = {
         'name': '--lab-json',
         'help': "Path to a JSON file with lab-specific info",
+        'section': SECTION_LAB,
     }
 
     lab_token = {


### PR DESCRIPTION
Put the lab_json option in the per-lab section in the settings file.
Each lab should have a separate JSON file with a locally saved copy of
its particular data (i.e. online device types...).

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>