### PR TITLE
kernelci.build: add missing kernel image targets for x86

### DIFF
--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -41,6 +41,8 @@ MAKE_TARGETS = {
     'arm': 'zImage',
     'arm64': 'Image',
     'arc': 'uImage',
+    'i386': 'bzImage',
+    'x86_64': 'bzImage',
 }
 
 # Hard-coded binary kernel image names for each CPU architecture


### PR DESCRIPTION
Add missing kernel image target definitions for x86_64 and i386.  This
is needed to build only the kernel image, separately from modules or
anything else.

Fixes: 723f653f00e6 ("kernelci.build: add functions to build and publish kernels")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>