### PR TITLE
Check skipped kselftests

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -193,6 +193,7 @@ test_plans:
     params:
       job_timeout: '10'
       kselftest_collections: "futex"
+      kselftest_skipfile: "skipfile-futex.yaml"
 
   kselftest-lib:
     <<: *kselftest

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -193,7 +193,6 @@ test_plans:
     params:
       job_timeout: '10'
       kselftest_collections: "futex"
-      kselftest_skipfile: "skipfile-futex.yaml"
 
   kselftest-lib:
     <<: *kselftest

--- a/config/lava/kselftest/kselftest.jinja2
+++ b/config/lava/kselftest/kselftest.jinja2
@@ -21,6 +21,6 @@
       name: {{ plan }}
       parameters:
         TESTPROG_URL: {{ kselftests_url }}
-        SKIPFILE: {{ kselftest_skipfile }}
+        SKIPFILE: {{ kselftest_skipfile|default("skipfile-lkft.yaml", true) }}
         TST_CMDFILES: {{ kselftest_collections }}
         TST_CASENAME: {{ kselftest_tests }}

--- a/config/lava/kselftest/kselftest.jinja2
+++ b/config/lava/kselftest/kselftest.jinja2
@@ -21,6 +21,6 @@
       name: {{ plan }}
       parameters:
         TESTPROG_URL: {{ kselftests_url }}
-        SKIPFILE: skipfile-lkft.yaml
+        SKIPFILE: {{ kselftest_skipfile }}
         TST_CMDFILES: {{ kselftest_collections }}
         TST_CASENAME: {{ kselftest_tests }}


### PR DESCRIPTION
This allows to use a different skipfile for each test set instead of
using a single skipfile for all kselftests. Finer granularity, better
control and better reporting.

Depends on:

- [ ] https://github.com/kernelci/test-definitions/pull/8