### PR TITLE
T29745 kernelci.test: fix logic around dtbs handling

### DIFF
--- a/kernelci/test.py
+++ b/kernelci/test.py
@@ -57,10 +57,9 @@ def match_configs(configs, meta, lab):
     for test_config in configs:
         if not test_config.match(arch, flags, filters):
             continue
-        if dtbs:
-            dtb = test_config.device_type.dtb
-            if dtb and dtb not in dtbs:
-                continue
+        dtb = test_config.device_type.dtb
+        if dtb and (not dtbs or dtb not in dtbs):
+            continue
         for plan_name, plan in test_config.test_plans.items():
             if not plan.match(filters):
                 continue


### PR DESCRIPTION
Fix the logic around matching test configs using the list of dtbs, to
not match if the device type requires a dtb but there were no dtbs in
the build.

Fixes: e4919f1e743e ("kernelci.test, kci_test: use Metadata class")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>