### PR TITLE
T27643 db-configs.yaml: add chromeos.kernelci.org

### DIFF
--- a/config/core/db-configs.yaml
+++ b/config/core/db-configs.yaml
@@ -8,6 +8,10 @@ db_configs:
     db_type: kernelci_backend
     url: https://api.staging.kernelci.org/
 
+  chromeos.kernelci.org:
+    db_type: kernelci_backend
+    url: https://api.chromeos.kernelci.org/
+
   localhost:
     db_type: kernelci_backend
     url: http://localhost:5001/


### PR DESCRIPTION
Add the chromeos.kernelci.org backend config entry to db-configs.yaml.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>