### PR TITLE
github/workflows: enable checks on chromeos branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,9 +7,9 @@ on:
   # Triggers the workflow on push or pull request events but only for the
   # main branch
   push:
-    branches: [ main ]
+    branches: [ main, chromeos ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, chromeos ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Enable GitHub checks to run on the chromeos branch in addition to the
main branch.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>