### PR TITLE
Extend kselftest coverage

### DIFF
--- a/config/core/lab-configs.yaml
+++ b/config/core/lab-configs.yaml
@@ -62,6 +62,8 @@ labs:
             - kselftest-filesystems
             - kselftest-futex
             - kselftest-lib
+            - kselftest-lkdtm
+            - kselftest-seccomp
             - lc-compliance
             - ltp-crypto
             - ltp-fcntl-locktests

--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -105,6 +105,7 @@ rootfs_configs:
       - arm64
       - armhf
     extra_packages:
+      - bc
       - ca-certificates
       - iproute2
       - jdim

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -58,6 +58,8 @@ file_systems:
     ramdisk: 'buster-kselftest/20210520.0/{arch}/initrd.cpio.gz'
     nfs: 'buster-kselftest/20210520.0/{arch}/full.rootfs.tar.xz'
     root_type: nfs
+    params:
+      os_config: 'debian'
 
   debian_buster-v4l2_ramdisk:
     type: debian
@@ -189,8 +191,6 @@ test_plans:
     pattern: 'kselftest/{category}-{method}-{protocol}-{rootfs}-kselftest-template.jinja2'
     filters:
       - passlist: {defconfig: ['kselftest']}
-    params:
-      job_timeout: '120'
 
   kselftest-filesystems:
     <<: *kselftest

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1709,6 +1709,8 @@ test_configs:
       - kselftest-filesystems
       - kselftest-futex
       - kselftest-lib
+      - kselftest-lkdtm
+      - kselftest-seccomp
       - ltp-crypto
       - ltp-ipc
       - ltp-mm
@@ -1831,6 +1833,8 @@ test_configs:
       - kselftest-filesystems
       - kselftest-futex
       - kselftest-lib
+      - kselftest-lkdtm
+      - kselftest-seccomp
       - ltp-crypto
       - ltp-fcntl-locktests
       - ltp-ipc


### PR DESCRIPTION
Enable the newly added kselftest collections lkdtm and seccomp on x86 devices.

Depends on #735 and #737