### PR TITLE
build-configs.yaml: add peterz queue/kernelci branch

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -88,6 +88,9 @@ trees:
   omap:
     url: "https://git.kernel.org/pub/scm/linux/kernel/git/tmlind/linux-omap.git"
 
+  peterz:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/peterz/queue.git"
+
   pm:
     url: "https://git.kernel.org/pub/scm/linux/kernel/git/rafael/linux-pm.git"
 
@@ -861,6 +864,11 @@ build_configs:
   omap:
     tree: omap
     branch: 'for-next'
+
+  peterz:
+    tree: peterz
+    branch: 'kernelci'
+    variants: *minimal_variants
 
   pm:
     tree: pm


### PR DESCRIPTION
Add peterz "queue" tree with the "kernelci" branch using the minimal
set of build variants.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>