### PR TITLE
T27947 config/k8s: add KCI_DB_CONFIG

### DIFF
--- a/config/k8s/job-build.jinja2
+++ b/config/k8s/job-build.jinja2
@@ -61,9 +61,9 @@ echo -e \"\
 [DEFAULT]\n\
 kdir: ${KDIR}\n\
 verbose: true\n\
-db_config: staging.kernelci.org\n\
+db_config: ${KCI_DB_CONFIG}\n\
 \n\
-[db:staging.kernelci.org]\n\
+[db:${KCI_DB_CONFIG}]\n\
 db_token: ${KCI_API_TOKEN}\n\
 api: ${KCI_API_URL}\n\
 \n\
@@ -125,6 +125,8 @@ exit 0; \
           value: "{{ "FIXME" | env_override('COMMIT_ID') }}"
         - name: BUILD_CONFIG
           value: "{{ "FIXME" | env_override('BUILD_CONFIG') }}"
+        - name: KCI_DB_CONFIG
+          value: "{{ "FIXME" | env_override('KCI_DB_CONFIG') }}"
         - name: KCI_API_URL
           value: "{{ "FIXME" | env_override('KCI_API_URL') }}"
         - name: KCI_API_TOKEN


### PR DESCRIPTION
Add a KCI_DB_CONFIG parameter to the Kubernetes job-build.jinja2
template to be able to specify the --db-config option to pass to
kci_data rather than having a hard-coded staging.kernelci.org.

Depends on https://github.com/kernelci/kernelci-jenkins/pull/54