### PR TITLE
test-configs: Add imx8mq-zii-ultra-zest

### DIFF
--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -679,6 +679,12 @@ device_types:
     dtb: 'freescale/imx8mp-evk.dtb'
     boot_method: uboot
 
+  imx8mq-zii-ultra-zest:
+    mach: imx
+    arch: arm64
+    dtb: 'freescale/imx8mq-zii-ultra-zest.dtb'
+    boot_method: barebox
+
   jetson-tk1:
     mach: tegra
     class: arm-dtb
@@ -1730,6 +1736,10 @@ test_configs:
       - baseline
 
   - device_type: imx8mm-ddr4-evk
+    test_plans:
+      - baseline
+
+  - device_type: imx8mq-zii-ultra-zest
     test_plans:
       - baseline
 


### PR DESCRIPTION
This patch adds support for imx8mq-zii-ultra-zest:
LAVA device-type is upstreamed: https://git.lavasoftware.org/lava/lava/-/merge_requests/????