### PR TITLE
test-configs.yaml: add ltp-crypto filters for crypto fragment

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -238,6 +238,10 @@ test_plans:
     params:
       <<: *ltp-params
       tst_cmdfiles: "crypto"
+    filters:
+      - passlist:
+          defconfig:
+            - '+crypto'
 
   ltp-ipc:
     <<: *ltp


### PR DESCRIPTION
Add a filter in test-configs to only run the ltp-crypto test plan with
kernel builds that have the crypto fragment enabled.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>