### PR TITLE
build-configs.yaml: enable kselftest builds again

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -252,6 +252,7 @@ build_configs_defaults:
 
       fragments: &default_fragments
         - 'debug'
+        - 'kselftest'
         - 'tinyconfig'
 
       architectures: &default_architectures


### PR DESCRIPTION
This reverts commit 45778bc423e485b88e743976d88b406057af4bfe.

Now that kci_build has a separate make_kselftest command, we can
enable the kselftest fragment again in production.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>