### PR TITLE
kernelci: Add support for cros defconfigs

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -237,7 +237,7 @@ build_environments:
   clang-12:
     cc: clang
     cc_version: 12
-    arch_params:
+    arch_params: &clang_12_arch_params
       <<: *clang_arch_params
       riscv:
         <<: *riscv_params
@@ -246,6 +246,11 @@ build_environments:
           LLVM_IAS: '1'
           LD: 'riscv64-linux-gnu-ld'
 
+  clang-13:
+    cc: clang
+    cc_version: 13
+    arch_params:
+      <<: *clang_12_arch_params
 
 # Default config with full build coverage
 build_configs_defaults:

--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -816,6 +816,26 @@ build_configs:
           arm: *arm_defconfig
           arm64: *arm64_defconfig
           x86_64: *x86_64_defconfig
+      chromeos-configs: &chromeos_configs
+        build_environment: clang-13
+        architectures:
+            arm:
+              base_defconfig: 'cros://chromeos-5.10/armel/chromiumos-arm.flavour.config'
+              extra_configs:
+                - 'cros://chromeos-5.10/armel/chromiumos-rockchip.flavour.config'
+            arm64:
+              base_defconfig: 'cros://chromeos-5.10/arm64/chromiumos-arm64.flavour.config'
+              extra_configs:
+                - 'cros://chromeos-5.10/arm64/chromiumos-mediatek.flavour.config'
+                - 'cros://chromeos-5.10/arm64/chromiumos-qualcomm.flavour.config'
+                - 'cros://chromeos-5.10/arm64/chromiumos-rockchip64.flavour.config'
+            x86_64:
+              base_defconfig: 'cros://chromeos-5.10/x86_64/chromiumos-x86_64.flavour.config'
+              extra_configs:
+                - 'cros://chromeos-5.10/x86_64/chromeos-amd-stoneyridge.flavour.config'
+                - 'cros://chromeos-5.10/x86_64/chromeos-intel-denverton.flavour.config'
+                - 'cros://chromeos-5.10/x86_64/chromeos-intel-pineview.flavour.config'
+
 
   media:
     tree: media
@@ -881,6 +901,10 @@ build_configs:
             filters:
               - passlist:
                   defconfig: *riscv_clang_configs
+
+      # ChromeOS configs
+      chromeos_configs:
+        <<: *&chromeos_configs
 
   next_pending-fixes:
     tree: next

--- a/config/docker/clang-13/Dockerfile
+++ b/config/docker/clang-13/Dockerfile
@@ -1,0 +1,45 @@
+FROM kernelci/build-base
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    software-properties-common \
+    gnupg2
+
+RUN wget -q -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+RUN apt-add-repository 'deb http://apt.llvm.org/buster/ llvm-toolchain-buster main'
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    binutils-aarch64-linux-gnu \
+    binutils-arm-linux-gnueabihf \
+    binutils-riscv64-linux-gnu \
+    binutils \
+    clang-13 lld-13 llvm-13
+
+ENV PATH=/usr/lib/llvm-13/bin:${PATH}
+
+# kselftest x86
+RUN apt-get update && apt-get install --no-install-recommends -y \
+   libc6-dev \
+   libcap-dev \
+   libcap-ng-dev \
+   libelf-dev \
+   libpopt-dev
+
+# kselftest arm64
+RUN dpkg --add-architecture arm64
+RUN apt-get update && apt-get install --no-install-recommends -y \
+   libc6-dev:arm64 \
+   libcap-dev:arm64 \
+   libcap-ng-dev:arm64 \
+   libelf-dev:arm64 \
+   libpopt-dev:arm64
+
+# kselftest arm
+RUN dpkg --add-architecture armhf
+RUN apt-get update && apt-get install --no-install-recommends -y \
+   libc6-dev:armhf \
+   libcap-dev:armhf \
+   libcap-ng-dev:armhf \
+   libelf-dev:armhf \
+   libpopt-dev:armhf
+
+RUN apt-get autoremove -y gcc

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -21,6 +21,7 @@ import itertools
 import json
 import os
 import platform
+import re
 import shutil
 import tarfile
 import time
@@ -34,6 +35,9 @@ from kernelci.storage import upload_files
 # This is used to get the mainline tags as a minimum for git describe
 TORVALDS_GIT_URL = \
     "git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git"
+
+CROS_CONFIG_URL = \
+    "https://chromium.googlesource.com/chromiumos/third_party/kernel/+archive/refs/heads/{branch}/chromeos/config.tar.gz"
 
 # Hard-coded make targets for each CPU architecture
 MAKE_TARGETS = {
@@ -1065,6 +1069,18 @@ scripts/kconfig/merge_config.sh -O {output} '{base}' '{frag}' {redir}
             cmd = self._output_to_file(cmd, self._log_path, self._kdir)
         return shell_cmd(cmd, True)
 
+    def _create_cros_config(self, config):
+        [(branch,config)] = re.findall("cros://([\w\-.]+)/(.*)", config)
+        cros_config = os.path.join(self._output_path, "cros-config.tgz")
+        url = CROS_CONFIG_URL.format(branch=branch)
+        if not _download_file(url, cros_config):
+            raise FileNotFoundError("Error reading {}".format(url))
+        tar = tarfile.open(cros_config)
+        with open(os.path.join(self._output_path, ".config"), 'wb') as f:
+            f.write(tar.extractfile("base.config").read())
+            f.write(tar.extractfile(os.path.join(os.path.dirname(config), "common.config")).read())
+            f.write(tar.extractfile(config).read())
+
     def run(self, jopt=None, verbose=False, opts=None):
         """Make the kernel config
 
@@ -1114,6 +1130,10 @@ scripts/kconfig/merge_config.sh -O {output} '{base}' '{frag}' {redir}
             'defconfig_extras': extras,
             'publish_path': publish_path,
         }
+
+        if target.startswith("cros://"):
+            self._create_cros_config(target)
+            target = "olddefconfig"
 
         res = self._make(target, jopt, verbose, opts)
 


### PR DESCRIPTION
ChromeOS maintain its own defconfigs as splitconfig files in its
repository.

Create a helper that is capable of fetching that configuration and
convert it into a standard oldconfig.

Fixes: #712
Signed-off-by: Ricardo Ribalda <ribalda@chromium.org>