### PR TITLE
build-configs: update amlogic repo

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -11,7 +11,7 @@ trees:
     url: "https://git.linaro.org/people/alex.bennee/linux.git"
 
   amlogic:
-    url: "https://git.kernel.org/pub/scm/linux/kernel/git/khilman/linux-amlogic.git"
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/amlogic/linux.git"
 
   android:
     url: "https://android.googlesource.com/kernel/common"


### PR DESCRIPTION
The linux-amlogic tree has moved due to a switch to group
maintainership.  Update with the new repo URL.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>