### PR TITLE
T23362 docker: add kselftest build dependencies to gcc-8 and clang-10

### DIFF
--- a/jenkins/dockerfiles/clang-10/Dockerfile
+++ b/jenkins/dockerfiles/clang-10/Dockerfile
@@ -15,4 +15,30 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 
 ENV PATH=/usr/lib/llvm-10/bin:${PATH}
 
+# kselftest x86
+RUN apt-get update && apt-get install --no-install-recommends -y \
+   libc6-dev \
+   libcap-dev \
+   libcap-ng-dev \
+   libelf-dev \
+   libpopt-dev
+
+# kselftest arm64
+RUN dpkg --add-architecture arm64
+RUN apt-get update && apt-get install --no-install-recommends -y \
+   libc6-dev:arm64 \
+   libcap-dev:arm64 \
+   libcap-ng-dev:arm64 \
+   libelf-dev:arm64 \
+   libpopt-dev:arm64
+
+# kselftest arm
+RUN dpkg --add-architecture armhf
+RUN apt-get update && apt-get install --no-install-recommends -y \
+   libc6-dev:armhf \
+   libcap-dev:armhf \
+   libcap-ng-dev:armhf \
+   libelf-dev:armhf \
+   libpopt-dev:armhf
+
 RUN apt-get autoremove -y gcc

--- a/jenkins/dockerfiles/gcc-8_arm/Dockerfile
+++ b/jenkins/dockerfiles/gcc-8_arm/Dockerfile
@@ -12,3 +12,12 @@ RUN update-alternatives \
     --slave /usr/bin/arm-linux-gnueabihf-gcc-gcov arm-linux-gnueabihf-gcov /usr/bin/arm-linux-gnueabihf-gcov-8 \
     --slave /usr/bin/arm-linux-gnueabihf-gcc-gcov-dump arm-linux-gnueabihf-gcov-dump /usr/bin/arm-linux-gnueabihf-gcov-dump-8 \
     --slave /usr/bin/arm-linux-gnueabihf-gcc-gcov-tool arm-linux-gnueabihf-gcov-tool /usr/bin/arm-linux-gnueabihf-gcov-tool-8
+
+# kselftest
+RUN dpkg --add-architecture armhf
+RUN apt-get update && apt-get install --no-install-recommends -y \
+   libc6-dev:armhf \
+   libcap-dev:armhf \
+   libcap-ng-dev:armhf \
+   libelf-dev:armhf \
+   libpopt-dev:armhf

--- a/jenkins/dockerfiles/gcc-8_arm64/Dockerfile
+++ b/jenkins/dockerfiles/gcc-8_arm64/Dockerfile
@@ -23,3 +23,12 @@ RUN update-alternatives \
     --slave /usr/bin/arm-linux-gnueabihf-gcc-gcov arm-linux-gnueabihf-gcov /usr/bin/arm-linux-gnueabihf-gcov-8 \
     --slave /usr/bin/arm-linux-gnueabihf-gcc-gcov-dump arm-linux-gnueabihf-gcov-dump /usr/bin/arm-linux-gnueabihf-gcov-dump-8 \
     --slave /usr/bin/arm-linux-gnueabihf-gcc-gcov-tool arm-linux-gnueabihf-gcov-tool /usr/bin/arm-linux-gnueabihf-gcov-tool-8
+
+# kselftest
+RUN dpkg --add-architecture arm64
+RUN apt-get update && apt-get install --no-install-recommends -y \
+   libc6-dev:arm64 \
+   libcap-dev:arm64 \
+   libcap-ng-dev:arm64 \
+   libelf-dev:arm64 \
+   libpopt-dev:arm64

--- a/jenkins/dockerfiles/gcc-8_x86/Dockerfile
+++ b/jenkins/dockerfiles/gcc-8_x86/Dockerfile
@@ -5,3 +5,11 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     gcc-8-plugin-dev
 
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 500
+
+# kselftest
+RUN apt-get update && apt-get install --no-install-recommends -y \
+   libc6-dev \
+   libcap-dev \
+   libcap-ng-dev \
+   libelf-dev \
+   libpopt-dev


### PR DESCRIPTION
Add build dependencies for x86, arm and arm64 to the gcc-8 and
clang-10 Docker images.  This causes some duplication, but there is no
easy way around it at the moment.