### PR TITLE
Revert "test-configs.yaml: update kseltest test plan to use new rootfs"

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -49,12 +49,6 @@ file_systems:
     type: debian
     ramdisk: 'buster-igt/20210503.0/{arch}/rootfs.cpio.gz'
 
-  debian_buster_kselftest:
-    type: debian
-    ramdisk: 'buster-kselftest/20210514.0/{arch}/rootfs.cpio.gz'
-    nfs: 'buster-kselftest/20210514.0/{arch}/full.rootfs.tar.xz'
-    root_type: nfs
-
   debian_buster-v4l2_ramdisk:
     type: debian
     ramdisk: 'buster-v4l2/20210503.0/{arch}/rootfs.cpio.gz'
@@ -175,7 +169,7 @@ test_plans:
         panfrost_submit
 
   kselftest: &kselftest
-    rootfs: debian_buster_kselftest
+    rootfs: debian_buster_nfs
     pattern: 'kselftest/{category}-{method}-{protocol}-{rootfs}-kselftest-template.jinja2'
     filters:
       - passlist: {defconfig: ['kselftest']}


### PR DESCRIPTION
This reverts commit f1fb532033fdc770235074fd835a96803ed7d66c.

The kselftest jobs appear to all be all failing with this rootfs, so
revert to using the plain Buster one instead for now.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>