### PR TITLE
STAGING use buster-kselftest 20210618.0 with bc

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -54,9 +54,9 @@ file_systems:
     ramdisk: 'buster-igt/20210520.0/{arch}/rootfs.cpio.gz'
 
   debian_buster_kselftest:
-    type: debian
-    ramdisk: 'buster-kselftest/20210520.0/{arch}/initrd.cpio.gz'
-    nfs: 'buster-kselftest/20210520.0/{arch}/full.rootfs.tar.xz'
+    type: debian-staging
+    ramdisk: 'buster-kselftest/20210618.0/{arch}/initrd.cpio.gz'
+    nfs: 'buster-kselftest/20210618.0/{arch}/full.rootfs.tar.xz'
     root_type: nfs
 
   debian_buster-v4l2_ramdisk:


### PR DESCRIPTION
To use the latest buster-kselftest with `bc` installed on staging until a rootfs image is in production.