### PR TITLE
kci_build: fix message in install_kernel

### DIFF
--- a/kci_build
+++ b/kci_build
@@ -297,7 +297,7 @@ class cmd_install_kernel(Command):
 Invalid arguments, either of these 2 sets are possible:
    --tree-name, --tree-url and --branch
 or
-   --config (in which case the tree and branch are read from the YAML config)\
+   --build-config (to get the information from the YAML config)
 """)
             return False
         return kernelci.build.install_kernel(


### PR DESCRIPTION
Fix message about command line options install_kernel since --config
has been renamed --build-config.

Fixes: 66a7727ecdf8 kci_build: ("use --build-config instead of --config")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>