### PR TITLE
rootfs-configs.yaml: add libnuma-dev package to buster-ltp

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -135,6 +135,8 @@ rootfs_configs:
       - amd64
       - arm64
       - armhf
+    extra_packages:
+      - libnuma-dev
     script: "scripts/buster-ltp.sh"
 
   buster-v4l2:


### PR DESCRIPTION
Some of the ltp-mm tests require this package to fully run:

19:35:37.330653  tst_test.c:870: CONF: test requires libnuma >= 2 and it's development packages
...
19:38:09.697595  vma02       1  TCONF  :  vma02.c:169: test requires libnuma >= 2 and it's development packages

Signed-off-by: Gustavo Padovan <gustavo.padovan@collabora.com>