### PR TITLE
build-configs.yaml: disable arc builds with clang

### DIFF
--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -209,9 +209,6 @@ build_environments:
     cc: clang
     cc_version: 10
     arch_params: &clang_arch_params
-      arc:
-        <<: *arc_params
-        name:
       arm:
         <<: *arm_params
         name:


### PR DESCRIPTION
The arc architecture is not actually supported by clang, this was most
likely enabled by mistake.  Drop them for now until the architecture
can at least get built in theory so that KernelCI results become
useful.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>