### PR TITLE
test-configs.yaml: Remove ltp-mm from a Collabora lab device

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1623,7 +1623,6 @@ test_configs:
       - baseline
       - ltp-crypto
       - ltp-ipc
-      - ltp-mm
       - sleep
       - usb
 


### PR DESCRIPTION
Remove ltp-mm job from Collabora device bcm2836-rpi-2-b-cbg-0

Signed-off-by: lakshmipathi.g <lakshmipathi.ganapathi@collabora.com>