### PR TITLE
kci_build: add make_firmware command

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -55,6 +55,9 @@ trees:
   evalenti:
     url: "https://git.kernel.org/pub/scm/linux/kernel/git/evalenti/linux-soc-thermal.git"
 
+  firmware:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git"
+
   gtucker:
     url: 'https://gitlab.collabora.com/gtucker/linux.git'
 
@@ -854,6 +857,10 @@ build_configs:
   evalenti:
     tree: evalenti
     branch: 'for-kernelci'
+
+  firmware:
+    tree: firmware
+    branch: main
 
   gtucker_stable:
     tree: gtucker

--- a/config/core/firmware-configs.yaml
+++ b/config/core/firmware-configs.yaml
@@ -1,0 +1,17 @@
+firmware_archives:
+
+  # include all device firmware in a single archive
+  firmware-all.tar.xz:
+    - '*'
+
+  # include all i195 firmware in one archive
+  firmware-i915.tar.xz:
+    - i915/*
+
+  # only include octopus specific fw in this archive
+  firmware-hp-x360-12b-n4000-octopus.tar.xz:
+    - rtl_nic/rtl8153b-2.fw
+    - i915/kbl_dmc_ver1_04.bin
+    - i915/glk_dmc_ver1_04.bin
+
+  # add below more device-specific firmware archives as needed

--- a/kci_build
+++ b/kci_build
@@ -388,6 +388,15 @@ class cmd_make_modules(MakeCommand):
         return step.install(args.verbose, args.j)
 
 
+class cmd_make_firmware(MakeCommand):
+    help = "Package kernel firmware"
+    step_cls = kernelci.build.MakeFirmware
+
+    def __call__(self, configs, args):
+        self.step_cls.fw_config = configs['firmware_configs']
+        return super().__call__(configs, args)
+
+
 class cmd_make_dtbs(MakeCommand):
     help = "Build device trees"
     step_cls = kernelci.build.MakeDeviceTrees

--- a/kernelci/config/__init__.py
+++ b/kernelci/config/__init__.py
@@ -25,6 +25,7 @@ import kernelci.config.data
 import kernelci.config.lab
 import kernelci.config.rootfs
 import kernelci.config.test
+import kernelci.config.firmware
 
 
 def load_yaml(config_path):
@@ -70,6 +71,7 @@ def from_data(data):
     config.update(kernelci.config.lab.from_yaml(data))
     config.update(kernelci.config.rootfs.from_yaml(data))
     config.update(kernelci.config.test.from_yaml(data))
+    config.update(kernelci.config.firmware.from_yaml(data))
     return config
 
 

--- a/kernelci/config/firmware.py
+++ b/kernelci/config/firmware.py
@@ -1,0 +1,48 @@
+# Copyright (C) 2020 Collabora Limited
+# Author: Adrian Ratiu <adrian.ratiu@collabora.com>
+#
+# This module is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+import yaml
+
+from kernelci.config.base import YAMLObject
+
+
+class DeviceFirmware(YAMLObject):
+
+    def __init__(self, name, files=None):
+        self._name = name
+        self._files = files or list()
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def files(self):
+        return self._files
+
+
+def from_yaml(data):
+    fw_archives = {
+        name: DeviceFirmware(name, config)
+        for name, config in data['firmware_archives'].items()
+    }
+
+    config_data = {
+        'firmware_configs': fw_archives
+    }
+
+    return config_data


### PR DESCRIPTION
This adds a make_firmware command which in a similar manner
to make_modules creates some firmware tarballs based on the
configuration definitions in the new firmware-configs.yaml.

A new "push_firmware" command should be added in the future
so artifacts resulting from this command could be added to
storage, then logic for LAVA boards to download & use them.

Fixes: #698 

Signed-off-by: Adrian Ratiu <adrian.ratiu@collabora.com>