### PR TITLE
test-configs.yaml: enable all current LTP subsets on coral

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1740,9 +1740,12 @@ test_configs:
       - kselftest-lkdtm
       - kselftest-seccomp
       - ltp-crypto
+      - ltp-fcntl-locktests
       - ltp-ima
       - ltp-ipc
       - ltp-mm
+      - ltp-pty
+      - ltp-timers
       - sleep_mem
 
   - device_type: at91-sama5d2_xplained


### PR DESCRIPTION
Enable a few missing LTP subsets on asus-C523NA-A20057-coral to cover
all the ones currently defined.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>