### PR TITLE
cros-ec: use kmsg for test shell messages

### DIFF
--- a/config/lava/cros-ec/cros-ec.jinja2
+++ b/config/lava/cros-ec/cros-ec.jinja2
@@ -14,6 +14,7 @@
         run:
           steps:
             - python3 -m cros.runners.lava_runner
+      lava-signal: kmsg
       from: inline
       name: {{ plan }}
       path: inline/{{ plan }}.yaml


### PR DESCRIPTION
Sometimes the output is interrupted by the kernel messages, for example:
   https://lava.collabora.co.uk/scheduler/job/4265012#L2561

Use /dev/kmsg to mitigate that; as it is already used in other test
cases.

Signed-off-by: Enric Balletbo i Serra <enric.balletbo@collabora.com>