### PR TITLE
T24799 docker qemu fixup

### DIFF
--- a/config/core/lab-configs.yaml
+++ b/config/core/lab-configs.yaml
@@ -9,8 +9,6 @@ labs:
       - passlist:
           plan:
             - baseline
-            - baseline-fastboot
-            - baseline-qemu-docker
             - kselftest
             - preempt-rt
 
@@ -35,7 +33,6 @@ labs:
       - passlist:
           plan:
             - baseline
-            - baseline-nfs
             - sleep
           tree:
             - kernelci
@@ -48,7 +45,9 @@ labs:
     lab_type: lava
     url: 'https://lava.collabora.co.uk/RPC2/'
     filters:
-      - blocklist: {tree: [android]}
+      - blocklist:
+          tree: [android]
+          plan: [baseline-qemu-docker]
       - passlist:
           plan:
             - baseline
@@ -75,7 +74,6 @@ labs:
       - passlist:
           plan:
             - baseline
-            - baseline-nfs
 
   lab-linaro-lkft:
     lab_type: lava
@@ -85,7 +83,6 @@ labs:
       - passlist:
           plan:
             - baseline
-            - baseline-uefi
           tree:
             - kernelci
             - next
@@ -100,7 +97,6 @@ labs:
       - passlist:
           plan:
             - baseline
-            - baseline-nfs
 
   lab-nxp:
     lab_type: lava
@@ -109,6 +105,7 @@ labs:
       - passlist:
           plan:
             - baseline
+      - blocklist: {plan: [baseline-qemu-docker]}
 
   lab-pengutronix:
     lab_type: lava
@@ -117,6 +114,7 @@ labs:
       - passlist:
           plan:
             - baseline
+      - blocklist: {plan: [baseline-qemu-docker]}
 
   lab-theobroma-systems:
     lab_type: lava
@@ -125,3 +123,4 @@ labs:
       - passlist:
           plan:
             - baseline
+      - blocklist: {plan: [baseline-qemu-docker]}


### PR DESCRIPTION
Depends on #558 to be merged first.

This fixes the "baseline" test plan filters in `lab-configs.yaml`.