### PR TITLE
build-configs.yaml: add more drivers to x86-chromebook

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -190,6 +190,20 @@ fragments:
       - 'CONFIG_MMC_SDHCI=y'
       - 'CONFIG_MMC_SDHCI_PCI=y'
       - 'CONFIG_MMC_SDHCI_ACPI=y'
+      - 'CONFIG_MMC_BLOCK=y'
+      - 'CONFIG_CHROME_PLATFORMS=y'
+      - 'CONFIG_CHROMEOS_LAPTOP=y'
+      - 'CONFIG_CHROMEOS_PSTORE=y'
+      - 'CONFIG_CHROMEOS_TBMC=y'
+      - 'CONFIG_PSTORE=y'
+      - 'CONFIG_EFI_VARS_PSTORE=y'
+      - 'CONFIG_BLK_DEV_NVME=y'
+      - 'CONFIG_NVME_CORE=y'
+      - 'CONFIG_DM_BUFIO=y'
+      - 'CONFIG_DM_CRYPT=y'
+      - 'CONFIG_DM_THIN_PROVISIONING=y'
+      - 'CONFIG_DM_INIT=y'
+      - 'CONFIG_DM_VERITY=y'
 
   x86_kvm_guest:
     path: "kernel/configs/kvm_guest.config"


### PR DESCRIPTION
These were needed to boot coral onto a Chrome OS filesystem on emmc.
Some like nvme would be needed for other machines but weren't tested.
The dm_* drivers are need to get some of the filesystems mounted,
otherwise the Chrome OS scripts are unhappy and reboot.  Pstore is
useful for debugging kernel crashes, so I enabled that as well.

Fixes: #719 

Signed-off-by: Sonny Rao <sonnyrao@chromium.org>