### PR TITLE
T23360 kci_build make_kselftest

### DIFF
--- a/kci_build
+++ b/kci_build
@@ -349,6 +349,19 @@ class cmd_make_dtbs(Command):
         return step.run(args.j, args.verbose)
 
 
+class cmd_make_kselftest(Command):
+    help = "Build kselftest"
+    args = [Args.kdir]
+    opt_args = [Args.verbose, Args.output, Args.j, Args.log]
+
+    def __call__(self, configs, args):
+        step = kernelci.build.MakeSelftests(args.kdir, args.output, args.log)
+        if not step.fragment_enabled():
+            print("No kselftest fragment being used, not building.")
+            return True
+        return step.run(args.j, args.verbose)
+
+
 class cmd_build_kernel(Command):
     help = "Build a kernel"
     args = [Args.build_env, Args.arch, Args.kdir]

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -978,6 +978,35 @@ class MakeDeviceTrees(Step):
         return res
 
 
+class MakeSelftests(Step):
+
+    def fragment_enabled(self):
+        """Check whether the kselftest fragment is enabled
+
+        Return True if the kselftest config fragment is enabled in the build
+        meta-data, or False otherwise.
+        """
+        return 'kselftest' in self._bmeta['kernel']['defconfig_extras']
+
+    def run(self, jopt=None, verbose=False):
+        """Make the kernel selftests
+
+        Make the kernel selftests or "kselftest" and produce a tarball so they
+        can be installed on a separate test platform.
+
+        *jopt* is the `make -j` option which will default to `nproc + 2`
+        *verbose* is whether the build output should be shown
+        """
+        opts = {
+            'FORMAT': '.xz',
+        }
+        res = self._make('gen_tar', jopt, verbose, opts,
+                         'tools/testing/selftests')
+        self._add_run_step('kselftest', jopt, res)
+        self._save_bmeta()
+        return res
+
+
 def _make_defconfig(defconfig, kwargs, extras, verbose, log_file):
     kdir, output_path = (kwargs.get(k) for k in ('kdir', 'output'))
     result = True

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -515,30 +515,45 @@ class Step:
         self._kdir = kdir
         self._output_path = output_path or os.path.join(kdir, 'build')
         self._bmeta_path = os.path.join(self._output_path, 'bmeta.json')
+        self._steps_path = os.path.join(self._output_path, 'steps.json')
         self._log_file = log
         self._log_path = os.path.join(self._output_path, log) if log else None
         self._bmeta = dict()
+        self._steps = list()
         self._dot_config = None
         self._start_time = time.time()
         if not os.path.exists(self._output_path):
             os.mkdir(self._output_path)
-        elif os.path.exists(self._bmeta_path):
-            if reset:
-                os.unlink(self._bmeta_path)
-            else:
-                with open(self._bmeta_path) as json_file:
-                    self._bmeta = json.load(json_file)
+        elif reset:
+            self._reset_bmeta()
+        else:
+            self._load_bmeta()
 
     @property
     def bmeta_path(self):
         """Path to the build meta-data JSON file"""
         return self._bmeta_path
 
-    def _add_run_bmeta(self, name, jopt=None, status=None):
+    def _reset_bmeta(self):
+        if os.path.exists(self._bmeta_path):
+            os.unlink(self._bmeta_path)
+        if os.path.exists(self._steps_path):
+            os.unlink(self._steps_path)
+
+    def _load_bmeta(self):
+        if os.path.exists(self._bmeta_path):
+            with open(self._bmeta_path) as json_file:
+                self._bmeta = json.load(json_file)
+        if os.path.exists(self._steps_path):
+            with open(self._steps_path) as json_file:
+                self._steps = json.load(json_file)
+
+    def _add_run_step(self, name, jopt=None, status=None):
         run_data = {
             'name': name,
             'start_time': self._start_time,
             'duration': time.time() - self._start_time,
+            'cpus': self._get_cpus(),
         }
         if jopt is not None:
             run_data['threads'] = str(jopt)
@@ -546,11 +561,33 @@ class Step:
             run_data['status'] = "PASS" if status is True else "FAIL"
         if self._log_path and os.path.exists(self._log_path):
             run_data['log_file'] = self._log_file
-        self._bmeta.setdefault('steps', list()).append(run_data)
+        self._steps.append(run_data)
+
+        total_duration = sum(s['duration'] for s in self._steps)
+        all_status = set(s['status'] for s in self._steps)
+        self._bmeta['build'] = {
+            'duration': total_duration,
+            'status': 'PASS' if all_status == {'PASS'} else 'FAIL'
+        }
 
     def _save_bmeta(self):
         with open(self._bmeta_path, 'w') as json_file:
             json.dump(self._bmeta, json_file, indent=4, sort_keys=True)
+        with open(self._steps_path, 'w') as json_file:
+            json.dump(self._steps, json_file, indent=4, sort_keys=True)
+
+    def _get_cpus(self):
+        cpus = {}
+        if os.path.exists('/proc/cpuinfo'):
+            cpu_list = []
+            with open('/proc/cpuinfo') as f:
+                for line in f:
+                    if 'model name' in line:
+                        cpu_list.append(line.split(':')[1].strip())
+            for cpu in cpu_list:
+                ncpus = cpus.get(cpu, 0)
+                cpus[cpu] = ncpus + 1
+        return cpus
 
     def _kernel_config_enabled(self, config_name):
         dot_config = os.path.join(self._output_path, '.config')
@@ -596,7 +633,7 @@ class RevisionData(Step):
             'describe_v': git_describe_verbose(self._kdir),
             'commit': head_commit(self._kdir),
         }
-        self._add_run_bmeta('revision', status=True)
+        self._add_run_step('revision', status=True)
         self._save_bmeta()
         return True
 
@@ -622,17 +659,6 @@ class EnvironmentData(Step):
         make_opts = {'KBUILD_BUILD_USER': 'KernelCI'}
         make_opts.update(build_env.get_arch_opts(arch))
         platform_data = {'uname': platform.uname()}
-        if os.path.exists('/proc/cpuinfo'):
-            cpu_list = []
-            with open('/proc/cpuinfo') as f:
-                for line in f:
-                    if 'model name' in line:
-                        cpu_list.append(line.split(':')[1].strip())
-            cpus = {}
-            for cpu in cpu_list:
-                ncpus = cpus.get(cpu, 0)
-                cpus[cpu] = ncpus + 1
-            platform_data['cpus'] = cpus
 
         self._bmeta['environment'] = {
             'arch': arch,
@@ -646,7 +672,7 @@ class EnvironmentData(Step):
             'use_ccache': shell_cmd("which ccache > /dev/null", True),
             'make_opts': make_opts,
         }
-        self._add_run_bmeta('environment', status=True)
+        self._add_run_step('environment', status=True)
         self._save_bmeta()
         return True
 
@@ -754,7 +780,7 @@ scripts/kconfig/merge_config.sh -O {output} '{base}' '{frag}' {redir}
             self._bmeta['kernel']['fragments'] = [kci_frag_name]
             res = self._merge_config(kci_frag_name, verbose)
 
-        self._add_run_bmeta('config', jopt, res)
+        self._add_run_step('config', jopt, res)
         self._save_bmeta()
         return res
 
@@ -791,7 +817,7 @@ class MakeKernel(Step):
                 kbmeta.update(vmlinux_meta)
                 kbmeta['vmlinux_file_size'] = os.stat(vmlinux_file).st_size
 
-        self._add_run_bmeta('kernel', jopt, res)
+        self._add_run_step('kernel', jopt, res)
         self._save_bmeta()
         return res
 
@@ -834,7 +860,7 @@ class MakeModules(Step):
             }
             res = self._run_make('modules_install', jopt, verbose, opts)
 
-        self._add_run_bmeta('modules', jopt, res)
+        self._add_run_step('modules', jopt, res)
         self._save_bmeta()
         return res
 
@@ -881,7 +907,7 @@ class MakeDeviceTrees(Step):
         res = self._run_make('dtbs', jopt, verbose)
         if res:
             self._dtbs_json()
-        self._add_run_bmeta('dtbs', jopt, res)
+        self._add_run_step('dtbs', jopt, res)
         self._save_bmeta()
         return res
 

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -550,9 +550,10 @@ class Step:
                 self._steps = json.load(json_file)
 
     def _add_run_step(self, name, jopt=None, status=None):
+        start_time = datetime.fromtimestamp(self._start_time).isoformat()
         run_data = {
             'name': name,
-            'start_time': self._start_time,
+            'start_time': start_time,
             'duration': time.time() - self._start_time,
             'cpus': self._get_cpus(),
         }

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -15,6 +15,7 @@
 # along with this library; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+from datetime import datetime
 import fnmatch
 import itertools
 import json
@@ -594,12 +595,19 @@ class Step:
         cmd = 'grep -cq CONFIG_{}=y {}'.format(config_name, dot_config)
         return shell_cmd(cmd, True)
 
-    def _output_to_file(self, cmd, log_file, rel_path=None):
-        open(log_file, 'a').write("#\n# {}\n#\n".format(cmd))
+    def _output_to_file(self, cmd, file_path, rel_path=None):
+        with open(file_path, 'a') as output_file:
+            output = ["#\n"]
+            if self._start_time:
+                dt = datetime.fromtimestamp(time.time())
+                output.append("# {}\n#\n".format(dt.isoformat()))
+            output.append("# {}\n".format(cmd))
+            output.append("#\n")
+            output_file.write("".join(output))
         if rel_path:
-            log_file = os.path.relpath(log_file, rel_path)
+            file_path = os.path.relpath(file_path, rel_path)
         cmd = "/bin/bash -c '(set -o pipefail; {} 2>&1 | tee -a {})'".format(
-            cmd, log_file)
+            cmd, file_path)
         return cmd
 
     def _get_make_opts(self, opts, make_path):

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -594,6 +594,14 @@ class Step:
         cmd = 'grep -cq CONFIG_{}=y {}'.format(config_name, dot_config)
         return shell_cmd(cmd, True)
 
+    def _output_to_file(self, cmd, log_file, rel_path=None):
+        open(log_file, 'a').write("#\n# {}\n#\n".format(cmd))
+        if rel_path:
+            log_file = os.path.relpath(log_file, rel_path)
+        cmd = "/bin/bash -c '(set -o pipefail; {} 2>&1 | tee -a {})'".format(
+            cmd, log_file)
+        return cmd
+
     def _get_make_opts(self, opts, make_path):
         env = self._bmeta['environment']
         make_opts = env['make_opts'].copy()
@@ -653,7 +661,7 @@ class Step:
         cmd = ' '.join(args)
         print_flush(cmd)
         if self._log_path:
-            cmd = _output_to_file(cmd, self._log_path)
+            cmd = self._output_to_file(cmd, self._log_path)
         return shell_cmd(cmd, True)
 
     def run(self):
@@ -786,7 +794,7 @@ scripts/kconfig/merge_config.sh -O {output} '{base}' '{frag}' {redir}
            redir='> /dev/null' if not verbose else '')
         print_flush(cmd.strip())
         if self._log_path:
-            cmd = _output_to_file(cmd, self._log_path, self._kdir)
+            cmd = self._output_to_file(cmd, self._log_path, self._kdir)
         return shell_cmd(cmd, True)
 
     def run(self, defconfig, jopt=None, verbose=False, frag='kernelci.config'):


### PR DESCRIPTION
Add the `kci_build make_kselftest` command to build kselftest as a separate step.

Depends on #554 

To test this locally, first create a `kernelci.conf` file in the current kernelci-core directory (to override any user or system-wide one):
```ini
[kci_build]
kdir: linux
build_env: gcc-8
j: 4
output: linux/build-kselftest
log: build.log
verbose: true
```
Then run these commands to generate the kselftest fragment and build in a Docker container:
```
$ ./kci_build generate_fragments --build-config=next
$ docker run -it -v $PWD:/root/kernelci-core kernelci/build-gcc-8_x86 /bin/bash
# ./kci_build init_bmeta --arch=x86_64 --build-config=next
# ./kci_build make_config --defconfig=x86_64_defconfig+kernel/configs/kselftest.config
# ./kci_build make_kernel
# ./kci_build make_kselftest
```
(the kselftest fragment can also be generated from within the container)