### PR TITLE
config/docker: Add clang-13 configuration

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -237,7 +237,7 @@ build_environments:
   clang-12:
     cc: clang
     cc_version: 12
-    arch_params:
+    arch_params: &clang_12_arch_params
       <<: *clang_arch_params
       riscv:
         <<: *riscv_params
@@ -246,6 +246,11 @@ build_environments:
           LLVM_IAS: '1'
           LD: 'riscv64-linux-gnu-ld'
 
+  clang-13:
+    cc: clang
+    cc_version: 13
+    arch_params:
+      <<: *clang_12_arch_params
 
 # Default config with full build coverage
 build_configs_defaults:

--- a/config/docker/clang-13/Dockerfile
+++ b/config/docker/clang-13/Dockerfile
@@ -1,0 +1,45 @@
+FROM kernelci/build-base
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    software-properties-common \
+    gnupg2
+
+RUN wget -q -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+RUN apt-add-repository 'deb http://apt.llvm.org/buster/ llvm-toolchain-buster main'
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    binutils-aarch64-linux-gnu \
+    binutils-arm-linux-gnueabihf \
+    binutils-riscv64-linux-gnu \
+    binutils \
+    clang-13 lld-13 llvm-13
+
+ENV PATH=/usr/lib/llvm-13/bin:${PATH}
+
+# kselftest x86
+RUN apt-get update && apt-get install --no-install-recommends -y \
+   libc6-dev \
+   libcap-dev \
+   libcap-ng-dev \
+   libelf-dev \
+   libpopt-dev
+
+# kselftest arm64
+RUN dpkg --add-architecture arm64
+RUN apt-get update && apt-get install --no-install-recommends -y \
+   libc6-dev:arm64 \
+   libcap-dev:arm64 \
+   libcap-ng-dev:arm64 \
+   libelf-dev:arm64 \
+   libpopt-dev:arm64
+
+# kselftest arm
+RUN dpkg --add-architecture armhf
+RUN apt-get update && apt-get install --no-install-recommends -y \
+   libc6-dev:armhf \
+   libcap-dev:armhf \
+   libcap-ng-dev:armhf \
+   libelf-dev:armhf \
+   libpopt-dev:armhf
+
+RUN apt-get autoremove -y gcc


### PR DESCRIPTION
ChromeOS uses clang-13, so lets make a docker image with that clang
version.

Fixes #714

Signed-off-by: Ricardo Ribalda <ricardo@ribalda.com>