### PR TITLE
kci_build: Modify the build directory structure

### DIFF
--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -645,7 +645,7 @@ def build_kernel(build_env, kdir, arch, defconfig=None, jopt=None,
             shutil.rmtree(mod_path)
         os.makedirs(mod_path)
         opts.update({
-            'INSTALL_MOD_PATH': mod_path,
+            'INSTALL_MOD_PATH': '_modules_',
             'INSTALL_MOD_STRIP': '1',
             'STRIP': "{}strip".format(cross_compile),
         })


### PR DESCRIPTION
The original build directory is nested in two layers /KDIR/build/KDIR/build/_modules_,  modify the directory to /KDIR/build/_modules_, so that there is only one /KDIR/build left.

Signed-off-by: Wang Mingyu <wangmy@cn.fujitsu.com>