### PR TITLE
templates: add kselftest subset parameters

### DIFF
--- a/templates/kselftest/kselftest.jinja2
+++ b/templates/kselftest/kselftest.jinja2
@@ -1,7 +1,6 @@
 - test:
     timeout:
-      minutes: 55
-
+      minutes: {{ job_timeout }}
     definitions:
     - from: inline
       repository:
@@ -19,7 +18,9 @@
       from: git
       revision: kernelci.org
       path: automated/linux/kselftest/kselftest.yaml
-      name: kselftest
+      name: {{ plan }}
       parameters:
         TESTPROG_URL: {{ kselftests_url }}
         SKIPFILE: skipfile-lkft.yaml
+        KSELFTEST_COLLECTIONS: {{ kselftest_collections }}
+        KSELFTEST_TESTS: {{ kselftest_tests }}


### PR DESCRIPTION
includes job template parameters to specify kselftest collections and tests to run.

Signed-off-by: Alexandra Pereira <alexandra.pereira@collabora.com>