### PR TITLE
T27948 kernelci.build: add default make target for MIPS

### DIFF
--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -42,6 +42,7 @@ MAKE_TARGETS = {
     'arc': 'uImage',
     'i386': 'bzImage',
     'x86_64': 'bzImage',
+    'mips': 'uImage.gz',
 }
 
 # Hard-coded binary kernel image names for each CPU architecture


### PR DESCRIPTION
Add default uImage.gz make target for MIPS otherwise some builds may
not produce any usable kernel image, depending on the defconfig.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>