### PR TITLE
test-configs.yaml: add igt-gpu-i915 to grunt

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1828,6 +1828,7 @@ test_configs:
       - baseline
       - baseline-nfs
       - cros-ec
+      - igt-gpu-i915
       - kselftest-filesystems
       - kselftest-futex
       - kselftest-lib


### PR DESCRIPTION
Includes igt-gpu-i915 plan to the chromebook grunt.

Signed-off-by: Alexandra Pereira <alexandra.pereira@collabora.com>