### PR TITLE
T24749 kci rootfs alpha

### DIFF
--- a/kci_rootfs
+++ b/kci_rootfs
@@ -34,6 +34,10 @@ class cmd_validate(Command):
 
     def __call__(self, config_data, args, **kwargs):
         # ToDo: Use jsonschema
+        err = kernelci.sort_check(configs['rootfs_configs'])
+        if err:
+            print("Rootfs broken order: '{}' before '{}".format(*err))
+            return False
         if args.verbose:
             rootfs_configs = config_data['rootfs_configs']
             for config_name, config in rootfs_configs.items():

--- a/kci_rootfs
+++ b/kci_rootfs
@@ -34,10 +34,28 @@ class cmd_validate(Command):
 
     def __call__(self, config_data, args, **kwargs):
         # ToDo: Use jsonschema
+
         err = kernelci.sort_check(configs['rootfs_configs'])
         if err:
             print("Rootfs broken order: '{}' before '{}".format(*err))
             return False
+        for name, config in configs['rootfs_configs'].items():
+            err = kernelci.sort_check(config.arch_list)
+            if err:
+                print("Arch order broken for {}: '{}' before '{}".format(
+                    name, err[0], err[1]))
+                return False
+            err = kernelci.sort_check(config.extra_packages)
+            if err:
+                print("Packages order broken for {}: '{}' before '{}".format(
+                    name, err[0], err[1]))
+                return False
+            err = kernelci.sort_check(config.extra_packages_remove)
+            if err:
+                print("Packages order broken for {}: '{}' before '{}".format(
+                    name, err[0], err[1]))
+                return False
+
         if args.verbose:
             rootfs_configs = config_data['rootfs_configs']
             for config_name, config in rootfs_configs.items():
@@ -57,6 +75,7 @@ class cmd_validate(Command):
                 print('\tdebian_mirror: {}'.format(config.debian_mirror))
                 print('\tkeyring_package: {}'.format(config.keyring_package))
                 print('\tkeyring_file: {}'.format(config.keyring_file))
+
         return True
 
 

--- a/rootfs-configs.yaml
+++ b/rootfs-configs.yaml
@@ -36,7 +36,7 @@ rootfs_configs:
     script: "scripts/install-bootrr.sh"
     test_overlay: "overlays/baseline"
 
-  buster-v4l2:
+  buster-cros-ec:
     rootfs_type: debos
     debian_release: buster
     arch_list:
@@ -44,16 +44,15 @@ rootfs_configs:
       - arm64
       - armhf
     extra_packages:
-      - libasound2
-      - libelf1
-      - libjpeg62-turbo
-      - libudev1
+      - python3-minimal
+      - python3-unittest2
     extra_packages_remove:
       - bash
       - e2fslibs
       - e2fsprogs
-    script: "scripts/buster-v4l2.sh"
-    test_overlay: "overlays/v4l2"
+      - libext2fs2
+    script: "scripts/buster-cros-ec-tests.sh"
+    test_overlay: ""
 
   buster-igt:
     rootfs_type: debos
@@ -98,7 +97,16 @@ rootfs_configs:
     script: "scripts/buster-igt.sh"
     test_overlay: "overlays/igt"
 
-  buster-cros-ec:
+  buster-ltp:
+    rootfs_type: debos
+    debian_release: buster
+    arch_list:
+      - amd64
+      - arm64
+      - armhf
+    script: "scripts/buster-ltp.sh"
+
+  buster-v4l2:
     rootfs_type: debos
     debian_release: buster
     arch_list:
@@ -106,15 +114,16 @@ rootfs_configs:
       - arm64
       - armhf
     extra_packages:
-      - python3-minimal
-      - python3-unittest2
+      - libasound2
+      - libelf1
+      - libjpeg62-turbo
+      - libudev1
     extra_packages_remove:
       - bash
       - e2fslibs
       - e2fsprogs
-      - libext2fs2
-    script: "scripts/buster-cros-ec-tests.sh"
-    test_overlay: ""
+    script: "scripts/buster-v4l2.sh"
+    test_overlay: "overlays/v4l2"
 
   sid:
     rootfs_type: debos
@@ -136,12 +145,3 @@ rootfs_configs:
       - libp11-kit0
       - sensible-utils
     extra_files_remove: *extra_files_remove_buster
-
-  buster-ltp:
-    rootfs_type: debos
-    debian_release: buster
-    arch_list:
-      - amd64
-      - arm64
-      - armhf
-    script: "scripts/buster-ltp.sh"

--- a/rootfs-configs.yaml
+++ b/rootfs-configs.yaml
@@ -9,8 +9,8 @@ rootfs_configs:
       - armhf
       - i386
       - mips
-      - mipsel
       - mips64el
+      - mipsel
     extra_packages:
       - isc-dhcp-client
     extra_packages_remove: &extra_packages_remove_buster
@@ -59,8 +59,8 @@ rootfs_configs:
     debian_release: buster
     arch_list:
         - amd64
-        - armhf
         - arm64
+        - armhf
         - mips
     extra_packages:
         - libcairo2


### PR DESCRIPTION
Add checks for sorting configuration in `rootfs-configs.yaml` alphabetically and fix issues.