### PR TITLE
build-configs: Change Renesas devel branch to master

### DIFF
--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -804,7 +804,7 @@ build_configs:
 
   renesas:
     tree: renesas
-    branch: 'devel'
+    branch: 'master'
 
   renesas_next:
     tree: renesas


### PR DESCRIPTION
The devel branch disappeared when the renesas-devel repo moved from horms
to geert.

Signed-off-by: Chris Paterson <chris.paterson2@renesas.com>