### PR TITLE
test-configs.yaml: enable all current LTP subsets on hana

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2124,6 +2124,12 @@ test_configs:
       - kselftest-lkdtm
       - kselftest-seccomp
       - lc-compliance
+      - ltp-crypto
+      - ltp-fcntl-locktests
+      - ltp-ipc
+      - ltp-mm
+      - ltp-pty
+      - ltp-timers
       - sleep
       - v4l2-compliance-uvc
 


### PR DESCRIPTION
Enable all the LTP subsets currently defined on the mt8173-elm-hana
arm64 Chromebook.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>