### PR TITLE
test-configs.yaml: Remove ltp-mm from odroid-xu3 and beaglebone-black

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1651,7 +1651,6 @@ test_configs:
       - baseline-nfs
       - ltp-crypto
       - ltp-ipc
-      - ltp-mm
 
   - device_type: cubietruck
     test_plans:
@@ -1979,7 +1978,6 @@ test_configs:
       - baseline-nfs
       - igt-kms-exynos
       - ltp-ipc
-      - ltp-mm
       - sleep
       - usb
 


### PR DESCRIPTION
To prevent longer queue and job wait time remove ltp-mm from
odroid-xu3 and beaglebone-black devices.

Signed-off-by: lakshmipathi <lakshmipathi.ganapathi@collabora.com>