### PR TITLE
test-configs.yaml: update Debian Buster rootfs URLs

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -37,44 +37,44 @@ file_systems:
 
   debian_buster_ramdisk:
     type: debian
-    ramdisk: 'buster/20210722.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'buster/20210730.6/{arch}/rootfs.cpio.gz'
 
   debian_buster_nfs:
     type: debian
-    ramdisk: 'buster/20210722.0/{arch}/initrd.cpio.gz'
-    nfs: 'buster/20210722.0/{arch}/full.rootfs.tar.xz'
+    ramdisk: 'buster/20210730.6/{arch}/initrd.cpio.gz'
+    nfs: 'buster/20210730.6/{arch}/full.rootfs.tar.xz'
     root_type: nfs
 
   debian_buster-cros-ec_ramdisk:
     type: debian
-    ramdisk: 'buster-cros-ec/20210722.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'buster-cros-ec/20210730.1/{arch}/rootfs.cpio.gz'
 
   debian_buster-igt_ramdisk:
     type: debian
-    ramdisk: 'buster-igt/20210722.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'buster-igt/20210730.2/{arch}/rootfs.cpio.gz'
 
   debian_buster_kselftest:
     type: debian
-    ramdisk: 'buster-kselftest/20210722.0/{arch}/initrd.cpio.gz'
-    nfs: 'buster-kselftest/20210722.0/{arch}/full.rootfs.tar.xz'
+    ramdisk: 'buster-kselftest/20210730.3/{arch}/initrd.cpio.gz'
+    nfs: 'buster-kselftest/20210730.3/{arch}/full.rootfs.tar.xz'
     root_type: nfs
     params:
       os_config: 'debian'
 
   debian_buster-v4l2_ramdisk:
     type: debian
-    ramdisk: 'buster-v4l2/20210722.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'buster-v4l2/20210730.4/{arch}/rootfs.cpio.gz'
 
   debian_buster-libcamera_nfs:
     type: debian
-    ramdisk: 'buster-libcamera/20210722.0/{arch}/initrd.cpio.gz'
-    nfs: 'buster-libcamera/20210722.0/{arch}/full.rootfs.tar.xz'
+    ramdisk: 'buster-libcamera/20210730.5/{arch}/initrd.cpio.gz'
+    nfs: 'buster-libcamera/20210730.5/{arch}/full.rootfs.tar.xz'
     root_type: nfs
 
   debian_buster-ltp_nfs:
     type: debian
-    ramdisk: 'buster-ltp/20210722.0/{arch}/initrd.cpio.gz'
-    nfs: 'buster-ltp/20210722.0/{arch}/full.rootfs.tar.xz'
+    ramdisk: 'buster-ltp/20210730.0/{arch}/initrd.cpio.gz'
+    nfs: 'buster-ltp/20210730.0/{arch}/full.rootfs.tar.xz'
     root_type: nfs
 
 


### PR DESCRIPTION
Update all the Debian Buster rootfs URLs with images built today in production, ahead of the update on Monday.