### PR TITLE
T25311 publish kernel

### DIFF
--- a/config/core/db-configs.yaml
+++ b/config/core/db-configs.yaml
@@ -2,12 +2,12 @@ db_configs:
 
   kernelci.org:
     db_type: kernelci_backend
-    url: https://api.kernelci.org/test
+    url: https://api.kernelci.org/
 
   staging.kernelci.org:
     db_type: kernelci_backend
-    url: https://api.staging.kernelci.org/test
+    url: https://api.staging.kernelci.org/
 
   localhost:
     db_type: kernelci_backend
-    url: http://localhost:5001/test
+    url: http://localhost:5001/

--- a/kci_data
+++ b/kci_data
@@ -18,6 +18,7 @@
 # along with this library; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+import json
 import sys
 
 from kernelci.cli import Args, Command, parse_opts
@@ -54,8 +55,8 @@ class cmd_submit(Command):
         if args.data_file == '-':
             data = sys.stdin.read()
         else:
-            with open(args.data_file, 'r') as f:
-                data = f.read()
+            with open(args.data_file, 'r') as json_file:
+                data = json.load(json_file)
         db = kernelci.data.get_db(config, args.db_token)
         return db.submit(data, args.verbose)
 

--- a/kci_data
+++ b/kci_data
@@ -57,7 +57,7 @@ class cmd_submit(Command):
             with open(args.data_file, 'r') as f:
                 data = f.read()
         db = kernelci.data.get_db(config, args.db_token)
-        return db.submit(data, 'test', args.verbose)
+        return db.submit(data, args.verbose)
 
 
 if __name__ == '__main__':

--- a/kci_data
+++ b/kci_data
@@ -74,6 +74,19 @@ class cmd_submit_build(Command):
         return db.submit_build(meta, args.verbose)
 
 
+class cmd_submit_test(Command):
+    help = "Submit test results"
+    args = [Args.db_config, Args.data_file]
+    opt_args = [Args.db_token, Args.verbose]
+
+    def __call__(self, config_data, args):
+        config = config_data['db_configs'][args.db_config]
+        with open(args.data_file, 'r') as json_file:
+            data = json.load(json_file)
+        db = kernelci.data.get_db(config, args.db_token)
+        return db.submit_test(data, args.verbose)
+
+
 if __name__ == '__main__':
     opts = parse_opts("kci_data", "config/core/db-configs.yaml", globals())
     configs = kernelci.config.data.from_yaml(opts.yaml_configs)

--- a/kci_data
+++ b/kci_data
@@ -22,6 +22,7 @@ import json
 import sys
 
 from kernelci.cli import Args, Command, parse_opts
+import kernelci.build
 import kernelci.config.data
 import kernelci.data
 
@@ -59,6 +60,18 @@ class cmd_submit(Command):
                 data = json.load(json_file)
         db = kernelci.data.get_db(config, args.db_token)
         return db.submit(data, args.verbose)
+
+
+class cmd_submit_build(Command):
+    help = "Submit meta-data for a kernel build"
+    args = [Args.kdir, Args.db_config]
+    opt_args = [Args.db_token, Args.output, Args.verbose]
+
+    def __call__(self, config_data, args):
+        config = config_data['db_configs'][args.db_config]
+        meta = kernelci.build.MetaStep(args.kdir, args.output)
+        db = kernelci.data.get_db(config, args.db_token)
+        return db.submit_build(meta, args.verbose)
 
 
 if __name__ == '__main__':

--- a/kci_data
+++ b/kci_data
@@ -57,7 +57,7 @@ class cmd_submit(Command):
             with open(args.data_file, 'r') as f:
                 data = f.read()
         db = kernelci.data.get_db(config, args.db_token)
-        return db.submit(data, args.verbose)
+        return db.submit(data, 'test', args.verbose)
 
 
 if __name__ == '__main__':

--- a/kernelci/data/__init__.py
+++ b/kernelci/data/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2020 Collabora Limited
 # Author: Michal Galka <michal.galka@collabora.com>
+# Author: Guillaume Tucker <guillaume.tucker@collabora.com>
 #
 # This module is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
@@ -19,16 +20,35 @@ import importlib
 
 
 class Database:
+    """KernelCI database interface"""
 
     def __init__(self, config, token=None):
+        """Handle KernelCI data and communicate with any supported database
+
+        This abstract class provides an interface for exchanging data with a
+        database using an arbitrary implementation.  It also provides common
+        logic when applicable, to handle KernelCI data in a generic way.
+
+        *config* is the database configuration object
+        *token* is an authentication token for the database
+        """
         self._config = config
         self._token = token
 
-    def submit(self, data):
+    def submit(self, data, path=None, verbose=False):
+        """Submit arbitrary data to the database
+
+        Primitive method to send some data to the database.
+
+        *data* is the payload to send to the database
+        *path* is to identify the part of the API to use to send the data
+        *verbose* is to print more information
+        """
         raise NotImplementedError("Database.submit() must be implemented")
 
     @property
     def config(self):
+        """Database configuration"""
         return self._config
 
 

--- a/kernelci/data/__init__.py
+++ b/kernelci/data/__init__.py
@@ -35,6 +35,11 @@ class Database:
         self._config = config
         self._token = token
 
+    @property
+    def config(self):
+        """Database configuration"""
+        return self._config
+
     def submit(self, data, verbose=False):
         """Submit arbitrary data to the database
 
@@ -45,10 +50,16 @@ class Database:
         """
         raise NotImplementedError("Database.submit() must be implemented")
 
-    @property
-    def config(self):
-        """Database configuration"""
-        return self._config
+    def submit_build(self, meta, verbose=False):
+        """Submit meta-data for a kernel build
+
+        Alternative entry point to submit the kernel build meta-data from a
+        build.MetaStep object.
+
+        *meta* is a kernelci.build.MetaStep object
+        *verbose* is to print more information
+        """
+        raise NotImplementedError("Database.submit_build() not implemented")
 
 
 def get_db(config, token=None):

--- a/kernelci/data/__init__.py
+++ b/kernelci/data/__init__.py
@@ -35,13 +35,12 @@ class Database:
         self._config = config
         self._token = token
 
-    def submit(self, data, path=None, verbose=False):
+    def submit(self, data, verbose=False):
         """Submit arbitrary data to the database
 
         Primitive method to send some data to the database.
 
-        *data* is the payload to send to the database
-        *path* is to identify the part of the API to use to send the data
+        *data* is a dictionary with the data to send to the database
         *verbose* is to print more information
         """
         raise NotImplementedError("Database.submit() must be implemented")

--- a/kernelci/data/__init__.py
+++ b/kernelci/data/__init__.py
@@ -61,6 +61,16 @@ class Database:
         """
         raise NotImplementedError("Database.submit_build() not implemented")
 
+    def submit_test(self, results, verbose=False):
+        """Submit test results
+
+        Alternative entry point to submit test results.
+
+        *results* is a dictionary with the test results data
+        *verbose* is to print more information
+        """
+        raise NotImplementedError("Database.submit_test() not implemented")
+
 
 def get_db(config, token=None):
     m = importlib.import_module('.'.join(['kernelci', 'data', config.db_type]))

--- a/kernelci/data/kernelci_backend.py
+++ b/kernelci/data/kernelci_backend.py
@@ -16,7 +16,6 @@
 # along with this library; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-import json
 import requests
 import urllib
 from kernelci.data import Database
@@ -38,8 +37,7 @@ class KernelCIBackend(Database):
             print(resp.text)
 
     def submit(self, data, verbose=False):
-        json_data = json.loads(data)
-        for path, item in json_data.items():
+        for path, item in data.items():
             self._submit(path, item, verbose)
         return True
 

--- a/kernelci/data/kernelci_backend.py
+++ b/kernelci/data/kernelci_backend.py
@@ -60,6 +60,9 @@ class KernelCIBackend(Database):
         }
         return self._submit('build',  data, verbose)
 
+    def submit_test(self, results, verbose=False):
+        self._submit('test', results, verbose)
+
 
 def get_db(config, token):
     """Get a KernelCI backend database object"""

--- a/kernelci/data/kernelci_backend.py
+++ b/kernelci/data/kernelci_backend.py
@@ -28,16 +28,19 @@ class KernelCIBackend(Database):
         super().__init__(config, token)
         if self._token is None:
             raise ValueError("API token required for kernelci_backend")
+        self._headers = {'Authorization': self._token}
 
-    def submit(self, data, path=None, verbose=False):
-        if path is None:
-            return False
+    def _submit(self, path, data, verbose):
         url = urllib.parse.urljoin(self.config.url, path)
-        resp = requests.post(url, json=json.loads(data),
-                             headers={'Authorization': self._token})
+        resp = requests.post(url, json=data, headers=self._headers)
         resp.raise_for_status()
         if verbose:
             print(resp.text)
+
+    def submit(self, data, verbose=False):
+        json_data = json.loads(data)
+        for path, item in json_data.items():
+            self._submit(path, item, verbose)
         return True
 
 

--- a/kernelci/data/kernelci_backend.py
+++ b/kernelci/data/kernelci_backend.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 Collabora Limited
+# Copyright (C) 2020, 2021 Collabora Limited
 # Author: Michal Galka <michal.galka@collabora.com>
 # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
 #
@@ -18,6 +18,7 @@
 
 import json
 import requests
+import urllib
 from kernelci.data import Database
 
 
@@ -28,8 +29,11 @@ class KernelCIBackend(Database):
         if self._token is None:
             raise ValueError("API token required for kernelci_backend")
 
-    def submit(self, data, verbose=False):
-        resp = requests.post(self.config.url, json=json.loads(data),
+    def submit(self, data, path=None, verbose=False):
+        if path is None:
+            return False
+        url = urllib.parse.urljoin(self.config.url, path)
+        resp = requests.post(url, json=json.loads(data),
                              headers={'Authorization': self._token})
         resp.raise_for_status()
         if verbose:

--- a/kernelci/data/kernelci_backend.py
+++ b/kernelci/data/kernelci_backend.py
@@ -16,6 +16,7 @@
 # along with this library; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+import json
 import requests
 import urllib
 from kernelci.data import Database
@@ -40,6 +41,24 @@ class KernelCIBackend(Database):
         for path, item in data.items():
             self._submit(path, item, verbose)
         return True
+
+    def submit_build(self, meta, verbose=False):
+        revision, kernel, env = (
+            meta.get_value(key) for key in [
+                'revision', 'kernel', 'environment']
+        )
+        data = {  # ToDo clean-up names and remove duplicates...
+            'path': kernel['publish_path'],
+            'file_server_resource': kernel['publish_path'],
+            'job': revision['tree'],
+            'git_branch': revision['branch'],
+            'arch': env['arch'],
+            'kernel': revision['describe'],
+            'build_environment': env['name'],
+            'defconfig': kernel['defconfig'],
+            'defconfig_full': kernel['defconfig_full'],
+        }
+        return self._submit('build',  data, verbose)
 
 
 def get_db(config, token):


### PR DESCRIPTION
Update implementation to submit the kernel build meta-data to the backend:
* move the "publish_kernel" from kci_build to kci_data since it's sent via the Database abstract interface.
* use the MetaStep class to load the build meta-data and pass it to the Database.submit_build() method
* generalise the Database.submit() method by including the "path" for the data in the payload (e.g. "test", "build"...)

This is still a work in progress as ideally it should be possible to just use the Database.submit() method.  Things may be simplified when all the components have been updated with the new meta-data format.

Depends on #612. 