### PR TITLE
T24131 test-configs.yaml: update Debian rootfs URLs with new buster-ltp

### DIFF
--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -33,30 +33,30 @@ file_systems:
 
   debian_buster_ramdisk:
     type: debian
-    ramdisk: 'buster/20201022.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'buster/20201029.0/{arch}/rootfs.cpio.gz'
 
   debian_buster_nfs:
     type: debian
-    ramdisk: 'buster/20201022.0/{arch}/initrd.cpio.gz'
-    nfs: 'buster/20201022.0/{arch}/full.rootfs.tar.xz'
+    ramdisk: 'buster/20201029.0/{arch}/initrd.cpio.gz'
+    nfs: 'buster/20201029.0/{arch}/full.rootfs.tar.xz'
     root_type: nfs
 
   debian_buster-cros-ec_ramdisk:
     type: debian
-    ramdisk: 'buster-cros-ec/20201022.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'buster-cros-ec/20201029.0/{arch}/rootfs.cpio.gz'
 
   debian_buster-igt_ramdisk:
     type: debian
-    ramdisk: 'buster-igt/20201022.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'buster-igt/20201029.0/{arch}/rootfs.cpio.gz'
 
   debian_buster-v4l2_ramdisk:
     type: debian
-    ramdisk: 'buster-v4l2/20201022.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'buster-v4l2/20201029.0/{arch}/rootfs.cpio.gz'
 
   debian_buster-ltp_nfs:
     type: debian
-    ramdisk: 'buster-ltp/20201022.0/{arch}/initrd.cpio.gz'
-    nfs: 'buster-ltp/20201022.0/{arch}/full.rootfs.tar.xz'
+    ramdisk: 'buster-ltp/20201029.0/{arch}/initrd.cpio.gz'
+    nfs: 'buster-ltp/20201029.0/{arch}/full.rootfs.tar.xz'
     root_type: nfs
 
 


### PR DESCRIPTION
Update all the Debian rootfs URLs which include a new buster-ltp
variant for armhf.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>