### PR TITLE
test-configs.yaml: remove usb from r8a7796-m3ulcb

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2154,7 +2154,6 @@ test_configs:
   - device_type: r8a7796-m3ulcb
     test_plans: &r8a7796-m3ulcb_test-plans
       - baseline
-      - usb
 
   - device_type: r8a77960-ulcb  # same as r8a7796-m3ulcb
     test_plans: *r8a7796-m3ulcb_test-plans


### PR DESCRIPTION
Drop usb tests from r8a7796-m3ulcb until we can run usb tests only for mainline and linux-next.

Signed-off-by: Alexandra Pereira <alexandra.pereira@collabora.com>