### PR TITLE
kernelci/build: kselftest use .tar.xz

### DIFF
--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -666,7 +666,7 @@ def build_kernel(build_env, kdir, arch, defconfig=None, jopt=None,
             'kdir': os.path.join(kdir, 'tools/testing/selftests')
         })
         opts.update({
-            'FORMAT': '.gz',
+            'FORMAT': '.xz',
         })
         # 'gen_tar' target does 'make install' and creates tarball
         result = _run_make(target='gen_tar', **kwargs)
@@ -819,7 +819,7 @@ def install_kernel(kdir, tree_name, tree_url, git_branch, git_commit=None,
             path=mod_path, tarball=modules_tarball_path))
 
     # 'make gen_tar' creates this tarball path
-    kselftest_tarball = 'kselftest-packages/kselftest.tar.gz'
+    kselftest_tarball = 'kselftest-packages/kselftest.tar.xz'
     kselftest_tarball_path = os.path.join(output_path, '_kselftest_',
                                           kselftest_tarball)
     if os.path.exists(kselftest_tarball_path):


### PR DESCRIPTION
The LAVA test-definition has been fixed to handle .tar.xz, so
compress kselftest tarball with xz now.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>