### PR TITLE
test-configs.yaml: remove ltp-ipc from odroid-xu3

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2015,7 +2015,6 @@ test_configs:
       - baseline
       - baseline-nfs
       - igt-kms-exynos
-      - ltp-ipc
       - sleep
       - usb
 


### PR DESCRIPTION
Drop ltp-ipc until we add more devices in the lab, it has just one odroid-xu3 and queue is getting longer.

Signed-off-by: Alexandra Pereira <alexandra.pereira@collabora.com>