### PR TITLE
test-configs.yaml: enable all kselftest plans on mt8173-elm-hana

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2090,6 +2090,11 @@ test_configs:
       - baseline
       - baseline-nfs
       - cros-ec
+      - kselftest-filesystems
+      - kselftest-futex
+      - kselftest-lib
+      - kselftest-lkdtm
+      - kselftest-seccomp
       - lc-compliance
       - sleep
       - v4l2-compliance-uvc


### PR DESCRIPTION
Enable all the currently defined kselftest plans on mt8173-elm-hana as
nfsroot support with kselftest kernel builds is being fixed for this
platform in lab-collabora.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>