### PR TITLE
add gcc-multilib to gcc-8 Docker image

### DIFF
--- a/jenkins/dockerfiles/gcc-8_x86/Dockerfile
+++ b/jenkins/dockerfiles/gcc-8_x86/Dockerfile
@@ -8,6 +8,7 @@ RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 500
 
 # kselftest
 RUN apt-get update && apt-get install --no-install-recommends -y \
+   gcc-multilib \
    libc6-dev \
    libcap-dev \
    libcap-ng-dev \


### PR DESCRIPTION
Add dependency for x86 build to gcc-8 Docker image. It fixes: filesystems/binderfs, pidfd and vm selftests build.

Signed-off-by: Alexandra Pereira <alexandra.pereira@collabora.com>