### PR TITLE
Use new build meta-data

### DIFF
--- a/config/core/db-configs.yaml
+++ b/config/core/db-configs.yaml
@@ -2,12 +2,12 @@ db_configs:
 
   kernelci.org:
     db_type: kernelci_backend
-    url: https://api.kernelci.org/test
+    url: https://api.kernelci.org/
 
   staging.kernelci.org:
     db_type: kernelci_backend
-    url: https://api.staging.kernelci.org/test
+    url: https://api.staging.kernelci.org/
 
   localhost:
     db_type: kernelci_backend
-    url: http://localhost:5001/test
+    url: http://localhost:5001/

--- a/config/k8s/gen.py
+++ b/config/k8s/gen.py
@@ -38,7 +38,7 @@ parallel_builds = os.getenv('PARALLEL_BUILDS')
 if parallel_builds:
     parallel_builds = int(parallel_builds)
     cpu_limit = min(cpu_limit, parallel_builds)
-    os.environ['PARALLEL_JOPT'] = "-j{}".format(parallel_builds)
+    os.environ['PARALLEL_JOPT'] = "{}".format(parallel_builds)
 
 if (cpu_limit < 8):
     cpu_request = cpu_limit * 0.875

--- a/config/k8s/job-build.jinja2
+++ b/config/k8s/job-build.jinja2
@@ -50,15 +50,61 @@ spec:
           name: scratch-volume
 
         command: ["/bin/bash", "-x", "-c"]
-        args: ["echo nproc=$(nproc); df; free; \
+        args: ["\
+echo nproc=$(nproc); df; free; \
 export KDIR=/tmp/kci/linux && export CCACHE_DISABLE=true && \
 cd /scratch/kernelci-core &&  \
-./kci_build pull_tarball --kdir ${KDIR} --url ${SRC_TARBALL} --retries 3 --delete && \
-./kci_build build_kernel --kdir ${KDIR} --output ${KDIR} --defconfig=${DEFCONFIG} --arch=${ARCH} --build-env=${BUILD_ENVIRONMENT} --verbose ${PARALLEL_JOPT}; export KERNEL_BUILD_RESULT=$?; \
-./kci_build install_kernel --kdir ${KDIR} --output ${KDIR} --build-config ${BUILD_CONFIG} --describe=${GIT_DESCRIBE} --describe-verbose=${GIT_DESCRIBE_VERBOSE} --commit=${COMMIT_ID}; \
-./kci_build push_kernel --kdir ${KDIR} --db-token=${KCI_API_TOKEN} --api=${KCI_API_URL}; \
-./kci_build publish_kernel --kdir ${KDIR} --db-token=${KCI_API_TOKEN} --api=${KCI_API_URL}; \
-echo KERNEL_BUILD_RESULT=$KERNEL_BUILD_RESULT; \
+\
+set +x; \
+[ -n \"${PARALLEL_JOPT}\" ] && jopt=\"j: ${PARALLEL_JOPT}\n\" || jopt=; \
+echo -e \"\
+[DEFAULT]\n\
+kdir: ${KDIR}\n\
+verbose: true\n\
+db_config: staging.kernelci.org\n\
+\n\
+[db:staging.kernelci.org]\n\
+db_token: ${KCI_API_TOKEN}\n\
+api: ${KCI_API_URL}\n\
+\n\
+[kci_build]\n\
+${jopt}\
+build_env: ${BUILD_ENVIRONMENT}\n\
+arch: ${ARCH}\n\
+output: ${KDIR}/build\n\
+install: true\n\
+\n\
+[kci_data]\n\
+output: ${KDIR}/build\n\
+\" > kernelci.conf; \
+set -x; \
+\
+./kci_build pull_tarball \
+  --url ${SRC_TARBALL} \
+  --retries 3 \
+  --delete; \
+\
+./kci_build init_bmeta \
+  --build-config=${BUILD_CONFIG} \
+  --commit=${COMMIT_ID} \
+  --describe=${GIT_DESCRIBE} \
+  --describe-verbose=${GIT_DESCRIBE_VERBOSE}; \
+\
+./kci_build make_config --defconfig=${DEFCONFIG} && \
+./kci_build make_kernel && \
+./kci_build make_modules && \
+./kci_build make_dtbs && \
+./kci_build make_kselftest; \
+export KERNEL_BUILD_RESULT=$?;
+\
+set +x; \
+echo Build result: ${KERNEL_BUILD_RESULT}; \
+echo; echo bmeta.json; cat ${KDIR}/build/bmeta.json; \
+echo; echo _install_; ls -l ${KDIR}/build/_install_; \
+\
+./kci_build push_kernel; \
+./kci_data submit_build; \
+\
 exit 0; \
 "]
 

--- a/kci_build
+++ b/kci_build
@@ -361,7 +361,8 @@ class cmd_make_config(MakeCommand):
     step_cls = kernelci.build.MakeConfig
 
     def _run_step(self, step, args, configs):
-        return step.run(args.defconfig, args.j, args.verbose)
+        frags_config = configs['fragments']
+        return step.run(args.defconfig, frags_config, args.j, args.verbose)
 
 
 class cmd_make_kernel(MakeCommand):

--- a/kci_build
+++ b/kci_build
@@ -306,7 +306,7 @@ or
             return False
 
         step = kernelci.build.RevisionData(args.kdir, args.output, reset=True)
-        print("Initialising build meta-data in {}".format(args.output))
+        print("Initialising build meta-data in {}".format(step.output_path))
         res = step.run(tree_name, tree_url, branch,
                        args.commit, args.describe, args.describe_verbose)
 

--- a/kci_build
+++ b/kci_build
@@ -440,9 +440,10 @@ class cmd_push_kernel(Command):
     opt_args = [Args.output, Args.db_config]
 
     def __call__(self, configs, args):
-        meta = kernelci.build.MetaStep(args.kdir, args.output)
-        publish_path = meta.get_value("kernel", "publish_path")
-        artifacts = kernelci.storage.discover_files(meta.install_path)
+        install = kernelci.build.Step.get_install_path(args.kdir, args.output)
+        meta = kernelci.build.Metadata(install)
+        publish_path = meta.get('bmeta', 'kernel', 'publish_path')
+        artifacts = kernelci.storage.discover_files(install)
         print("Upload path: {}".format(publish_path))
         kernelci.storage.upload_files(
             args.api, args.db_token, publish_path, artifacts

--- a/kci_build
+++ b/kci_build
@@ -282,6 +282,7 @@ class cmd_init_bmeta(Command):
     args = [Args.kdir]
     opt_args = [Args.output, Args.build_config, Args.install,
                 Args.tree_name, Args.tree_url, Args.branch,
+                Args.commit, Args.describe, Args.describe_verbose,
                 Args.build_env, Args.arch]
 
     def __call__(self, configs, args):
@@ -305,7 +306,8 @@ or
 
         step = kernelci.build.RevisionData(args.kdir, args.output, reset=True)
         print("Initialising build meta-data in {}".format(args.output))
-        res = step.run(tree_name, tree_url, branch)
+        res = step.run(tree_name, tree_url, branch,
+                       args.commit, args.describe, args.describe_verbose)
 
         if args.install:
             print("Install directory: {}".format(step.install_path))

--- a/kci_build
+++ b/kci_build
@@ -307,8 +307,14 @@ or
 
         step = kernelci.build.RevisionData(args.kdir, args.output, reset=True)
         print("Initialising build meta-data in {}".format(step.output_path))
-        res = step.run(tree_name, tree_url, branch,
-                       args.commit, args.describe, args.describe_verbose)
+        res = step.run(opts={
+            'tree': tree_name,
+            'url': tree_url,
+            'branch': branch,
+            'commit': args.commit,
+            'describe': args.describe,
+            'describe_verbose': args.describe_verbose
+        })
 
         if args.install:
             print("Install directory: {}".format(step.install_path))
@@ -321,7 +327,7 @@ Invalid arguments, --build-env and --arch need to be used together.""")
                 return False
             build_env = configs['build_environments'][args.build_env]
             step = kernelci.build.EnvironmentData(args.kdir, args.output)
-            res = step.run(build_env, args.arch)
+            res = step.run(opts={'build_env': build_env, 'arch': args.arch})
             if args.install:
                 step.install()
 
@@ -338,7 +344,8 @@ class MakeCommand(Command):
         if not step.is_enabled():
             print("Not enabled, skipping.")
             return True
-        res = self._run_step(step, args, configs)
+        opts = self._get_opts(args, configs)
+        res = step.run(args.j, args.verbose, opts)
         if args.install:
             install_res = self._install_step(step, args)
             res = res and install_res
@@ -349,8 +356,8 @@ class MakeCommand(Command):
             raise ValueError("Step class not defined.")
         return self.step_cls(args.kdir, args.output, args.log)
 
-    def _run_step(self, step, args, configs):
-        return step.run(args.j, args.verbose)
+    def _get_opts(self, args, configs):
+        return dict()
 
     def _install_step(self, step, args):
         return step.install(args.verbose)
@@ -361,9 +368,11 @@ class cmd_make_config(MakeCommand):
     args = MakeCommand.args + [Args.defconfig]
     step_cls = kernelci.build.MakeConfig
 
-    def _run_step(self, step, args, configs):
-        frags_config = configs['fragments']
-        return step.run(args.defconfig, frags_config, args.j, args.verbose)
+    def _get_opts(self, args, configs):
+        return {
+            'defconfig': args.defconfig,
+            'frags_config': configs['fragments'],
+        }
 
 
 class cmd_make_kernel(MakeCommand):

--- a/kci_build
+++ b/kci_build
@@ -23,6 +23,7 @@ from kernelci.cli import Args, Command, parse_opts
 import kernelci
 import kernelci.build
 import kernelci.config.build
+import kernelci.storage
 
 
 class cmd_validate(Command):
@@ -434,13 +435,19 @@ or
 
 
 class cmd_push_kernel(Command):
-    help = "Push the kernel binaries"
+    help = "Push the kernel build artifacts"
     args = [Args.kdir, Args.api, Args.db_token]
-    opt_args = [Args.install_path, Args.db_config]
+    opt_args = [Args.output, Args.db_config]
 
     def __call__(self, configs, args):
-        return kernelci.build.push_kernel(args.kdir, args.api, args.db_token,
-                                          args.install_path)
+        meta = kernelci.build.MetaStep(args.kdir, args.output)
+        publish_path = meta.get_value("kernel", "publish_path")
+        artifacts = kernelci.storage.discover_files(meta.install_path)
+        print("Upload path: {}".format(publish_path))
+        kernelci.storage.upload_files(
+            args.api, args.db_token, publish_path, artifacts
+        )
+        return True
 
 
 class cmd_publish_kernel(Command):

--- a/kci_build
+++ b/kci_build
@@ -337,7 +337,7 @@ class MakeCommand(Command):
         if not step.is_enabled():
             print("Not enabled, skipping.")
             return True
-        res = self._run_step(step, args)
+        res = self._run_step(step, args, configs)
         if args.install:
             install_res = self._install_step(step, args)
             res = res and install_res
@@ -348,7 +348,7 @@ class MakeCommand(Command):
             raise ValueError("Step class not defined.")
         return self.step_cls(args.kdir, args.output, args.log)
 
-    def _run_step(self, step, args):
+    def _run_step(self, step, args, configs):
         return step.run(args.j, args.verbose)
 
     def _install_step(self, step, args):
@@ -360,7 +360,7 @@ class cmd_make_config(MakeCommand):
     args = MakeCommand.args + [Args.defconfig]
     step_cls = kernelci.build.MakeConfig
 
-    def _run_step(self, step, args):
+    def _run_step(self, step, args, configs):
         return step.run(args.defconfig, args.j, args.verbose)
 
 

--- a/kci_data
+++ b/kci_data
@@ -18,6 +18,7 @@
 # along with this library; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+import json
 import sys
 
 from kernelci.cli import Args, Command, parse_opts
@@ -54,8 +55,8 @@ class cmd_submit(Command):
         if args.data_file == '-':
             data = sys.stdin.read()
         else:
-            with open(args.data_file, 'r') as f:
-                data = f.read()
+            with open(args.data_file, 'r') as json_file:
+                data = json.load(json_file)
         db = kernelci.data.get_db(config, args.db_token)
         return db.submit(data, args.verbose)
 

--- a/kci_data
+++ b/kci_data
@@ -57,7 +57,7 @@ class cmd_submit(Command):
             with open(args.data_file, 'r') as f:
                 data = f.read()
         db = kernelci.data.get_db(config, args.db_token)
-        return db.submit(data, 'test', args.verbose)
+        return db.submit(data, args.verbose)
 
 
 if __name__ == '__main__':

--- a/kci_data
+++ b/kci_data
@@ -74,6 +74,19 @@ class cmd_submit_build(Command):
         return db.submit_build(meta, args.verbose)
 
 
+class cmd_submit_test(Command):
+    help = "Submit test results"
+    args = [Args.db_config, Args.data_file]
+    opt_args = [Args.db_token, Args.verbose]
+
+    def __call__(self, config_data, args):
+        config = config_data['db_configs'][args.db_config]
+        with open(args.data_file, 'r') as json_file:
+            data = json.load(json_file)
+        db = kernelci.data.get_db(config, args.db_token)
+        return db.submit_test(data, args.verbose)
+
+
 if __name__ == '__main__':
     opts = parse_opts("kci_data", "config/core/db-configs.yaml", globals())
     configs = kernelci.config.data.from_yaml(opts.yaml_configs)

--- a/kci_data
+++ b/kci_data
@@ -69,7 +69,8 @@ class cmd_submit_build(Command):
 
     def __call__(self, config_data, args):
         config = config_data['db_configs'][args.db_config]
-        meta = kernelci.build.MetaStep(args.kdir, args.output)
+        install = kernelci.build.Step.get_install_path(args.kdir, args.output)
+        meta = kernelci.build.Metadata(install)
         db = kernelci.data.get_db(config, args.db_token)
         return db.submit_build(meta, args.verbose)
 

--- a/kci_data
+++ b/kci_data
@@ -22,6 +22,7 @@ import json
 import sys
 
 from kernelci.cli import Args, Command, parse_opts
+import kernelci.build
 import kernelci.config.data
 import kernelci.data
 
@@ -59,6 +60,18 @@ class cmd_submit(Command):
                 data = json.load(json_file)
         db = kernelci.data.get_db(config, args.db_token)
         return db.submit(data, args.verbose)
+
+
+class cmd_submit_build(Command):
+    help = "Submit meta-data for a kernel build"
+    args = [Args.kdir, Args.db_config]
+    opt_args = [Args.db_token, Args.output, Args.verbose]
+
+    def __call__(self, config_data, args):
+        config = config_data['db_configs'][args.db_config]
+        meta = kernelci.build.MetaStep(args.kdir, args.output)
+        db = kernelci.data.get_db(config, args.db_token)
+        return db.submit_build(meta, args.verbose)
 
 
 if __name__ == '__main__':

--- a/kci_data
+++ b/kci_data
@@ -57,7 +57,7 @@ class cmd_submit(Command):
             with open(args.data_file, 'r') as f:
                 data = f.read()
         db = kernelci.data.get_db(config, args.db_token)
-        return db.submit(data, args.verbose)
+        return db.submit(data, 'test', args.verbose)
 
 
 if __name__ == '__main__':

--- a/kci_test
+++ b/kci_test
@@ -77,13 +77,23 @@ class cmd_validate(Command):
 
 class cmd_list_jobs(Command):
     help = "List all the jobs that need to be run for a given build and lab"
-    args = [Args.bmeta_json, Args.lab_config]
-    opt_args = [Args.dtbs_json, Args.user, Args.lab_token, Args.lab_json]
+    args = [Args.lab_config]
+    opt_args = [Args.user, Args.lab_token, Args.lab_json,
+                Args.build_output, Args.install_path]
 
     def __call__(self, test_configs, lab_configs, args):
-        bmeta, dtbs = kernelci.build.load_json(args.bmeta_json, args.dtbs_json)
+        path_args = (args.build_output, args.install_path)
+        if not any(path_args) or all(path_args):
+            print("Either --build-output or --install-path is required")
+            return False
 
-        if bmeta['status'] != "PASS":
+        install = (
+            args.install_path if args.install_path else
+            kernelci.build.Step.get_install_path(None, args.build_output)
+        )
+        meta = kernelci.build.Metadata(install)
+
+        if meta.get('bmeta', 'build', 'status') != "PASS":
             return True
 
         lab = lab_configs['labs'][args.lab_config]
@@ -91,7 +101,7 @@ class cmd_list_jobs(Command):
             lab, args.user, args.lab_token, args.lab_json)
 
         configs = kernelci.test.match_configs(
-            test_configs['test_configs'], bmeta, dtbs, lab)
+            test_configs['test_configs'], meta, lab)
         for device_type, plan in configs:
             if not api.device_type_online(device_type):
                 continue
@@ -144,8 +154,9 @@ class cmd_get_lab_info(Command):
 
 class cmd_generate(Command):
     help = "Generate the job definition for a given build"
-    args = [Args.bmeta_json, Args.storage, Args.lab_config]
-    opt_args = [Args.plan, Args.target, Args.output, Args.dtbs_json,
+    args = [Args.lab_config, Args.storage]
+    opt_args = [Args.plan, Args.target, Args.output,
+                Args.build_output, Args.install_path,
                 Args.lab_json, Args.user, Args.lab_token, Args.db_config,
                 Args.callback_id, Args.callback_dataset,
                 Args.callback_type, Args.callback_url, Args.mach]
@@ -155,9 +166,18 @@ class cmd_generate(Command):
             print("--callback-url is required with --callback-id")
             return False
 
-        bmeta, dtbs = kernelci.build.load_json(args.bmeta_json, args.dtbs_json)
+        path_args = (args.build_output, args.install_path)
+        if not any(path_args) or all(path_args):
+            print("Either --build-output or --install-path is required")
+            return False
 
-        if bmeta['status'] != "PASS":
+        install = (
+            args.install_path
+            or kernelci.build.Step.get_install_path(None, args.build_output)
+        )
+        meta = kernelci.build.Metadata(install)
+
+        if meta.get('bmeta', 'build', 'status') != "PASS":
             return True
 
         lab = lab_configs['labs'][args.lab_config]
@@ -171,7 +191,7 @@ class cmd_generate(Command):
         else:
             jobs_list = []
             configs = kernelci.test.match_configs(
-                test_configs['test_configs'], bmeta, dtbs, lab)
+                test_configs['test_configs'], meta, lab)
             for device_type, plan in configs:
                 if not api.device_type_online(device_type):
                     continue
@@ -183,10 +203,6 @@ class cmd_generate(Command):
                     continue
                 jobs_list.append((device_type, plan))
 
-        # ToDo: deal with a JSON file containing a list of builds to iterate
-        # over, such as the one produced by "kci_build publish" or saved as a
-        # result of a new command "kci_build get_meta" to download meta-data
-        # from the backend API.
         callback_opts = {
             'id': args.callback_id,
             'dataset': args.callback_dataset or 'all',
@@ -197,7 +213,7 @@ class cmd_generate(Command):
             os.makedirs(args.output)
         for target, plan in jobs_list:
             params = kernelci.test.get_params(
-                bmeta, target, plan, args.storage)
+                meta, target, plan, args.storage)
             job = api.generate(params, target, plan, callback_opts)
             if job is None:
                 print("Failed to generate the job definition")

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -527,10 +527,10 @@ class Step:
         """
         self._kdir = kdir
         self._reset = reset
-        self._output_path = output_path or os.path.join(kdir, 'build')
+        self._output_path = output_path or self.get_default_output_path(kdir)
         if not os.path.exists(self._output_path):
             os.mkdir(self._output_path)
-        self._install_path = os.path.join(self._output_path, '_install_')
+        self._install_path = self.get_install_path(kdir, self._output_path)
         self._create_install_dir()
         self._bmeta_path = os.path.join(self._output_path, 'bmeta.json')
         self._steps_path = os.path.join(self._output_path, 'steps.json')
@@ -552,9 +552,43 @@ class Step:
         raise NotImplementedError("Step.name needs to be implemented.")
 
     @property
+    def output_path(self):
+        """Path to the kernel build output"""
+        return self._output_path
+
+    @property
     def install_path(self):
         """Path to the installation directory"""
         return self._install_path
+
+    @classmethod
+    def get_default_output_path(cls, kdir):
+        """Get the default build output path based on the kernel source path
+
+        *kdir* is the path to the kernel source directory
+        """
+        return os.path.join(kdir, 'build')
+
+    @classmethod
+    def get_install_path(cls, kdir=None, output_path=None):
+        """Get the default build install path
+
+        Get the default path where the kernel build artifacts get installed
+        based on the kernel source tree or a supplied output path.  They are
+        both optional to be able to deal with all the cases: the build output
+        directory may be the default one or an arbitrary one instead.  When
+        neither is supplied, the default path is `_install_` relative to the
+        current working directory.
+
+        *kdir* is the optional path to the kernel source directory
+        *output_path* is the optional path to the kernel build output
+        """
+        if output_path is None:
+            if kdir is None:
+                output_path = ''
+            else:
+                output_path = cls.get_default_output_path(kdir)
+        return os.path.join(output_path, '_install_')
 
     def _load_json(self, json_path, default):
         data = default

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -758,7 +758,8 @@ class RevisionData(Step):
     def name(self):
         return 'revision'
 
-    def run(self, tree_name, tree_url, branch):
+    def run(self, tree_name, tree_url, branch,
+            commit=None, describe=None, describe_v=None):
         """Add all the meta-data related to the current kernel revision.
 
         This step retrieves the revision information from the current kernel
@@ -768,14 +769,23 @@ class RevisionData(Step):
         *tree_name* is the short name of the kernel tree e.g. mainline, next...
         *tree_url* is the URL of the remote Git repository for the tree
         *branch* is the name of the Git branch
+
+        Optional arguments:
+
+        *commit* is the Git commit checksum, if None it will be determined
+                 automatically
+        *describe* is the Git describe string, if None it will be determined
+                   automatically
+        *describe_v* is the Git describe "verbose" string, if None it will be
+                     determined automatically
         """
         self._bmeta['revision'] = {
             'tree': tree_name,
             'url': tree_url,
             'branch': branch,
-            'describe': git_describe(tree_name, self._kdir),
-            'describe_v': git_describe_verbose(self._kdir),
-            'commit': head_commit(self._kdir),
+            'describe': describe or git_describe(tree_name, self._kdir),
+            'describe_v': describe_v or git_describe_verbose(self._kdir),
+            'commit': commit or head_commit(self._kdir),
         }
         return self._add_run_step(True)
 

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -936,11 +936,22 @@ scripts/kconfig/merge_config.sh -O {output} '{base}' '{frag}' {redir}
             kci_frag_name = 'kernelci.config'
             self._gen_kci_frag(configs, fragments, kci_frag_name)
 
+        rev, env = (self._bmeta[cat] for cat in ('revision', 'environment'))
+        publish_path = '/'.join(item.replace('/', '-') for item in [
+            rev['tree'],
+            rev['branch'],
+            rev['describe'],
+            env['arch'],
+            defconfig,
+            env['name'],
+        ])
+
         self._bmeta['kernel'] = {
             'defconfig': target,
             'defconfig_full': defconfig,
             'defconfig_expanded': defconfig_expanded,
             'defconfig_extras': extras,
+            'publish_path': publish_path,
         }
 
         res = self._make(target, jopt, verbose, opts)

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -752,6 +752,35 @@ class Step:
         return status
 
 
+class MetaStep(Step):
+    """Access the existing meta-data without running any actual step"""
+
+    def __init__(self, kdir, output_path=None):
+        super().__init__(kdir, output_path, 'meta')
+
+    def get_value(self, *keys):
+        """Find some meta-data value
+
+        Without any argument, all the meta-data dictionary will be returned.
+        Otherwise, each argument will be used to look up the meta-data
+        recursively.  For example, to get the build status use
+        `.get_meta("build", "status")`.  If the key doesn't exist, None is
+        returned.
+
+        *keys* is an arbitary number of keys to look up the meta-data
+        """
+        if len(keys) == 0:
+            return self._bmeta
+        if len(keys) == 1:
+            return self._bmeta.get(keys[0])
+        value = self._bmeta
+        for key in keys:
+            value = value.get(key)
+            if value is None:
+                break
+        return value
+
+
 class RevisionData(Step):
 
     @property

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -813,7 +813,8 @@ class RevisionData(Step):
             'url': tree_url,
             'branch': branch,
             'describe': describe or git_describe(tree_name, self._kdir),
-            'describe_v': describe_v or git_describe_verbose(self._kdir),
+            # ToDo: consolidate describe and describe_verbose
+            'describe_verbose': describe_v or git_describe_verbose(self._kdir),
             'commit': commit or head_commit(self._kdir),
         }
         return self._add_run_step(True)

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -1312,7 +1312,7 @@ class MakeSelftests(Step):
         }
         res = self._make('gen_tar', jopt, verbose, opts,
                          'tools/testing/selftests')
-        return self._add_run_step(jopt, res)
+        return self._add_run_step(res, jopt)
 
     def _get_kselftests(self, kselftest_tarball):
         with tarfile.open(kselftest_tarball, 'r:xz') as tarball:

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -504,6 +504,195 @@ def _run_make(kdir, arch, target=None, jopt=None, silent=True, cc='gcc',
     return shell_cmd(cmd, True)
 
 
+class Metadata:
+    """Kernel build meta-data"""
+
+    def __init__(self, data_path, reset=False):
+        """All the kernel build meta-data is read and written via this class
+
+        *data_path* is the path to where the meta-data can be found
+        *reset* is whether the meta-data should be reset in this step
+        """
+        self._bmeta_path = os.path.join(data_path, 'bmeta.json')
+        self._steps_path = os.path.join(data_path, 'steps.json')
+        self._artifacts_path = os.path.join(data_path, 'artifacts.json')
+        self._bmeta = self._load_json(self._bmeta_path, dict(), reset)
+        self._steps = self._load_json(self._steps_path, list(), reset)
+        self._artifacts = self._load_json(self._artifacts_path, dict(), reset)
+        self._artifacts_map = {
+            step: {art['path']: art for art in artifacts}
+            for step, artifacts in self._artifacts.items()
+        }
+        self._data = {
+            'bmeta': self._bmeta,
+            'steps': self._steps,
+            'artifacts': self._artifacts,
+        }
+
+    @property
+    def bmeta_path(self):
+        """Path to bmeta.json"""
+        return self._bmeta_path
+
+    @property
+    def steps_path(self):
+        """Path to steps.json"""
+        return self._steps_path
+
+    @property
+    def artifacts_path(self):
+        """Path to artifacts.json"""
+        return self._artifacts_path
+
+    def _load_json(self, json_path, default, reset):
+        data = default
+        if os.path.exists(json_path):
+            if reset:
+                os.unlink(json_path)
+            else:
+                with open(json_path) as json_file:
+                    data = json.load(json_file)
+        return data
+
+    def save(self, save_artifacts=True):
+        """Save all the meta-data
+
+        *save_artifacts* is to tell whether artifacts.json should also be saved
+        """
+        with open(self._bmeta_path, 'w') as json_file:
+            json.dump(self._bmeta, json_file, indent=4, sort_keys=True)
+        with open(self._steps_path, 'w') as json_file:
+            json.dump(self._steps, json_file, indent=4, sort_keys=True)
+        if save_artifacts:
+            self.save_artifacts()
+
+    def save_artifacts(self):
+        """Save artifacts.json"""
+        artifacts = {step: art for step, art in self._artifacts.items() if art}
+        with open(self._artifacts_path, 'w') as json_file:
+            json.dump(artifacts, json_file, indent=4, sort_keys=True)
+
+    def get(self, *keys):
+        """Find some meta-data value
+
+        Without any argument, all the meta-data dictionary will be returned.
+        Otherwise, each argument will be used to look up the meta-data
+        recursively.  For example, to get the build status use
+        `.get('bmeta', 'build', 'status')`.  If the key doesn't exist, 'None'
+        is returned.
+
+        *keys* is an arbitary number of keys to look up the meta-data
+        """
+        if len(keys) == 0:
+            return self._data
+        if len(keys) == 1:
+            return self._data.get(keys[0])
+        value = self._data
+        for key in keys:
+            value = value.get(key)
+            if value is None:
+                break
+        return value
+
+    def add_step(self, data):
+        """Add meta-data for a build step
+
+        *data* is the data for the step, following the schema
+        """
+        self._steps.append(data)
+        total_duration = sum(s['duration'] for s in self._steps)
+        all_status = set(s['status'] for s in self._steps)
+        self._bmeta['build'] = {
+            'duration': total_duration,
+            'status': 'PASS' if all_status == {'PASS'} else 'FAIL'
+        }
+
+    def clear_artifacts(self, step_name):
+        """Delete all artifacts for a given step
+
+        *step_name* is the name of the step for which artifact entries should
+                    be removed from the meta-data
+        """
+        self._artifacts[step_name] = dict()
+
+    def _add_artifact(self, step_name, artifact_type, artifact_path,
+                      contents=None, key=None):
+        artifacts = self._artifacts_map.setdefault(step_name, dict())
+        entry = artifacts.get(artifact_path)
+        if entry is None:
+            entry = {
+                'type': artifact_type,
+                'path': artifact_path,
+            }
+            if key:
+                entry['key'] = key
+            if contents:
+                entry['contents'] = list(sorted(set(contents)))
+            artifacts[artifact_path] = entry
+        elif entry['type'] != artifact_type:
+            raise ValueError("Conflicting artifact types")
+        elif entry.get('key') != key:
+            raise ValueError("Conflicting artifact keys")
+        self._artifacts[step_name] = list(artifacts.values())
+        return entry
+
+    def add_artifact(self, step_name, directory, file_name, key=None):
+        """Add meta-data for a single artifact file
+
+        Add a meta-data entry for a single file located in a given directory.
+        The directory may be an empty string to provide a full path to the file
+        directly.
+
+        *step_name* is the name of the build step
+        *directory* is the directory where the file is
+        *file_name* is the name of the file within that directory
+        *key* is an optional key attribute to retrieve the artifact
+        """
+        path = os.path.join(directory, file_name)
+        return self._add_artifact(step_name, 'file', path, None, key)
+
+    def add_artifact_contents(self, step_name, artifact_type, path,
+                              contents, key=None):
+        """Add meta-data for artifacts with file contents
+
+        Add a meta-data entry for an artifact with a list of files as its
+        contents.  This is typically for directories or tarballs containing
+        many files.
+
+        *step_name* is the name of the build step
+        *artifact_type* is the type of artifact, typically either 'tarball' or
+                       'directory'
+        *path* is the path to the artifact, i.e. the path to the directory or
+               tarball
+        *contents* is a list of file names contained in the directory or
+                   tarball
+        *key* is an optional key attribute to retrieve the artifact
+        """
+        return self._add_artifact(
+            step_name, artifact_type, path, contents, key)
+
+    def get_single_artifact(self, step_name, key=None, attr=None):
+        """Get meta-data for a single artifact
+
+        Get the meta-data entry for a single artifact.
+
+        *step_name* is the name of the build step
+        *key* is an optional key attribute to retrieve the artifact
+
+        *attr* is an optional attribute name to directly only get that
+               attribute from the artifact meta-data (e.g. 'path'...)
+        """
+        artifacts = self.get('artifacts', step_name)
+        if artifacts:
+            if key:
+                artifacts_map = {art['key']: art for art in artifacts}
+                artifact = artifacts_map.get(key)
+            else:
+                artifact = artifacts[0]
+            return artifact.get(attr) if attr and artifact else artifact
+        return None
+
+
 class Step:
     """Kernel build step"""
 
@@ -526,19 +715,13 @@ class Step:
         *reset* is whether the meta-data should be reset in this step
         """
         self._kdir = kdir
-        self._reset = reset
         self._output_path = output_path or self.get_default_output_path(kdir)
         if not os.path.exists(self._output_path):
             os.mkdir(self._output_path)
         self._install_path = self.get_install_path(kdir, self._output_path)
-        self._create_install_dir()
-        self._bmeta_path = os.path.join(self._output_path, 'bmeta.json')
-        self._steps_path = os.path.join(self._output_path, 'steps.json')
-        self._artifacts_path = os.path.join(
-            self._install_path, 'artifacts.json')
-        self._bmeta = self._load_json(self._bmeta_path, dict())
-        self._steps = self._load_json(self._steps_path, list())
-        self._artifacts = dict()
+        self._create_install_dir(reset)
+        self._meta = Metadata(self._output_path, reset)
+        self._meta.clear_artifacts(self.name)
         self._log_file = '.'.join([self.name, 'log']) if log is None else log
         self._log_path = os.path.join(self._output_path, self._log_file)
         if log is None and os.path.exists(self._log_path):
@@ -590,24 +773,8 @@ class Step:
                 output_path = cls.get_default_output_path(kdir)
         return os.path.join(output_path, '_install_')
 
-    def _load_json(self, json_path, default):
-        data = default
-        if os.path.exists(json_path):
-            if self._reset:
-                os.unlink(json_path)
-            else:
-                with open(json_path) as json_file:
-                    data = json.load(json_file)
-        return data
-
-    def _save_bmeta(self):
-        with open(self._bmeta_path, 'w') as json_file:
-            json.dump(self._bmeta, json_file, indent=4, sort_keys=True)
-        with open(self._steps_path, 'w') as json_file:
-            json.dump(self._steps, json_file, indent=4, sort_keys=True)
-
-    def _create_install_dir(self):
-        if self._reset:
+    def _create_install_dir(self, reset):
+        if reset:
             shutil.rmtree(self._install_path, ignore_errors=True)
         if not os.path.exists(self._install_path):
             os.makedirs(self._install_path)
@@ -626,15 +793,8 @@ class Step:
         if self._log_path and os.path.exists(self._log_path):
             run_data['log_file'] = self._log_file
         run_data['status'] = "PASS" if status is True else "FAIL"
-        self._steps.append(run_data)
-
-        total_duration = sum(s['duration'] for s in self._steps)
-        all_status = set(s['status'] for s in self._steps)
-        self._bmeta['build'] = {
-            'duration': total_duration,
-            'status': 'PASS' if all_status == {'PASS'} else 'FAIL'
-        }
-        self._save_bmeta()
+        self._meta.add_step(run_data)
+        self._meta.save(save_artifacts=False)
         return status
 
     def _get_cpus(self):
@@ -649,6 +809,13 @@ class Step:
                 ncpus = cpus.get(cpu, 0)
                 cpus[cpu] = ncpus + 1
         return cpus
+
+    def _add_artifact(self, directory, file_name, key=None):
+        return self._meta.add_artifact(self.name, directory, file_name, key)
+
+    def _add_artifact_contents(self, artifact_type, path, contents, key=None):
+        return self._meta.add_artifact_contents(
+            self.name, artifact_type, path, contents, key)
 
     def _kernel_config_enabled(self, config_name):
         dot_config = os.path.join(self._output_path, '.config')
@@ -671,7 +838,7 @@ class Step:
         return cmd
 
     def _get_make_opts(self, opts, make_path):
-        env = self._bmeta['environment']
+        env = self._meta.get('bmeta', 'environment')
         make_opts = env['make_opts'].copy()
         if opts:
             make_opts.update(opts)
@@ -744,42 +911,6 @@ class Step:
         shutil.copy(path, install_path)
         return dest_name
 
-    def _add_artifacts_entry(self, artifact_type, artifact_path, key=None):
-        entry = self._artifacts.get(artifact_path)
-        if entry is None:
-            entry = {
-                'type': artifact_type,
-                'path': artifact_path,
-            }
-            if key:
-                entry['key'] = key
-            self._artifacts[artifact_path] = entry
-        elif entry['type'] != artifact_type:
-            raise ValueError("Conflicting artifact types")
-        elif entry.get('key') != key:
-            raise ValueError("Conflicting artifact keys")
-        return entry
-
-    def _add_artifact(self, directory, file_name, key=None):
-        path = os.path.join(directory, file_name)
-        return self._add_artifacts_entry('file', path, key)
-
-    def _add_artifact_contents(self, artifact_type, path, contents, key=None):
-        entry = self._add_artifacts_entry(artifact_type, path, key)
-        entry['contents'] = contents
-        return entry
-
-    def _save_artifacts_json(self):
-        for entry in self._artifacts.values():
-            contents = entry.get('contents')
-            if contents:
-                entry['contents'] = list(sorted(set(contents)))
-        data = self._load_json(self._artifacts_path, dict())
-        data[self.name] = list(self._artifacts.values())
-        data = {k: v for k, v in data.items() if v}
-        with open(self._artifacts_path, 'w') as json_file:
-            json.dump(data, json_file, indent=4, sort_keys=True)
-
     def is_enabled(self):
         """Determine whether the step is enabled with the current kernel."""
         return True
@@ -800,8 +931,8 @@ class Step:
         """
         self._add_run_step(status, action='install')
         files = [
-            (self._bmeta_path, '', ''),
-            (self._steps_path, '', ''),
+            (self._meta.bmeta_path, '', ''),
+            (self._meta.steps_path, '', ''),
             (self._log_path, 'logs', 'log'),
         ]
         for file_name, dest_dir, key in files:
@@ -809,40 +940,9 @@ class Step:
                 item = self._install_file(file_name, dest_dir, verbose=verbose)
                 if dest_dir:
                     self._add_artifact(dest_dir, item, key)
-        self._save_artifacts_json()
+        self._meta.save_artifacts()
+        self._install_file(self._meta.artifacts_path, verbose=verbose)
         return status
-
-
-class MetaStep(Step):
-    """Access the existing meta-data without running any actual step"""
-
-    def __init__(self, kdir, output_path=None):
-        super().__init__(kdir, output_path, 'meta')
-        self._bmeta['steps'] = self._steps
-        self._bmeta['artifacts'] = self._load_json(
-            self._artifacts_path, dict())
-
-    def get_value(self, *keys):
-        """Find some meta-data value
-
-        Without any argument, all the meta-data dictionary will be returned.
-        Otherwise, each argument will be used to look up the meta-data
-        recursively.  For example, to get the build status use
-        `.get_meta("build", "status")`.  If the key doesn't exist, None is
-        returned.
-
-        *keys* is an arbitary number of keys to look up the meta-data
-        """
-        if len(keys) == 0:
-            return self._bmeta
-        if len(keys) == 1:
-            return self._bmeta.get(keys[0])
-        value = self._bmeta
-        for key in keys:
-            value = value.get(key)
-            if value is None:
-                break
-        return value
 
 
 class RevisionData(Step):
@@ -872,7 +972,7 @@ class RevisionData(Step):
         *describe_v* is the Git describe "verbose" string, if None it will be
                      determined automatically
         """
-        self._bmeta['revision'] = {
+        self._meta.get('bmeta')['revision'] = {
             'tree': tree_name,
             'url': tree_url,
             'branch': branch,
@@ -910,7 +1010,7 @@ class EnvironmentData(Step):
         make_opts.update(build_env.get_arch_opts(arch))
         platform_data = {'uname': platform.uname()}
 
-        self._bmeta['environment'] = {
+        self._meta.get('bmeta')['environment'] = {
             'arch': arch,
             'compiler': cc,
             'compiler_version': build_env.cc_version,
@@ -976,7 +1076,7 @@ class MakeConfig(Step):
 
     def _merge_config(self, kci_frag_name, verbose=False):
         rel_path = os.path.relpath(self._output_path, self._kdir)
-        env = self._bmeta['environment']
+        env = self._meta.get('bmeta', 'environment')
         cc = env['compiler']
         cc_env = (
             "export LLVM=1" if cc.startswith('clang') else
@@ -1030,7 +1130,8 @@ scripts/kconfig/merge_config.sh -O {output} '{base}' '{frag}' {redir}
             kci_frag_name = 'kernelci.config'
             self._gen_kci_frag(configs, fragments, kci_frag_name)
 
-        rev, env = (self._bmeta[cat] for cat in ('revision', 'environment'))
+        bmeta = self._meta.get('bmeta')
+        rev, env = (bmeta[cat] for cat in ('revision', 'environment'))
         publish_path = '/'.join(item.replace('/', '-') for item in [
             rev['tree'],
             rev['branch'],
@@ -1040,7 +1141,7 @@ scripts/kconfig/merge_config.sh -O {output} '{base}' '{frag}' {redir}
             env['name'],
         ])
 
-        self._bmeta['kernel'] = {
+        bmeta['kernel'] = {
             'defconfig': target,
             'defconfig_full': defconfig,
             'defconfig_expanded': defconfig_expanded,
@@ -1053,7 +1154,7 @@ scripts/kconfig/merge_config.sh -O {output} '{base}' '{frag}' {redir}
         if res and kci_frag_name:
             # ToDo: treat kernelci.config as an implementation detail and list
             # the actual input config fragment files here instead
-            self._bmeta['kernel']['fragments'] = [kci_frag_name]
+            bmeta['kernel']['fragments'] = [kci_frag_name]
             res = self._merge_config(kci_frag_name, verbose)
 
         return self._add_run_step(res, jopt)
@@ -1070,7 +1171,7 @@ scripts/kconfig/merge_config.sh -O {output} '{base}' '{frag}' {redir}
             'kernel.config', verbose
         )
         self._add_artifact('config', item, 'config')
-        for frag in self._bmeta['kernel'].get('fragments', list()):
+        for frag in self._meta.get('bmeta', 'kernel').get('fragments', list()):
             item = self._install_file(
                 os.path.join(self._output_path, frag), 'config', frag, verbose
             )
@@ -1094,14 +1195,15 @@ class MakeKernel(Step):
         *jopt* is the `make -j` option which will default to `nproc + 2`
         *verbose* is whether the build output should be shown
         """
+        bmeta = self._meta.get('bmeta')
         if self._kernel_config_enabled('XIP_KERNEL'):
             target = 'xipImage'
         elif self._kernel_config_enabled('SYS_SUPPORTS_ZBOOT'):
             target = 'vmlinuz'
         else:
-            target = MAKE_TARGETS.get(self._bmeta['environment']['arch'])
+            target = MAKE_TARGETS.get(bmeta['environment']['arch'])
 
-        kbmeta = self._bmeta.setdefault('kernel', dict())
+        kbmeta = bmeta.setdefault('kernel', dict())
         if target:
             kbmeta['image'] = target
 
@@ -1117,7 +1219,7 @@ class MakeKernel(Step):
         return self._add_run_step(res, jopt)
 
     def _find_kernel_images(self, image):
-        arch = self._bmeta['environment']['arch']
+        arch = self._meta.get('bmeta', 'environment', 'arch')
         boot_dir = os.path.join(self._output_path, 'arch', arch, 'boot')
         kimage_names = KERNEL_IMAGE_NAMES[arch]
         kimages = dict()
@@ -1149,7 +1251,7 @@ class MakeKernel(Step):
 
         *verbose* is whether the build output should be shown
         """
-        kbmeta = self._bmeta['kernel']
+        kbmeta = self._meta.get('bmeta', 'kernel')
         image = kbmeta.get('image')
         kimages = self._find_kernel_images(image)
         res = bool(kimages)
@@ -1202,7 +1304,7 @@ class MakeModules(Step):
         if os.path.exists(self._mod_path):
             shutil.rmtree(self._mod_path)
         os.makedirs(self._mod_path)
-        cross_compile = self._bmeta['environment']['cross_compile']
+        cross_compile = self._meta.get('bmeta', 'environment', 'cross_compile')
         opts = {
             'INSTALL_MOD_PATH': os.path.abspath(self._mod_path),
             'INSTALL_MOD_STRIP': '1',
@@ -1279,7 +1381,7 @@ class MakeDeviceTrees(Step):
         return self._add_run_step(res, jopt)
 
     def _install_dtbs(self, verbose):
-        arch = self._bmeta['environment']['arch']
+        arch = self._meta.get('bmeta', 'environment', 'arch')
         boot_dir = os.path.join(self._output_path, 'arch', arch, 'boot')
         dts_dir = os.path.join(boot_dir, 'dts')
         dtb_list = []
@@ -1329,7 +1431,9 @@ class MakeSelftests(Step):
         Return True if the kselftest config fragment is enabled in the build
         meta-data, or False otherwise.
         """
-        return 'kselftest' in self._bmeta['kernel']['defconfig_extras']
+        return 'kselftest' in self._meta.get(
+            'bmeta', 'kernel', 'defconfig_extras'
+        )
 
     def run(self, jopt=None, verbose=False):
         """Make the kernel selftests

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -378,13 +378,16 @@ def pull_tarball(kdir, url, dest_filename, retries, delete):
     return True
 
 
-def _add_frag_configs(kdir, frag_list, frag_paths, frag_configs):
+def _get_frag_configs(kdir, frag_list):
+    configs = set()
+    names = set()
     for frag in frag_list:
         if os.path.exists(os.path.join(kdir, frag.path)):
             if frag.defconfig:
-                frag_configs.add(frag.defconfig)
+                configs.add(frag.defconfig)
             else:
-                frag_paths.add(frag.path)
+                names.add(frag.name)
+    return configs, names
 
 
 def list_kernel_configs(config, kdir, single_variant=None, single_arch=None):
@@ -414,16 +417,17 @@ def list_kernel_configs(config, kdir, single_variant=None, single_arch=None):
         if single_variant and variant.name != single_variant:
             continue
         build_env = variant.build_environment.name
-        frag_paths = set()
-        frag_configs = set()
-        _add_frag_configs(kdir, variant.fragments, frag_paths, frag_configs)
+        frag_configs, frag_names = _get_frag_configs(kdir, variant.fragments)
+
         for arch in variant.architectures:
             if single_arch and arch.name != single_arch:
                 continue
-            frags = set(frag_paths)
+            frags = set(frag_names)
             defconfigs = set(frag_configs)
             defconfigs.add(arch.base_defconfig)
-            _add_frag_configs(kdir, arch.fragments, frags, defconfigs)
+            configs, names = _get_frag_configs(kdir, arch.fragments)
+            frags = frags.union(names)
+            defconfigs = defconfigs.union(configs)
             for frag in frags:
                 defconfigs.add('+'.join([arch.base_defconfig, frag]))
             defconfigs.update(arch.extra_configs)

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -780,6 +780,9 @@ class MetaStep(Step):
 
     def __init__(self, kdir, output_path=None):
         super().__init__(kdir, output_path, 'meta')
+        self._bmeta['steps'] = self._steps
+        self._bmeta['artifacts'] = self._load_json(
+            self._artifacts_path, dict())
 
     def get_value(self, *keys):
         """Find some meta-data value

--- a/kernelci/cli.py
+++ b/kernelci/cli.py
@@ -47,6 +47,11 @@ class Args:
         'section': SECTION_DB,
     }
 
+    build_output = {
+        'name': '--build-output',
+        'help': "Path to the build output directory",
+    }
+
     bmeta_json = {
         'name': '--bmeta-json',
         'help': "Path to the build.json file",

--- a/kernelci/data/__init__.py
+++ b/kernelci/data/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2020 Collabora Limited
 # Author: Michal Galka <michal.galka@collabora.com>
+# Author: Guillaume Tucker <guillaume.tucker@collabora.com>
 #
 # This module is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
@@ -19,16 +20,35 @@ import importlib
 
 
 class Database:
+    """KernelCI database interface"""
 
     def __init__(self, config, token=None):
+        """Handle KernelCI data and communicate with any supported database
+
+        This abstract class provides an interface for exchanging data with a
+        database using an arbitrary implementation.  It also provides common
+        logic when applicable, to handle KernelCI data in a generic way.
+
+        *config* is the database configuration object
+        *token* is an authentication token for the database
+        """
         self._config = config
         self._token = token
 
-    def submit(self, data):
+    def submit(self, data, path=None, verbose=False):
+        """Submit arbitrary data to the database
+
+        Primitive method to send some data to the database.
+
+        *data* is the payload to send to the database
+        *path* is to identify the part of the API to use to send the data
+        *verbose* is to print more information
+        """
         raise NotImplementedError("Database.submit() must be implemented")
 
     @property
     def config(self):
+        """Database configuration"""
         return self._config
 
 

--- a/kernelci/data/__init__.py
+++ b/kernelci/data/__init__.py
@@ -54,9 +54,9 @@ class Database:
         """Submit meta-data for a kernel build
 
         Alternative entry point to submit the kernel build meta-data from a
-        build.MetaStep object.
+        build.Metadata object.
 
-        *meta* is a kernelci.build.MetaStep object
+        *meta* is a kernelci.build.Metadata object
         *verbose* is to print more information
         """
         raise NotImplementedError("Database.submit_build() not implemented")

--- a/kernelci/data/__init__.py
+++ b/kernelci/data/__init__.py
@@ -35,6 +35,11 @@ class Database:
         self._config = config
         self._token = token
 
+    @property
+    def config(self):
+        """Database configuration"""
+        return self._config
+
     def submit(self, data, verbose=False):
         """Submit arbitrary data to the database
 
@@ -45,10 +50,16 @@ class Database:
         """
         raise NotImplementedError("Database.submit() must be implemented")
 
-    @property
-    def config(self):
-        """Database configuration"""
-        return self._config
+    def submit_build(self, meta, verbose=False):
+        """Submit meta-data for a kernel build
+
+        Alternative entry point to submit the kernel build meta-data from a
+        build.MetaStep object.
+
+        *meta* is a kernelci.build.MetaStep object
+        *verbose* is to print more information
+        """
+        raise NotImplementedError("Database.submit_build() not implemented")
 
 
 def get_db(config, token=None):

--- a/kernelci/data/__init__.py
+++ b/kernelci/data/__init__.py
@@ -35,13 +35,12 @@ class Database:
         self._config = config
         self._token = token
 
-    def submit(self, data, path=None, verbose=False):
+    def submit(self, data, verbose=False):
         """Submit arbitrary data to the database
 
         Primitive method to send some data to the database.
 
-        *data* is the payload to send to the database
-        *path* is to identify the part of the API to use to send the data
+        *data* is a dictionary with the data to send to the database
         *verbose* is to print more information
         """
         raise NotImplementedError("Database.submit() must be implemented")

--- a/kernelci/data/__init__.py
+++ b/kernelci/data/__init__.py
@@ -61,6 +61,16 @@ class Database:
         """
         raise NotImplementedError("Database.submit_build() not implemented")
 
+    def submit_test(self, results, verbose=False):
+        """Submit test results
+
+        Alternative entry point to submit test results.
+
+        *results* is a dictionary with the test results data
+        *verbose* is to print more information
+        """
+        raise NotImplementedError("Database.submit_test() not implemented")
+
 
 def get_db(config, token=None):
     m = importlib.import_module('.'.join(['kernelci', 'data', config.db_type]))

--- a/kernelci/data/kernelci_backend.py
+++ b/kernelci/data/kernelci_backend.py
@@ -16,7 +16,6 @@
 # along with this library; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-import json
 import requests
 import urllib
 from kernelci.data import Database
@@ -38,8 +37,7 @@ class KernelCIBackend(Database):
             print(resp.text)
 
     def submit(self, data, verbose=False):
-        json_data = json.loads(data)
-        for path, item in json_data.items():
+        for path, item in data.items():
             self._submit(path, item, verbose)
         return True
 

--- a/kernelci/data/kernelci_backend.py
+++ b/kernelci/data/kernelci_backend.py
@@ -60,6 +60,9 @@ class KernelCIBackend(Database):
         }
         return self._submit('build',  data, verbose)
 
+    def submit_test(self, results, verbose=False):
+        self._submit('test', results, verbose)
+
 
 def get_db(config, token):
     """Get a KernelCI backend database object"""

--- a/kernelci/data/kernelci_backend.py
+++ b/kernelci/data/kernelci_backend.py
@@ -28,16 +28,19 @@ class KernelCIBackend(Database):
         super().__init__(config, token)
         if self._token is None:
             raise ValueError("API token required for kernelci_backend")
+        self._headers = {'Authorization': self._token}
 
-    def submit(self, data, path=None, verbose=False):
-        if path is None:
-            return False
+    def _submit(self, path, data, verbose):
         url = urllib.parse.urljoin(self.config.url, path)
-        resp = requests.post(url, json=json.loads(data),
-                             headers={'Authorization': self._token})
+        resp = requests.post(url, json=data, headers=self._headers)
         resp.raise_for_status()
         if verbose:
             print(resp.text)
+
+    def submit(self, data, verbose=False):
+        json_data = json.loads(data)
+        for path, item in json_data.items():
+            self._submit(path, item, verbose)
         return True
 
 

--- a/kernelci/data/kernelci_backend.py
+++ b/kernelci/data/kernelci_backend.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 Collabora Limited
+# Copyright (C) 2020, 2021 Collabora Limited
 # Author: Michal Galka <michal.galka@collabora.com>
 # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
 #
@@ -18,6 +18,7 @@
 
 import json
 import requests
+import urllib
 from kernelci.data import Database
 
 
@@ -28,8 +29,11 @@ class KernelCIBackend(Database):
         if self._token is None:
             raise ValueError("API token required for kernelci_backend")
 
-    def submit(self, data, verbose=False):
-        resp = requests.post(self.config.url, json=json.loads(data),
+    def submit(self, data, path=None, verbose=False):
+        if path is None:
+            return False
+        url = urllib.parse.urljoin(self.config.url, path)
+        resp = requests.post(url, json=json.loads(data),
                              headers={'Authorization': self._token})
         resp.raise_for_status()
         if verbose:

--- a/kernelci/data/kernelci_backend.py
+++ b/kernelci/data/kernelci_backend.py
@@ -53,7 +53,7 @@ class KernelCIBackend(Database):
         return True
 
     def submit_build(self, meta, verbose=False):
-        return self._submit('build', meta.get_value(), verbose)
+        return self._submit('build', meta.get(), verbose)
 
     def submit_test(self, results, verbose=False):
         return self._submit('test', results, verbose)

--- a/kernelci/data/kernelci_backend.py
+++ b/kernelci/data/kernelci_backend.py
@@ -16,6 +16,7 @@
 # along with this library; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+import json
 import requests
 import urllib
 from kernelci.data import Database
@@ -40,6 +41,24 @@ class KernelCIBackend(Database):
         for path, item in data.items():
             self._submit(path, item, verbose)
         return True
+
+    def submit_build(self, meta, verbose=False):
+        revision, kernel, env = (
+            meta.get_value(key) for key in [
+                'revision', 'kernel', 'environment']
+        )
+        data = {  # ToDo clean-up names and remove duplicates...
+            'path': kernel['publish_path'],
+            'file_server_resource': kernel['publish_path'],
+            'job': revision['tree'],
+            'git_branch': revision['branch'],
+            'arch': env['arch'],
+            'kernel': revision['describe'],
+            'build_environment': env['name'],
+            'defconfig': kernel['defconfig'],
+            'defconfig_full': kernel['defconfig_full'],
+        }
+        return self._submit('build',  data, verbose)
 
 
 def get_db(config, token):

--- a/kernelci/data/kernelci_backend.py
+++ b/kernelci/data/kernelci_backend.py
@@ -43,22 +43,7 @@ class KernelCIBackend(Database):
         return True
 
     def submit_build(self, meta, verbose=False):
-        revision, kernel, env = (
-            meta.get_value(key) for key in [
-                'revision', 'kernel', 'environment']
-        )
-        data = {  # ToDo clean-up names and remove duplicates...
-            'path': kernel['publish_path'],
-            'file_server_resource': kernel['publish_path'],
-            'job': revision['tree'],
-            'git_branch': revision['branch'],
-            'arch': env['arch'],
-            'kernel': revision['describe'],
-            'build_environment': env['name'],
-            'defconfig': kernel['defconfig'],
-            'defconfig_full': kernel['defconfig_full'],
-        }
-        return self._submit('build',  data, verbose)
+        return self._submit('build', meta.get_value(), verbose)
 
     def submit_test(self, results, verbose=False):
         self._submit('test', results, verbose)

--- a/kernelci/storage.py
+++ b/kernelci/storage.py
@@ -21,6 +21,24 @@ from urllib.parse import urljoin
 from kernelci import shell_cmd
 
 
+def discover_files(path):
+    """Discover files recustively so they can then be uploaded
+
+    Recursively walk through a file hierarchy and return a dictionary with the
+    file paths and open file objects which can then be passed directly to
+    upload_files().
+
+    *path* is the path to the file hierarchy where to look for files
+    """
+    artifacts = {}
+    for root, _, files in os.walk(path):
+        for fname in files:
+            px = os.path.relpath(root, path)
+            artifacts[os.path.join(px, fname)] = open(
+                os.path.join(root, fname), "rb")
+    return artifacts
+
+
 def upload_files(api, token, path, input_files):
     """Upload rootfs to KernelCI backend.
 

--- a/kernelci/test.py
+++ b/kernelci/test.py
@@ -19,27 +19,32 @@ import os
 import urllib.parse
 
 
-def match_configs(configs, bmeta, dtbs, lab):
+def match_configs(configs, meta, lab):
     """Filter the test configs for a given kernel build and lab.
 
     *configs* is a list of all the initial test configs
-    *bmeta* is a dictionary with the kernel build meta-data
+    *meta* is a MetaStep object
     *dtbs* is the list of dtb files included in the kernel build
     *lab* is a Lab object instance
 
     The returned value is a list with a subset of the configs that match the
     provided kernel build meta-data and lab filters.
     """
-    defconfig = bmeta['defconfig_full']
-    arch = bmeta['arch']
+    dtbs = meta.get_single_artifact('dtbs', attr='contents')
+    bmeta = meta.get('bmeta')
+    env, kernel, rev = (bmeta.get(key) for key in [
+        'environment', 'kernel', 'revision'
+    ])
+    defconfig = kernel['defconfig_full']
+    arch = env['arch']
 
     filters = {
         'arch': arch,
         'defconfig': defconfig,
-        'kernel': bmeta['git_describe'],
-        'build_environment': bmeta['build_environment'],
-        'tree': bmeta['job'],
-        'branch': bmeta['git_branch'],
+        'kernel': rev['describe'],
+        'build_environment': env['name'],
+        'tree': rev['tree'],
+        'branch': rev['branch'],
     }
 
     flags = {
@@ -52,9 +57,10 @@ def match_configs(configs, bmeta, dtbs, lab):
     for test_config in configs:
         if not test_config.match(arch, flags, filters):
             continue
-        dtb = test_config.device_type.dtb
-        if dtb and dtb not in dtbs:
-            continue
+        if dtbs:
+            dtb = test_config.device_type.dtb
+            if dtb and dtb not in dtbs:
+                continue
         for plan_name, plan in test_config.test_plans.items():
             if not plan.match(filters):
                 continue
@@ -65,44 +71,45 @@ def match_configs(configs, bmeta, dtbs, lab):
     return match
 
 
-def get_params(bmeta, target, plan_config, storage):
+def get_params(meta, target, plan_config, storage):
     """Get a dictionary with all the test parameters to run a test job
 
-    *bmeta* is a dictionary with the kernel build meta-data
+    *meta* is a MetaStep object
     *target* is the name of the target platform to run the test
     *plan_config* is a TestPlan object for the test plan to run
     *storage* is the URL of the storage server
     """
+    kernel, rev = (meta.get('bmeta', key) for key in ['kernel', 'revision'])
     arch = target.arch
     dtb = dtb_full = target.dtb
-    dtb_dir = bmeta.get("dtb_dir", "")
     if dtb:
+        dtb_dir = meta.get_single_artifact('dtbs', attr='path')
         dtb = dtb_full = os.path.join(dtb_dir, target.dtb)
         dtb = os.path.basename(dtb)  # hack for dtbs in subfolders
-    file_server_resource = bmeta['file_server_resource']
-    job_px = file_server_resource.replace('/', '-')
-    url_px = file_server_resource
+    publish_path = kernel['publish_path']
+    job_px = publish_path.replace('/', '-')
+    url_px = publish_path
     job_name = '-'.join([job_px, dtb or 'no-dtb',
                          target.name, plan_config.name])
     base_url = urllib.parse.urljoin(storage, '/'.join([url_px, '']))
-    kernel_img = bmeta['kernel_image']
+    kernel_img = meta.get_single_artifact('kernel', 'image', 'path')
     kernel_url = urllib.parse.urljoin(storage, '/'.join([url_px, kernel_img]))
     if dtb_full and dtb_full.endswith('.dtb'):
         dtb_url = urllib.parse.urljoin(
             storage, '/'.join([url_px, dtb_full]))
     else:
         dtb_url = None
-    modules = bmeta.get('modules')
+    modules = meta.get_single_artifact('modules', attr='path')
     modules_url = (
         urllib.parse.urljoin(storage, '/'.join([url_px, modules]))
         if modules else None
     )
     rootfs = plan_config.rootfs
-    defconfig_full = bmeta['defconfig_full']
+    defconfig_full = kernel['defconfig_full']
     defconfig = ''.join(defconfig_full.split('+')[:1])
     endian = 'big' if 'BIG_ENDIAN' in defconfig_full else 'little'
-    describe = bmeta['git_describe']
-    kselftests = bmeta.get('kselftests')
+    describe = rev['describe']
+    kselftests = meta.get_single_artifact('kselftest', attr='path')
     kselftests_url = (
         urllib.parse.urljoin(storage, '/'.join([url_px, kselftests]))
         if kselftests else None
@@ -121,7 +128,7 @@ def get_params(bmeta, target, plan_config, storage):
         'plan': plan_config.base_name,
         'plan_variant': plan_config.name,
         'kernel': describe,
-        'tree': bmeta['job'],
+        'tree': rev['tree'],
         'defconfig': defconfig,
         'defconfig_full': defconfig_full,
         'fastboot': str(target.get_flag('fastboot')).lower(),
@@ -130,17 +137,17 @@ def get_params(bmeta, target, plan_config, storage):
         'base_url': base_url,
         'endian': endian,
         'arch': arch,
-        'git_branch': bmeta['git_branch'],
-        'git_commit': bmeta['git_commit'],
+        'git_branch': rev['branch'],
+        'git_commit': rev['commit'],
         'git_describe': describe,
-        'git_url': bmeta['git_url'],
+        'git_url': rev['url'],
         'initrd_url': rootfs.get_url('ramdisk', arch, endian),
-        'kernel_image': kernel_img,
+        'kernel_image': os.path.basename(kernel_img),
         'nfsrootfs_url': rootfs.get_url('nfs', arch, endian),
         'context': target.context,
         'rootfs_prompt': rootfs.prompt,
-        'file_server_resource': file_server_resource,
-        'build_environment': bmeta['build_environment'],
+        'file_server_resource': publish_path,
+        'build_environment': meta.get('bmeta', 'environment', 'name'),
         'kselftests_url': kselftests_url,
     }
 


### PR DESCRIPTION
Full integration of the new build meta-data with k8s builds and generated LAVA jobs.

Should be merged at the same time as the following PRs:
- [x] https://github.com/kernelci/kernelci-frontend/pull/140 "Build logs" on frontend
- [x] https://github.com/kernelci/kernelci-backend/pull/281 build meta-data parsing in backend
- [x] https://github.com/kernelci/kernelci-jenkins/pull/52 Jenkins jobs updates to match command line changes