### PR TITLE
build-configs.yaml: enable kselftest build on staging

### DIFF
--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -239,6 +239,7 @@ build_configs_defaults:
 
       fragments: &default_fragments
         - 'debug'
+        - 'kselftest'
         - 'tinyconfig'
 
       architectures: &default_architectures


### PR DESCRIPTION
Enable builds with kselftest fragment on staging environment with experimental and testing purposes until we have some kselftest runtime working properly to get merged in production.

Signed-off-by: Alexandra Pereira <alexandra.pereira@collabora.com>