### PR TITLE
Add lc-compliance rootfs

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -142,7 +142,7 @@ rootfs_configs:
       - e2fslibs
       - e2fsprogs
     script: "scripts/buster-libcamera.sh"
-    # test_overlay: "overlays/libcamera"
+    test_overlay: "overlays/libcamera"
 
   buster-ltp:
     rootfs_type: debos

--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -128,6 +128,22 @@ rootfs_configs:
       - wget
       - xz-utils
 
+  buster-libcamera:
+    rootfs_type: debos
+    debian_release: buster
+    arch_list:
+      - amd64
+      - arm64
+      - armhf
+    extra_packages:
+      - libevent-dev
+    extra_packages_remove:
+      - bash
+      - e2fslibs
+      - e2fsprogs
+    script: "scripts/buster-libcamera.sh"
+    # test_overlay: "overlays/libcamera"
+
   buster-ltp:
     rootfs_type: debos
     debian_release: buster

--- a/config/rootfs/debos/overlays/libcamera/usr/bin/lc-compliance-parser.sh
+++ b/config/rootfs/debos/overlays/libcamera/usr/bin/lc-compliance-parser.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Get first camera name
+get_cam_name() {
+	LIBCAMERA_LOG_LEVELS=FATAL lc-compliance | while read -r line; do
+		echo "$line" | grep -qe '^- .*' && {
+			cam_name=$(echo "$line" | sed 's/^- \(.*\)/\1/')
+			echo "$cam_name"
+			break
+		}
+	done
+}
+
+lc-compliance -c "$(get_cam_name)" | while read line; do
+
+	echo "$line"
+
+	# Look for a test
+	echo "$line" | grep -qe '^\[ RUN      \]' && {
+
+		test_set=$(echo "$line" | sed 's/^\[ RUN      \] \([^.]*\).*/\1/')
+
+		test_case=$(echo "$line" | sed 's/^\[ RUN      \] [^.]*\.\(.*\)/\1/')
+
+		[ "$test_set" != "$prev_test_set" ] && {
+			[ -n "$prev_test_set" ] && lava-test-set stop
+			lava-test-set start $test_set
+			prev_test_set="$test_set"
+		}
+
+		continue
+	}
+
+	# Check for test result
+	echo "$line" | grep -qe '^\[       OK \]' && res=pass
+	echo "$line" | grep -qe '^\[  SKIPPED \]' && res=skip
+	echo "$line" | grep -qe '^\[  FAILED  \]' && res=fail
+	[ -n "$res" ] && lava-test-case "$test_case" --result "$res"
+
+	res=''
+
+	# End
+	echo "$line" | grep -qe '^\[==========\]' && [ -n "$test_set" ] && {
+		lava-test-set stop
+		break
+	}
+
+done
+
+exit 0

--- a/config/rootfs/debos/scripts/buster-libcamera.sh
+++ b/config/rootfs/debos/scripts/buster-libcamera.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# Important: This script is run under QEMU
+
+set -e
+
+# No libudev, it's needed only for hotplug detection
+# No libboost or raspberrypi pipeline, should be added if tested on raspberrypi
+
+BUILD_DEPS="\
+      g++ \
+      ninja-build \
+      python3-yaml \
+      python3-ply \
+      python3-jinja2 \
+      python3-setuptools \
+      libgnutls28-dev \
+      openssl \
+      pkg-config \
+      libevent-dev \
+
+      python3-pip \
+      git \
+      ca-certificates \
+"
+
+# Get latest libgtest from backports
+echo 'deb http://deb.debian.org/debian buster-backports main' >> /etc/apt/sources.list
+apt-get update
+apt-get install --no-install-recommends -y libgtest-dev/buster-backports
+
+apt-get install --no-install-recommends -y  ${BUILD_DEPS}
+
+# Get latest meson from pip
+pip3 install meson
+
+BUILDFILE=/test_suites.json
+echo '{  "tests_suites": [' >> $BUILDFILE
+
+# Build libcamera and lc-compliance
+########################################################################
+
+LIBCAMERA_URL=https://gitlab.collabora.com/nfraprado/libcamera.git
+mkdir -p /tmp/tests/libcamera && cd /tmp/tests/libcamera
+
+# Use my fork until it gets merged
+git clone --single-branch --branch lcc-gtest-v5 --depth=1 $LIBCAMERA_URL .
+
+echo '    {"name": "lc-compliance", "git_url": "'$LIBCAMERA_URL'", "git_commit": ' \"`git rev-parse HEAD`\" '}' >> $BUILDFILE
+
+meson build --prefix=/usr -Ddocumentation=disabled -Dgstreamer=disabled -Dpipelines=uvcvideo,rkisp1
+ninja -C build install
+
+echo '  ]}' >> $BUILDFILE
+
+########################################################################
+# Cleanup: remove files and packages we don't want in the images       #
+########################################################################
+rm -rf /tmp/tests
+
+apt-get remove --purge -y ${BUILD_DEPS}
+apt-get remove --purge -y libgtest-dev
+apt-get autoremove --purge -y
+apt-get clean
+
+# re-add some stuff that is removed by accident
+apt-get install -y initramfs-tools


### PR DESCRIPTION
Add a rootfs and accompanying build script that contains libcamera and
its test suite: lc-compliance.

Running lc-compliance will be useful to test for regressions in the
media subsystem.

Signed-off-by: Nícolas F. R. A. Prado <nfraprado@collabora.com>