### PR TITLE
rootfs: libcamera: Update repository URL to point to upstream

### DIFF
--- a/config/rootfs/debos/scripts/buster-libcamera.sh
+++ b/config/rootfs/debos/scripts/buster-libcamera.sh
@@ -40,11 +40,10 @@ echo '{  "tests_suites": [' >> $BUILDFILE
 # Build libcamera and lc-compliance
 ########################################################################
 
-LIBCAMERA_URL=https://gitlab.collabora.com/nfraprado/libcamera.git
+LIBCAMERA_URL=https://git.linuxtv.org/libcamera.git
 mkdir -p /tmp/tests/libcamera && cd /tmp/tests/libcamera
 
-# Use my fork until it gets merged
-git clone --single-branch --branch lcc-gtest-v5 --depth=1 $LIBCAMERA_URL .
+git clone --depth=1 $LIBCAMERA_URL .
 
 echo '    {"name": "lc-compliance", "git_url": "'$LIBCAMERA_URL'", "git_commit": ' \"`git rev-parse HEAD`\" '}' >> $BUILDFILE
 


### PR DESCRIPTION
The refactor patch series of lc-compliance using Googletest has been
merged upstream [1]. That series changes the test output format and was
required for the lc-compliance tests. Now that it has been merged,
update the libcamera repository URL to point to upstream.

[1] https://git.linuxtv.org/libcamera.git/commit/?id=143b252462b9b795a1286a30349348642fcb87f5

Signed-off-by: Nícolas F. R. A. Prado <nfraprado@collabora.com>