### PR TITLE
Reduce sabrelite tests

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1836,13 +1836,13 @@ test_configs:
   - device_type: imx6q-sabrelite
     test_plans:
       - baseline
+
+  - device_type: imx6q-sabrelite
+    test_plans:
       - baseline-nfs
-      - ltp-crypto
-      - ltp-ipc
-      - ltp-mm
-      - ltp-timers
-      - sleep
-      - usb
+    filters:
+      - passlist:
+          lab: [lab-baylibre]
 
   - device_type: imx6q-sabresd
     test_plans:

--- a/kernelci/test.py
+++ b/kernelci/test.py
@@ -45,6 +45,7 @@ def match_configs(configs, meta, lab):
         'build_environment': env['name'],
         'tree': rev['tree'],
         'branch': rev['branch'],
+        'lab': lab.name,
     }
 
     flags = {


### PR DESCRIPTION
Reduce the number of tests run on `imx6q-sabrelite` boards in Collabora's lab until more hardware becomes available.