### PR TITLE
test-configs.yaml: enable jacuzzi in kernelCI

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1042,6 +1042,11 @@ device_types:
     class: arm64-dtb
     boot_method: depthcharge
 
+  mt8183-kukui-jacuzzi-juniper-sku16:
+    mach: mediatek
+    class: arm64-dtb
+    boot_method: depthcharge
+
   mustang:
     mach: apm
     class: arm64-dtb
@@ -2145,6 +2150,16 @@ test_configs:
       - ltp-timers
       - sleep
       - v4l2-compliance-uvc
+
+  - device_type: mt8183-kukui-jacuzzi-juniper-sku16
+    test_plans:
+      - baseline
+      - baseline-nfs
+      - kselftest-filesystems
+      - kselftest-futex
+      - kselftest-lib
+      - kselftest-lkdtm
+      - kselftest-seccomp
 
   - device_type: mustang
     test_plans:


### PR DESCRIPTION
Enable acer-mt8183-cp311-3h-jacuzzi device type in kernelCI and include baseline and kselftest test plans to it.

Signed-off-by: Alexandra Pereira <alexandra.pereira@collabora.com>