### PR TITLE
Add ltp-ima test plan (#710)

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -154,6 +154,13 @@ fragments:
   kselftest:
     path: "kernel/configs/kselftest.config"
 
+  ltp-ima:
+    path: "kernel/configs/ltp-ima.config"
+    configs:
+      - 'CONFIG_INTEGRITY=y'
+      - 'CONFIG_IMA=y'
+      - 'CONFIG_IMA_READ_POLICY=y'
+
   preempt_rt:
     path: "kernel/configs/preempt_rt.config"
     configs:
@@ -261,6 +268,7 @@ build_configs_defaults:
         - 'debug'
         - 'kselftest'
         - 'tinyconfig'
+        - 'ltp-ima'
 
       architectures: &default_architectures
 

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -233,6 +233,15 @@ test_plans:
       <<: *ltp-params
       tst_cmdfiles: "fcntl-locktests"
 
+  ltp-ima:
+    <<: *ltp
+    params:
+      <<: *ltp-params
+      tst_cmdfiles: "ima"
+    filters:
+      - passlist:
+          defconfig:
+            - 'defconfig+ltp-ima'
   ltp-mm:
     <<: *ltp
     params:
@@ -1689,6 +1698,7 @@ test_configs:
       - ltp-crypto
       - ltp-ipc
       - ltp-mm
+      - ltp-ima
       - sleep_mem
 
   - device_type: at91-sama5d2_xplained


### PR DESCRIPTION
Added a 'ltp-ima' fragment and a 'ltp-ima' test plan.
The test-definition part seems work fine with the latest LTP version by passing 'ima' to tst_cmdfiles.

Don't know if it's the correct way to use 'filters/passlist' in the test_plan to force it using a kernel with ltp-ima fragment.   
