### PR TITLE
Rename references from 'jenkins/debos' to 'config/roots'

### DIFF
--- a/doc/kci_rootfs.md
+++ b/doc/kci_rootfs.md
@@ -86,7 +86,7 @@ rootfs name along with its architecture.
     ```
     ./kci_rootfs build \
         --rootfs-config buster \
-        --data-path jenkins/debian/debos \
+        --data-path config/rootfs/debos \
         --arch i386
     ```
 
@@ -100,10 +100,10 @@ rootfs name along with its architecture.
     Powering off.
     ==== Recipe done ====
     ```
-    Finally newly built rootfs images can be found under the directory pointed by `--data-path`. In our case, its `jenkins/debian/debos/buster/i386/`
+    Finally newly built rootfs images can be found under the directory pointed by `--data-path`. In our case, its `config/rootfs/debos/buster/i386/`
 
     ```
-    $ ls jenkins/debian/debos/buster/i386/
+    $ ls config/rootfs/debos/buster/i386/
     build_info.json  full.rootfs.cpio.gz  full.rootfs.tar.xz  initrd.cpio.gz  rootfs.cpio.gz  rootfs.ext4.xz
     ```
 
@@ -148,14 +148,14 @@ Now you know how to build default `kci_rootfs` images. Let's look at how to add 
     ```
     ./kci_rootfs build \
         --rootfs-config buster-example \
-        --data-path jenkins/debian/debos \
+        --data-path config/rootfs/debos \
         --arch amd64
     ```
     and wait for its completion. If everything went fine you should see
-    something like below under `jenkins/debian/debos/buster-example/amd64/`
+    something like below under `config/rootfs/debos/buster-example/amd64/`
     directory.
 
     ```
-    ls jenkins/debian/debos/buster-example/amd64/
+    ls config/rootfs/debos/buster-example/amd64/
     build_info.json  full.rootfs.cpio.gz  full.rootfs.tar.xz  initrd.cpio.gz  rootfs.cpio.gz  rootfs.ext4.xz
     ```


### PR DESCRIPTION
In commit 5b583dced4ed ("config/rootfs/debos: move all debos files to new
directory") the directory 'jenkins/debian' was moved to 'config/rootfs'.
The documentation for the kci_rootfs, written before that commit, still
has references to the old directory structure. It's nice have the
documentation up-to-date with current directory structure, so update
that file and replace the old directory with the new one.

This makes the life a bit easier when you're following instructions and
do silly copy and pastes.

Signed-off-by: Enric Balletbo i Serra <enric.balletbo@collabora.com>