### PR TITLE
Detect better the endianess of a build

### DIFF
--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -1173,6 +1173,11 @@ class MakeKernel(Step):
         if target:
             kbmeta['image'] = target
 
+        if self._kernel_config_enabled('CPU_BIG_ENDIAN'):
+            kbmeta['endianness'] = 'big'
+        else:
+            kbmeta['endianness'] = 'little'
+
         res = self._make(target, jopt, verbose)
 
         if res:

--- a/kernelci/test.py
+++ b/kernelci/test.py
@@ -108,7 +108,6 @@ def get_params(meta, target, plan_config, storage):
     rootfs = plan_config.rootfs
     defconfig_full = kernel['defconfig_full']
     defconfig = ''.join(defconfig_full.split('+')[:1])
-
     endian = kernel["endianness"]
     describe = rev['describe']
     kselftests = meta.get_single_artifact('kselftest', attr='path')

--- a/kernelci/test.py
+++ b/kernelci/test.py
@@ -108,7 +108,8 @@ def get_params(meta, target, plan_config, storage):
     rootfs = plan_config.rootfs
     defconfig_full = kernel['defconfig_full']
     defconfig = ''.join(defconfig_full.split('+')[:1])
-    endian = 'big' if 'BIG_ENDIAN' in defconfig_full else 'little'
+
+    endian = kernel["endianness"]
     describe = rev['describe']
     kselftests = meta.get_single_artifact('kselftest', attr='path')
     kselftests_url = (


### PR DESCRIPTION
The current way to detect endianess is to check if a BIG ENDIAN defconfig frag was added.
But this is wrong for defconfig which is are nativly big endian like arm
ixp4xx_defconfig.

So the ultimate way to know the endianess is to download the kernel
config and grep it.

Signed-off-by: Corentin Labbe <clabbe@baylibre.com>