### PR TITLE
lab-configs.yaml: add lab-collabora-staging

### DIFF
--- a/config/core/lab-configs.yaml
+++ b/config/core/lab-configs.yaml
@@ -45,7 +45,7 @@ labs:
     lab_type: lava
     url: 'https://lava.collabora.co.uk/RPC2/'
     priority: '45'
-    filters:
+    filters: &collabora-filters
       - blocklist:
           tree: [android]
           plan: [baseline-qemu-docker]
@@ -75,6 +75,12 @@ labs:
             - usb
             - v4l2-compliance-uvc
             - v4l2-compliance-vivid
+
+  lab-collabora-staging:
+    lab_type: lava
+    url: 'https://staging.lava.collabora.dev/RPC2/'
+    priority: '45'
+    filters: *collabora-filters
 
   lab-kontron:
     lab_type: lava


### PR DESCRIPTION
Add lab-collabora-staging which is a Collabora LAVA lab used for testing new device types and changes made in LAVA itself.  It is not a production lab and should only be used with staging.kernelci.org and potentially chromeos.kernelci.org.
