### PR TITLE
Replace characters introduced by cros://

### DIFF
--- a/config/k8s/gen.py
+++ b/config/k8s/gen.py
@@ -27,7 +27,7 @@ if frag:
     job_name += "-{}".format(frag)
 
 # job name can only have '-'
-job_name = re.sub('[\./_+=]', '-', job_name).lower()
+job_name = re.sub('[\./_+=:]', '-', job_name).lower()
 
 # k8s limits job-name to max 63 chars (and be sure it doesn't end with '-')
 job_name = job_name[0:63].rstrip('-')

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -1115,14 +1115,16 @@ scripts/kconfig/merge_config.sh -O {output} '{base}' '{frag}' {redir}
 
         bmeta = self._meta.get('bmeta')
         rev, env = (bmeta[cat] for cat in ('revision', 'environment'))
-        publish_path = '/'.join(item.replace('/', '-') for item in [
-            rev['tree'],
-            rev['branch'],
-            rev['describe'],
-            env['arch'],
-            defconfig,
-            env['name'],
-        ])
+        publish_path = '/'.join((
+            re.sub(r'[\/:]', '-', item).lower() for item in [
+                rev['tree'],
+                rev['branch'],
+                rev['describe'],
+                env['arch'],
+                defconfig,
+                env['name'],
+            ])
+        )
 
         bmeta['kernel'] = {
             'defconfig': target,


### PR DESCRIPTION
Add the colon`:` to the list of characters to replace with dashes in the Kubernetes job names.

Also replace more than just slash `/` characters in the upload file path to avoid issues and keep it readable.

Depends on #729 