### PR TITLE
kci_bisect: start adding new tool to run bisection commands

### DIFF
--- a/kci_bisect
+++ b/kci_bisect
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2021 Collabora Limited
+# Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+#
+# This module is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+import sys
+
+from kernelci.cli import Args, Command, parse_opts
+import kernelci.bisect
+import kernelci.config
+
+
+class cmd_get_recipients(Command):
+    help = "Get the list of email recipients as JSON lists for To: and Cc:"
+    args = [Args.kdir, Args.commit]
+    opt_args = [Args.to, Args.cc]
+
+    def __call__(self, configs, args):
+        to, cc = (
+            set(arg.split(' ') if arg else []) for arg in (args.to, args.cc)
+        )
+        rcpts = kernelci.bisect.get_recipients(args.kdir, args.commit, to, cc)
+        for header, category in [("To:", 'to'), ("Cc:", 'cc')]:
+            print(header)
+            for rcpt in rcpts[category]:
+                print("  {}".format(rcpt))
+        return True
+
+
+if __name__ == '__main__':
+    opts = parse_opts("kci_bisect", globals())
+    configs = kernelci.config.load(opts.yaml_config)
+    status = opts.command(configs, opts)
+    sys.exit(0 if status is True else 1)

--- a/kernelci/bisect.py
+++ b/kernelci/bisect.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2021 Collabora Limited
+# Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+#
+# This module is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+import re
+import subprocess
+
+from kernelci import shell_cmd
+
+RE_ADDR = r'.*@.*\.[a-z]+'
+RE_TRAILER = re.compile(r'^(?P<tag>[A-Z][a-z-]*)\: (?P<value>.*)$')
+RE_EMAIL = re.compile(r'^(?P<name>.*)(?P<email><{}>)'.format(RE_ADDR))
+RE_MAILING_LIST = re.compile(r'^(?P<email>{}) \('.format(RE_ADDR))
+
+
+def _git_show_fmt(kdir, revision, fmt):
+    show = shell_cmd("""
+set -e
+cd {kdir}
+git show {revision} -s --pretty=format:'{fmt}'
+""".format(kdir=kdir, revision=revision, fmt=fmt))
+    show.strip()
+    return show
+
+
+def _name_address(data):
+    name, address = (data.get(k, '').strip() for k in ['name', 'email'])
+    if name:
+        address = ' '.join([name, address])
+    return address
+
+
+def _git_maintainers(kdir, revision):
+    maintainers = set()
+    p = subprocess.Popen(
+        "cd {}; git show {} --pretty=format:%b".format(kdir, revision),
+        shell=True, stdout=subprocess.PIPE)
+    body = p.communicate()[0]
+    p = subprocess.Popen(
+        "cd {}; ./scripts/get_maintainer.pl --nogit".format(kdir),
+        shell=True, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
+    raw = p.communicate(input=body)[0].decode()
+    for ln in raw.split('\n'):
+        m = RE_EMAIL.match(ln) or RE_MAILING_LIST.match(ln)
+        if m:
+            maintainers.add(_name_address(m.groupdict()))
+    return list(maintainers)
+
+
+def _git_people(kdir, revision):
+    people = {
+        'maintainers': _git_maintainers(kdir, revision),
+        'author': [_git_show_fmt(kdir, revision, '%an <%ae>')],
+        'committer': [_git_show_fmt(kdir, revision, '%cn <%ce>')],
+        'Acked-by': [],
+        'Reported-by': [],
+        'Reviewed-by': [],
+        'Signed-off-by': [],
+        'Tested-by': [],
+    }
+    body = _git_show_fmt(kdir, revision, '%b')
+
+    for ln in body.split('\n'):
+        m = RE_TRAILER.match(ln)
+        if m:
+            md = m.groupdict()
+            tag, value = (md[k] for k in ['tag', 'value'])
+            if tag in people:
+                e = RE_EMAIL.match(value)
+                if e:
+                    people[tag].append(_name_address(e.groupdict()))
+
+    return people
+
+
+def get_recipients(kdir, commit, to=set(), cc=set()):
+    """Create list of recipients for a bisection report
+
+    Automatically gather all the recipients for a bisection email report using
+    the get_maintainers.pl script as well as trailers and meta-data from the
+    commit found.
+
+    *kdir* is the path to a kernel source directory
+    *commit* is the Git commit checksum from the bisection result
+    *to* is a set with extra recipients to be added as To:
+    *cc* is a set with extra recipients to be added as Cc:
+    """
+    recipients_map = {
+        'author': to,
+        'committer': cc,
+        'maintainers': cc,
+        'Acked-by': to,
+        'Reported-by': to,
+        'Reviewed-by': to,
+        'Signed-off-by': to,
+        'Tested-by': to,
+    }
+    people = _git_people(kdir, commit)
+
+    for category, entries in people.items():
+        recip = recipients_map[category]
+        for e in entries:
+            recip.add(e)
+
+    cc = cc.difference(to)
+
+    return {'to': list(to), 'cc': list(cc)}

--- a/kernelci/cli.py
+++ b/kernelci/cli.py
@@ -96,6 +96,11 @@ class Args:
         'section': SECTION_DB,
     }
 
+    cc = {
+        'name': '--cc',
+        'help': "Recipients to be added as Cc:",
+    }
+
     commit = {
         'name': '--commit',
         'help': "Git commit checksum",
@@ -262,6 +267,11 @@ class Args:
     target = {
         'name': '--target',
         'help': "Name of a target platform",
+    }
+
+    to = {
+        'name': '--to',
+        'help': "Recipients to be added as To:",
     }
 
     tree_name = {


### PR DESCRIPTION
Add a new kci_bisect tool to start implementing the bisection steps
currently found in push-bisection-results.py, lava-v2-callback.py and
bisect.jpl.  Start with the get_recipients command to provide the list
of recipients to add as To: and Cc: in email reports, for a given git
commit found by a bisection.

This is particularly useful when triaging email reports which
currently aren't sent to the public automatically, to populate the
list of recipients for valid ones.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>