### PR TITLE
test-configs.yaml: reduce test plans on hip07-d05

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1748,11 +1748,7 @@ test_configs:
     test_plans:
       - baseline
       - baseline-nfs
-      - kselftest-filesystems
       - kselftest-futex
-      - kselftest-lib
-      - ltp-crypto
-      - ltp-fcntl-locktests
       - ltp-pty
 
   - device_type: hp-11A-G6-EE-grunt


### PR DESCRIPTION
The hip07-d05 platform takes a long time to boot with experimental
firmware and is therefore not able to cope with the test load being
scheduled, with a single instance available.  Keep only one collection
for kselftest and LTP as a simple measure to contain the queue length.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>