### PR TITLE
test-configs.yaml: Add seccomp and lkdtm kselftest collections

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -210,6 +210,18 @@ test_plans:
       job_timeout: '10'
       kselftest_collections: "lib"
 
+  kselftest-lkdtm:
+    <<: *kselftest
+    params:
+      job_timeout: '10'
+      kselftest_collections: "lkdtm"
+
+kselftest-seccomp:
+    <<: *kselftest
+    params:
+      job_timeout: '10'
+      kselftest_collections: "seccomp"
+
   ltp: &ltp
     rootfs: debian_buster-ltp_nfs
     pattern: 'ltp/{category}-{method}-{protocol}-{rootfs}-ltp-template.jinja2'

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -216,7 +216,7 @@ test_plans:
       job_timeout: '10'
       kselftest_collections: "lkdtm"
 
-kselftest-seccomp:
+  kselftest-seccomp:
     <<: *kselftest
     params:
       job_timeout: '10'


### PR DESCRIPTION
Add "seccomp" and "lkdtm" kselftests to the default test configs, since they both have architectural variations.