### PR TITLE
T25987 kernelci.lab: pass DeviceType object to .device_type_online()

### DIFF
--- a/kci_test
+++ b/kci_test
@@ -93,7 +93,7 @@ class cmd_list_jobs(Command):
         configs = kernelci.test.match_configs(
             test_configs['test_configs'], bmeta, dtbs, lab)
         for device_type, plan in configs:
-            if not api.device_type_online(device_type.name):
+            if not api.device_type_online(device_type):
                 continue
             print(' '.join([device_type.name, plan.name]))
 
@@ -173,7 +173,7 @@ class cmd_generate(Command):
             configs = kernelci.test.match_configs(
                 test_configs['test_configs'], bmeta, dtbs, lab)
             for device_type, plan in configs:
-                if not api.device_type_online(device_type.name):
+                if not api.device_type_online(device_type):
                     continue
                 if args.target and device_type.name != args.target:
                     continue

--- a/kernelci/lab/__init__.py
+++ b/kernelci/lab/__init__.py
@@ -71,12 +71,12 @@ class LabAPI:
         """
         self._devices = data
 
-    def device_type_online(self, device_type_name):
+    def device_type_online(self, device_type_config):
         """Check whether a given device type is online
 
         Return True if the device type is online in the lab, False otherwise.
 
-        *device_type_name* is the name of the device type
+        *device_type_config* is a config.test.DeviceType object
         """
         return True
 

--- a/kernelci/lab/lava.py
+++ b/kernelci/lab/lava.py
@@ -83,8 +83,8 @@ class LAVA(LabAPI):
         aliases = self.devices.get('aliases', dict())
         return aliases.get(device_type, device_type)
 
-    def device_type_online(self, device_type):
-        device_type = self._alias_device_type(device_type)
+    def device_type_online(self, device_type_config):
+        device_type = self._alias_device_type(device_type_config.base_name)
         return device_type in self.devices['device_type_online']
 
     def job_file_name(self, params):


### PR DESCRIPTION
Pass a DeviceType configuration object to Lab.device_type_online() and
let the implementation of the method decide how to look up the status
of the device type.  This is because the base name is used with LAVA
labs, so using DeviceType.name doesn't work.  Other types of lab may
need the specific name instead, and in any case this is not something
the API users should have to deal with.

This fixes issues with submitting jobs to qemu and r8a77960-ulcb
devices in particular.

Fixes: 9ba487d2f861 ("kernelci.lab.lava: fix and simplify logic to handle LAVA aliases")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>