### PR TITLE
T24951 roxell allmodconfig

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -148,6 +148,13 @@ trees:
 
 fragments:
 
+  # from roxell, to build an allmodconfig kernel that boots on arm64
+  allmodconfig-arm64-boot:
+    path: "kernel/configs/allmodconfig-fixup.config"
+    configs:
+      - '# CONFIG_PROVE_RAW_LOCK_NESTING is not set'
+      - '# CONFIG_RCU_STRICT_GRACE_PERIOD is not set'
+
   amdgpu:
     path: "kernel/configs/amdgpu.config"
     configs:

--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -1271,8 +1271,7 @@ build_configs:
           arm64:
             <<: *arm64_arch
             extra_configs:
-# Disabling to reduce load
-#              - 'allmodconfig'
+              - 'allmodconfig+KCONFIG_ALLCONFIG=arch/arm64/configs/defconfig'
               - 'allnoconfig'
               - 'defconfig+CONFIG_ARM64_16K_PAGES=y'
               - 'defconfig+CONFIG_ARM64_64K_PAGES=y'

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1791,7 +1791,7 @@ device_types:
       machine: 'virt,gic-version=2,mte=on,accel=tcg'
       memory: 1g
     filters:
-      - regex: { defconfig: 'defconfig' }
+      - passlist: {defconfig: ['defconfig', 'allmodconfig+KCONFIG_ALLCONFIG']}
 
   qemu_arm64-virt-gicv2-uefi:
     <<: *qemu_arm64-virt-gicv2
@@ -1810,7 +1810,7 @@ device_types:
       machine: 'virt,gic-version=3,mte=on,accel=tcg'
       memory: 1g
     filters:
-      - passlist: {defconfig: ['defconfig']}
+      - passlist: {defconfig: ['defconfig', 'allmodconfig+KCONFIG_ALLCONFIG']}
 
   qemu_arm64-virt-gicv3-uefi:
     <<: *qemu_arm64-virt-gicv3


### PR DESCRIPTION
This is to build `allmodconfig` for `arm64` with default values based on `defconfig` in an attempt at producing a kernel that can boot, and get tests to run on QEMU.

Replaces #248, rebased and adjusted with changes in kernelci-core made since then.