### PR TITLE
k8s: build kernels using normal storage

### DIFF
--- a/config/k8s/job-build.jinja2
+++ b/config/k8s/job-build.jinja2
@@ -33,7 +33,7 @@ spec:
           name: scratch-volume
 
         command: ["/bin/bash", "-x", "-c"]
-        args: ["cd /scratch && git clone --depth=1 --branch ${KCI_CORE_BRANCH} ${KCI_CORE_URL}"]
+        args: ["mkdir -p /tmp/kci && cd /scratch && git clone --depth=1 --branch ${KCI_CORE_BRANCH} ${KCI_CORE_URL}"]
 
         env:
         - name: KCI_CORE_URL
@@ -51,7 +51,7 @@ spec:
 
         command: ["/bin/bash", "-x", "-c"]
         args: ["echo nproc=$(nproc); df; free; \
-export KDIR=/scratch/linux && export CCACHE_DISABLE=true && \
+export KDIR=/tmp/kci/linux && export CCACHE_DISABLE=true && \
 cd /scratch/kernelci-core &&  \
 ./kci_build pull_tarball --kdir ${KDIR} --url ${SRC_TARBALL} --retries 3 --delete && \
 ./kci_build build_kernel --kdir ${KDIR} --output ${KDIR} --defconfig=${DEFCONFIG} --arch=${ARCH} --build-env=${BUILD_ENVIRONMENT} --verbose ${PARALLEL_JOPT}; export KERNEL_BUILD_RESULT=$?; \


### PR DESCRIPTION
Currently, we build everything in a memory-backed tmpfs using a volume
with the properties:

  emptyDir: { medium: "Memory" }

However, k8s limits the max size of tmpfs volumes to 50% of the memory
of the node.  The smallest nodes we use have 16G of memory, leading to
a max size tmpfs of 8Gb.

Some kernel builds (notably arm64 defconfig using CONFIG_DEBUG_INFO=y)
can have build artifacts that, combined with the kernel source, exceed
this limit.

To workaround that, don't build the kernel in tmpfs, instead just use
the default storage, backed by whatever storage is configured for the
cluster (typically an SSD disk.)

Signed-off-by: Kevin Hilman <khilman@baylibre.com>