### PR TITLE
test-configs.yaml: Enable kselftest and LTP for QDF2400

### DIFF
--- a/config/core/lab-configs.yaml
+++ b/config/core/lab-configs.yaml
@@ -74,6 +74,8 @@ labs:
       - passlist:
           plan:
             - baseline
+            - kselftest
+            - ltp
           tree:
             - kernelci
             - next

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2281,6 +2281,18 @@ test_configs:
   - device_type: qcom-qdf2400
     test_plans:
       - baseline
+      - kselftest-filesystems
+      - kselftest-futex
+      - kselftest-lib
+      - kselftest-lkdtm
+      - kselftest-seccomp
+      - ltp-crypto
+      - ltp-fcntl-locktests
+      - ltp-ima
+      - ltp-ipc
+      - ltp-mm
+      - ltp-pty
+      - ltp-timers
 
   - device_type: qemu_arm-versatilepb
     test_plans:


### PR DESCRIPTION
The QDF2400 is quite a powerful server platform and the system we have
available seems to have lots of spare capacity so let's enable kselftest
and LTP on it.

Signed-off-by: Mark Brown <broonie@kernel.org>