### PR TITLE
kernelci.build: fix MakeSelftests build result

### DIFF
--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -1305,7 +1305,7 @@ class MakeSelftests(Step):
         }
         res = self._make('gen_tar', jopt, verbose, opts,
                          'tools/testing/selftests')
-        return self._add_run_step(jopt, res)
+        return self._add_run_step(res, jopt)
 
     def _get_kselftests(self, kselftest_tarball):
         with tarfile.open(kselftest_tarball, 'r:xz') as tarball:


### PR DESCRIPTION
Fix a mistake in the call to add the build step meta-data which
resulted in the wrong status to be saved.

Fixes: fa346b304840 ("kernelci.build: use Step.name in meta-data")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>