### PR TITLE
Add crypto test plan

### DIFF
--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -139,6 +139,13 @@ trees:
 
 fragments:
 
+  crypto:
+    path: "kernel/configs/crypto.config"
+    configs:
+      - 'CONFIG_CRYPTO_TEST=m'
+      - 'CONFIG_CRYPTO_MANAGER_EXTRA_TESTS=y'
+      - '# CONFIG_CRYPTO_MANAGER_DISABLE_TESTS is not set'
+
   debug:
     path: "kernel/configs/debug.config"
 

--- a/lab-configs.yaml
+++ b/lab-configs.yaml
@@ -12,6 +12,7 @@ labs:
             - baseline-fastboot
             - kselftest
             - preempt-rt
+            - crypto
 
   lab-broonie:
     lab_type: lava
@@ -36,6 +37,7 @@ labs:
             - baseline
             - baseline-nfs
             - sleep
+            - crypto
           tree:
             - kernelci
             - mainline

--- a/templates/crypto/crypto.jinja2
+++ b/templates/crypto/crypto.jinja2
@@ -1,0 +1,9 @@
+- test:
+    timeout:
+      minutes: 10
+    definitions:
+    - repository: https://github.com/linaro/test-definitions
+      from: git
+      history: False
+      path: automated/linux/crypto/crypto.yaml
+      name: crypto

--- a/templates/crypto/generic-uboot-tftp-ramdisk-crypto-template.jinja2
+++ b/templates/crypto/generic-uboot-tftp-ramdisk-crypto-template.jinja2
@@ -1,0 +1,7 @@
+{% extends 'boot/generic-uboot-tftp-ramdisk-boot-template.jinja2' %}
+{% block actions %}
+{{ super () }}
+
+{% include 'crypto/crypto.jinja2' %}
+
+{% endblock %}

--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -117,6 +117,11 @@ test_plans:
   cros-ec:
     rootfs: debian_buster-cros-ec_ramdisk
 
+  crypto:
+    base_name: crypto
+    rootfs: debian_buster_ramdisk
+    pattern: 'crypto/{category}-{method}-{protocol}-{rootfs}-crypto-template.jinja2'
+
   igt-kms: &igt
     rootfs: debian_buster-igt_ramdisk
     pattern: 'igt/{category}-{method}-{protocol}-{rootfs}-igt.jinja2'
@@ -1558,10 +1563,12 @@ test_configs:
     test_plans:
       - baseline
       - baseline-nfs
+      - crypto
 
   - device_type: d2500cc
     test_plans:
       - baseline
+      - crypto
 
   - device_type: d03
     test_plans:
@@ -1676,6 +1683,7 @@ test_configs:
     test_plans:
       - baseline
       - baseline-nfs
+      - crypto
       - sleep
       - usb
 
@@ -1796,6 +1804,7 @@ test_configs:
   - device_type: meson-gxl-s905x-libretech-cc
     test_plans:
       - baseline
+      - crypto
 
   - device_type: meson-gxm-khadas-vim2
     test_plans:
@@ -1860,6 +1869,7 @@ test_configs:
   - device_type: panda
     test_plans:
       - baseline
+      - crypto
 
   - device_type: panda-es
     test_plans:
@@ -1963,6 +1973,7 @@ test_configs:
     test_plans: &r8a7795-salvator-x_test-plans
       - baseline
       - baseline-nfs
+      - crypto
 
 # this is the same device than r8a7795-salvator-x
   - device_type: r8a77950-salvator-x
@@ -2033,51 +2044,63 @@ test_configs:
   - device_type: stm32mp157c-dk2
     test_plans:
       - baseline
+      - crypto
 
   - device_type: sun4i-a10-olinuxino-lime
     test_plans:
       - baseline
       - baseline-nfs
+      - crypto
 
   - device_type: sun50i-a64-bananapi-m64
     test_plans:
       - baseline
+      - crypto
 
   - device_type: sun50i-a64-pine64-plus
     test_plans:
       - baseline
+      - crypto
 
   - device_type: sun50i-h5-libretech-all-h3-cc
     test_plans:
       - baseline
+      - crypto
 
   - device_type: sun50i-h5-nanopi-neo-plus2
     test_plans:
       - baseline
+      - crypto
 
   - device_type: sun50i-h6-orangepi-one-plus
     test_plans:
       - baseline
+      - crypto
 
   - device_type: sun50i-h6-orangepi-3
     test_plans:
       - baseline
+      - crypto
 
   - device_type: sun50i-h6-pine-h64
     test_plans:
       - baseline
+      - crypto
 
   - device_type: sun50i-h6-pine-h64-model-b
     test_plans:
       - baseline
+      - crypto
 
   - device_type: sun50i-h6-pine-h64-model-b_5.4
     test_plans:
       - baseline
+      - crypto
 
   - device_type: sun5i-a13-olinuxino-micro
     test_plans:
       - baseline
+      - crypto
 
   - device_type: sun5i-gr8-chip
     test_plans:
@@ -2090,11 +2113,13 @@ test_configs:
   - device_type: sun7i-a20-cubieboard2
     test_plans:
       - baseline
+      - crypto
 
   - device_type: sun7i-a20-olinuxino-lime2
     test_plans:
       - baseline
       - baseline-nfs
+      - crypto
 
   - device_type: sun8i-a23-evb
     test_plans:
@@ -2107,10 +2132,12 @@ test_configs:
   - device_type: sun8i-a33-olinuxino
     test_plans:
       - baseline
+      - crypto
 
   - device_type: sun8i-a83t-bananapi-m3
     test_plans:
       - baseline
+      - crypto
 
   - device_type: sun8i-a83t-allwinner-h8homlet-v2
     test_plans:
@@ -2119,30 +2146,37 @@ test_configs:
   - device_type: sun8i-h2-plus-orangepi-zero
     test_plans:
       - baseline
+      - crypto
 
   - device_type: sun8i-h2-plus-orangepi-r1
     test_plans:
       - baseline
+      - crypto
 
   - device_type: sun8i-h2-plus-libretech-all-h3-cc
     test_plans:
       - baseline
+      - crypto
 
   - device_type: sun8i-h3-bananapi-m2-plus
     test_plans:
       - baseline
+      - crypto
 
   - device_type: sun8i-h3-libretech-all-h3-cc
     test_plans:
       - baseline
+      - crypto
 
   - device_type: sun8i-h3-orangepi-pc
     test_plans:
       - baseline
+      - crypto
 
   - device_type: sun8i-r40-bananapi-m2-ultra
     test_plans:
       - baseline
+      - crypto
 
   - device_type: synquacer-acpi
     test_plans:


### PR DESCRIPTION
This patch adds the first steps to test crypto in kernelCI
First a crypto fragment is added for enabling Linux crypto selftest.
Then a crypto test plan is added.
This test plan is enabled on various device with hardware crypto accelerator.
This test plan is enabled i both lab-baylibre and lab-clabbe where
thoses devices are present.