### PR TITLE
lava-v2-callback: fix login test case and remove dead code

### DIFF
--- a/lava-v2-callback.py
+++ b/lava-v2-callback.py
@@ -70,17 +70,9 @@ def handle_boot(cb, verbose):
     return BOOT_STATUS_MAP.get(job_status, BISECT_SKIP)
 
 
-def _add_login_case(cases, tests):
-    tests_by_name = {t['name']: t for t in tests}
-    login = tests_by_name.get(name)
-    if not login:
-        return
-    cases.append({'login': login['result']})
-
-
 def _add_login_case(results, tests):
-    tests_by_name = {t['name']: t for t in tests}
-    login = tests_by_name.get('auto-login-action')
+    tests_map = {t['name']: t for t in tests}
+    login = tests_map.get('auto-login-action') or tests_map.get('login-action')
     if login:
         results['login'] = login['result']
 


### PR DESCRIPTION
Update _add_login_case() to look for either `auto-login-action` or the
new name `login-action` which changed in LAVA 2020.03.  This is to fix
bisections for the `login` test case e.g. `baseline.login`.

Also remove a duplicate of the _add_login_case() function which was
likely the result of a merge conflict.

Fixes: 07b9a0ae3c99 ("lava-v2-callback.py: add support for login test case")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>