### PR TITLE
kernelci.config: drop verbose when loading YAML config

### DIFF
--- a/kci_build
+++ b/kci_build
@@ -429,6 +429,6 @@ class cmd_pull_tarball(Command):
 
 if __name__ == '__main__':
     opts = parse_opts("kci_build", globals())
-    configs = kernelci.config.load(opts.yaml_config, opts.verbose)
+    configs = kernelci.config.load(opts.yaml_config)
     status = opts.command(configs, opts)
     sys.exit(0 if status is True else 1)

--- a/kci_data
+++ b/kci_data
@@ -90,6 +90,6 @@ class cmd_submit_test(Command):
 
 if __name__ == '__main__':
     opts = parse_opts("kci_data", globals())
-    configs = kernelci.config.load(opts.yaml_config, opts.verbose)
+    configs = kernelci.config.load(opts.yaml_config)
     status = opts.command(configs, opts)
     sys.exit(0 if status is True else 1)

--- a/kci_rootfs
+++ b/kci_rootfs
@@ -147,6 +147,6 @@ class cmd_upload(Command):
 
 if __name__ == '__main__':
     opts = parse_opts("kci_rootfs", globals())
-    configs = kernelci.config.load(opts.yaml_config, opts.verbose)
+    configs = kernelci.config.load(opts.yaml_config)
     status = opts.command(configs, opts)
     sys.exit(0 if status is True else 1)

--- a/kci_test
+++ b/kci_test
@@ -259,6 +259,6 @@ class cmd_submit(Command):
 
 if __name__ == '__main__':
     opts = parse_opts("kci_test", globals())
-    configs = kernelci.config.load(opts.yaml_config, opts.verbose)
+    configs = kernelci.config.load(opts.yaml_config)
     status = opts.command(configs, opts)
     sys.exit(0 if status is True else 1)

--- a/kernelci/config/__init__.py
+++ b/kernelci/config/__init__.py
@@ -27,7 +27,7 @@ import kernelci.config.rootfs
 import kernelci.config.test
 
 
-def load_yaml(config_path, verbose=False):
+def load_yaml(config_path):
     """Load the YAML configuration
 
     Load all the YAML files found in the configuration directory into a single
@@ -36,8 +36,6 @@ def load_yaml(config_path, verbose=False):
 
     *config_path* is the path to the YAML config directory, or alternative a
                   single YAML file
-
-    *verbose* is whether to show the names of the YAML files being loaded
     """
     if config_path.endswith('.yaml'):
         yaml_files = [config_path]
@@ -45,8 +43,6 @@ def load_yaml(config_path, verbose=False):
         yaml_files = glob.glob(os.path.join(config_path, "*.yaml"))
     config = dict()
     for yaml_path in yaml_files:
-        if verbose:
-            print("Loading {}".format(yaml_path))
         with open(yaml_path) as yaml_file:
             data = yaml.safe_load(yaml_file)
             for k, v in data.items():
@@ -77,14 +73,13 @@ def from_data(data):
     return config
 
 
-def load(config_path, verbose=False):
+def load(config_path):
     """Load the configuration from YAML files
 
     Load all the YAML files found in the configuration directory then create
     a dictionary containing the configuration objects and return it.
 
     *config_path* is the path to the YAML config directory
-    *verbose* is whether to show the names of the YAML files being loaded
     """
-    data = load_yaml(config_path, verbose)
+    data = load_yaml(config_path)
     return from_data(data)


### PR DESCRIPTION
Drop the verbose option when loading the YAML config files as this
interferes with the output and generates more noise than useful
information.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>