### PR TITLE
T25311 bmeta fixup

### DIFF
--- a/kci_build
+++ b/kci_build
@@ -282,6 +282,7 @@ class cmd_init_bmeta(Command):
     args = [Args.kdir]
     opt_args = [Args.output, Args.build_config, Args.install,
                 Args.tree_name, Args.tree_url, Args.branch,
+                Args.commit, Args.describe, Args.describe_verbose,
                 Args.build_env, Args.arch]
 
     def __call__(self, configs, args):
@@ -305,7 +306,8 @@ or
 
         step = kernelci.build.RevisionData(args.kdir, args.output, reset=True)
         print("Initialising build meta-data in {}".format(args.output))
-        res = step.run(tree_name, tree_url, branch)
+        res = step.run(tree_name, tree_url, branch,
+                       args.commit, args.describe, args.describe_verbose)
 
         if args.install:
             print("Install directory: {}".format(step.install_path))

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -755,7 +755,8 @@ class RevisionData(Step):
     def name(self):
         return 'revision'
 
-    def run(self, tree_name, tree_url, branch):
+    def run(self, tree_name, tree_url, branch,
+            commit=None, describe=None, describe_v=None):
         """Add all the meta-data related to the current kernel revision.
 
         This step retrieves the revision information from the current kernel
@@ -765,14 +766,23 @@ class RevisionData(Step):
         *tree_name* is the short name of the kernel tree e.g. mainline, next...
         *tree_url* is the URL of the remote Git repository for the tree
         *branch* is the name of the Git branch
+
+        Optional arguments:
+
+        *commit* is the Git commit checksum, if None it will be determined
+                 automatically
+        *describe* is the Git describe string, if None it will be determined
+                   automatically
+        *describe_v* is the Git describe "verbose" string, if None it will be
+                     determined automatically
         """
         self._bmeta['revision'] = {
             'tree': tree_name,
             'url': tree_url,
             'branch': branch,
-            'describe': git_describe(tree_name, self._kdir),
-            'describe_v': git_describe_verbose(self._kdir),
-            'commit': head_commit(self._kdir),
+            'describe': describe or git_describe(tree_name, self._kdir),
+            'describe_v': describe_v or git_describe_verbose(self._kdir),
+            'commit': commit or head_commit(self._kdir),
         }
         return self._add_run_step(True)
 


### PR DESCRIPTION
Add extra optional arguments to `RevisionData.run()` for when building a kernel source tree that is not a Git repository (e.g. a extracted from a source tarball).