### PR TITLE
test-configs.yaml: adjust kselftest coverage to match documentation

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2394,6 +2394,8 @@ test_configs:
   - device_type: sun50i-h6-pine-h64
     test_plans:
       - baseline
+      - kselftest-filesystems
+      - kselftest-seccomp
       - ltp-crypto
       - ltp-ipc
       - ltp-mm


### PR DESCRIPTION
Enable a few kselftest plans on arm platforms to match the
documentation on https://kernelci.org/docs/tests/.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>