### PR TITLE
T24749 Add checks for alphabetical order of device types

### DIFF
--- a/kci_test
+++ b/kci_test
@@ -65,6 +65,7 @@ class cmd_validate(Command):
             if err:
                 print("Plans broken order for {}: '{}' before '{}'".format(
                     config.device_type, err[0], err[1]))
+                return False
 
         return True
 

--- a/kci_test
+++ b/kci_test
@@ -60,6 +60,12 @@ class cmd_validate(Command):
                 print("Device type has no test config: {}".format(device_type))
                 return False
 
+        for config in test_configs['test_configs']:
+            err = kernelci.sort_check(config.test_plans.keys())
+            if err:
+                print("Plans broken order for {}: '{}' before '{}'".format(
+                    config.device_type, err[0], err[1]))
+
         return True
 
 

--- a/kci_test
+++ b/kci_test
@@ -55,6 +55,11 @@ class cmd_validate(Command):
             print("Test configs broken order: '{}' before '{}'".format(*err))
             return False
 
+        for device_type in test_configs['device_types'].keys():
+            if device_type not in test_config_devices:
+                print("Device type has no test config: {}".format(device_type))
+                return False
+
         return True
 
 

--- a/kci_test
+++ b/kci_test
@@ -47,6 +47,14 @@ class cmd_validate(Command):
             print("Device types broken order: '{}' before '{}'".format(*err))
             return False
 
+        test_config_devices = list(
+            str(config.device_type) for config in test_configs['test_configs']
+        )
+        err = kernelci.sort_check(test_config_devices)
+        if err:
+            print("Test configs broken order: '{}' before '{}'".format(*err))
+            return False
+
         return True
 
 

--- a/kci_test
+++ b/kci_test
@@ -24,6 +24,7 @@ import os
 import sys
 
 from kernelci.cli import Args, Command
+import kernelci
 import kernelci.config.lab
 import kernelci.config.test
 import kernelci.build
@@ -41,6 +42,11 @@ class cmd_validate(Command):
 
     def __call__(self, test_configs, lab_configs, args):
         # ToDo: Use jsonschema
+        err = kernelci.sort_check(test_configs['device_types'].keys())
+        if err:
+            print("Device types broken order: '{}' before '{}'".format(*err))
+            return False
+
         return True
 
 

--- a/kci_test
+++ b/kci_test
@@ -67,6 +67,11 @@ class cmd_validate(Command):
                     config.device_type, err[0], err[1]))
                 return False
 
+        err = kernelci.sort_check(lab_configs['labs'].keys())
+        if err:
+            print("Labs broken order: '{}' before '{}'".format(*err))
+            return False
+
         return True
 
 

--- a/kernelci/__init__.py
+++ b/kernelci/__init__.py
@@ -15,6 +15,7 @@
 # along with this library; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+import re
 import subprocess
 import sys
 
@@ -29,3 +30,22 @@ def shell_cmd(cmd, ret_code=False):
 def print_flush(msg):
     print(msg)
     sys.stdout.flush()
+
+
+def sort_check(keys):
+    parsed_keys = list((tuple(re.split(r'-|_|\.', key)), key) for key in keys)
+    keys_map = dict(parsed_keys)
+    split_keys = list(k[0] for k in parsed_keys)
+    numeric_keys = []
+    for split_key in split_keys:
+        numeric_keys.extend(k for k in split_key if k.isdigit())
+    max_digits = max(len(k) for k in numeric_keys) if numeric_keys else 0
+    fmt = '{{:0{}d}}'.format(max_digits)
+    sorted_keys = sorted(
+        split_keys,
+        key=lambda x: list(fmt.format(int(k)) if k.isdigit() else k for k in x)
+    )
+    for key_raw, key_sorted in zip(split_keys, sorted_keys):
+        if key_raw != key_sorted:
+            return keys_map[key_raw], keys_map[key_sorted]
+    return None

--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -2091,8 +2091,8 @@ test_configs:
       - baseline
       - baseline-nfs
       - cros-ec
-      - igt-kms-rockchip
       - igt-gpu-panfrost
+      - igt-kms-rockchip
       - kselftest
       - ltp-crypto
       - ltp-ipc
@@ -2115,7 +2115,9 @@ test_configs:
       - v4l2-compliance-uvc
 
   - device_type: rk3399-gru-kevin
-    test_plans: [igt-kms-rockchip, igt-gpu-panfrost]
+    test_plans:
+      - igt-gpu-panfrost
+      - igt-kms-rockchip
     filters:
       - blocklist: {kernel: ['v3.', 'v4.4', 'v4.9', 'v4.14']}
 

--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -428,15 +428,6 @@ device_types:
       - passlist: {defconfig: ['bcm2835_defconfig']}
       - blocklist: {kernel: ['v3.', '4.4-', '4.9-', 'v4.13']}
 
-  beaglebone-black:
-    mach: omap2
-    class: arm-dtb
-    boot_method: uboot
-    dtb: 'am335x-boneblack.dtb'
-    filters:
-      - blocklist: *allmodconfig_filter
-      - blocklist: {lab: ['lab-baylibre']}
-
   beagle-xm:
     mach: omap2
     class: arm-dtb
@@ -445,6 +436,15 @@ device_types:
     filters:
       - blocklist: *allmodconfig_filter
       - blocklist: {kernel: ['v3.14']}
+
+  beaglebone-black:
+    mach: omap2
+    class: arm-dtb
+    boot_method: uboot
+    dtb: 'am335x-boneblack.dtb'
+    filters:
+      - blocklist: *allmodconfig_filter
+      - blocklist: {lab: ['lab-baylibre']}
 
   cubietruck:
     mach: allwinner
@@ -472,17 +472,17 @@ device_types:
     class: arm-dtb
     boot_method: uboot
 
-  dra7-evm:
-    mach: omap2
-    class: arm-dtb
-    boot_method: uboot
-
   dove-cubox:
     mach: mvebu
     class: arm-dtb
     boot_method: barebox
     filters:
       - blocklist: *allmodconfig_filter
+
+  dra7-evm:
+    mach: omap2
+    class: arm-dtb
+    boot_method: uboot
 
   fsl-ls1012a-rdb:
     mach: freescale
@@ -534,13 +534,19 @@ device_types:
           defconfig: ['tinyconfig']
           kernel: ['v4.', 'v5.1', 'v5.2']
 
+  hip07-d05:
+    mach: hisilicon
+    class: arm64-dtb
+    boot_method: grub
+    filters:
+      - blocklist: {defconfig: ['allnoconfig', 'allmodconfig']}
+
   hp-11A-G6-EE-grunt:
     mach: x86
     arch: x86_64
     boot_method: depthcharge
     filters:
       - passlist: {defconfig: ['x86-chromebook']}
-
   hsdk:
     mach: arc
     class: arc-dtb
@@ -548,13 +554,6 @@ device_types:
     filters:
       - blocklist:
           kernel: ['v4.14']
-
-  hip07-d05:
-    mach: hisilicon
-    class: arm64-dtb
-    boot_method: grub
-    filters:
-      - blocklist: {defconfig: ['allnoconfig', 'allmodconfig']}
 
   imx23-olinuxino:
     mach: imx
@@ -610,35 +609,6 @@ device_types:
             - 'multi_v5_defconfig'
             - 'allmodconfig'
 
-  imx6qp-wandboard-revd1:
-    mach: imx
-    class: arm-dtb
-    boot_method: barebox
-    flags: ['fastboot']
-    filters:
-      - blocklist:
-          defconfig:
-            - 'imx_v4_v5_defconfig'
-            - 'multi_v5_defconfig'
-            - 'allmodconfig'
-
-  imx6q-var-dt6customboard:
-    mach: imx
-    class: arm-dtb
-    boot_method: uboot
-
-  imx6ul-pico-hobbit:
-    mach: imx
-    class: arm-dtb
-    boot_method: barebox
-    flags: ['fastboot']
-    filters:
-      - blocklist:
-          defconfig:
-            - 'imx_v4_v5_defconfig'
-            - 'multi_v5_defconfig'
-            - 'allmodconfig'
-
   imx6q-sabrelite:
     mach: imx
     class: arm-dtb
@@ -658,10 +628,27 @@ device_types:
     class: arm-dtb
     boot_method: uboot
 
+  imx6q-var-dt6customboard:
+    mach: imx
+    class: arm-dtb
+    boot_method: uboot
+
   imx6qp-sabresd:
     mach: imx
     class: arm-dtb
     boot_method: uboot
+
+  imx6qp-wandboard-revd1:
+    mach: imx
+    class: arm-dtb
+    boot_method: barebox
+    flags: ['fastboot']
+    filters:
+      - blocklist:
+          defconfig:
+            - 'imx_v4_v5_defconfig'
+            - 'multi_v5_defconfig'
+            - 'allmodconfig'
 
   imx6sll-evk:
     mach: imx
@@ -677,6 +664,18 @@ device_types:
     mach: imx
     class: arm-dtb
     boot_method: uboot
+
+  imx6ul-pico-hobbit:
+    mach: imx
+    class: arm-dtb
+    boot_method: barebox
+    flags: ['fastboot']
+    filters:
+      - blocklist:
+          defconfig:
+            - 'imx_v4_v5_defconfig'
+            - 'multi_v5_defconfig'
+            - 'allmodconfig'
 
   imx6ull-14x14-evk:
     mach: imx
@@ -757,11 +756,6 @@ device_types:
     dtb: 'freescale/fsl-ls1028a-kontron-sl28-var3-ads2.dtb'
     boot_method: uboot
 
-  meson8b-odroidc1:
-    mach: amlogic
-    class: arm-dtb
-    boot_method: uboot
-
   meson-g12a-sei510:
     mach: amlogic
     class: arm64-dtb
@@ -790,14 +784,14 @@ device_types:
     filters:
       - blocklist: {defconfig: ['allnoconfig', 'allmodconfig']}
 
-  meson-g12b-odroid-n2:
+  meson-g12b-a311d-khadas-vim3:
     mach: amlogic
     class: arm64-dtb
     boot_method: uboot
     filters:
       - blocklist: {defconfig: ['allnoconfig', 'allmodconfig']}
 
-  meson-g12b-a311d-khadas-vim3:
+  meson-g12b-odroid-n2:
     mach: amlogic
     class: arm64-dtb
     boot_method: uboot
@@ -852,7 +846,7 @@ device_types:
     filters:
       - blocklist: {defconfig: ['allnoconfig', 'allmodconfig']}
 
-  meson-gxl-s905x-libretech-cc:
+  meson-gxl-s905x-khadas-vim:
     mach: amlogic
     class: arm64-dtb
     boot_method: uboot
@@ -860,7 +854,7 @@ device_types:
     filters:
       - blocklist: {defconfig: ['allnoconfig', 'allmodconfig']}
 
-  meson-gxl-s905x-khadas-vim:
+  meson-gxl-s905x-libretech-cc:
     mach: amlogic
     class: arm64-dtb
     boot_method: uboot
@@ -904,6 +898,11 @@ device_types:
       dtb_addr: '0x1000000'
       ramdisk_addr: '0x6000000'
       cmdline: '"console=ttyAML0,115200 consoleblank=0 earlycon"'
+
+  meson8b-odroidc1:
+    mach: amlogic
+    class: arm-dtb
+    boot_method: uboot
 
   minnowboard-turbot-E3826:
     mach: x86
@@ -1010,22 +1009,6 @@ device_types:
     filters:
       - passlist: {defconfig: ['versatile_defconfig']}
 
-  qemu_arm-vexpress-a9:
-    base_name: qemu
-    mach: qemu
-    arch: arm
-    context:
-      arch: 'arm'
-      machine: 'vexpress-a9'
-      cpu: 'cortex-a9'
-      model: 'model=lan9118'
-      guestfs_interface: 'none'
-      extra_options: ['-device virtio-blk-device,drive=lavatest']
-    dtb: 'vexpress-v2p-ca9.dtb'
-    boot_method: qemu
-    filters:
-      - passlist: {defconfig: ['vexpress_defconfig']}
-
   qemu_arm-vexpress-a15:
     base_name: qemu
     mach: qemu
@@ -1040,6 +1023,22 @@ device_types:
         - '-device virtio-blk-device,drive=lavatest'
         - '-smp 2'
     dtb: 'vexpress-v2p-ca15-tc1.dtb'
+    boot_method: qemu
+    filters:
+      - passlist: {defconfig: ['vexpress_defconfig']}
+
+  qemu_arm-vexpress-a9:
+    base_name: qemu
+    mach: qemu
+    arch: arm
+    context:
+      arch: 'arm'
+      machine: 'vexpress-a9'
+      cpu: 'cortex-a9'
+      model: 'model=lan9118'
+      guestfs_interface: 'none'
+      extra_options: ['-device virtio-blk-device,drive=lavatest']
+    dtb: 'vexpress-v2p-ca9.dtb'
     boot_method: qemu
     filters:
       - passlist: {defconfig: ['vexpress_defconfig']}
@@ -1179,6 +1178,17 @@ device_types:
     class: arm-dtb
     boot_method: uboot
 
+  r8a7795-salvator-x: &r8a7795-salvator-x
+    base_name: r8a7795-salvator-x
+    mach: renesas
+    class: arm64-dtb
+    boot_method: uboot
+    flags: ['big_endian']
+    filters:
+      - blocklist: {defconfig: ['allnoconfig', 'allmodconfig']}
+
+  r8a77950-salvator-x: *r8a7795-salvator-x # same device as r8a7795-salvator-x
+
   r8a7796-m3ulcb: &r8a7796-m3ulcb
     base_name: r8a7796-m3ulcb
     mach: renesas
@@ -1188,6 +1198,26 @@ device_types:
       - blocklist: {defconfig: ['allnoconfig', 'allmodconfig']}
 
   r8a77960-ulcb: *r8a7796-m3ulcb # same device as r8a7796-m3ulcb
+
+  rk3288-rock2-square:
+    mach: rockchip
+    class: arm-dtb
+    boot_method: uboot
+    flags: ['lpae', 'fastboot']
+
+  rk3288-veyron-jaq:
+    mach: rockchip
+    class: arm-dtb
+    boot_method: depthcharge
+    flags: ['lpae']
+
+  rk3328-rock64:
+    mach: rockchip
+    class: arm64-dtb
+    boot_method: uboot
+    filters:
+      - blocklist: *allmodconfig_filter
+      - blocklist: {kernel: ['v3.', 'v4.4', 'v4.9']}
 
   rk3399-gru-kevin:
     mach: rockchip
@@ -1202,49 +1232,6 @@ device_types:
       - blocklist: *allmodconfig_filter
       - blocklist: {kernel: ['v3.', 'v4.4', 'v4.9']}
 
-  rk3288-rock2-square:
-    mach: rockchip
-    class: arm-dtb
-    boot_method: uboot
-    flags: ['lpae', 'fastboot']
-
-  rk3328-rock64:
-    mach: rockchip
-    class: arm64-dtb
-    boot_method: uboot
-    filters:
-      - blocklist: *allmodconfig_filter
-      - blocklist: {kernel: ['v3.', 'v4.4', 'v4.9']}
-
-  rk3288-veyron-jaq:
-    mach: rockchip
-    class: arm-dtb
-    boot_method: depthcharge
-    flags: ['lpae']
-
-  r8a7795-salvator-x: &r8a7795-salvator-x
-    base_name: r8a7795-salvator-x
-    mach: renesas
-    class: arm64-dtb
-    boot_method: uboot
-    flags: ['big_endian']
-    filters:
-      - blocklist: {defconfig: ['allnoconfig', 'allmodconfig']}
-
-  r8a77950-salvator-x: *r8a7795-salvator-x # same device as r8a7795-salvator-x
-
-  sun8i-a33-sinlinx-sina33:
-    mach: allwinner
-    class: arm-dtb
-    boot_method: uboot
-
-  socfpga-cyclone5-socrates:
-    mach: socfpga
-    class: arm-dtb
-    boot_method: barebox
-    filters:
-      - blocklist: *allmodconfig_filter
-
   snow:
     mach: exynos
     class: arm-dtb
@@ -1254,6 +1241,13 @@ device_types:
     filters:
       - blocklist: *allmodconfig_filter
       - blocklist: {defconfig: ['multi_v7_defconfig+CONFIG_SMP=n']}
+
+  socfpga-cyclone5-socrates:
+    mach: socfpga
+    class: arm-dtb
+    boot_method: barebox
+    filters:
+      - blocklist: *allmodconfig_filter
 
   stm32mp157c-dk2:
     mach: stm32
@@ -1364,6 +1358,14 @@ device_types:
     class: arm-dtb
     boot_method: uboot
 
+  sun8i-a33-sinlinx-sina33:
+    mach: allwinner
+    class: arm-dtb
+    boot_method: uboot
+    filters:
+      - blocklist: *allmodconfig_filter
+      - blocklist: {kernel: ['v3.', 'v4.4', 'v4.9']}
+
   sun8i-a83t-allwinner-h8homlet-v2:
     mach: allwinner
     class: arm-dtb
@@ -1374,17 +1376,17 @@ device_types:
     class: arm-dtb
     boot_method: uboot
 
+  sun8i-h2-plus-libretech-all-h3-cc:
+    mach: allwinner
+    class: arm-dtb
+    boot_method: uboot
+
   sun8i-h2-plus-orangepi-r1:
     mach: allwinner
     class: arm-dtb
     boot_method: uboot
 
   sun8i-h2-plus-orangepi-zero:
-    mach: allwinner
-    class: arm-dtb
-    boot_method: uboot
-
-  sun8i-h2-plus-libretech-all-h3-cc:
     mach: allwinner
     class: arm-dtb
     boot_method: uboot

--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -1613,6 +1613,10 @@ test_configs:
     test_plans:
       - baseline
 
+  - device_type: beagle-xm
+    test_plans:
+      - baseline
+
   - device_type: beaglebone-black
     test_plans:
       - baseline
@@ -1620,20 +1624,16 @@ test_configs:
       - ltp-crypto
       - ltp-ipc
 
-  - device_type: beagle-xm
-    test_plans:
-      - baseline
-
   - device_type: cubietruck
     test_plans:
       - baseline
       - baseline-nfs
 
-  - device_type: d2500cc
+  - device_type: d03
     test_plans:
       - baseline
 
-  - device_type: d03
+  - device_type: d2500cc
     test_plans:
       - baseline
 
@@ -1684,16 +1684,16 @@ test_configs:
       - baseline
       - baseline-nfs
 
+  - device_type: hifive-unleashed-a00
+    test_plans:
+      - baseline
+
   - device_type: hip07-d05
     test_plans:
       - baseline
       - baseline-nfs
       - kselftest
       - ltp-crypto
-
-  - device_type: hifive-unleashed-a00
-    test_plans:
-      - baseline
 
   - device_type: hp-11A-G6-EE-grunt
     test_plans:
@@ -1740,20 +1740,6 @@ test_configs:
     test_plans:
       - baseline
 
-  - device_type: imx6qp-wandboard-revd1
-    test_plans:
-      - baseline
-
-  - device_type: imx6q-var-dt6customboard
-    test_plans:
-      - baseline
-
-  - device_type: imx6ul-pico-hobbit
-    test_plans:
-      - baseline
-      - baseline-nfs
-      - sleep
-
   - device_type: imx6q-sabrelite
     test_plans:
       - baseline
@@ -1767,7 +1753,15 @@ test_configs:
     test_plans:
       - baseline
 
+  - device_type: imx6q-var-dt6customboard
+    test_plans:
+      - baseline
+
   - device_type: imx6qp-sabresd
+    test_plans:
+      - baseline
+
+  - device_type: imx6qp-wandboard-revd1
     test_plans:
       - baseline
 
@@ -1782,6 +1776,12 @@ test_configs:
   - device_type: imx6ul-14x14-evk
     test_plans:
       - baseline
+
+  - device_type: imx6ul-pico-hobbit
+    test_plans:
+      - baseline
+      - baseline-nfs
+      - sleep
 
   - device_type: imx6ull-14x14-evk
     test_plans:
@@ -1799,15 +1799,15 @@ test_configs:
     test_plans:
       - baseline
 
-  - device_type: imx8mq-zii-ultra-zest
-    test_plans:
-      - baseline
-
   - device_type: imx8mn-ddr4-evk
     test_plans:
       - baseline
 
   - device_type: imx8mp-evk
+    test_plans:
+      - baseline
+
+  - device_type: imx8mq-zii-ultra-zest
     test_plans:
       - baseline
 
@@ -1838,10 +1838,6 @@ test_configs:
       - baseline
       - baseline-nfs
 
-  - device_type: meson8b-odroidc1
-    test_plans:
-      - baseline
-
   - device_type: meson-g12a-sei510
     test_plans:
       - baseline
@@ -1855,15 +1851,15 @@ test_configs:
     test_plans:
       - baseline
 
-  - device_type: meson-g12b-odroid-n2
-    test_plans:
-      - baseline
-      - kselftest
-
   - device_type: meson-g12b-a311d-khadas-vim3
     test_plans:
       - baseline
       - baseline-nfs
+
+  - device_type: meson-g12b-odroid-n2
+    test_plans:
+      - baseline
+      - kselftest
 
   - device_type: meson-gxbb-nanopi-k2
     test_plans:
@@ -1881,11 +1877,11 @@ test_configs:
     test_plans:
       - baseline
 
-  - device_type: meson-gxl-s905d-p230
+  - device_type: meson-gxl-s805x-p241
     test_plans:
       - baseline
 
-  - device_type: meson-gxl-s805x-p241
+  - device_type: meson-gxl-s905d-p230
     test_plans:
       - baseline
 
@@ -1916,6 +1912,10 @@ test_configs:
     test_plans:
       - baseline
       - baseline-fastboot
+
+  - device_type: meson8b-odroidc1
+    test_plans:
+      - baseline
 
   - device_type: minnowboard-turbot-E3826
     test_plans:
@@ -1982,11 +1982,11 @@ test_configs:
     test_plans:
       - baseline_qemu
 
-  - device_type: qemu_arm-vexpress-a9
+  - device_type: qemu_arm-vexpress-a15
     test_plans:
       - baseline_qemu
 
-  - device_type: qemu_arm-vexpress-a15
+  - device_type: qemu_arm-vexpress-a9
     test_plans:
       - baseline_qemu
 
@@ -2069,13 +2069,39 @@ test_configs:
   - device_type: r8a77950-salvator-x  # same as r8a7795-salvator-x
     test_plans: *r8a7795-salvator-x_test-plans
 
-  - device_type: r8a77960-ulcb
-    test_plans: &r8a77960-ulcb_test-plans
+  - device_type: r8a7796-m3ulcb
+    test_plans: &r8a7796-m3ulcb_test-plans
       - baseline
       - usb
 
-  - device_type: r8a7796-m3ulcb  # same as r8a77960-ulcb
-    test_plans: *r8a77960-ulcb_test-plans
+  - device_type: r8a77960-ulcb  # same as r8a7796-m3ulcb
+    test_plans: *r8a7796-m3ulcb_test-plans
+
+  - device_type: rk3288-rock2-square
+    test_plans:
+      - baseline
+      - baseline-nfs
+      - ltp-crypto
+      - ltp-ipc
+      - sleep
+      - usb
+
+  - device_type: rk3288-veyron-jaq
+    test_plans:
+      - baseline
+      - baseline-nfs
+      - cros-ec
+      - igt-kms-rockchip
+      - igt-gpu-panfrost
+      - kselftest
+      - ltp-crypto
+      - ltp-ipc
+      - sleep
+      - usb
+
+  - device_type: rk3328-rock64
+    test_plans:
+      - baseline
 
   - device_type: rk3399-gru-kevin
     test_plans:
@@ -2097,43 +2123,16 @@ test_configs:
     test_plans:
       - baseline
 
-  - device_type: rk3288-rock2-square
+  - device_type: snow
     test_plans:
       - baseline
       - baseline-nfs
-      - ltp-crypto
-      - ltp-ipc
-      - sleep
-      - usb
-
-  - device_type: rk3328-rock64
-    test_plans:
-      - baseline
-
-  - device_type: rk3288-veyron-jaq
-    test_plans:
-      - baseline
-      - baseline-nfs
-      - cros-ec
-      - igt-kms-rockchip
-      - igt-gpu-panfrost
-      - kselftest
-      - ltp-crypto
-      - ltp-ipc
-      - sleep
-      - usb
-      - v4l2-compliance-uvc
 
   - device_type: socfpga-cyclone5-socrates
     test_plans:
       - baseline
       - baseline-nfs
       - sleep
-
-  - device_type: snow
-    test_plans:
-      - baseline
-      - baseline-nfs
 
   - device_type: stm32mp157c-dk2
     test_plans:
@@ -2160,11 +2159,11 @@ test_configs:
     test_plans:
       - baseline
 
-  - device_type: sun50i-h6-orangepi-one-plus
+  - device_type: sun50i-h6-orangepi-3
     test_plans:
       - baseline
 
-  - device_type: sun50i-h6-orangepi-3
+  - device_type: sun50i-h6-orangepi-one-plus
     test_plans:
       - baseline
 
@@ -2207,15 +2206,11 @@ test_configs:
     test_plans:
       - baseline
 
-  - device_type: sun8i-a33-sinlinx-sina33
-    test_plans:
-      - baseline
-
   - device_type: sun8i-a33-olinuxino
     test_plans:
       - baseline
 
-  - device_type: sun8i-a83t-bananapi-m3
+  - device_type: sun8i-a33-sinlinx-sina33
     test_plans:
       - baseline
 
@@ -2223,7 +2218,11 @@ test_configs:
     test_plans:
       - baseline
 
-  - device_type: sun8i-h2-plus-orangepi-zero
+  - device_type: sun8i-a83t-bananapi-m3
+    test_plans:
+      - baseline
+
+  - device_type: sun8i-h2-plus-libretech-all-h3-cc
     test_plans:
       - baseline
 
@@ -2231,7 +2230,7 @@ test_configs:
     test_plans:
       - baseline
 
-  - device_type: sun8i-h2-plus-libretech-all-h3-cc
+  - device_type: sun8i-h2-plus-orangepi-zero
     test_plans:
       - baseline
 


### PR DESCRIPTION
Add checks to `kci_test validate` to detect when device types are not in alphabetical order.  Fixed any issues so the checks pass.