### PR TITLE
Add buildroot Dockerfile

### DIFF
--- a/config/docker/build-and-push.sh
+++ b/config/docker/build-and-push.sh
@@ -32,6 +32,7 @@
 set -e
 tag_px='kernelci/'
 
+
 options='npbdrikqQt:'
 while getopts $options option
 do
@@ -66,86 +67,51 @@ echo_push() {
   echo "Pushing [$1]"
 }
 
+docker_push() {
+    echo_push $1
+    docker push $1
+}
+
+docker_build_and_tag() {
+  tag=${tag_px}$2
+  echo_build $tag
+  docker build ${quiet} ${cache_args} $1 -t $tag
+  if [ "x${push}" == "xtrue" ]
+  then
+    docker_push $tag
+  fi
+}
 
 if [ "x${builders}" == "xtrue" ]
 then
-  tag=${tag_px}build-base
-  echo_build $tag
-  docker build ${quiet} ${cache_args} build-base -t $tag
-  if [ "x${push}" == "xtrue" ]
-  then
-    echo_push $tag
-    docker push $tag
-  fi
+  docker_build_and_tag build-base build-base
   for c in {gcc,clang}-*
   do
-      tag=${tag_px}build-$c
-      echo_build $tag
-      docker build ${quiet} ${cache_args} $c -t $tag
-      if [ "x${push}" == "xtrue" ]
-      then
-          echo_push $tag
-          docker push $tag
-      fi
+      docker_build_and_tag $c build-$c
   done
 fi
 
 if [ "x${debos}" == "xtrue" ]
 then
-  tag=${tag_px}debos
-  echo_build $tag
-  docker build ${quiet} ${cache_args} debos -t $tag
-  if [ "x${push}" == "xtrue" ]
-  then
-    echo_push $tag
-    docker push $tag
-  fi
+  docker_build_and_tag debos debos
 fi
 
 if [ "x${buildroot}" == "xtrue" ]
 then
-  tag=${tag_px}buildroot
-  echo_build $tag
-  docker build ${quiet} ${cache_args} debos -t $tag
-  if [ "x${push}" == "xtrue" ]
-  then
-    echo_push $tag
-    docker push $tag
-  fi
+  docker_build_and_tag buildroot buildroot
 fi
 
 if [ "x${dt_validation}" == "xtrue" ]
 then
-  tag=${tag_px}dt-validation
-  echo_build $tag
-  docker build ${quiet} ${cache_args} dt-validation -t $tag
-  if [ "x${push}" == "xtrue" ]
-  then
-    echo_push $tag
-    docker push $tag
-  fi
+  docker_build_and_tag dt-validation dt-validation
 fi
 
 if [ "x${k8s}" == "xtrue" ]
 then
-  tag=${tag_px}build-k8s
-  echo_build $tag
-  docker build ${quiet} ${cache_args} build-k8s -t $tag
-  if [ "x${push}" == "xtrue" ]
-  then
-    echo_push $tag
-    docker push $tag
-  fi
+  docker_build_and_tag build-k8s build-k8s
 fi
 
 if [ "x${qemu}" == "xtrue" ]
 then
-  tag=${tag_px}qemu
-  echo_build $tag
-  docker build ${quiet} ${cache_args} qemu -t $tag
-  if [ "x${push}" == "xtrue" ]
-  then
-    echo_push $tag
-    docker push $tag
-  fi
+  docker_build_and_tag qemu qemu
 fi

--- a/config/docker/build-and-push.sh
+++ b/config/docker/build-and-push.sh
@@ -23,6 +23,7 @@
 # -p = push to dockerhub
 # -b = also rebuild kernel builders
 # -d = also rebuild debos
+# -r = also rebuild buildroot
 # -i = also rebuild dt-validation
 # -q = make the builds quiet
 # -Q = also rebuild qemu docker image
@@ -31,7 +32,7 @@
 set -e
 tag_px='kernelci/'
 
-options='npbdikqQt:'
+options='npbdrikqQt:'
 while getopts $options option
 do
   case $option in
@@ -39,6 +40,7 @@ do
     p )  push=true;;
     b )  builders=true;;
     d )  debos=true;;
+    r )  buildroot=true;;
     i )  dt_validation=true;;
     k )  k8s=true;;
     q )  quiet="--quiet";;
@@ -91,6 +93,18 @@ fi
 if [ "x${debos}" == "xtrue" ]
 then
   tag=${tag_px}debos
+  echo_build $tag
+  docker build ${quiet} ${cache_args} debos -t $tag
+  if [ "x${push}" == "xtrue" ]
+  then
+    echo_push $tag
+    docker push $tag
+  fi
+fi
+
+if [ "x${buildroot}" == "xtrue" ]
+then
+  tag=${tag_px}buildroot
   echo_build $tag
   docker build ${quiet} ${cache_args} debos -t $tag
   if [ "x${push}" == "xtrue" ]

--- a/config/docker/buildroot/Dockerfile
+++ b/config/docker/buildroot/Dockerfile
@@ -1,0 +1,31 @@
+FROM debian:buster-slim
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Docker for Jenkins really needs procps otherwise the Jenkins side fails
+RUN apt-get update && apt-get install --no-install-recommends -y procps
+
+ENV FORCE_UNSAFE_CONFIGURE=1
+
+# SSL / HTTPS support
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    apt-transport-https \
+    ca-certificates
+
+# Dependencies to run buildroot
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    bc \
+    bzip2 \
+    cpio \
+    file \
+    gcc \
+    g++ \
+    git \
+    make \
+    rsync \
+    patch \
+    python3 \
+    unzip \
+    wget \
+    xz-utils
+


### PR DESCRIPTION
Add Dockerfile that creates an image that contains all dependencies and
tools needed to build buildroot based rootfs images.

This docker image is to be used by Jenkins instead of a dedicated machine/node for buildroot builds.