### PR TITLE
test-configs.yaml: update Debian rootfs URLs

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -33,30 +33,30 @@ file_systems:
 
   debian_buster_ramdisk:
     type: debian
-    ramdisk: 'buster/20210315.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'buster/20210324.0/{arch}/rootfs.cpio.gz'
 
   debian_buster_nfs:
     type: debian
-    ramdisk: 'buster/20210315.0/{arch}/initrd.cpio.gz'
-    nfs: 'buster/20210315.0/{arch}/full.rootfs.tar.xz'
+    ramdisk: 'buster/20210324.0/{arch}/initrd.cpio.gz'
+    nfs: 'buster/20210324.0/{arch}/full.rootfs.tar.xz'
     root_type: nfs
 
   debian_buster-cros-ec_ramdisk:
     type: debian
-    ramdisk: 'buster-cros-ec/20210315.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'buster-cros-ec/20210324.0/{arch}/rootfs.cpio.gz'
 
   debian_buster-igt_ramdisk:
     type: debian
-    ramdisk: 'buster-igt/20210315.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'buster-igt/20210324.0/{arch}/rootfs.cpio.gz'
 
   debian_buster-v4l2_ramdisk:
     type: debian
-    ramdisk: 'buster-v4l2/20210315.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'buster-v4l2/20210324.0/{arch}/rootfs.cpio.gz'
 
   debian_buster-ltp_nfs:
     type: debian
-    ramdisk: 'buster-ltp/20210208.0/{arch}/initrd.cpio.gz'
-    nfs: 'buster-ltp/20210208.0/{arch}/full.rootfs.tar.xz'
+    ramdisk: 'buster-ltp/20210324.0/{arch}/initrd.cpio.gz'
+    nfs: 'buster-ltp/20210324.0/{arch}/full.rootfs.tar.xz'
     root_type: nfs
 
 


### PR DESCRIPTION
Update all the Debian rootfs URLs including buster-ltp as the builds
are now completing for all 3 architectures.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>