### PR TITLE
T25311 kernel build install

### DIFF
--- a/kci_build
+++ b/kci_build
@@ -371,6 +371,9 @@ class cmd_make_modules(MakeCommand):
     help = "Build kernel modules"
     step_cls = kernelci.build.MakeModules
 
+    def _install_step(self, step, args):
+        return step.install(args.verbose, args.j)
+
 
 class cmd_make_dtbs(MakeCommand):
     help = "Build device trees"

--- a/kci_build
+++ b/kci_build
@@ -280,7 +280,7 @@ class cmd_list_kernel_configs(Command):
 class cmd_init_bmeta(Command):
     help = "Create initial bmeta.json"
     args = [Args.kdir]
-    opt_args = [Args.output, Args.build_config,
+    opt_args = [Args.output, Args.build_config, Args.install,
                 Args.tree_name, Args.tree_url, Args.branch,
                 Args.build_env, Args.arch]
 
@@ -307,6 +307,10 @@ or
         print("Initialising build meta-data in {}".format(args.output))
         res = step.run(tree_name, tree_url, branch)
 
+        if args.install:
+            print("Install directory: {}".format(step.install_path))
+            step.install()
+
         if res and (args.build_env or args.arch):
             if not (args.build_env and args.arch):
                 print("""\
@@ -315,13 +319,15 @@ Invalid arguments, --build-env and --arch need to be used together.""")
             build_env = configs['build_environments'][args.build_env]
             step = kernelci.build.EnvironmentData(args.kdir, args.output)
             res = step.run(build_env, args.arch)
+            if args.install:
+                step.install()
 
         return res
 
 
 class MakeCommand(Command):
     args = [Args.kdir]
-    opt_args = [Args.verbose, Args.output, Args.j, Args.log]
+    opt_args = [Args.verbose, Args.output, Args.j, Args.log, Args.install]
     step_cls = None
 
     def __call__(self, configs, args):
@@ -329,7 +335,11 @@ class MakeCommand(Command):
         if not step.is_enabled():
             print("Not enabled, skipping.")
             return True
-        return self._run_step(step, args)
+        res = self._run_step(step, args)
+        if args.install:
+            install_res = self._install_step(step, args)
+            res = res and install_res
+        return res
 
     def _get_step(self, args):
         if self.step_cls is None:
@@ -338,6 +348,9 @@ class MakeCommand(Command):
 
     def _run_step(self, step, args):
         return step.run(args.j, args.verbose)
+
+    def _install_step(self, step, args):
+        return step.install(args.verbose)
 
 
 class cmd_make_config(MakeCommand):

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -568,10 +568,10 @@ class Step:
         if not os.path.exists(self._install_path):
             os.makedirs(self._install_path)
 
-    def _add_run_step(self, status, jopt=None):
+    def _add_run_step(self, status, jopt=None, action=''):
         start_time = datetime.fromtimestamp(self._start_time).isoformat()
         run_data = {
-            'name': self.name,
+            'name': ' '.join([self.name, action]) if action else self.name,
             'start_time': start_time,
             'duration': time.time() - self._start_time,
             'cpus': self._get_cpus(),

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -825,7 +825,7 @@ class MakeConfig(Step):
                 kci_frag.write(config + '\n')
             for name, path in fragments.items():
                 with open(path) as frag:
-                    kci_frag.write("\n# fragment from : {}\n".format(name))
+                    kci_frag.write("\n# fragment from: {}\n".format(name))
                     kci_frag.writelines(frag)
 
     def _merge_config(self, kci_frag_name, verbose=False):
@@ -898,6 +898,24 @@ scripts/kconfig/merge_config.sh -O {output} '{base}' '{frag}' {redir}
             res = self._merge_config(kci_frag_name, verbose)
 
         return self._add_run_step(res, jopt)
+
+    def install(self, verbose=False):
+        """Install the kernel configuration files
+
+        Install the Linux kernel config file and associated fragments.
+
+        *verbose* is whether the build output should be shown
+        """
+        self._install_file(
+            os.path.join(self._output_path, '.config'),
+            'kernel.config',
+            verbose
+        )
+        for frag in self._bmeta['kernel'].get('fragments', list()):
+            self._install_file(
+                os.path.join(self._output_path, frag), frag, verbose
+            )
+        return super().install(verbose)
 
 
 class MakeKernel(Step):

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -939,11 +939,11 @@ class MakeKernel(Step):
         elif self._kernel_config_enabled('SYS_SUPPORTS_ZBOOT'):
             target = 'vmlinuz'
         else:
-            env = self._bmeta['environment']
-            target = MAKE_TARGETS.get(env['arch'])
+            target = MAKE_TARGETS.get(self._bmeta['environment']['arch'])
 
         kbmeta = self._bmeta.setdefault('kernel', dict())
-        kbmeta['image'] = target
+        if target:
+            kbmeta['image'] = target
 
         res = self._make(target, jopt, verbose)
 

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -1026,31 +1026,69 @@ class MakeModules(Step):
         """
         return self._kernel_config_enabled('MODULES')
 
+    def _make_modules_install(self, jopt, verbose):
+        if os.path.exists(self._mod_path):
+            shutil.rmtree(self._mod_path)
+        os.makedirs(self._mod_path)
+        cross_compile = self._bmeta['environment']['cross_compile']
+        opts = {
+            'INSTALL_MOD_PATH': os.path.abspath(self._mod_path),
+            'INSTALL_MOD_STRIP': '1',
+            'STRIP': "{}strip".format(cross_compile),
+        }
+        return self._make('modules_install', jopt, verbose, opts)
+
+    def _create_modules_json(self, verbose):
+        mod_json = os.path.join(self._install_path, 'modules.json')
+        if verbose:
+            print("Creating {}".format(mod_json))
+        modules = []
+        for root, _, files in os.walk(self._mod_path):
+            rel_path = os.path.relpath(self._kdir)
+            for fname in fnmatch.filter(files, '*.ko'):
+                module_path = os.path.join(rel_path, fname)
+                modules.append(module_path)
+        with open(mod_json, 'w') as json_file:
+            json.dump({'modules': sorted(modules)}, json_file, indent=4)
+
+    def _create_modules_tarball(self, verbose):
+        modules_tarball = 'modules.tar.xz'
+        modules_tarball_path = os.path.join(
+            self._install_path, modules_tarball)
+        if verbose:
+            print("Creating {}".format(modules_tarball_path))
+        shell_cmd("tar -C{path} -cJf {tarball} .".format(
+            path=self._mod_path, tarball=modules_tarball_path))
+
     def run(self, jopt=None, verbose=False):
         """Make the kernel modules
 
-        Make the kernel modules and install them as stripped binaries in a
-        _modules_ output sub-directory.  This step does not add any extra build
+        Make the kernel modules and   This step does not add any extra build
         meta-data.
 
         *jopt* is the `make -j` option which will default to `nproc + 2`
         *verbose* is whether the build output should be shown
         """
         res = self._make('modules', jopt, verbose)
+        return self._add_run_step(res, jopt)
+
+    def install(self, verbose=False, jopt=None):
+        """Install the kernel modules
+
+        Install the kernel modules as stripped binaries in a _modules_ output
+        sub-directory.  Also create a modules.json file with the list of all
+        the module files and a tarball with all the modules.
+
+        *verbose* is whether the build output should be shown
+        *jopt* is the `make -j` option which will default to `nproc + 2`
+        """
+        res = self._make_modules_install(jopt, verbose)
 
         if res:
-            if os.path.exists(self._mod_path):
-                shutil.rmtree(self._mod_path)
-            os.makedirs(self._mod_path)
-            cross_compile = self._bmeta['environment']['cross_compile']
-            opts = {
-                'INSTALL_MOD_PATH': os.path.abspath(self._mod_path),
-                'INSTALL_MOD_STRIP': '1',
-                'STRIP': "{}strip".format(cross_compile),
-            }
-            res = self._make('modules_install', jopt, verbose, opts)
+            self._create_modules_json(verbose)
+            self._create_modules_tarball(verbose)
 
-        return self._add_run_step(res, jopt)
+        return super().install(verbose, res)
 
 
 class MakeDeviceTrees(Step):

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -576,6 +576,7 @@ class Step:
             'duration': time.time() - self._start_time,
             'cpus': self._get_cpus(),
         }
+        self._start_time = time.time()
         if jopt is not None:
             run_data['threads'] = str(jopt)
         if self._log_path and os.path.exists(self._log_path):

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -1182,7 +1182,8 @@ class MakeSelftests(Step):
         """Make the kernel selftests
 
         Make the kernel selftests or "kselftest" and produce a tarball so they
-        can be installed on a separate test platform.
+        can be installed on a separate test platform.  This step does not add
+        any extrabuild meta-data.
 
         *jopt* is the `make -j` option which will default to `nproc + 2`
         *verbose* is whether the build output should be shown
@@ -1193,6 +1194,25 @@ class MakeSelftests(Step):
         res = self._make('gen_tar', jopt, verbose, opts,
                          'tools/testing/selftests')
         return self._add_run_step(jopt, res)
+
+    def install(self, verbose=False):
+        """Install the kselftest tarball
+
+        Install the kselftest tarball which was already packaged as part of the
+        build action.
+
+        *verbose* is whether the build output should be shown
+        """
+        kselftest_tarball = os.path.join(
+            self._output_path,
+            'kselftest/kselftest_install/kselftest-packages/kselftest.tar.xz'
+        )
+
+        res = os.path.exists(kselftest_tarball)
+        if res:
+            self._install_file(kselftest_tarball, verbose=verbose)
+
+        return super().install(verbose, res)
 
 
 def _make_defconfig(defconfig, kwargs, extras, verbose, log_file):

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -1106,12 +1106,31 @@ class MakeDeviceTrees(Step):
         """
         return self._kernel_config_enabled('OF_FLATTREE')
 
-    def _dtbs_json(self):
+    def run(self, jopt=None, verbose=False):
+        """Make the device trees
+
+        Make the device tree binary files (dtbs).  This step does not add any
+        extra build meta-data.
+
+        *jopt* is the `make -j` option which will default to `nproc + 2`
+        *verbose* is whether the build output should be shown
+        """
+        res = self._make('dtbs', jopt, verbose)
+        return self._add_run_step(res, jopt)
+
+    def _install_dtbs(self, verbose):
         arch = self._bmeta['environment']['arch']
         boot_dir = os.path.join(self._output_path, 'arch', arch, 'boot')
         dts_dir = os.path.join(boot_dir, 'dts')
-        dtbs_path = os.path.join(self._output_path, '_dtbs_')
         dtb_list = []
+
+        dtbs_path = os.path.join(self._install_path, 'dtbs')
+        if os.path.exists(dtbs_path):
+            shutil.rmtree(dtbs_path)
+
+        if verbose:
+            print("Copying dtbs to {}".format(dtbs_path))
+
         for root, _, files in os.walk(dts_dir):
             for f in fnmatch.filter(files, '*.dtb'):
                 dtb_path = os.path.join(root, f)
@@ -1122,22 +1141,27 @@ class MakeDeviceTrees(Step):
                 if not os.path.exists(dest_dir):
                     os.makedirs(dest_dir)
                 shutil.copy(dtb_path, dest_path)
-        with open(os.path.join(self._output_path, 'dtbs.json'), 'w') as f:
-            json.dump({'dtbs': sorted(dtb_list)}, f, indent=4)
 
-    def run(self, jopt=None, verbose=False):
-        """Make the device trees
+        return dtb_list
 
-        Make the device tree binary files (dtbs).  This step does not add any
-        extrabuild meta-data.
+    def _create_dtbs_json(self, dtb_list, verbose):
+        dtbs_json = os.path.join(self._install_path, 'dtbs.json')
+        if verbose:
+            print("Creating {}".format(dtbs_json))
+        with open(dtbs_json, 'w') as json_file:
+            json.dump({'dtbs': sorted(dtb_list)}, json_file, indent=4)
 
-        *jopt* is the `make -j` option which will default to `nproc + 2`
+    def install(self, verbose=False):
+        """Install the device trees
+
+        Install the device tree binary blobs (dtbs) and generate dtbs.json with
+        the list of device tree files.
+
         *verbose* is whether the build output should be shown
         """
-        res = self._make('dtbs', jopt, verbose)
-        if res:
-            self._dtbs_json()
-        return self._add_run_step(res, jopt)
+        dtb_list = self._install_dtbs(verbose)
+        self._create_dtbs_json(dtb_list, verbose)
+        return super().install(verbose)
 
 
 class MakeSelftests(Step):

--- a/kernelci/cli.py
+++ b/kernelci/cli.py
@@ -143,6 +143,12 @@ class Args:
         'help': "Path to the dtbs.json file",
     }
 
+    install = {
+        'name': '--install',
+        'action': 'store_true',
+        'help': "Install the build artifacts ",
+    }
+
     install_path = {
         'name': '--install-path',
         'help':


### PR DESCRIPTION
Implement the "install" method for each build step.

This introduces the `--install` option when running any `kci_build make_*` command, to also install the binary files in the `_install_` directory.

Depends on #574. 

## Notes

* The `make modules_install` command is now only called if the `--install` option is enabled, rather than implicitly at the end of the modules build.
* Each install "action" will be added to the `steps.json` file as a separate entry, e.g. `modules install`.
* Each step now has a default separate log file with the step name, e.g. `modules.log` and it will be overwritten if the modules are built again.

The same applies to each step: `config`, `kernel`, `modules`, `dtbs`, `kselftest`.  The `--log` option can be used to manually override this behaviour, in which case the log file specified by the user will be used and all the output will be appended rather than overwriting the file.

## Sample instructions to test this PR

Sample local `kernelci.conf` file with `install` enabled so all steps will install their binaries, and no `log` option so the default log file names will be used:
```ini
[kci_build]
kdir: linux
build_env: gcc-8
j: 4
arch: arm64
output: linux/build-arm64
verbose: true
install: true
```
To use Docker:
```
docker run -it -v $PWD:/root/kernelci-core kernelci/build-gcc-8_arm64 /bin/bash
root@8987f5cb854c:/ # cd /root/kernelci-core
```
First, get a Linux kernel source tree.  This can be done with `kci_build update_repo` or directly with `git`:
```
git clone https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git linux
```
Then generate the config fragments, which should add the `kselftest.config` file.  Note that this will require the pending patch from #564 in order to enable the fragment to be generated:
```
git cherry-pick 01fd8ec1ed99078c95eb8eda5e095e9c3cfdd987
./kci_build generate_fragments --build-config=next
```
Then the sample commands below will build everything that can currently be built with `kci_build`:
```
./kci_build init_bmeta --build-config=next
./kci_build make_config --defconfig=defconfig+kernel/configs/kselftest.config
./kci_build make_kernel
./kci_build make_modules
./kci_build make_dtbs
./kci_build make_kselftest
```
Here's the list of all the generated files copied to the `_install_` directory: https://people.collabora.com/~gtucker/kernelci/PR-575_install_/
```
root@8987f5cb854c:~/kernelci-core# ls -l linux/build-arm64/_install_
total 62344
-rw-r--r--  1 1000 1000 43969024 Jan  7 16:14 Image
-rw-r--r--  1 1000 1000  8441864 Jan  7 16:14 System.map
-rw-r--r--  1 1000 1000     1618 Jan  7 16:30 bmeta.json
-rw-r--r--  1 1000 1000      909 Jan  7 16:04 config.log
drwxr-xr-x 30 1000 1000     4096 Jan  7 16:29 dtbs
-rw-r--r--  1 1000 1000    16719 Jan  7 16:29 dtbs.json
-rw-r--r--  1 1000 1000      497 Jan  7 16:29 dtbs.log
-rw-r--r--  1 1000 1000   251428 Jan  7 16:04 kernel.config
-rw-r--r--  1 1000 1000   157671 Jan  7 16:14 kernel.log
-rw-r--r--  1 1000 1000     8313 Jan  7 16:04 kernelci.config
-rw-r--r--  1 1000 1000   123300 Jan  7 16:30 kselftest.log
-rw-r--r--  1 1000 1000  1787908 Jan  7 16:30 kselftest.tar.xz
-rw-r--r--  1 1000 1000    26282 Jan  7 16:28 modules.json
-rw-r--r--  1 1000 1000   255190 Jan  7 16:28 modules.log
-rw-r--r--  1 1000 1000  8617464 Jan  7 16:28 modules.tar.xz
-rw-r--r--  1 1000 1000     3896 Jan  7 16:30 steps.json
```
The `kselftest` build failed with a few targets, which propagated as the overall build result to be `FAIL` in [`bmeta.json`](https://people.collabora.com/~gtucker/kernelci/PR-757_install_/bmeta.json):
```json
{
    "build": {
        "duration": 1558.8823194503784,
        "status": "FAIL"
    },
    "environment": {
        "arch": "arm64",
        "compiler": "gcc",
        "compiler_version": "8",
        "compiler_version_full": "aarch64-linux-gnu-gcc (Debian 8.3.0-2) 8.3.0",
        "cross_compile": "aarch64-linux-gnu-",
        "cross_compile_compat": "arm-linux-gnueabihf-",
        "make_opts": {
            "KBUILD_BUILD_USER": "KernelCI"
        },
        "name": "gcc-8",
        "platform": {
            "uname": [
                "Linux",
                "8987f5cb854c",
                "4.19.0-12-amd64",
                "#1 SMP Debian 4.19.152-1 (2020-10-18)",
                "x86_64",
                ""
            ]
        },
        "use_ccache": true
    },
    "kernel": {
        "defconfig": "defconfig",
        "defconfig_extras": [
            "kselftest"
        ],
        "defconfig_full": "defconfig+kernel/configs/kselftest.config",
        "fragments": [
            "kernelci.config"
        ],
        "image": "Image",
        "system_map": "System.map",
        "text_offset": "0x10000000",
        "vmlinux_bss_size": 11560040,
        "vmlinux_data_size": 4525392,
        "vmlinux_file_size": 559828496,
        "vmlinux_text_size": 19301576
    },
    "revision": {
        "branch": "master",
        "commit": "950c3769192512118a87432dd42e71c5241dbd10",
        "describe": "v5.10-rc7-223-g950c37691925",
        "describe_v": "v5.10-rc7-223-g950c37691925",
        "tree": "next",
        "url": "https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git"
    }
}
```
However, everything else succeeded.  The detail can be seen in [`steps.json`](https://people.collabora.com/~gtucker/kernelci/PR-757_install_/steps.json).