### PR TITLE
T25311 push kernel

### DIFF
--- a/kci_build
+++ b/kci_build
@@ -361,7 +361,8 @@ class cmd_make_config(MakeCommand):
     step_cls = kernelci.build.MakeConfig
 
     def _run_step(self, step, args, configs):
-        return step.run(args.defconfig, args.j, args.verbose)
+        frags_config = configs['fragments']
+        return step.run(args.defconfig, frags_config, args.j, args.verbose)
 
 
 class cmd_make_kernel(MakeCommand):

--- a/kci_build
+++ b/kci_build
@@ -23,6 +23,7 @@ from kernelci.cli import Args, Command, parse_opts
 import kernelci
 import kernelci.build
 import kernelci.config.build
+import kernelci.storage
 
 
 class cmd_validate(Command):
@@ -434,13 +435,19 @@ or
 
 
 class cmd_push_kernel(Command):
-    help = "Push the kernel binaries"
+    help = "Push the kernel build artifacts"
     args = [Args.kdir, Args.api, Args.db_token]
-    opt_args = [Args.install_path, Args.db_config]
+    opt_args = [Args.output, Args.db_config]
 
     def __call__(self, configs, args):
-        return kernelci.build.push_kernel(args.kdir, args.api, args.db_token,
-                                          args.install_path)
+        meta = kernelci.build.MetaStep(args.kdir, args.output)
+        publish_path = meta.get_value("kernel", "publish_path")
+        artifacts = kernelci.storage.discover_files(meta.install_path)
+        print("Upload path: {}".format(publish_path))
+        kernelci.storage.upload_files(
+            args.api, args.db_token, publish_path, artifacts
+        )
+        return True
 
 
 class cmd_publish_kernel(Command):

--- a/kci_build
+++ b/kci_build
@@ -337,7 +337,7 @@ class MakeCommand(Command):
         if not step.is_enabled():
             print("Not enabled, skipping.")
             return True
-        res = self._run_step(step, args)
+        res = self._run_step(step, args, configs)
         if args.install:
             install_res = self._install_step(step, args)
             res = res and install_res
@@ -348,7 +348,7 @@ class MakeCommand(Command):
             raise ValueError("Step class not defined.")
         return self.step_cls(args.kdir, args.output, args.log)
 
-    def _run_step(self, step, args):
+    def _run_step(self, step, args, configs):
         return step.run(args.j, args.verbose)
 
     def _install_step(self, step, args):
@@ -360,7 +360,7 @@ class cmd_make_config(MakeCommand):
     args = MakeCommand.args + [Args.defconfig]
     step_cls = kernelci.build.MakeConfig
 
-    def _run_step(self, step, args):
+    def _run_step(self, step, args, configs):
         return step.run(args.defconfig, args.j, args.verbose)
 
 

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -856,6 +856,17 @@ class MakeConfig(Step):
 
         return opts, configs, fragments, extras
 
+    def _expand_defconfig(self, defconfig, frags):
+        split = defconfig.split('+')
+        expanded = [split.pop(0)]
+        for part in split:
+            frag = frags.get(part)
+            if frag:
+                expanded.append(frag.path)
+            else:
+                expanded.append(part)
+        return '+'.join(expanded)
+
     def _gen_kci_frag(self, configs, fragments, name):
         kci_frag_path = os.path.join(self._output_path, name)
         with open(kci_frag_path, 'w') as kci_frag:
@@ -895,7 +906,7 @@ scripts/kconfig/merge_config.sh -O {output} '{base}' '{frag}' {redir}
             cmd = self._output_to_file(cmd, self._log_path, self._kdir)
         return shell_cmd(cmd, True)
 
-    def run(self, defconfig, jopt=None, verbose=False, frag='kernelci.config'):
+    def run(self, defconfig, frags_config, jopt=None, verbose=False):
         """Make the kernel config
 
         Make the kernel .config file using a number of options.  This will
@@ -908,22 +919,24 @@ scripts/kconfig/merge_config.sh -O {output} '{base}' '{frag}' {redir}
         and fragments.
 
         *defconfig* is the defconfig name, e.g. defconfig, x86_64_defconfig...
+        *frags_config* is a dict with the Fragment configuration objects
         *jopt* is the `make -j` option which will default to `nproc + 2`
         *verbose* is whether the build output should be shown
-        *frag* is the name of the output kernel config fragment
         """
-        elements = defconfig.split('+')
+        defconfig_expanded = self._expand_defconfig(defconfig, frags_config)
+        elements = defconfig_expanded.split('+')
         target = elements.pop(0)
         kci_frag_name = None
         opts, configs, fragments, extras = self._parse_elements(elements)
 
         if configs or fragments:
-            kci_frag_name = frag
+            kci_frag_name = 'kernelci.config'
             self._gen_kci_frag(configs, fragments, kci_frag_name)
 
         self._bmeta['kernel'] = {
             'defconfig': target,
             'defconfig_full': defconfig,
+            'defconfig_expanded': defconfig_expanded,
             'defconfig_extras': extras,
         }
 

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -749,6 +749,35 @@ class Step:
         return status
 
 
+class MetaStep(Step):
+    """Access the existing meta-data without running any actual step"""
+
+    def __init__(self, kdir, output_path=None):
+        super().__init__(kdir, output_path, 'meta')
+
+    def get_value(self, *keys):
+        """Find some meta-data value
+
+        Without any argument, all the meta-data dictionary will be returned.
+        Otherwise, each argument will be used to look up the meta-data
+        recursively.  For example, to get the build status use
+        `.get_meta("build", "status")`.  If the key doesn't exist, None is
+        returned.
+
+        *keys* is an arbitary number of keys to look up the meta-data
+        """
+        if len(keys) == 0:
+            return self._bmeta
+        if len(keys) == 1:
+            return self._bmeta.get(keys[0])
+        value = self._bmeta
+        for key in keys:
+            value = value.get(key)
+            if value is None:
+                break
+        return value
+
+
 class RevisionData(Step):
 
     @property

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -933,11 +933,22 @@ scripts/kconfig/merge_config.sh -O {output} '{base}' '{frag}' {redir}
             kci_frag_name = 'kernelci.config'
             self._gen_kci_frag(configs, fragments, kci_frag_name)
 
+        rev, env = (self._bmeta[cat] for cat in ('revision', 'environment'))
+        publish_path = '/'.join(item.replace('/', '-') for item in [
+            rev['tree'],
+            rev['branch'],
+            rev['describe'],
+            env['arch'],
+            defconfig,
+            env['name'],
+        ])
+
         self._bmeta['kernel'] = {
             'defconfig': target,
             'defconfig_full': defconfig,
             'defconfig_expanded': defconfig_expanded,
             'defconfig_extras': extras,
+            'publish_path': publish_path,
         }
 
         res = self._make(target, jopt, verbose, opts)

--- a/kernelci/storage.py
+++ b/kernelci/storage.py
@@ -21,6 +21,24 @@ from urllib.parse import urljoin
 from kernelci import shell_cmd
 
 
+def discover_files(path):
+    """Discover files recustively so they can then be uploaded
+
+    Recursively walk through a file hierarchy and return a dictionary with the
+    file paths and open file objects which can then be passed directly to
+    upload_files().
+
+    *path* is the path to the file hierarchy where to look for files
+    """
+    artifacts = {}
+    for root, _, files in os.walk(path):
+        for fname in files:
+            px = os.path.relpath(root, path)
+            artifacts[os.path.join(px, fname)] = open(
+                os.path.join(root, fname), "rb")
+    return artifacts
+
+
 def upload_files(api, token, path, input_files):
     """Upload rootfs to KernelCI backend.
 


### PR DESCRIPTION
Refactor the `kci_build push_kernel` implementation to use the new meta-data based on `kenrelci.build.Step`.

Note: Other changes for `kci_build publish_kernel` and in `kernelci-backend` are required before this can be enabled on staging, hence the `staging-skip` tag.