### PR TITLE
lab-configs: add Kontron's lab

### DIFF
--- a/lab-configs.yaml
+++ b/lab-configs.yaml
@@ -64,6 +64,14 @@ labs:
             - v4l2-compliance-uvc
             - v4l2-compliance-vivid
 
+  lab-kontron:
+    lab_type: lava
+    url: 'https://lavalab.kontron.com/RPC2/'
+    filters:
+      - passlist:
+          plan:
+            - baseline
+
   lab-linaro-lkft:
     lab_type: lava
     url: 'https://lkft.validation.linaro.org/RPC2/'


### PR DESCRIPTION
The lab will contain upstreamed Kontron products. We are starting with:
 * KBox A-230-LS
 * SMARC-sAL28 on a SMARC Evaluation Carrier 2.0

Signed-off-by: Michael Walle <michael@walle.cc>