### PR TITLE
build-configs.yaml: add eMMC configs to x86-chromebook

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -186,6 +186,10 @@ fragments:
       - 'CONFIG_USB_GADGET=y'
       - 'CONFIG_USB_ETH=y'
       - 'CONFIG_USB_RTL8152=y'
+      - 'CONFIG_MMC=y'
+      - 'CONFIG_MMC_SDHCI=y'
+      - 'CONFIG_MMC_SDHCI_PCI=y'
+      - 'CONFIG_MMC_SDHCI_ACPI=y'
 
   x86_kvm_guest:
     path: "kernel/configs/kvm_guest.config"


### PR DESCRIPTION
Add kernel config options to be able to enable the eMMC on x86
Chromebook devices.  Tested on Grunt AMD platform.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>