### PR TITLE
Enable kselftest on baylibre lab

### DIFF
--- a/config/core/lab-configs.yaml
+++ b/config/core/lab-configs.yaml
@@ -9,7 +9,9 @@ labs:
       - passlist:
           plan:
             - baseline
-            - kselftest
+            - kselftest-filesystems
+            - kselftest-futex
+            - kselftest-lib
             - preempt-rt
 
   lab-broonie:

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1804,6 +1804,7 @@ test_configs:
     test_plans:
       - baseline
       - baseline-nfs
+      - kselftest-lib
       - ltp-crypto
       - ltp-ipc
       - ltp-mm
@@ -1923,6 +1924,7 @@ test_configs:
     test_plans:
       - baseline
       - baseline-nfs
+      - kselftest-lib
 
   - device_type: meson-g12b-odroid-n2
     test_plans:
@@ -2035,6 +2037,7 @@ test_configs:
   - device_type: panda
     test_plans:
       - baseline
+      - kselftest-lib
 
   - device_type: panda-es
     test_plans:
@@ -2256,6 +2259,7 @@ test_configs:
   - device_type: sun50i-h6-pine-h64
     test_plans:
       - baseline
+      - kselftest-lib
       - ltp-crypto
       - ltp-ipc
       - ltp-mm

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1960,6 +1960,9 @@ test_configs:
   - device_type: meson-gxl-s905x-libretech-cc
     test_plans:
       - baseline
+      - kselftest-filesystems
+      - kselftest-futex
+      - kselftest-lib
 
   - device_type: meson-gxm-khadas-vim2
     test_plans:
@@ -2234,6 +2237,9 @@ test_configs:
   - device_type: sun50i-h5-libretech-all-h3-cc
     test_plans:
       - baseline
+      - kselftest-filesystems
+      - kselftest-futex
+      - kselftest-lib
 
   - device_type: sun50i-h5-nanopi-neo-plus2
     test_plans:


### PR DESCRIPTION
Enable kselftest on devices present in lab-baylibre.