### PR TITLE
test-configs: Add stm32mp157c-lxa-mc1

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1271,6 +1271,13 @@ device_types:
     filters:
       - blocklist: {defconfig: ['stm32_defconfig']}
 
+  stm32mp157c-lxa-mc1:
+    mach: stm32
+    class: arm-dtb
+    boot_method: barebox
+    filters:
+      - blocklist: {defconfig: ['stm32_defconfig']}
+
   sun4i-a10-olinuxino-lime:
     mach: allwinner
     class: arm-dtb
@@ -2163,6 +2170,10 @@ test_configs:
       - sleep
 
   - device_type: stm32mp157c-dk2
+    test_plans:
+      - baseline
+
+  - device_type: stm32mp157c-lxa-mc1
     test_plans:
       - baseline
 


### PR DESCRIPTION
This patch adds support for stm32mp157c-lxa-mc1
LAVA device-type is upstreamed: https://git.lavasoftware.org/lava/lava/-/merge_requests/1438