### PR TITLE
buster-ltp: Fix openposix testsuite path

### DIFF
--- a/config/rootfs/debos/scripts/buster-ltp.sh
+++ b/config/rootfs/debos/scripts/buster-ltp.sh
@@ -44,10 +44,10 @@ make all
 find . -executable -type f -exec strip {} \;
 make install
 
-cd testcases/open_posix_testsuite/ && make generate-makefiles
+cd testcases/open_posix_testsuite/ && make generate-makefiles prefix=/opt/ltp
 make all
-mkdir /opt/openposix_testsuite/bin -p
-make install
+make install prefix=/opt/ltp
+
 ########################################################################
 # Cleanup: remove files and packages we don't want in the images       #
 ########################################################################


### PR DESCRIPTION
Update LTP openposix-testsuite path on buster-ltp rootfs.

Signed-off-by: lakshmipathi.ganapathi <lakshmipathi.ganapathi@collabora.com>