### PR TITLE
test-configs.yaml: adjust LTP coverage to match documentation

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1859,7 +1859,6 @@ test_configs:
       - baseline
       - baseline-nfs
       - kselftest-futex
-      - ltp-pty
 
   - device_type: hp-11A-G6-EE-grunt
     test_plans:
@@ -2012,9 +2011,6 @@ test_configs:
     test_plans:
       - baseline
       - baseline-nfs
-      - ltp-crypto
-      - ltp-ipc
-      - ltp-mm
 
   - device_type: kirkwood-db-88f6282
     test_plans:
@@ -2330,10 +2326,7 @@ test_configs:
       - baseline
       - baseline-nfs
       - cros-ec
-      - ltp-crypto
       - ltp-fcntl-locktests
-      - ltp-ipc
-      - ltp-mm
       - ltp-pty
       - ltp-timers
       - sleep


### PR DESCRIPTION
Drop LTP test plans on devices that are now mostly offline (jeton-tk1,
hip07-d05) and reduce the number run on rk3399-gru-kevin to match the
documentation in https://kernelci.org/docs/tests/.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>