### PR TITLE
add libc6-dev-amd64-cross in arm64 gcc-8 Dockerfile

### DIFF
--- a/jenkins/dockerfiles/gcc-8_arm64/Dockerfile
+++ b/jenkins/dockerfiles/gcc-8_arm64/Dockerfile
@@ -31,4 +31,5 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
    libcap-dev:arm64 \
    libcap-ng-dev:arm64 \
    libelf-dev:arm64 \
-   libpopt-dev:arm64
+   libpopt-dev:arm64 \ 
+   libc6-dev-amd64-cross:amd64


### PR DESCRIPTION
Add dependency for arm64 build to gcc-8 Docker image. It fixes: filesystems/binderfs, pidfd and vm selftests build.

Signed-off-by: Alexandra Pereira <alexandra.pereira@collabora.com>