### PR TITLE
build-configs: Enable builds of 16K pages on arm64

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -926,6 +926,7 @@ build_configs:
             extra_configs:
               - 'allmodconfig'
               - 'allnoconfig'
+              - 'defconfig+CONFIG_ARM64_16K_PAGES=y'
               - 'defconfig+CONFIG_ARM64_64K_PAGES=y'
               - 'defconfig+CONFIG_CPU_BIG_ENDIAN=y'
               - 'defconfig+CONFIG_RANDOMIZE_BASE=y'


### PR DESCRIPTION
Add coverage of 16K pages on arm64 in -next since while it's available on
a number of systems it is not widely covered by test systems so can turn
up issues from time to time.

Signed-off-by: Mark Brown <broonie@kernel.org>