### PR TITLE
build-configs.yaml: enable arm/fixes branch in soc tree

### DIFF
--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -847,12 +847,9 @@ build_configs:
     branch: 'stable-next'
     variants: *stable_variants
 
-#  Disabled as the branch name contains a '/'.  See discussion here:
-#  https://github.com/kernelci/kernelci-core/issues/23
-#
-#  soc_fixes:
-#    tree: soc
-#    branch: 'arm/fixes'
+  soc_fixes:
+    tree: soc
+    branch: 'arm/fixes'
 
   soc_for-next:
     tree: soc


### PR DESCRIPTION
Now that slash "/" characters can be used in git branch names, enable
the arm/fixes branch in the soc tree.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>