### PR TITLE
T25488 kselftest x86 chromebook

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -307,7 +307,10 @@ build_configs_defaults:
 
         x86_64: &x86_64_arch
           base_defconfig: 'x86_64_defconfig'
-          extra_configs: ['allmodconfig', 'allnoconfig']
+          extra_configs:
+            - 'allmodconfig'
+            - 'allnoconfig'
+            - 'x86_64_defconfig+x86-chromebook+kselftest'
           fragments: [x86_kvm_guest, x86-chromebook]
 
   reference:

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1788,6 +1788,12 @@ test_configs:
       - kselftest-filesystems
       - kselftest-futex
       - kselftest-lib
+      - ltp-crypto
+      - ltp-fcntl-locktests
+      - ltp-ipc
+      - ltp-mm
+      - ltp-pty
+      - ltp-timers
       - sleep
 
   - device_type: hp-x360-12b-n4000-octopus

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1663,6 +1663,9 @@ test_configs:
       - baseline-nfs
       - cros-ec
       - igt-gpu-i915
+      - kselftest-filesystems
+      - kselftest-futex
+      - kselftest-lib
       - ltp-crypto
       - ltp-ipc
       - ltp-mm

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1793,6 +1793,9 @@ test_configs:
       - baseline-nfs
       - cros-ec
       - igt-gpu-i915
+      - kselftest-filesystems
+      - kselftest-futex
+      - kselftest-lib
       - ltp-crypto
       - ltp-ipc
       - ltp-mm

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1785,6 +1785,9 @@ test_configs:
       - baseline
       - baseline-nfs
       - cros-ec
+      - kselftest-filesystems
+      - kselftest-futex
+      - kselftest-lib
       - sleep
 
   - device_type: hp-x360-12b-n4000-octopus


### PR DESCRIPTION
Enable kselftest on x86 Intel Chromebook devices.

Also enable LTP on x86 AMD Chromebook `grunt`.

Depends on:
- [x] #572 enable coral Chromebook
- [x] #580 enable octopus Chromebook