### PR TITLE
setup.py: install kernelci.data package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setuptools.setup(
         "kernelci",
         "kernelci.config",
         "kernelci.lab",
+        "kernelci.data",
     ],
     package_data={
         '': ['../doc/*.md'],


### PR DESCRIPTION
Otherwise, kci_data fails.