### PR TITLE
kernelci.build: drop O= option when output is kernel tree

### DIFF
--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -478,7 +478,7 @@ def _run_make(kdir, arch, target=None, jopt=None, silent=True, cc='gcc',
     elif cc != 'gcc':
         args.append('CC={}'.format(cc))
 
-    if output:
+    if output != kdir:
         # due to kselftest Makefile issues, O= cannot be a relative path
         args.append('O={}'.format(os.path.abspath(output)))
 


### PR DESCRIPTION
Drop the make O= option when the output directory is the same as the
kernel source tree.  This should result in the same thing, but with
kernels earlier than 4.9 there appears to be a difference in the
kernel build system causing some builds to fail when usig O= in that
case.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>

This may be an alternative to #544.