### PR TITLE
kernelci.build: make and install perf

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -278,15 +278,19 @@ build_environments:
         cross_compile: 'arc-elf32-'
       arm: &arm_params
         cross_compile: 'arm-linux-gnueabihf-'
+        build_perf: true
       arm64: &arm64_params
         cross_compile: 'aarch64-linux-gnu-'
         cross_compile_compat: 'arm-linux-gnueabihf-'
+        build_perf: true
       i386: &i386_params
         name: 'x86'
+        build_perf: true
       mips: &mips_params
         cross_compile: 'mips-linux-gnu-'
       x86_64: &x86_64_params
         name: 'x86'
+        build_perf: true
       riscv: &riscv_params
         name: 'riscv64'
         cross_compile: 'riscv64-linux-gnu-'
@@ -297,9 +301,11 @@ build_environments:
     arch_params: &clang_arch_params
       arm:
         <<: *arm_params
+        build_perf: false
         name:
       arm64:
         <<: *arm64_params
+        build_perf: false
         name:
       i386:
         <<: *i386_params

--- a/config/k8s/job-build.jinja2
+++ b/config/k8s/job-build.jinja2
@@ -94,7 +94,8 @@ set -x; \
 ./kci_build make_kernel && \
 ./kci_build make_modules && \
 ./kci_build make_dtbs && \
-./kci_build make_kselftest; \
+./kci_build make_kselftest && \
+./kci_build make_perf; \
 export KERNEL_BUILD_RESULT=$?;
 \
 set +x; \

--- a/kci_build
+++ b/kci_build
@@ -398,6 +398,11 @@ class cmd_make_kselftest(MakeCommand):
     step_cls = kernelci.build.MakeSelftests
 
 
+class cmd_make_perf(MakeCommand):
+    help = "Build perf"
+    step_cls = kernelci.build.MakePerf
+
+
 class cmd_push_kernel(Command):
     help = "Push the kernel build artifacts"
     args = [Args.kdir, Args.api, Args.db_token]

--- a/kernelci/config/build.py
+++ b/kernelci/config/build.py
@@ -252,6 +252,10 @@ class BuildEnvironment(YAMLObject):
         params = self._arch_params.get(arch) or dict()
         return params.get('cross_compile_compat', '')
 
+    def get_build_perf(self, arch):
+        params = self._arch_params.get(arch) or dict()
+        return params.get('build_perf', False)
+
 
 class BuildVariant(YAMLObject):
     """A variant of a given build configuration."""

--- a/kernelci/test.py
+++ b/kernelci/test.py
@@ -115,6 +115,11 @@ def get_params(meta, target, plan_config, storage):
         urllib.parse.urljoin(storage, '/'.join([url_px, kselftests]))
         if kselftests else None
     )
+    perf = meta.get_single_artifact('perf', attr='path')
+    perf_url = (
+        urllib.parse.urljoin(storage, '/'.join([url_px, perf]))
+        if perf else None
+    )
 
     params = {
         'name': job_name,
@@ -150,6 +155,7 @@ def get_params(meta, target, plan_config, storage):
         'file_server_resource': publish_path,
         'build_environment': meta.get('bmeta', 'environment', 'name'),
         'kselftests_url': kselftests_url,
+        'perf': perf_url,
     }
 
     params.update(rootfs.params)


### PR DESCRIPTION
make linux perf in linux/tools/perf and install the binary as an
artifact.

Signed-off-by: Hsin-Yi Wang <hsinyi@chromium.org>