### PR TITLE
T24646 sleep: add wakeup check and abort if checks fail

### DIFF
--- a/config/lava/sleep/sleep.sh
+++ b/config/lava/sleep/sleep.sh
@@ -1,18 +1,30 @@
 #!/bin/sh
 
 modes=$*
-ls -l /dev/rtc0
-if [ $? -eq 0 ];then
-	lava-test-case rtc-exist --result pass
-	for mode in $modes; do
-		for i in $(seq 1 10); do
-			rtcwake -d rtc0 -m $mode -s 5
-		if [ $? -eq 0 ] && result="pass" || result="fail" ;then
-				lava-test-case rtcwake-$mode-$i --result $result
-			fi
-		done
-	done
+
+if [ -e /dev/rtc0 ]; then
+    lava-test-case rtc-exist --result pass
 else
-	lava-test-case rtc-exist --result fail
-	echo "No real time clock found !"
+    lava-test-case rtc-exist --result fail
+    echo "No real-time clock found"
+    exit 1
 fi
+
+if [ $(cat /sys/class/rtc/rtc0/device/power/wakeup) = enabled ]; then
+    lava-test-case rtc-wakeup-enabled --result pass
+else
+    lava-test-case rtc-wakeup-enabled --result fail
+    echo "Real-time clock wakeup not enabled"
+    exit 1
+fi
+
+for mode in $modes; do
+    for i in $(seq 1 10); do
+	rtcwake -d rtc0 -m $mode -s 5
+	if [ $? -eq 0 ] && result="pass" || result="fail" ;then
+	    lava-test-case rtcwake-$mode-$i --result $result
+	fi
+    done
+done
+
+exit 0


### PR DESCRIPTION
Move the check for the presence of the rtc0 device outside of the main
loop, and add a check for wakeup enabled.  Abort if any of these
checks fail before starting the main loop to keep the script easier to
maintain.

Depends on #586 