### PR TITLE
config/rootfs/debos: add nosuspend overlay

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -28,6 +28,7 @@ rootfs_configs:
     extra_files_remove: &extra_files_remove_buster
       - '*networkd*'
       - '*resolved*'
+      - nosuspend.conf
       - tar
       - patch
       - dir

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -36,13 +36,13 @@ file_systems:
     ramdisk: '{arch}/baseline/rootfs.cpio.gz'
 
   debian_buster_ramdisk:
-    type: debian
-    ramdisk: 'buster/20210520.0/{arch}/rootfs.cpio.gz'
+    type: debian-staging
+    ramdisk: 'buster/gtucker-20210702-001/{arch}/rootfs.cpio.gz'
 
   debian_buster_nfs:
-    type: debian
-    ramdisk: 'buster/20210520.0/{arch}/initrd.cpio.gz'
-    nfs: 'buster/20210520.0/{arch}/full.rootfs.tar.xz'
+    type: debian-staging
+    ramdisk: 'buster/gtucker-20210702-001/{arch}/initrd.cpio.gz'
+    nfs: 'buster/gtucker-20210702-001/{arch}/full.rootfs.tar.xz'
     root_type: nfs
 
   debian_buster-cros-ec_ramdisk:
@@ -54,9 +54,9 @@ file_systems:
     ramdisk: 'buster-igt/20210628.5/{arch}/rootfs.cpio.gz'
 
   debian_buster_kselftest:
-    type: debian
-    ramdisk: 'buster-kselftest/20210628.3/{arch}/initrd.cpio.gz'
-    nfs: 'buster-kselftest/20210628.3/{arch}/full.rootfs.tar.xz'
+    type: debian-staging
+    ramdisk: 'buster-kselftest/gtucker-20210702-001/{arch}/initrd.cpio.gz'
+    nfs: 'buster-kselftest/gtucker-20210702-001/{arch}/full.rootfs.tar.xz'
     root_type: nfs
     params:
       os_config: 'debian'

--- a/config/rootfs/debos/overlays/nosuspend/etc/systemd/sleep.conf.d/nosuspend.conf
+++ b/config/rootfs/debos/overlays/nosuspend/etc/systemd/sleep.conf.d/nosuspend.conf
@@ -1,0 +1,5 @@
+[Sleep]
+AllowSuspend=no
+AllowHibernation=no
+AllowSuspendThenHibernate=no
+AllowHybridSleep=no

--- a/config/rootfs/debos/rootfs.yaml
+++ b/config/rootfs/debos/rootfs.yaml
@@ -90,6 +90,10 @@ actions:
     description: Add /var/tmp
     source: overlays/minimal
 
+  - action: overlay
+    description: Disable suspend in systemd
+    source: overlays/nosuspend
+
 {{ if $test_overlay }}
   - action: overlay
     description: Add test overlay {{ $test_overlay }}


### PR DESCRIPTION
Add "nosuspend" overlay for Debian Buster rootfs images to disable
suspend in systemd.  This is to work around spurious suspend requests
on Chromebook devices in particular.  Remove this file in the ramdisk
image as it's only an issue with nfsroot.

On a side note, the "sleep" and "usb" test plans use rtcwake which
bypasses systemd so this should not have any effect anyway.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>