### PR TITLE
test-configs: add i945gsex-qs

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -630,6 +630,13 @@ device_types:
       - blocklist:
           kernel: ['v4.14']
 
+  i945gsex-qs:
+    mach: x86
+    arch: i386
+    boot_method: grub
+    filters:
+      - passlist: {defconfig: ['i386_defconfig']}
+
   imx23-olinuxino:
     mach: imx
     class: arm-dtb
@@ -1842,6 +1849,10 @@ test_configs:
       - sleep_mem
 
   - device_type: hsdk
+    test_plans:
+      - baseline
+
+  - device_type: i945gsex-qs
     test_plans:
       - baseline
 


### PR DESCRIPTION
I have an i945gsex-qs mother board in my lab.
It is an industrial mother board with an i386 N270 Atom.

Signed-off-by: Corentin LABBE <clabbe@baylibre.com>