### PR TITLE
T21323 kernelci.build: use - instead of / in resource path components

### DIFF
--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -830,10 +830,9 @@ def install_kernel(kdir, tree_name, tree_url, git_branch, git_commit=None,
 
     build_env = bmeta['build_environment']
     defconfig_full = bmeta['defconfig_full']
-    defconfig_dir = defconfig_full.replace('/', '-')
     if not publish_path:
-        publish_path = '/'.join([
-            tree_name, git_branch, describe, arch, defconfig_dir, build_env,
+        publish_path = '/'.join(item.replace('/', '-') for item in [
+            tree_name, git_branch, describe, arch, defconfig_full, build_env,
         ])
 
     bmeta.update({

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -325,14 +325,15 @@ def push_tarball(config, kdir, storage, api, token):
     """
     tarball_name = "linux-src_{}.tar.gz".format(config.name)
     describe = git_describe(config.tree.name, kdir)
-    tarball_url = '/'.join([
-        storage, config.tree.name, config.branch, describe, tarball_name])
+    path = '/'.join(list(item.replace('/', '-') for item in [
+        config.tree.name, config.branch, describe
+    ]))
+    tarball_url = urllib.parse.urljoin(storage, '/'.join([path, tarball_name]))
     resp = requests.head(tarball_url)
     if resp.status_code == 200:
         return tarball_url
     tarball = "{}.tar.gz".format(config.name)
     make_tarball(kdir, tarball)
-    path = '/'.join([config.tree.name, config.branch, describe]),
     upload_files(api, token, path, {tarball_name: open(tarball, 'rb')})
     os.unlink(tarball)
     return tarball_url


### PR DESCRIPTION
Replace any instance of a slash character "/" in each component making
up the file server resource path with a "-" so they don't end up
creating sub-directories.  This was already done for the
defconfig_full component, but it needs to be done for all of them as
it's a common issue with branch names in particular.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>

Depends on https://github.com/kernelci/kernelci-backend/pull/254
Depends on https://github.com/kernelci/kernelci-frontend/pull/124