### PR TITLE
config/core: drop kselftest test-plan

### DIFF
--- a/config/core/lab-configs.yaml
+++ b/config/core/lab-configs.yaml
@@ -9,7 +9,9 @@ labs:
       - passlist:
           plan:
             - baseline
-            - kselftest
+            - kselftest-filesystems
+            - kselftest-futex
+            - kselftest-lib
             - preempt-rt
 
   lab-broonie:

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1974,6 +1974,9 @@ test_configs:
   - device_type: meson-gxl-s905x-libretech-cc
     test_plans:
       - baseline
+      - kselftest-filesystems
+      - kselftest-futex
+      - kselftest-lib
 
   - device_type: meson-gxm-khadas-vim2
     test_plans:
@@ -2258,6 +2261,9 @@ test_configs:
   - device_type: sun50i-h5-libretech-all-h3-cc
     test_plans:
       - baseline
+      - kselftest-filesystems
+      - kselftest-futex
+      - kselftest-lib
 
   - device_type: sun50i-h5-nanopi-neo-plus2
     test_plans:

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1758,7 +1758,6 @@ test_configs:
     test_plans:
       - baseline
       - baseline-nfs
-      - kselftest
       - kselftest-filesystems
       - kselftest-futex
       - kselftest-lib
@@ -1942,7 +1941,6 @@ test_configs:
   - device_type: meson-g12b-odroid-n2
     test_plans:
       - baseline
-      - kselftest
       - kselftest-lib
 
   - device_type: meson-gxbb-nanopi-k2
@@ -2017,7 +2015,6 @@ test_configs:
       - baseline
       - baseline-nfs
       - cros-ec
-      - kselftest
       - sleep
       - v4l2-compliance-uvc
 
@@ -2191,7 +2188,6 @@ test_configs:
       - cros-ec
       - igt-gpu-panfrost
       - igt-kms-rockchip
-      - kselftest
       - kselftest-lib
       - ltp-crypto
       - ltp-ipc
@@ -2209,7 +2205,6 @@ test_configs:
       - baseline
       - baseline-nfs
       - cros-ec
-      - kselftest
       - ltp-crypto
       - ltp-fcntl-locktests
       - ltp-ipc

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1816,6 +1816,7 @@ test_configs:
     test_plans:
       - baseline
       - baseline-nfs
+      - kselftest-lib
       - ltp-crypto
       - ltp-ipc
       - ltp-mm
@@ -1936,6 +1937,7 @@ test_configs:
     test_plans:
       - baseline
       - baseline-nfs
+      - kselftest-lib
 
   - device_type: meson-g12b-odroid-n2
     test_plans:
@@ -2050,6 +2052,7 @@ test_configs:
   - device_type: panda
     test_plans:
       - baseline
+      - kselftest-lib
 
   - device_type: panda-es
     test_plans:
@@ -2164,6 +2167,7 @@ test_configs:
   - device_type: r8a7796-m3ulcb
     test_plans: &r8a7796-m3ulcb_test-plans
       - baseline
+      - kselftest-lib
       - usb
 
   - device_type: r8a77960-ulcb  # same as r8a7796-m3ulcb
@@ -2280,6 +2284,7 @@ test_configs:
   - device_type: sun50i-h6-pine-h64
     test_plans:
       - baseline
+      - kselftest-lib
       - ltp-crypto
       - ltp-ipc
       - ltp-mm


### PR DESCRIPTION
It removes the generic kselftest test-plan. We are now focusing on collection approach before to start to run all kselftest in a job/device.

Signed-off-by: Alexandra Pereira <alexandra.pereira@collabora.com>