### PR TITLE
build-configs: Add clang-11 coverage for -next

### DIFF
--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -761,9 +761,10 @@ build_configs:
               - 'allnoconfig'
               - 'allmodconfig'
 
+      # clang-10 is the current minium clang version for -next
       clang-10:
         build_environment: clang-10
-        architectures:
+        architectures: &clang_arches_next
           arm64:
             extra_configs:
               - 'allmodconfig'
@@ -785,6 +786,11 @@ build_configs:
             extra_configs:
               - 'allmodconfig'
               - 'allnoconfig'
+
+      # Latest clang release
+      clang-11:
+        build_environment: clang-11
+        architectures: *clang_arches_next
 
   next_pending-fixes:
     tree: next


### PR DESCRIPTION
Now that it is released add clang-11 coverage for -next, covering the
same set of configs as we do for the current clang-10 builds.  Leave the
clang-10 builds in place since this is the minimum clang version the
kernel currently uses on the basis that coverage of both newest and
oldest releases would be useful, when clang-12 arrives we can replace
clang-11 with it.

Before deploying this the clang-11 docker containers should be rebuilt
to pick up the release.

Signed-off-by: Mark Brown <broonie@kernel.org>