### PR TITLE
kernelci.build: use absolute path for INSTALL_MOD_PATH

### DIFF
--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -647,7 +647,7 @@ def build_kernel(build_env, kdir, arch, defconfig=None, jopt=None,
             shutil.rmtree(mod_path)
         os.makedirs(mod_path)
         opts.update({
-            'INSTALL_MOD_PATH': mod_path,
+            'INSTALL_MOD_PATH': os.path.abspath(mod_path),
             'INSTALL_MOD_STRIP': '1',
             'STRIP': "{}strip".format(cross_compile),
         })


### PR DESCRIPTION
Use an absolute path based on the current working directory when
setting the value of INSTALL_MOD_PATH to avoid creating a
sub-directory relative to the root of the kernel source tree.

Reported-by: Wang Mingyu <wangmy@cn.fujitsu.com>
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>