### PR TITLE
Add more params for build config filters and use it with riscv

### DIFF
--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -266,6 +266,9 @@ build_configs_defaults:
 
         riscv: &riscv_arch
           extra_configs: ['allnoconfig']
+          filters:
+            - blocklist: &riscv_kernel_filter
+                kernel: ['v3.', 'v4.4', 'v4.9', 'v4.14']
 
         x86_64: &x86_64_arch
           base_defconfig: 'x86_64_defconfig'
@@ -328,6 +331,7 @@ arch_defconfigs: &arch_defconfigs
     base_defconfig: 'defconfig'
     filters:
       - regex: { defconfig: 'defconfig' }
+      - blocklist: *riscv_kernel_filter
   x86_64: &x86_64_defconfig
     base_defconfig: 'x86_64_defconfig'
     filters:
@@ -364,6 +368,8 @@ stable_variants: &stable_variants
         filters: *mips_default_filters
       riscv:
         extra_configs: ['allnoconfig']
+        filters:
+          - blocklist: *riscv_kernel_filter
       x86_64:
         base_defconfig: 'x86_64_defconfig'
         extra_configs: ['allnoconfig']

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -394,6 +394,11 @@ def list_kernel_configs(config, kdir, single_variant=None, single_arch=None):
                   combinations that match it
     """
     kernel_configs = set()
+    filter_params = {
+        'kernel': git_describe_verbose(kdir),
+        'tree': config.tree.name,
+        'branch': config.branch,
+    }
 
     for variant in config.variants:
         if single_variant and variant.name != single_variant:
@@ -418,7 +423,8 @@ def list_kernel_configs(config, kdir, single_variant=None, single_arch=None):
                     if f.endswith('defconfig'):
                         defconfigs.add(f)
             for defconfig in defconfigs:
-                if arch.match({'defconfig': defconfig}):
+                filter_params['defconfig'] = defconfig
+                if arch.match(filter_params):
                     kernel_configs.add((arch.name, defconfig, build_env))
 
     return kernel_configs


### PR DESCRIPTION
Add more parameters to the filters used in build-configs.yaml and use it to define a blocklist for riscv on kernels earlier than v4.19.

Fixes: #541 