### PR TITLE
test-configs.yaml: Enable kselftest and LTP on qemu platforms

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2215,6 +2215,18 @@ test_configs:
     test_plans:
       - baseline_qemu
       - baseline-qemu-docker
+      - kselftest-filesystems
+      - kselftest-futex
+      - kselftest-lib
+      - kselftest-lkdtm
+      - kselftest-seccomp
+      - ltp-crypto
+      - ltp-fcntl-locktests
+      - ltp-ima
+      - ltp-ipc
+      - ltp-mm
+      - ltp-pty
+      - ltp-timers
       - v4l2-compliance-vivid
 
   - device_type: qemu_arm-virt-gicv3-uefi
@@ -2233,6 +2245,18 @@ test_configs:
     test_plans:
       - baseline_qemu
       - baseline-qemu-docker
+      - kselftest-filesystems
+      - kselftest-futex
+      - kselftest-lib
+      - kselftest-lkdtm
+      - kselftest-seccomp
+      - ltp-crypto
+      - ltp-fcntl-locktests
+      - ltp-ima
+      - ltp-ipc
+      - ltp-mm
+      - ltp-pty
+      - ltp-timers
       - v4l2-compliance-vivid
 
   - device_type: qemu_arm64-virt-gicv3-uefi
@@ -2256,6 +2280,18 @@ test_configs:
     test_plans:
       - baseline_qemu
       - baseline-qemu-docker
+      - kselftest-filesystems
+      - kselftest-futex
+      - kselftest-lib
+      - kselftest-lkdtm
+      - kselftest-seccomp
+      - ltp-crypto
+      - ltp-fcntl-locktests
+      - ltp-ima
+      - ltp-ipc
+      - ltp-mm
+      - ltp-pty
+      - ltp-timers
       - v4l2-compliance-vivid
 
   - device_type: qemu_x86_64-uefi


### PR DESCRIPTION
Enable kselftest and LTP on representitive qemu platforms for arm, arm64
and x86. These are low level testsuites with limited hardware interaction
so quite well matched to emulated platforms.

This is particularly useful for kselftest which is where tests for low
level architecture features tend to be added, these features are initially
only going to be available in emulation.

Signed-off-by: Mark Brown <broonie@kernel.org>