### PR TITLE
kernelci: add __version__ with package version string

### DIFF
--- a/kernelci/__init__.py
+++ b/kernelci/__init__.py
@@ -19,6 +19,8 @@ import re
 import subprocess
 import sys
 
+__version__ = '1.1'
+
 
 def shell_cmd(cmd, ret_code=False):
     if ret_code:

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -27,7 +27,7 @@ import time
 import urllib.parse
 
 import requests
-from kernelci import shell_cmd, print_flush
+from kernelci import shell_cmd, print_flush, __version__ as kernelci_version
 import kernelci.elf
 from kernelci.storage import upload_files
 
@@ -347,7 +347,7 @@ def push_tarball(config, kdir, storage, api, token):
 
 def _download_file(url, dest_filename, chunk_size=1024):
     headers = {
-        'User-Agent': 'kernelci 1.1'
+        'User-Agent': 'kernelci {}'.format(kernelci_version),
     }
     resp = requests.get(url, stream=True, headers=headers)
     if resp.status_code == 200:

--- a/setup.py
+++ b/setup.py
@@ -16,10 +16,11 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 import setuptools
+import kernelci
 
 setuptools.setup(
     name='kernelci',
-    version='1.1',
+    version=kernelci.__version__,
     description="KernelCI core functions",
     author="kernelci.org",
     author_email="kernelci@groups.io",


### PR DESCRIPTION
Add `kernelci.__version__` with the kernelci package version string
'1.1'.  Import it where the version is required in place of hard-coded
strings (setup.py, build.py).

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>