### PR TITLE
build-configs: Add ltp-crypto fragment

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -148,6 +148,60 @@ trees:
 
 fragments:
 
+  crypto:
+    path: "kernel/configs/crypto.config"
+    configs:
+      - 'CONFIG_CRYPTO_CHACHA20POLY1305=y'
+      - 'CONFIG_CRYPTO_CHACHA20=y'
+      - 'CONFIG_CRYPTO_POLY1305=y'
+      - 'CONFIG_CRYPTO_AEAD=y'
+      - 'CONFIG_CRYPTO_MANAGER=y'
+      - 'CONFIG_CRYPTO_LIB_CHACHA_GENERIC=y'
+      - 'CONFIG_CRYPTO_SKCIPHER=y'
+      - 'CONFIG_CRYPTO_HASH=y'
+      - 'CONFIG_CRYPTO_LIB_POLY1305_GENERIC=y'
+      - 'CONFIG_CRYPTO_AEAD2=y'
+      - 'CONFIG_CRYPTO_ALGAPI=y'
+      - 'CONFIG_CRYPTO_MANAGER2=y'
+      - 'CONFIG_CRYPTO_SKCIPHER2=y'
+      - 'CONFIG_CRYPTO_HASH2=y'
+      - 'CONFIG_CRYPTO_ALGAPI2=y'
+      - 'CONFIG_CRYPTO_NULL2=y'
+      - 'CONFIG_CRYPTO_RNG2=y'
+      - 'CONFIG_CRYPTO_AKCIPHER2=y'
+      - 'CONFIG_CRYPTO_KPP2=y'
+      - 'CONFIG_CRYPTO_ACOMP2=y'
+      - 'CONFIG_SGL_ALLOC=y'
+      - 'CONFIG_CRYPTO_VMAC=y'
+      - 'CONFIG_CRYPTO_PCRYPT=y'
+      - 'CONFIG_PADATA=y'
+      - 'CONFIG_CRYPTO_HMAC=y'
+      - 'CONFIG_CRYPTO_AES=y'
+      - 'CONFIG_CRYPTO_LIB_AES=y'
+      - 'CONFIG_CRYPTO_SHA256=y'
+      - 'CONFIG_CRYPTO_CBC=y'
+      - 'CONFIG_CRYPTO_MD5=y'
+      - 'CONFIG_CRYPTO_SHA1=y'
+      - 'CONFIG_CRYPTO_AUTHENC=y'
+      - 'CONFIG_CRYPTO_USER=y'
+      - 'CONFIG_CRYPTO_USER_API_HASH=y'
+      - 'CONFIG_CRYPTO_USER_API_SKCIPHER=y'
+      - 'CONFIG_CRYPTO_USER_API_RNG=y'
+      - 'CONFIG_CRYPTO_USER_API_AEAD=y'
+      - 'CONFIG_CRYPTO_SHA3=y'
+      - 'CONFIG_CRYPTO_LIB_CHACHA20POLY1305=y'
+      - 'CONFIG_CRYPTO_DEV_FSL_CAAM_CRYPTO_API=y'
+      - 'CONFIG_CRYPTO_DEV_FSL_CAAM_CRYPTO_API_DESC=y'
+      - 'CONFIG_CRYPTO_AEAD=y'
+      - 'CONFIG_CRYPTO_AUTHENC=y'
+      - 'CONFIG_CRYPTO_SKCIPHER=y'
+      - 'CONFIG_CRYPTO_LIB_DES=y'
+      - 'CONFIG_CRYPTO_XTS=y'
+      - 'CONFIG_CRYPTO_DEV_FSL_CAAM_CRYPTO_API_QI=y'
+      - 'CONFIG_CRYPTO_DEV_FSL_CAAM_CRYPTO_API_DESC=y'
+      - 'CONFIG_CRYPTO_DES=y'
+      - 'CONFIG_CRYPTO_ECB=y'
+
   debug:
     path: "kernel/configs/debug.config"
 
@@ -281,6 +335,7 @@ build_configs_defaults:
             - 'multi_v7_defconfig+CONFIG_CPU_BIG_ENDIAN=y'
             - 'multi_v7_defconfig+CONFIG_SMP=n'
             - 'multi_v7_defconfig+CONFIG_EFI=y+CONFIG_ARM_LPAE=y'
+          fragments: [crypto]
 
         arm64: &arm64_arch
           extra_configs:
@@ -288,6 +343,7 @@ build_configs_defaults:
             - 'allnoconfig'
             - 'defconfig+CONFIG_CPU_BIG_ENDIAN=y'
             - 'defconfig+CONFIG_RANDOMIZE_BASE=y'
+          fragments: [crypto]
 
         i386: &i386_arch
           base_defconfig: 'i386_defconfig'
@@ -311,7 +367,7 @@ build_configs_defaults:
             - 'allmodconfig'
             - 'allnoconfig'
             - 'x86_64_defconfig+x86-chromebook+kselftest'
-          fragments: [x86_kvm_guest, x86-chromebook]
+          fragments: [crypto, x86_kvm_guest, x86-chromebook]
 
   reference:
     tree: mainline


### PR DESCRIPTION
Almost all of the ltp-crypto tests are being skipped since the required
kernel config option for crypto algorithms are not enabled.
Hence add ltp_crypto fragment in build-configs.yaml file which would
enable the config options.

Signed-off-by: Shreeya Patel <shreeya.patel@collabora.com>