### PR TITLE
doc: add weight attributes

### DIFF
--- a/doc/_index.md
+++ b/doc/_index.md
@@ -3,6 +3,7 @@ title: "Core"
 date: 2021-02-10T20:19:50Z
 draft: true
 description: "Core KernelCI Python tools"
+weight: 4
 ---
 
 This section covers the tools and Python modules from the

--- a/doc/config/_index.md
+++ b/doc/config/_index.md
@@ -3,6 +3,7 @@ title: "YAML configuration"
 date: 2021-08-03
 draft: false
 description: "How to use the YAML configuration"
+weight: 1
 ---
 
 This section covers the YAML configuration located in

--- a/doc/config/_index.md
+++ b/doc/config/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "YAML configuration"
+title: "Configuration"
 date: 2021-08-03
 draft: false
 description: "How to use the YAML configuration"

--- a/doc/config/build-configs.md
+++ b/doc/config/build-configs.md
@@ -3,6 +3,7 @@ title: "Build configurations"
 date: 2021-08-03
 draft: false
 description: "How to configure kernel builds"
+weight: 2
 ---
 
 All the top-level build configurations are contained in a YAML file:

--- a/doc/config/filters.md
+++ b/doc/config/filters.md
@@ -3,6 +3,7 @@ title: "Filters"
 date: 2021-08-03
 draft: false
 description: "Configuration filters"
+weight: 1
 ---
 
 Filters are implemented in

--- a/doc/config/test-configs.md
+++ b/doc/config/test-configs.md
@@ -3,6 +3,7 @@ title: "Test Configurations"
 date: 2021-08-03
 draft: false
 description: "How to configure tests"
+weight: 3
 ---
 
 All the top-level test configurations are contained in a YAML file:

--- a/doc/kci_build.md
+++ b/doc/kci_build.md
@@ -1,8 +1,9 @@
 ---
 title: "kci_build"
-date: 2021-02-10T11:48:13Z
+date: 2021-08-05
 draft: false
 description: "Command line tool to build the Linux kernel"
+weight: 3
 ---
 
 The

--- a/doc/kci_data.md
+++ b/doc/kci_data.md
@@ -3,6 +3,7 @@ title: "kci_data"
 date: 2021-08-04
 draft: false
 description: "Command line tool to handle KernelCI data"
+weight: 4
 ---
 
 The [`kci_data`](https://github.com/kernelci/kernelci-core/blob/main/kci_data)

--- a/doc/kci_rootfs.md
+++ b/doc/kci_rootfs.md
@@ -1,8 +1,9 @@
 ---
 title: "kci_rootfs"
-date: 2021-02-10T11:48:13Z
-draft: true
+date: 2021-08-05
+draft: false
 description: "Command line tool to build rootfs images"
+weight: 5
 ---
 
 ### How to build a rootfs image using kci_rootfs

--- a/doc/kci_test.md
+++ b/doc/kci_test.md
@@ -1,8 +1,9 @@
 ---
 title: "kci_test"
-date: 2021-02-10T11:48:13Z
-draft: true
+date: 2021-08-05
+draft: false
 description: "Command line tool to generate and run tests"
+weight: 6
 ---
 
 ## `kci_test`

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -1,11 +1,10 @@
 ---
-title: "settings"
-date: 2021-02-10T11:48:13Z
-draft: true
+title: "Settings"
+date: 2021-08-05
+draft: false
 description: "User-defined settings"
+weight: 2
 ---
-
-## User Settings File
 
 The user settings file is intended to be created by end-users with options
 specific to their local setup.  It can also be used by automated CI systems, in
@@ -48,7 +47,7 @@ To get started quickly, see the [kernelci.conf.sample](../kernelci.conf.sample)
 file.  You can copy it as `kernelci.conf` into a suitable location as described
 above and edit it to suit your particular needs.
 
-### Command sections
+## Command sections
 
 Each command line tool will be looking for a section with a matching name in
 the settings file, such as `[kci_build]`, `[kci_test]` or `[kci_data]`.  These
@@ -73,7 +72,7 @@ you can now omit the `--mirror` argument:
 kci_build update_mirror --build-config=mainline
 ```
 
-### Component sections
+## Component sections
 
 Other sections are specific to a component, such as a test lab or a database
 backend.  This is to allow different values to be set for a same option
@@ -108,7 +107,7 @@ user: user-name
 lab_token: 1234-5678
 ```
 
-### `[DEFAULT]` section
+## `[DEFAULT]` section
 
 As per the INI file standard specifications, the `[DEFAULT]` section is where
 catch-all default values can be set regardless of the settings section being

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -1,8 +1,8 @@
 ---
-title: "Settings"
+title: "User settings"
 date: 2021-08-05
 draft: false
-description: "User-defined settings"
+description: "User-defined local settings"
 weight: 2
 ---
 


### PR DESCRIPTION
Add Hugo "weight" attributes to each documentation page to sort them
in the index.  Also clean up minor things in the settings.md file.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>