### PR TITLE
T23360 Refactor kci_build build_kernel with separate steps

### DIFF
--- a/kci_build
+++ b/kci_build
@@ -336,6 +336,19 @@ class cmd_make_modules(Command):
         return step.run(args.mod_path, args.j, args.verbose)
 
 
+class cmd_make_dtbs(Command):
+    help = "Build device trees"
+    args = [Args.kdir]
+    opt_args = [Args.verbose, Args.output, Args.j, Args.log]
+
+    def __call__(self, configs, args):
+        step = kernelci.build.MakeDeviceTrees(args.kdir, args.output, args.log)
+        if not step.dt_enabled():
+            print("Device tree support disabled, not building.")
+            return True
+        return step.run(args.j, args.verbose)
+
+
 class cmd_build_kernel(Command):
     help = "Build a kernel"
     args = [Args.build_env, Args.arch, Args.kdir]

--- a/kci_build
+++ b/kci_build
@@ -323,6 +323,19 @@ class cmd_make_kernel(Command):
         return step.run(args.j, args.verbose)
 
 
+class cmd_make_modules(Command):
+    help = "Build kernel modules"
+    args = [Args.kdir]
+    opt_args = [Args.verbose, Args.output, Args.j, Args.log, Args.mod_path]
+
+    def __call__(self, configs, args):
+        step = kernelci.build.MakeModules(args.kdir, args.output, args.log)
+        if not step.modules_enabled():
+            print("Kernel modules disabled, not building.")
+            return True
+        return step.run(args.mod_path, args.j, args.verbose)
+
+
 class cmd_build_kernel(Command):
     help = "Build a kernel"
     args = [Args.build_env, Args.arch, Args.kdir]

--- a/kci_build
+++ b/kci_build
@@ -313,6 +313,16 @@ class cmd_make_config(Command):
         return step.run(args.defconfig, args.j, args.verbose)
 
 
+class cmd_make_kernel(Command):
+    help = "Make a kernel image"
+    args = [Args.kdir]
+    opt_args = [Args.verbose, Args.output, Args.j, Args.log]
+
+    def __call__(self, configs, args):
+        step = kernelci.build.MakeKernel(args.kdir, args.output, args.log)
+        return step.run(args.j, args.verbose)
+
+
 class cmd_build_kernel(Command):
     help = "Build a kernel"
     args = [Args.build_env, Args.arch, Args.kdir]

--- a/kci_build
+++ b/kci_build
@@ -303,6 +303,16 @@ Invalid arguments, --build-env and --arch need to be used together.""")
         return res
 
 
+class cmd_make_config(Command):
+    help = "Make kernel config"
+    args = [Args.kdir, Args.defconfig]
+    opt_args = [Args.verbose, Args.output, Args.j, Args.log]
+
+    def __call__(self, configs, args):
+        step = kernelci.build.MakeConfig(args.kdir, args.output, args.log)
+        return step.run(args.defconfig, args.j, args.verbose)
+
+
 class cmd_build_kernel(Command):
     help = "Build a kernel"
     args = [Args.build_env, Args.arch, Args.kdir]

--- a/kci_build
+++ b/kci_build
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2018, 2019 Collabora Limited
+# Copyright (C) 2018, 2019, 2020 Collabora Limited
 # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
 #
 # This module is free software; you can redistribute it and/or modify it under
@@ -259,6 +259,48 @@ class cmd_list_kernel_configs(Command):
         for item in configs:
             print(' '.join(item))
         return True
+
+
+class cmd_init_bmeta(Command):
+    help = "Create initial bmeta.json"
+    args = [Args.kdir]
+    opt_args = [Args.output, Args.build_config,
+                Args.tree_name, Args.tree_url, Args.branch,
+                Args.build_env, Args.arch]
+
+    def __call__(self, configs, args):
+        if args.build_config:
+            conf = configs['build_configs'][args.build_config]
+            tree_name = conf.tree.name
+            tree_url = conf.tree.url
+            branch = conf.branch
+        else:
+            tree_name = args.tree_name
+            tree_url = args.tree_url
+            branch = args.branch
+        if not all((tree_name, tree_url, branch)):
+            print("""\
+Invalid arguments, either of these 2 sets are possible:
+   --tree-name, --tree-url and --branch
+or
+   --build-config (the tree and branch are read from the YAML config)\
+""")
+            return False
+
+        step = kernelci.build.RevisionData(args.kdir, args.output, reset=True)
+        print("Initialising build meta-data in {}".format(step.bmeta_path))
+        res = step.run(tree_name, tree_url, branch)
+
+        if res and (args.build_env or args.arch):
+            if not (args.build_env and args.arch):
+                print("""\
+Invalid arguments, --build-env and --arch need to be used together.""")
+                return False
+            build_env = configs['build_environments'][args.build_env]
+            step = kernelci.build.EnvironmentData(args.kdir, args.output)
+            res = step.run(build_env, args.arch)
+
+        return res
 
 
 class cmd_build_kernel(Command):

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -564,6 +564,68 @@ class Step:
         raise NotImplementedError("Step.run() needs to be implemented.")
 
 
+class RevisionData(Step):
+
+    def run(self, tree_name, tree_url, branch):
+        """Add all the meta-data related to the current kernel revision.
+
+        This step retrieves the revision information from the current kernel
+        source directory using Git, typically to initialise `bmeta.json` file
+        with just a revision section before running any actual build step.
+
+        *tree_name* is the short name of the kernel tree e.g. mainline, next...
+        *tree_url* is the URL of the remote Git repository for the tree
+        *branch* is the name of the Git branch
+        """
+        self._bmeta['revision'] = {
+            'tree': tree_name,
+            'url': tree_url,
+            'branch': branch,
+            'describe': git_describe(tree_name, self._kdir),
+            'describe_v': git_describe_verbose(self._kdir),
+            'commit': head_commit(self._kdir),
+        }
+        self._save_bmeta()
+        return True
+
+
+class EnvironmentData(Step):
+
+    def run(self, build_env, arch):
+        """Add all the meta-data related to the current build.
+
+        This step relies on a BuildEnvironment object and also queries any
+        currently installed compiler toolchain to populate the build
+        environment section of the `bmeta.json` file.
+
+        *build_env* is a BuildEnvironment object
+        *arch* is the CPU architecture name e.g. x86_64, arm64, riscv...
+        """
+        cross_compile = build_env.get_cross_compile(arch) or ''
+        cross_compile_compat = build_env.get_cross_compile_compat(arch) or ''
+        cc = build_env.cc
+        cc_version_cmd = "{}{} --version 2>&1".format(
+            cross_compile if cross_compile and cc == 'gcc' else '', cc)
+        cc_version_full = shell_cmd(cc_version_cmd).splitlines()[0]
+        make_opts = {'KBUILD_BUILD_USER': 'KernelCI'}
+        make_opts.update(build_env.get_arch_opts(arch))
+
+        self._bmeta['environment'] = {
+            'arch': arch,
+            'compiler': cc,
+            'compiler_version': build_env.cc_version,
+            'compiler_version_full': cc_version_full,
+            'cross_compile': cross_compile,
+            'cross_compile_compat': cross_compile_compat,
+            'name': build_env.name,
+            'platform': platform.uname(),
+            'use_ccache': shell_cmd("which ccache > /dev/null", True),
+            'make_opts': make_opts,
+        }
+        self._save_bmeta()
+        return True
+
+
 def _make_defconfig(defconfig, kwargs, extras, verbose, log_file):
     kdir, output_path = (kwargs.get(k) for k in ('kdir', 'output'))
     result = True

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -519,6 +519,7 @@ class Step:
         self._log_path = os.path.join(self._output_path, log) if log else None
         self._bmeta = dict()
         self._dot_config = None
+        self._start_time = time.time()
         if not os.path.exists(self._output_path):
             os.mkdir(self._output_path)
         elif os.path.exists(self._bmeta_path):
@@ -533,11 +534,21 @@ class Step:
         """Path to the build meta-data JSON file"""
         return self._bmeta_path
 
-    def _save_bmeta(self):
+    def _add_run_bmeta(self, name, jopt=None, status=None):
+        run_data = {
+            'name': name,
+            'start_time': self._start_time,
+            'duration': time.time() - self._start_time,
+        }
+        if jopt is not None:
+            run_data['threads'] = str(jopt)
+        if status is not None:
+            run_data['status'] = "PASS" if status is True else "FAIL"
         if self._log_path and os.path.exists(self._log_path):
-            logs = self._bmeta.setdefault('logs', list())
-            if self._log_file not in logs:
-                logs.append(self._log_file)
+            run_data['log_file'] = self._log_file
+        self._bmeta.setdefault('steps', list()).append(run_data)
+
+    def _save_bmeta(self):
         with open(self._bmeta_path, 'w') as json_file:
             json.dump(self._bmeta, json_file, indent=4, sort_keys=True)
 
@@ -585,6 +596,7 @@ class RevisionData(Step):
             'describe_v': git_describe_verbose(self._kdir),
             'commit': head_commit(self._kdir),
         }
+        self._add_run_bmeta('revision', status=True)
         self._save_bmeta()
         return True
 
@@ -634,6 +646,7 @@ class EnvironmentData(Step):
             'use_ccache': shell_cmd("which ccache > /dev/null", True),
             'make_opts': make_opts,
         }
+        self._add_run_bmeta('environment', status=True)
         self._save_bmeta()
         return True
 
@@ -741,6 +754,7 @@ scripts/kconfig/merge_config.sh -O {output} '{base}' '{frag}' {redir}
             self._bmeta['kernel']['fragments'] = [kci_frag_name]
             res = self._merge_config(kci_frag_name, verbose)
 
+        self._add_run_bmeta('config', jopt, res)
         self._save_bmeta()
         return res
 
@@ -777,6 +791,7 @@ class MakeKernel(Step):
                 kbmeta.update(vmlinux_meta)
                 kbmeta['vmlinux_file_size'] = os.stat(vmlinux_file).st_size
 
+        self._add_run_bmeta('kernel', jopt, res)
         self._save_bmeta()
         return res
 
@@ -819,6 +834,7 @@ class MakeModules(Step):
             }
             res = self._run_make('modules_install', jopt, verbose, opts)
 
+        self._add_run_bmeta('modules', jopt, res)
         self._save_bmeta()
         return res
 
@@ -865,6 +881,8 @@ class MakeDeviceTrees(Step):
         res = self._run_make('dtbs', jopt, verbose)
         if res:
             self._dtbs_json()
+        self._add_run_bmeta('dtbs', jopt, res)
+        self._save_bmeta()
         return res
 
 

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -609,6 +609,18 @@ class EnvironmentData(Step):
         cc_version_full = shell_cmd(cc_version_cmd).splitlines()[0]
         make_opts = {'KBUILD_BUILD_USER': 'KernelCI'}
         make_opts.update(build_env.get_arch_opts(arch))
+        platform_data = {'uname': platform.uname()}
+        if os.path.exists('/proc/cpuinfo'):
+            cpu_list = []
+            with open('/proc/cpuinfo') as f:
+                for line in f:
+                    if 'model name' in line:
+                        cpu_list.append(line.split(':')[1].strip())
+            cpus = {}
+            for cpu in cpu_list:
+                ncpus = cpus.get(cpu, 0)
+                cpus[cpu] = ncpus + 1
+            platform_data['cpus'] = cpus
 
         self._bmeta['environment'] = {
             'arch': arch,
@@ -618,7 +630,7 @@ class EnvironmentData(Step):
             'cross_compile': cross_compile,
             'cross_compile_compat': cross_compile_compat,
             'name': build_env.name,
-            'platform': platform.uname(),
+            'platform': platform_data,
             'use_ccache': shell_cmd("which ccache > /dev/null", True),
             'make_opts': make_opts,
         }

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -733,6 +733,42 @@ scripts/kconfig/merge_config.sh -O {output} '{base}' '{frag}' {redir}
         return res
 
 
+class MakeKernel(Step):
+
+    def run(self, jopt=None, verbose=False):
+        """Make the kernel image
+
+        Make the actual kernel image given the parameters already provided in
+        previous steps via `bmeta.json`.  This will also add some meta-data
+        such as the kernel image name and ELF properties.
+
+        *jopt* is the `make -j` option which will default to `nproc + 2`
+        *verbose* is whether the build output should be shown
+        """
+        if self._kernel_config_enabled('XIP_KERNEL'):
+            target = 'xipImage'
+        elif self._kernel_config_enabled('SYS_SUPPORTS_ZBOOT'):
+            target = 'vmlinuz'
+        else:
+            env = self._bmeta['environment']
+            target = MAKE_TARGETS.get(env['arch'])
+
+        kbmeta = self._bmeta.setdefault('kernel', dict())
+        kbmeta['image'] = target
+
+        res = self._run_make(target, jopt, verbose)
+
+        if res:
+            vmlinux_file = os.path.join(self._output_path, 'vmlinux')
+            if os.path.isfile(vmlinux_file):
+                vmlinux_meta = kernelci.elf.read(vmlinux_file)
+                kbmeta.update(vmlinux_meta)
+                kbmeta['vmlinux_file_size'] = os.stat(vmlinux_file).st_size
+
+        self._save_bmeta()
+        return res
+
+
 def _make_defconfig(defconfig, kwargs, extras, verbose, log_file):
     kdir, output_path = (kwargs.get(k) for k in ('kdir', 'output'))
     result = True

--- a/kernelci/cli.py
+++ b/kernelci/cli.py
@@ -191,6 +191,11 @@ class Args:
         'section': SECTION_LAB,
     }
 
+    log = {
+        'name': '--log',
+        'help': "Path to log file",
+    }
+
     mach = {
         'name': '--mach',
         'help': "Mach name (aka SoC family)",


### PR DESCRIPTION
This is a first step to redesign how the builds are run in `kci_build`.  It adds the concept of a build step, with the state between steps being kept in `bmeta.json`.  This defines a number of new `kci_build` commands without affecting how `kci_build build_kernel` currently works, until the new commands can be used instead.

Some changes may then be required with the integration in Jenkins and the Kubernetes build job definitions, but it is not yet required as part of this PR.

- [x] demonstrated how this can be used manually (see below)
- [x] docstrings added to the new classes
- [x] at least one resulting kernel tested in LAVA, outside of KernelCI pipeline https://lava.collabora.co.uk/scheduler/job/2931143

## Steps to use locally

In this example, we're going to build the mainline kernel with `gcc-8` for `arm64` with the generic `defconfig` and `KCONFIG_KASAN=y` on top of it using the new commands provided by this PR.

### Config file

First, let's use a local `kernelci.conf` file to simplify the command line arguments:
```ini
[kci_build]
kdir: linux
build_env: gcc-8
j: 4
output: linux/local-build
log: kernel-build.log
verbose: true
```

### Docker (optional)

You will need to either install a GCC toolchain for `aarch64` with all the kernel build dependencies or use the KernelCI Docker image:

```
$ docker run -it -v $PWD:/root/kernelci-core kernelci/build-gcc-8_arm64 /bin/bash
root@76ad3035ee88:/# cd /root/kernelci-core
root@76ad3035ee88:~/kernelci-core# 
```

### Kernel tree

Then, get the kernel source code.  This hasn't changed:
```
./kci_build update_repo --build-config=mainline
```

You should now have a `linux` directory with the latest mainline kernel source tree.

### The build

The following commands will build the kernel step by step, starting with the initial `bmeta.json` meta-data file which contains some information about the kernel revision and the build environment.  This will keep getting used between each build step, and you can open the file between each command to see what is being added to it.  Then the subsequent commands are to generate the kernel config, build the kernel image, then the modules and the dtbs:
```
./kci_build init_bmeta --build-config=mainline --arch=arm64
./kci_build make_config --defconfig=defconfig+CONFIG_KASAN=y 
./kci_build make_kernel
./kci_build make_modules
./kci_build make_dtbs
```

Once the build is complete, you should have everything in the output directory as specified in the config file, including the build log:
```
root@76ad3035ee88:~/kernelci-core# head linux/local-build/kernel.log
#
# make KBUILD_BUILD_USER=KernelCI -Clinux -j4 ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- HOSTCC=gcc CC="ccache aarch64-linux-gnu-gcc" O=/root/kernelci-core/linux/local-build defconfig
#
make: Entering directory '/root/kernelci-core/linux'
```

### JSON meta-data

The `linux/local-build/bmeta.json` file should now be complete with all the information about the build:
```json
{
    "environment": {
        "arch": "arm64",
        "compiler": "gcc",
        "compiler_version": "8",
        "compiler_version_full": "aarch64-linux-gnu-gcc (Debian 8.3.0-2) 8.3.0",
        "cross_compile": "aarch64-linux-gnu-",
        "cross_compile_compat": "arm-linux-gnueabihf-",
        "make_opts": {
            "KBUILD_BUILD_USER": "KernelCI"
        },
        "name": "gcc-8",
        "platform": {
            "cpus": {
                "Intel Core Processor (Skylake, IBRS)": 3
            },
            "uname": [
                "Linux",
                "cros-build",
                "4.19.0-12-amd64",
                "#1 SMP Debian 4.19.152-1 (2020-10-18)",
                "x86_64",
                ""
            ]
        },
        "use_ccache": true
    },
    "kernel": {
        "defconfig": "defconfig",
        "defconfig_extras": [
            "CONFIG_KASAN=y"
        ],
        "defconfig_full": "defconfig+CONFIG_KASAN=y",
        "fragments": [
            "kernelci.config"
        ],
        "image": "Image",
        "vmlinux_bss_size": 9193632,
        "vmlinux_data_size": 13861696,
        "vmlinux_file_size": 508192704,
        "vmlinux_text_size": 21295464
    },
    "revision": {
        "branch": "master",
        "commit": "418baf2c28f3473039f2f7377760bd8f6897ae18",
        "describe": "v5.10-rc5",
        "describe_v": "v5.10-rc5",
        "tree": "mainline",
        "url": "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git"
    },
    "steps": [
        {
            "duration": 0.12980270385742188,
            "name": "revision",
            "start_time": 1606494404.139411,
            "status": "PASS"
        },
        {
            "duration": 0.006347179412841797,
            "name": "environment",
            "start_time": 1606494404.269703,
            "status": "PASS"
        },
        {
            "duration": 17.760863304138184,
            "log_file": "kernel.log",
            "name": "config",
            "start_time": 1606494406.8110063,
            "status": "PASS",
            "threads": "4"
        },
        {
            "duration": 298.7760851383209,
            "log_file": "kernel.log",
            "name": "kernel",
            "start_time": 1606495414.587251,
            "status": "PASS",
            "threads": "4"
        },
        {
            "duration": 1197.6061565876007,
            "log_file": "kernel.log",
            "name": "modules",
            "start_time": 1606495747.7965348,
            "status": "PASS",
            "threads": "4"
        },
        {
            "duration": 12.293006896972656,
            "log_file": "kernel.log",
            "name": "dtbs",
            "start_time": 1606507046.7938302,
            "status": "PASS",
            "threads": "4"
        }
    ]
}
```
One of the new features compared to the current `build_kernel` command is that we can now have a different log file when running each step, by passing a different value to the `--log` option on the command line.  We also know the duration and start time of each step.  Also, the CPU information is more detailed (this example is on a VM with 3 vCPUs...).

### Next steps

Before this can be used in production for kernelci.org, a few more things will need to be done in follow-up PRs:
* create the modules tarball and install all the files to publish as per the `install_kernel` command
* produce the meta-data in the format expected by `api.kernelci.org` for publishing a new kernel build
* update the Kubernetes build job template to use the new commands
* potentially, keep `build_kernel` but turn it into a super-command to run all these things in one go