### PR TITLE
build-configs.yaml: add rppt tree and define medium_variants

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -109,6 +109,9 @@ trees:
   robh:
     url: "https://git.kernel.org/pub/scm/linux/kernel/git/robh/linux.git"
 
+  rppt:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/rppt/memblock.git/"
+
   rt-stable:
     url: "https://git.kernel.org/pub/scm/linux/kernel/git/rt/linux-stable-rt.git"
 
@@ -375,10 +378,21 @@ arch_defconfigs: &arch_defconfigs
       - regex: { defconfig: 'x86_64_defconfig' }
 
 
+# Small subset of builds, only defconfigs
 minimal_variants: &minimal_variants
   gcc-8: &gcc_8_minimal
     build_environment: gcc-8
     architectures: *arch_defconfigs
+
+# Medium subset of builds
+medium_variants: &medium_variants
+  gcc-8:
+    build_environment: gcc-8
+    architectures:
+      x86_64: *x86_64_arch
+      i386: *i386_arch
+      arm64: *arm64_arch
+      arm: *arm_arch
 
 
 # Build fewer kernel configs with stable branches
@@ -764,14 +778,7 @@ build_configs:
   lee_android_3.18:
     tree: lee
     branch: 'android-3.18-preview'
-    variants:
-      gcc-8:
-        build_environment: gcc-8
-        architectures:
-          x86_64: *x86_64_arch
-          i386: *i386_arch
-          arm64: *arm64_arch
-          arm: *arm_arch
+    variants: *medium_variants
 
   linusw_devel:
     tree: linusw
@@ -912,6 +919,11 @@ build_configs:
     tree: robh
     branch: 'for-kernelci'
     variants: *minimal_variants
+
+  rppt:
+    tree: rppt
+    branch: 'for-kernelci'
+    variants: *medium_variants
 
   rt-stable_v3.18-rt:
     tree: rt-stable


### PR DESCRIPTION
Add Mike Rapoport's tree and enable the for-kernelci branch with a
medium subset of builds.  Define the medium_variants anchor to
simplify syntax and reuse it where appropriate (lee_android_3.18).

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>