### PR TITLE
kernelci.cli: handle case where option is not defined

### DIFF
--- a/kernelci/cli.py
+++ b/kernelci/cli.py
@@ -392,7 +392,7 @@ class Options:
                `~/.config/kernelci/kernelci.conf` or
                `/etc/kernelci/kernelci.conf`
 
-        *command* is a `Command` object for the commant being run
+        *command* is a `Command` object for the command being run
 
         *cli_args* is an object with command line arguments as produced by
                    argparse
@@ -441,7 +441,7 @@ class Options:
         if value:
             return value
         opt_data = self._command.get_arg_data(option)
-        section_data = opt_data.get('section')
+        section_data = opt_data.get('section') if opt_data else None
         if section_data:
             section_name, section_config_option = section_data
             section_config = self.get(section_config_option)


### PR DESCRIPTION
Handle the case where the requested option is not associated with the
command in Options.get().

This doesn't normally happen as the code using Options normally only
looks for options that were defined, but it may happen in some corner
cases when such things can't be determined.  Also, if it does happen
for any reason, it should return None rather than fail with an
exception.

Fixes: df17ad416551 ("kernelci.cli: add Options class to use a settings file")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>