### PR TITLE
T24886 - templates/k8s: update kernel build output

### DIFF
--- a/templates/k8s/job-build.jinja2
+++ b/templates/k8s/job-build.jinja2
@@ -51,11 +51,11 @@ spec:
 
         command: ["/bin/bash", "-x", "-c"]
         args: ["echo nproc=$(nproc); df; free; \
-export KDIR=/scratch/linux && export OUTPUT=$HOME/build && export CCACHE_DISABLE=true && \
+export KDIR=/scratch/linux && export CCACHE_DISABLE=true && \
 cd /scratch/kernelci-core &&  \
 ./kci_build pull_tarball --kdir ${KDIR} --url ${SRC_TARBALL} --retries 3 --delete && \
-./kci_build build_kernel --kdir ${KDIR} --output ${OUTPUT} --defconfig=${DEFCONFIG} --arch=${ARCH} --build-env=${BUILD_ENVIRONMENT} --verbose ${PARALLEL_JOPT}; export KERNEL_BUILD_RESULT=$?; \
-./kci_build install_kernel --kdir ${KDIR} --output ${OUTPUT} --build-config ${BUILD_CONFIG} --describe=${GIT_DESCRIBE} --describe-verbose=${GIT_DESCRIBE_VERBOSE} --commit=${COMMIT_ID}; \
+./kci_build build_kernel --kdir ${KDIR} --output ${KDIR} --defconfig=${DEFCONFIG} --arch=${ARCH} --build-env=${BUILD_ENVIRONMENT} --verbose ${PARALLEL_JOPT}; export KERNEL_BUILD_RESULT=$?; \
+./kci_build install_kernel --kdir ${KDIR} --output ${KDIR} --build-config ${BUILD_CONFIG} --describe=${GIT_DESCRIBE} --describe-verbose=${GIT_DESCRIBE_VERBOSE} --commit=${COMMIT_ID}; \
 ./kci_build push_kernel --kdir ${KDIR} --db-token=${KCI_API_TOKEN} --api=${KCI_API_URL}; \
 ./kci_build publish_kernel --kdir ${KDIR} --db-token=${KCI_API_TOKEN} --api=${KCI_API_URL}; \
 echo KERNEL_BUILD_RESULT=$KERNEL_BUILD_RESULT; \


### PR DESCRIPTION
Many selftests are expecting to find headers in kernel directory, so it updates the output to kdir during build.

Signed-off-by: Alexandra Pereira <alexandra.pereira@collabora.com>