### PR TITLE
build-configs.yaml: enable CONFIG_FB in virtualvideo fragment

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -229,6 +229,7 @@ fragments:
   virtualvideo:
     path: "kernel/configs/virtualvideo.config"
     configs:
+      - 'CONFIG_FB=y'
       - 'CONFIG_MEDIA_SUPPORT=y'
       - 'CONFIG_MEDIA_CAMERA_SUPPORT=y'
       - 'CONFIG_MEDIA_TEST_SUPPORT=y'


### PR DESCRIPTION
As CONFIG_DRM_FBDEV_EMULATION now doesn't enable CONFIG_FD as per
f611b1e7624c ("drm: Avoid circular dependencies for CONFIG_FB"),
enable it in the virtualvideo fragment used by KernelCI.  This fixes
the issue where the vivid driver is not built and the
v4l2-compliance-vivid.device-presence test case fails.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>