### PR TITLE
test-configs.yaml: remove kselftest and igt from minnowboard

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2067,10 +2067,7 @@ test_configs:
   - device_type: minnowboard-turbot-E3826
     test_plans:
       - baseline
-      - igt-gpu-i915
-      - kselftest-filesystems
-      - kselftest-futex
-      - kselftest-lib
+      - baseline-nfs
 
   - device_type: mt8173-elm-hana
     test_plans:


### PR DESCRIPTION
The minnowboard device type is congested as Apertis job, so running igt and kselftest is not possible, so it should be dropped.

Signed-off-by: Alexandra Pereira <alexandra.pereira@collabora.com>