### PR TITLE
Add kci_rootfs support for buildroot based rootfs images

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -1,4 +1,18 @@
 rootfs_configs:
+  buildroot-baseline:
+    rootfs_type: buildroot
+    arch_list:
+      - arc
+      - arm64
+      - arm64be
+      - armeb
+      - armel
+      - mipsel
+      - riscv
+      - x86
+    frags:
+      - baseline
+
   buster:
     rootfs_type: debos
     debian_release: buster

--- a/kci_rootfs
+++ b/kci_rootfs
@@ -35,48 +35,10 @@ class cmd_validate(Command):
     def __call__(self, config_data, args, **kwargs):
         # ToDo: Use jsonschema
 
-        err = kernelci.sort_check(configs['rootfs_configs'])
-        if err:
-            print("Rootfs broken order: '{}' before '{}".format(*err))
-            return False
-        for name, config in configs['rootfs_configs'].items():
-            err = kernelci.sort_check(config.arch_list)
-            if err:
-                print("Arch order broken for {}: '{}' before '{}".format(
-                    name, err[0], err[1]))
-                return False
-            err = kernelci.sort_check(config.extra_packages)
-            if err:
-                print("Packages order broken for {}: '{}' before '{}".format(
-                    name, err[0], err[1]))
-                return False
-            err = kernelci.sort_check(config.extra_packages_remove)
-            if err:
-                print("Packages order broken for {}: '{}' before '{}".format(
-                    name, err[0], err[1]))
-                return False
-
-        if args.verbose:
-            rootfs_configs = config_data['rootfs_configs']
-            for config_name, config in rootfs_configs.items():
-                print(config_name)
-                print('\trootfs_type: {}'.format(config.rootfs_type))
-                print('\tarch_list: {}'.format(config.arch_list))
-                print('\tdebian_release: {}'.format(config.debian_release))
-                print('\textra_packages: {}'.format(config.extra_packages))
-                print('\textra_packages_remove: {}'.format(
-                    config.extra_packages_remove))
-                print('\textra_files_remove: {}'.format(
-                    config.extra_files_remove))
-                print('\tscript: {}'.format(config.script))
-                print('\ttest_overlay: {}'.format(config.test_overlay))
-                print('\tcrush_image_options: {}'.format(
-                    config.crush_image_options))
-                print('\tdebian_mirror: {}'.format(config.debian_mirror))
-                print('\tkeyring_package: {}'.format(config.keyring_package))
-                print('\tkeyring_file: {}'.format(config.keyring_file))
-
-        return True
+        result = kernelci.config.rootfs.validate(configs)
+        if args.verbose and result:
+            kernelci.config.rootfs.dump_configs(configs)
+        return result
 
 
 class cmd_list_configs(Command):

--- a/kci_rootfs
+++ b/kci_rootfs
@@ -81,10 +81,17 @@ class cmd_validate(Command):
 
 class cmd_list_configs(Command):
     help = "List all rootfs config names"
+    opt_args = [Args.rootfs_type]
 
-    def __call__(self, config_data, *args, **kwargs):
+    def __call__(self, config_data, args, **kwargs):
         rootfs_configs = config_data['rootfs_configs']
-        for config_name in rootfs_configs:
+        if args.rootfs_type is None:
+            config_names = rootfs_configs
+        else:
+            config_names = (name
+                            for name, config_data in rootfs_configs.items()
+                            if config_data.rootfs_type == args.rootfs_type)
+        for config_name in config_names:
             print(config_name)
         return True
 

--- a/kci_rootfs
+++ b/kci_rootfs
@@ -98,12 +98,13 @@ class cmd_list_configs(Command):
 
 class cmd_list_variants(Command):
     help = "List all rootfs variants"
-    opt_args = [Args.rootfs_config, Args.arch]
+    opt_args = [Args.rootfs_config, Args.arch, Args.rootfs_type]
 
     def __call__(self, config_data, args, **kwargs):
         rootfs_configs = config_data['rootfs_configs']
         config_name = args.rootfs_config
         arch = args.arch
+        rootfs_type = args.rootfs_type
 
         if config_name and config_name not in rootfs_configs:
             print("{} : invalid config entry".format(config_name))
@@ -114,8 +115,10 @@ class cmd_list_variants(Command):
             print("{} : invalid arch entry".format(arch))
             return False
 
-        configs = (config for config in rootfs_configs
-                   if config == config_name or config_name is None)
+        configs = (name for name, config in rootfs_configs.items()
+                   if (name == config_name or config_name is None) and
+                   (config.rootfs_type == rootfs_type or rootfs_type is None)
+                   )
         for config in configs:
             for arch_type in rootfs_configs[config].arch_list:
                 if arch_type == arch or arch is None:

--- a/kernelci/cli.py
+++ b/kernelci/cli.py
@@ -259,6 +259,13 @@ class Args:
         'help': "Path to the rootfs images directory",
     }
 
+    rootfs_type = {
+        'name': '--rootfs-type',
+        'help': "Rootfs type",
+        'type': str,
+        'choices': ('debos', 'buildroot')
+    }
+
     storage = {
         'name': '--storage',
         'help': "Storage URL",

--- a/kernelci/config/rootfs.py
+++ b/kernelci/config/rootfs.py
@@ -115,9 +115,32 @@ class RootFS_Debos(RootFS):
         return self._keyring_file
 
 
+class RootFS_Buildroot(RootFS):
+    def __init__(self, name, rootfs_type, arch_list=None, frags=None):
+        super().__init__(name, rootfs_type)
+        self._arch_list = arch_list or list()
+        self._frags = frags or list()
+
+    @classmethod
+    def from_yaml(cls, config, name):
+        kw = name
+        kw.update(cls._kw_from_yaml(
+            config, ['name', 'arch_list', 'frags']))
+        return cls(**kw)
+
+    @property
+    def frags(self):
+        return self._frags
+
+    @property
+    def arch_list(self):
+        return list(self._arch_list)
+
+
 class RootFSFactory(YAMLObject):
     _rootfs_types = {
-        'debos': RootFS_Debos
+        'debos': RootFS_Debos,
+        'buildroot': RootFS_Buildroot
     }
 
     @classmethod

--- a/kernelci/rootfs.py
+++ b/kernelci/rootfs.py
@@ -1,5 +1,6 @@
-# Copyright (C) 2019 Collabora Limited
+# Copyright (C) 2019, 2020, 2021 Collabora Limited
 # Author: Lakshmipathi G <lakshmipathi.ganapathi@collabora.com>
+# Author: Michal Galka <michal.galka@collabora.com>
 #
 # This module is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
@@ -52,16 +53,27 @@ rootfs.yaml'.format(
     return shell_cmd(cmd, True)
 
 
+def _build_buildroot(name, config, data_path, arch, frag='baseline'):
+    cmd = 'cd {data_path} && ./configs/frags/build {arch} {frag}'.format(
+        data_path=data_path,
+        arch=arch,
+        frag=frag
+    )
+    return shell_cmd(cmd, True)
+
+
 def build(name, config, data_path, arch):
     """Build rootfs images.
 
     *name* is the rootfs config
     *config* contains rootfs-configs.yaml entries
-    *data_path* points to debos location
+    *data_path* points to debos or buildroot location
     *arch* required architecture
     """
     if config.rootfs_type == "debos":
         return _build_debos(name, config, data_path, arch)
+    elif config.rootfs_type == "buildroot":
+        return _build_buildroot(name, config, data_path, arch)
     else:
         raise ValueError("rootfs_type not supported: {}"
                          .format(config.rootfs_type))


### PR DESCRIPTION
- rootfs-configs.yaml: Add buildroot-basline rootfs definition
    
    Add buildroot baseline rootfilesystem. Itroduced new buildroot rootfs_type.
    
- kci_rootfs: Add validation for buildroot rootfs type
    
    Refactor kci_rootfs validate code. Add functions that validate buildroot
    and debos rootfs configs. Move validation implementation from kci_rootfs to kernelci.rootfs.
    
- kci_rootfs: Add rootfs_type filter to kci_rootfs list_variants
    
    Add --rootfs-type option to kci_rootfs list_variants. When option is
    specified listed variants are limited to a rootfs type specified.
    
- kci_rootfs: Add rootfs_type filter to list_configs
    
    --rootfs-type option has been added to kci_rootfs list_configs. When
    specified only rootfs configs of a specific type will be listed.
    Currently supported vlues are: debos and buildroot. If --rootfs-type
    option is not used all rootfs configs will be listed.
    
-  Add buildroot support to kci_rootfs build
    
    Add support for building buildroot based rootfs images. Buildroot rootfs
    needs to have rootfs_type set to buildroot in rootfs-configs.yaml.
    --data-path option must point to buildroot directory.
