### PR TITLE
workflows: update path to scripts for pycodestyle

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           pycodestyle kernelci
           pycodestyle kci_*
-          pycodestyle *.py
+          pycodestyle scripts/*.py
 
       - name: Run YAML config validation
         run: |


### PR DESCRIPTION
The standalone Python scripts have moved from the root directory to
scripts, so update the pycodestyle check accordingly.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>