### PR TITLE
docker: Add clang-12 containers

### DIFF
--- a/jenkins/dockerfiles/clang-12/Dockerfile
+++ b/jenkins/dockerfiles/clang-12/Dockerfile
@@ -1,0 +1,44 @@
+FROM kernelci/build-base
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    software-properties-common \
+    gnupg2
+
+RUN wget -q -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+RUN apt-add-repository 'deb http://apt.llvm.org/buster/ llvm-toolchain-buster-12 main'
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    binutils-aarch64-linux-gnu \
+    binutils-arm-linux-gnueabihf \
+    binutils \
+    clang-12 lld-12 llvm-12
+
+ENV PATH=/usr/lib/llvm-12/bin:${PATH}
+
+# kselftest x86
+RUN apt-get update && apt-get install --no-install-recommends -y \
+   libc6-dev \
+   libcap-dev \
+   libcap-ng-dev \
+   libelf-dev \
+   libpopt-dev
+
+# kselftest arm64
+RUN dpkg --add-architecture arm64
+RUN apt-get update && apt-get install --no-install-recommends -y \
+   libc6-dev:arm64 \
+   libcap-dev:arm64 \
+   libcap-ng-dev:arm64 \
+   libelf-dev:arm64 \
+   libpopt-dev:arm64
+
+# kselftest arm
+RUN dpkg --add-architecture armhf
+RUN apt-get update && apt-get install --no-install-recommends -y \
+   libc6-dev:armhf \
+   libcap-dev:armhf \
+   libcap-ng-dev:armhf \
+   libelf-dev:armhf \
+   libpopt-dev:armhf
+
+RUN apt-get autoremove -y gcc


### PR DESCRIPTION
clang-12 is due for release any day now so let's add clang-12 containers
so we can use them to enable build testing with it.

Signed-off-by: Mark Brown <broonie@kernel.org>