### PR TITLE
build-configs.yaml: Set compat cross compilers for clang-10

### DIFF
--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -199,6 +199,7 @@ build_environments:
     cc_version: 10
     arch_map: *clang_arch_map
     cross_compile: *default_cross_compile
+    cross_compile_compat: *default_cross_compile_compat
 
 
 # Default config with full build coverage


### PR DESCRIPTION
The clang-10 build configuration did not provide compat cross compilers
meaning that we weren't getting coverage of the arm64 compat vDSO. While
clang can build arm without any compat tools the kernel build system
currently requires that a compat cross toolchain be explicitly configured
to enable build of the arm64 compat vDSO.

Reported-by: Kevin Hilman <khilman@baylibre.com>
Signed-off-by: Mark Brown <broonie@kernel.org>