### PR TITLE
templates: boot: generic-qemu: Add console params

### DIFF
--- a/templates/boot/generic-qemu-boot-template.jinja2
+++ b/templates/boot/generic-qemu-boot-template.jinja2
@@ -1,15 +1,15 @@
 {% extends 'base/kernel-ci-base.jinja2' %}
 {% if arch == "arm" %}
-{% set console_dev = 'ttyAMA0' %}
+{% set console_dev = console_dev|default('ttyAMA0') %}
 {% endif %}
 {% if arch == "arm64" %}
-{% set console_dev = 'ttyAMA0' %}
+{% set console_dev = console_dev|default('ttyAMA0') %}
 {% endif %}
 {% if arch == 'x86_64' %}
-{% set console_dev = 'ttyS0' %}
+{% set console_dev = console_dev|default('ttyS0') %}
 {% endif %}
 {% if arch == 'i386' %}
-{% set console_dev = 'ttyS0' %}
+{% set console_dev = console_dev|default('ttyS0') %}
 {% endif %}
 {% block metadata %}
 {{ super() }}


### PR DESCRIPTION
Hello,

Here is a pull-request to add the possibility to set the console used by QEMU
using 'params' keyword in test-configs.yaml.
The default console will be the value of 'console_dev' entry, as done previously.

Thanks to that, if the emulated device has a different console than the one defined in the top of the file, it is possible to modify it using this `params: console:` entry.

Let me know what you think about it.
Best regards,
Mylène
