### PR TITLE
baseline: use kmsg for test shell messages

### DIFF
--- a/templates/baseline/baseline.jinja2
+++ b/templates/baseline/baseline.jinja2
@@ -19,6 +19,7 @@
         run:
           steps:
             - KERNELCI_LAVA=y /bin/sh /opt/kernelci/dmesg.sh
+      lava-signal: kmsg
       from: inline
       name: dmesg
       path: inline/dmesg.yaml


### PR DESCRIPTION
Sometimes the output is interrupted by the kernel messages, for example:
  https://lavalab.kontron.com/scheduler/job/1174#L1000

Use /dev/kmsg to mitigate that; as it is already used in the bootrr test
case.

Signed-off-by: Michael Walle <michael@walle.cc>