### PR TITLE
T23766 octopus

### DIFF
--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -1700,6 +1700,7 @@ test_configs:
       - baseline
       - baseline-nfs
       - cros-ec
+      - igt-gpu-i915
       - sleep
 
   - device_type: hsdk

--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -97,22 +97,7 @@ test_plans:
     rootfs: debian_buster_nfs
     pattern: 'baseline/{category}-{method}-{protocol}-nfs-baseline-template.jinja2'
     filters:
-      - combination:
-          keys: ['arch', 'defconfig']
-          values:
-            - ['arm', 'exynos_defconfig']
-            - ['arm', 'omap2plus_defconfig']
-            - ['arm', 'sunxi_defconfig']
-            - ['arm', 'hisi_defconfig']
-            - ['arm', 'sama5_defconfig']
-            - ['arm', 'tegra_defconfig']
-            - ['arm', 'mvebu_v5_defconfig']
-            - ['arm', 'multi_v5_defconfig']
-            - ['arm', 'multi_v7_defconfig']
-            - ['arm', 'mvebu_v7_defconfig']
-            - ['arm', 'at91_dt_defconfig']
-            - ['arm', 'davinci_all_defconfig']
-            - ['arm64', 'defconfig']
+      - blocklist: *kselftest_defconfig_filter
 
   cros-ec:
     rootfs: debian_buster-cros-ec_ramdisk

--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -69,6 +69,7 @@ test_plan_default_filters:
         - ['arm64', 'defconfig']
         - ['i386', 'i386_defconfig']
         - ['x86_64', 'x86_64_defconfig']
+        - ['x86_64', 'x86_64_defconfig+x86-chromebook']
 
   - blocklist: &kselftest_defconfig_filter
       defconfig: ['kselftest']

--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -547,6 +547,14 @@ device_types:
     boot_method: depthcharge
     filters:
       - passlist: {defconfig: ['x86-chromebook']}
+
+  hp-x360-12b-ca0004na-octopus:
+    mach: x86
+    arch: x86_64
+    boot_method: depthcharge
+    filters:
+      - passlist: {defconfig: ['x86-chromebook']}
+
   hsdk:
     mach: arc
     class: arc-dtb
@@ -1696,6 +1704,13 @@ test_configs:
       - ltp-crypto
 
   - device_type: hp-11A-G6-EE-grunt
+    test_plans:
+      - baseline
+      - baseline-nfs
+      - cros-ec
+      - sleep
+
+  - device_type: hp-x360-12b-ca0004na-octopus
     test_plans:
       - baseline
       - baseline-nfs


### PR DESCRIPTION
Add the `hp-x360-12b-ca0004na-octopus` device using the `x86-chromebook` config fragment.

Depends on #427. 