### PR TITLE
T22500 x86 chromebook fragment

### DIFF
--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -168,6 +168,12 @@ fragments:
       - 'CONFIG_VIDEO_VIVID=y'
       - 'CONFIG_VIDEO_VIVID_MAX_DEVS=64'
 
+  x86_chromebook:
+    path: "kernel/configs/x86-chromebook.config"
+    configs:
+      - 'CONFIG_SERIAL_8250_DW=y'
+      - 'CONFIG_X86_AMD_PLATFORM_DEVICE=y'
+
   x86_kvm_guest:
     path: "kernel/configs/kvm_guest.config"
 

--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -173,6 +173,7 @@ fragments:
     configs:
       - 'CONFIG_SERIAL_8250_DW=y'
       - 'CONFIG_X86_AMD_PLATFORM_DEVICE=y'
+      - 'CONFIG_MFD_INTEL_LPSS_PCI=y'
 
   x86_kvm_guest:
     path: "kernel/configs/kvm_guest.config"

--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -174,6 +174,9 @@ fragments:
       - 'CONFIG_SERIAL_8250_DW=y'
       - 'CONFIG_X86_AMD_PLATFORM_DEVICE=y'
       - 'CONFIG_MFD_INTEL_LPSS_PCI=y'
+      - 'CONFIG_USB_GADGET=y'
+      - 'CONFIG_USB_ETH=y'
+      - 'CONFIG_USB_RTL8152=y'
 
   x86_kvm_guest:
     path: "kernel/configs/kvm_guest.config"


### PR DESCRIPTION
Add an `x86-chromebook` config fragment to enable the serial console on most x86 Chromebooks (AMD and Intel), as well as the USB-Ethernet adapter found in the [Servo v4](https://chromium.googlesource.com/chromiumos/third_party/hdctools/+/master/docs/servo_v4.md#Type_C-Version) debug boards.