### PR TITLE
test-configs.yaml: only run baseline on minnowboard-turbot

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2121,7 +2121,6 @@ test_configs:
   - device_type: minnowboard-turbot-E3826
     test_plans:
       - baseline
-      - baseline-nfs
 
   - device_type: mt8173-elm-hana
     test_plans:


### PR DESCRIPTION
As this platform doesn't have enough capacity available in any lab,
drop baseline-nfs to reduce the coverage to the bare minimal with only
baseline.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>