### PR TITLE
rootfs-configs.yaml: Update buster-ltp rootfs

### DIFF
--- a/jenkins/debian/debos/scripts/buster-ltp.sh
+++ b/jenkins/debian/debos/scripts/buster-ltp.sh
@@ -39,8 +39,8 @@ echo '  ]}' >> $BUILDFILE
 
 git clone --depth=1 -b 20200515 ${LTP_URL}
 cd ltp && make autotools 
-./configure 
-make all
+./configure --with-open-posix-testsuite
+make -j`nproc` all
 find . -executable -type f -exec strip {} \;
 make install
 


### PR DESCRIPTION
Make sure to configure open-posix-testsuite and build.
This helps to run timers testcases.

Signed-off-by: Lakshmipathi <lakshmipathi.ganapathi@collabora.com>