### PR TITLE
add libhugetlbfs and libmnl headers 

### DIFF
--- a/jenkins/dockerfiles/gcc-8_arm/Dockerfile
+++ b/jenkins/dockerfiles/gcc-8_arm/Dockerfile
@@ -21,5 +21,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
    libcap-ng-dev:armhf \
    libelf-dev:armhf \
    libfuse-dev:armhf \
+   libhugetlbfs-dev:armhf \
+   libmnl-dev:armhf \
    libnuma-dev:armhf \
    libpopt-dev:armhf

--- a/jenkins/dockerfiles/gcc-8_arm64/Dockerfile
+++ b/jenkins/dockerfiles/gcc-8_arm64/Dockerfile
@@ -32,5 +32,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
    libcap-ng-dev:arm64 \
    libelf-dev:arm64 \
    libfuse-dev:arm64 \
+   libhugetlbfs-dev:arm64 \
+   libmnl-dev:arm64 \
    libnuma-dev:arm64 \
    libpopt-dev:arm64

--- a/jenkins/dockerfiles/gcc-8_x86/Dockerfile
+++ b/jenkins/dockerfiles/gcc-8_x86/Dockerfile
@@ -13,5 +13,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
    libcap-ng-dev \
    libelf-dev \
    libfuse-dev \
+   libhugetlbfs-dev \
+   libmnl-dev \
    libnuma-dev \
    libpopt-dev


### PR DESCRIPTION
include libhugetlbfs and libmnl header files that have not been installed in arm, arm64, x86_64 platforms during build process.

Signed-off-by: Alexandra Pereira <alexandra.pereira@collabora.com>