### PR TITLE
test-configs.yaml: add Kontron sl28 boards

### DIFF
--- a/test-configs.yaml
+++ b/test-configs.yaml
@@ -713,6 +713,18 @@ device_types:
       - blocklist: {defconfig: ['allmodconfig', 'multi_v5_defconfig']}
       - blocklist: {kernel: ['v3.']}
 
+  kontron-kbox-a-230-ls:
+    mach: freescale
+    class: arm64-dtb
+    dtb: 'freescale/fsl-ls1028a-kontron-kbox-a-230-ls.dtb'
+    boot_method: uboot
+
+  kontron-sl28-var3-ads2:
+    mach: freescale
+    class: arm64-dtb
+    dtb: 'freescale/fsl-ls1028a-kontron-sl28-var3-ads2.dtb'
+    boot_method: uboot
+
   meson8b-odroidc1:
     mach: amlogic
     class: arm-dtb
@@ -1769,6 +1781,14 @@ test_configs:
     test_plans:
       - baseline
       - baseline-nfs
+
+  - device_type: kontron-kbox-a-230-ls
+    test_plans:
+      - baseline
+
+  - device_type: kontron-sl28-var3-ads2
+    test_plans:
+      - baseline
 
   - device_type: meson8b-odroidc1
     test_plans:


### PR DESCRIPTION
Add the definitions for the following two boards:
 * KBox A-230-LS
 * SMARC-sAL28 on a SMARC Evaluation Carrier 2.0

Signed-off-by: Michael Walle <michael@walle.cc>