### PR TITLE
build-configs.yaml: add riscv to the clang configs

### DIFF
--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -214,9 +214,6 @@ build_environments:
       mips:
         <<: *mips_params
         name:
-      riscv:
-        <<: *riscv_params
-        name:
       x86_64:
         <<: *x86_64_params
         name:
@@ -224,7 +221,14 @@ build_environments:
   clang-11:
     cc: clang
     cc_version: 11
-    arch_params: *clang_arch_params
+    arch_params:
+      <<: *clang_arch_params
+      riscv:
+        <<: *riscv_params
+        name:
+        opts:
+          LLVM_IAS: '1'
+          LD: 'riscv64-linux-gnu-ld'
 
 
 # Default config with full build coverage
@@ -815,7 +819,15 @@ build_configs:
       # Latest clang release
       clang-11:
         build_environment: clang-11
-        architectures: *arch_clang_configs
+        architectures:
+          <<: *arch_clang_configs
+          riscv:
+            extra_configs: &riscv_clang_configs
+              - 'allnoconfig'
+              - 'defconfig+CONFIG_EFI=n'
+            filters:
+              - passlist:
+                  defconfig: *riscv_clang_configs
 
   next_pending-fixes:
     tree: next

--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -177,39 +177,54 @@ build_environments:
   gcc-8:
     cc: gcc
     cc_version: 8
-    arch_map: &gcc_arch_map
-      i386: 'x86'
-      x86_64: 'x86'
-      riscv: 'riscv64'
-    cross_compile: &default_cross_compile
-      arc: 'arc-elf32-'
-      arm: 'arm-linux-gnueabihf-'
-      arm64: 'aarch64-linux-gnu-'
-      mips: 'mips-linux-gnu-'
-      riscv: 'riscv64-linux-gnu-'
-    cross_compile_compat: &default_cross_compile_compat
-      arm64: 'arm-linux-gnueabihf-'
+    arch_params: &gcc_arch_params
+      arc: &arc_params
+        cross_compile: 'arc-elf32-'
+      arm: &arm_params
+        cross_compile: 'arm-linux-gnueabihf-'
+      arm64: &arm64_params
+        cross_compile: 'aarch64-linux-gnu-'
+        cross_compile_compat: 'arm-linux-gnueabihf-'
+      i386: &i386_params
+        name: 'x86'
+      mips: &mips_params
+        cross_compile: 'mips-linux-gnu-'
+      x86_64: &x86_64_params
+        name: 'x86'
+      riscv: &riscv_params
+        name: 'riscv64'
+        cross_compile: 'riscv64-linux-gnu-'
 
   clang-10:
     cc: clang
     cc_version: 10
-    arch_map: &clang_arch_map
-      i386:
-      x86_64:
-      arm:
-      arm64:
-      mips:
+    arch_params: &clang_arch_params
       arc:
+        <<: *arc_params
+        name:
+      arm:
+        <<: *arm_params
+        name:
+      arm64:
+        <<: *arm64_params
+        name:
+      i386:
+        <<: *i386_params
+        name:
+      mips:
+        <<: *mips_params
+        name:
       riscv:
-    cross_compile: *default_cross_compile
-    cross_compile_compat: *default_cross_compile_compat
+        <<: *riscv_params
+        name:
+      x86_64:
+        <<: *x86_64_params
+        name:
 
   clang-11:
     cc: clang
     cc_version: 11
-    arch_map: *clang_arch_map
-    cross_compile: *default_cross_compile
-    cross_compile_compat: *default_cross_compile_compat
+    arch_params: *clang_arch_params
 
 
 # Default config with full build coverage

--- a/jenkins/dockerfiles/clang-10/Dockerfile
+++ b/jenkins/dockerfiles/clang-10/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-add-repository 'deb http://apt.llvm.org/buster/ llvm-toolchain-buster-10
 RUN apt-get update && apt-get install --no-install-recommends -y \
     binutils-aarch64-linux-gnu \
     binutils-arm-linux-gnueabihf \
+    binutils-riscv64-linux-gnu \
     binutils \
     clang-10 lld-10 llvm-10
 

--- a/jenkins/dockerfiles/clang-11/Dockerfile
+++ b/jenkins/dockerfiles/clang-11/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-add-repository 'deb http://apt.llvm.org/buster/ llvm-toolchain-buster-11
 RUN apt-get update && apt-get install --no-install-recommends -y \
     binutils-aarch64-linux-gnu \
     binutils-arm-linux-gnueabihf \
+    binutils-riscv64-linux-gnu \
     binutils \
     clang-11 lld-11 llvm-11
 

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -599,6 +599,8 @@ def build_kernel(build_env, kdir, arch, defconfig=None, jopt=None,
         'KBUILD_BUILD_USER': 'KernelCI',
     }
 
+    opts.update(build_env.get_arch_opts(arch))
+
     kwargs = {
         'kdir': kdir,
         'arch': arch,

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -540,10 +540,12 @@ cd {kdir}
 export ARCH={arch}
 export CROSS_COMPILE={cross}
 export CROSS_COMPILE_COMPAT={cross_compat}
+export LLVM_IAS={llvm_ias}
 scripts/kconfig/merge_config.sh -O {output} '{base}' '{frag}' {redir}
 """.format(kdir=kdir, arch=kwargs['arch'], cc_env=cc_env,
            cross=kwargs['cross_compile'], output=rel_path,
            cross_compat=kwargs['cross_compile_compat'],
+           llvm_ias=defconfig_opts.get('LLVM_IAS', ''),
            base=os.path.join(rel_path, '.config'),
            frag=os.path.join(rel_path, kconfig_frag_name),
            redir='> /dev/null' if not verbose else '')

--- a/kernelci/config/build.py
+++ b/kernelci/config/build.py
@@ -192,8 +192,7 @@ class Architecture(YAMLObject):
 class BuildEnvironment(YAMLObject):
     """Kernel build environment model."""
 
-    def __init__(self, name, cc, cc_version, arch_map=None,
-                 cross_compile=None, cross_compile_compat=None):
+    def __init__(self, name, cc, cc_version, arch_params=None):
         """A build environment is a compiler and tools to build a kernel.
 
         *name* is the name of the build environment so it can be referred to in
@@ -206,24 +205,15 @@ class BuildEnvironment(YAMLObject):
 
         *cc_version* is the full version of the compiler.
 
-        *arch_map* is a dictionary mapping kernel CPU architecture names to
-                   ones used in compiler names.  For example, gcc compilers are
-                   the same "x86" for both "i386" and "x86_64" kernel
-                   architectures.
-
-        *cross_compile* is a dictionary mapping kernel CPU architecture names
-                        to cross-compiler prefixes.
-
-        *cross_compile_compat* is a dictionary mapping kernel CPU
-                               architecture names to cross-compiler
-                               prefixes for building compat VDSOs.
+        *arch_params* is a dictionary with parameters for each CPU architecture
+                      using names defined in the kernel.  For example, gcc
+                      compilers use the same "x86" architecture name "x86" for
+                      both "i386" and "x86_64" kernel architectures.
         """
         self._name = name
         self._cc = cc
         self._cc_version = str(cc_version)
-        self._arch_map = arch_map or dict()
-        self._cross_compile = cross_compile or dict()
-        self._cross_compile_compat = cross_compile_compat or dict()
+        self._arch_params = arch_params or dict()
 
     @classmethod
     def from_yaml(cls, config, name):
@@ -231,8 +221,7 @@ class BuildEnvironment(YAMLObject):
             'name': name,
         }
         kw.update(cls._kw_from_yaml(
-            config, ['name', 'cc', 'cc_version', 'arch_map', 'cross_compile',
-                     'cross_compile_compat']))
+            config, ['name', 'cc', 'cc_version', 'arch_params']))
         return cls(**kw)
 
     @property
@@ -248,13 +237,16 @@ class BuildEnvironment(YAMLObject):
         return self._cc_version
 
     def get_arch_name(self, kernel_arch):
-        return self._arch_map.get(kernel_arch, kernel_arch)
+        params = self._arch_params.get(kernel_arch) or dict()
+        return params.get('name', kernel_arch)
 
-    def get_cross_compile(self, kernel_arch):
-        return self._cross_compile.get(kernel_arch, '')
+    def get_cross_compile(self, arch):
+        params = self._arch_params.get(arch) or dict()
+        return params.get('cross_compile', '')
 
-    def get_cross_compile_compat(self, kernel_arch):
-        return self._cross_compile_compat.get(kernel_arch, '')
+    def get_cross_compile_compat(self, arch):
+        params = self._arch_params.get(arch) or dict()
+        return params.get('cross_compile_compat', '')
 
 
 class BuildVariant(YAMLObject):

--- a/kernelci/config/build.py
+++ b/kernelci/config/build.py
@@ -240,6 +240,10 @@ class BuildEnvironment(YAMLObject):
         params = self._arch_params.get(kernel_arch) or dict()
         return params.get('name', kernel_arch)
 
+    def get_arch_opts(self, arch):
+        params = self._arch_params.get(arch) or dict()
+        return params.get('opts') or dict()
+
     def get_cross_compile(self, arch):
         params = self._arch_params.get(arch) or dict()
         return params.get('cross_compile', '')


### PR DESCRIPTION
Add the riscv architecture to the list of configs built with clang, with all the core changes needed to be able to support it. This is used with clang-10 on mainline and clang-11 on linux-next.
