### PR TITLE
lab-configs.yaml: run in lab-collabora with priority 45/100

### DIFF
--- a/config/core/lab-configs.yaml
+++ b/config/core/lab-configs.yaml
@@ -44,6 +44,7 @@ labs:
   lab-collabora:
     lab_type: lava
     url: 'https://lava.collabora.co.uk/RPC2/'
+    priority: '45'
     filters:
       - blocklist:
           tree: [android]


### PR DESCRIPTION
Se the LAVA priority to 45/100 in lab-collabora to better manage how
the resources are being shared with other projects which are running
at "medium" priority (50/100).

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>