### PR TITLE
core/test-configs.yaml: Drop few LTP jobs

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1666,7 +1666,6 @@ test_configs:
     test_plans:
       - baseline
       - ltp-crypto
-      - ltp-ipc
       - sleep
       - usb
 
@@ -1687,7 +1686,6 @@ test_configs:
     test_plans:
       - baseline
       - baseline-nfs
-      - ltp-crypto
       - ltp-ipc
 
   - device_type: cubietruck
@@ -1770,7 +1768,6 @@ test_configs:
       - baseline
       - baseline-nfs
       - cros-ec
-      - ltp-timers
       - sleep
 
   - device_type: hsdk
@@ -1891,7 +1888,6 @@ test_configs:
       - ltp-crypto
       - ltp-ipc
       - ltp-mm
-      - ltp-timers
 
   - device_type: kirkwood-db-88f6282
     test_plans:
@@ -2167,10 +2163,7 @@ test_configs:
     test_plans:
       - baseline
       - baseline-nfs
-      - ltp-crypto
-      - ltp-ipc
       - ltp-mm
-      - ltp-timers
       - sleep
       - usb
 
@@ -2182,9 +2175,6 @@ test_configs:
       - igt-gpu-panfrost
       - igt-kms-rockchip
       - kselftest-lib
-      - ltp-crypto
-      - ltp-ipc
-      - ltp-mm
       - ltp-timers
       - sleep
       - usb
@@ -2203,7 +2193,6 @@ test_configs:
       - ltp-ipc
       - ltp-mm
       - ltp-pty
-      - ltp-timers
       - sleep
       - v4l2-compliance-uvc
 
@@ -2272,7 +2261,6 @@ test_configs:
       - ltp-crypto
       - ltp-ipc
       - ltp-mm
-      - ltp-timers
 
   - device_type: sun50i-h6-pine-h64-model-b
     test_plans:


### PR DESCRIPTION
To reduce the load on specific devices we dropped
specific ltp testruns from few devices.

From now on, beaglebone-black runs only ltp-ipc.
rk3288-rock2-square runs only ltp-mm and
bcm2836-rpi-2-b runs only ltp-crypto. veyron-jaq
runs only ltp-timers.

Signed-off-by: lakshmipathi ganapathi <lakshmipathi.ganapathi@collabora.com>