### PR TITLE
Add config fragment for gemini_defconfig

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -148,6 +148,12 @@ fragments:
   debug:
     path: "kernel/configs/debug.config"
 
+  gemini:
+    path: "kernel/configs/gemini.config"
+    configs:
+      - 'CONFIG_CMDLINE="console=ttyS0,19200n8 ip=dhcp initrdmem=0x800000,10M"'
+      - 'CONFIG_CMDLINE_FORCE=y'
+
   kselftest:
     path: "kernel/configs/kselftest.config"
 
@@ -841,6 +847,7 @@ build_configs:
               - 'multi_v7_defconfig+CONFIG_EFI=y+CONFIG_ARM_LPAE=y'
               - 'allnoconfig'
               - 'allmodconfig'
+              - 'gemini_defconfig+gemini'
 
       # clang-10 is the current minium clang version for -next
       clang-10:


### PR DESCRIPTION
I have two gemini boards but their bootloader are an old vendor one.
There are no way to pass CMDLINE nor tell where to find initrd easily.

The easiest way is to hack CONFIG_CMDLINE and set initrd address in it.
There are no need to do two build since CONFIG_CMDLINE is not a
sufficiant hack to break a build.

Signed-off-by: Corentin LABBE <clabbe@baylibre.com>