### PR TITLE
Extend x86_64_defconfig to support more drivers

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -251,6 +251,17 @@ fragments:
       - 'CONFIG_MMC_SDHCI=y'
       - 'CONFIG_MMC_SDHCI_PCI=y'
       - 'CONFIG_MMC_SDHCI_ACPI=y'
+      - 'CONFIG_CHROME_PLATFORMS=y'
+      - 'CONFIG_CHROMEOS_LAPTOP=y'
+      - 'CONFIG_CHROMEOS_TBMC=y'
+      - 'CONFIG_CROS_EC=y'
+      - 'CONFIG_CROS_EC_LPC=y'
+      - 'CONFIG_CROS_EC_I2C=y'
+      - 'CONFIG_IIO=m'
+      - 'CONFIG_IIO_CROS_EC_SENSORS_CORE=m'
+      - 'CONFIG_IIO_CROS_EC_SENSORS=m'
+      - 'CONFIG_MFD_CROS_EC_DEV=m'
+      - 'CONFIG_I2C_DESIGNWARE_PLATFORM=y'
 
   x86_kvm_guest:
     path: "kernel/configs/kvm_guest.config"


### PR DESCRIPTION
This is a simplification of PR 728 [1] to remove values enabled
by default (via make savedefconfig) and adds a few more configs
to enable EC tests which are independent of ChromeOS (eg can work
on Debian).

Manually tested on Eve (Adrian) and Coral (Sonny).
Ran cros-ec-tests on KernelCI Octopus and Coral boards [2] [3]
where test passes went from 0 to 4-7 depending on the board.

[1] #728
[2] https://lava.collabora.co.uk/scheduler/job/4249724#results_158406973
[3] https://lava.collabora.co.uk/scheduler/job/4249260#results_158391223

Signed-off-by: Sonny Rao <sonnyrao@chromium.org>
Signed-off-by: Adrian Ratiu <adrian.ratiu@collabora.com>

Fixes: #728 