### PR TITLE
test-configs.yaml: enable ltp-timers on kevin Chromebook

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2313,6 +2313,7 @@ test_configs:
       - ltp-ipc
       - ltp-mm
       - ltp-pty
+      - ltp-timers
       - sleep
       - v4l2-compliance-uvc
 


### PR DESCRIPTION
Enable the ltp-timers test plan on rk3399-gru-kevin.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>