### PR TITLE
Validate YAML files individually

### DIFF
--- a/config/core/db-configs.yaml
+++ b/config/core/db-configs.yaml
@@ -1,17 +1,17 @@
 db_configs:
 
-  kernelci.org:
-    db_type: kernelci_backend
-    url: https://api.kernelci.org/
-
-  staging.kernelci.org:
-    db_type: kernelci_backend
-    url: https://api.staging.kernelci.org/
-
   chromeos.kernelci.org:
     db_type: kernelci_backend
     url: https://api.chromeos.kernelci.org/
 
+  kernelci.org:
+    db_type: kernelci_backend
+    url: https://api.kernelci.org/
+
   localhost:
     db_type: kernelci_backend
     url: http://localhost:5001/
+
+  staging.kernelci.org:
+    db_type: kernelci_backend
+    url: https://api.staging.kernelci.org/

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -99,6 +99,18 @@ test_plans:
     filters:
       - blocklist: *kselftest_defconfig_filter
 
+  baseline-fastboot:
+    rootfs: buildroot_baseline_ramdisk
+    pattern: 'baseline/generic-fastboot-baseline-template.jinja2'
+    params:
+      job_timeout: '50'
+
+  baseline-nfs:
+    rootfs: debian_buster_nfs
+    pattern: 'baseline/{category}-{method}-{protocol}-nfs-baseline-template.jinja2'
+    filters:
+      - blocklist: *kselftest_defconfig_filter
+
   baseline_qemu:
     base_name: baseline
     rootfs: buildroot_baseline_ramdisk
@@ -112,56 +124,12 @@ test_plans:
     filters:
       - blocklist: *kselftest_defconfig_filter
 
-  baseline-fastboot:
-    rootfs: buildroot_baseline_ramdisk
-    pattern: 'baseline/generic-fastboot-baseline-template.jinja2'
-    params:
-      job_timeout: '50'
-
-  baseline-nfs:
-    rootfs: debian_buster_nfs
-    pattern: 'baseline/{category}-{method}-{protocol}-nfs-baseline-template.jinja2'
-    filters:
-      - blocklist: *kselftest_defconfig_filter
-
   cros-ec:
     rootfs: debian_buster-cros-ec_ramdisk
 
-  igt-kms: &igt
+  igt: &igt
     rootfs: debian_buster-igt_ramdisk
     pattern: 'igt/{category}-{method}-{protocol}-{rootfs}-igt.jinja2'
-    params: &igt-kms-test-list
-      tests: >
-        core_auth
-        core_getclient
-        core_getstats
-        core_getversion
-        core_setmaster_vs_auth
-        drm_read
-        kms_addfb_basic
-        kms_atomic
-        kms_flip_event_leak
-        kms_prop_blob
-        kms_setmode
-        kms_vblank
-
-  igt-kms-rockchip:
-    <<: *igt
-    params:
-      <<: *igt-kms-test-list
-      drm_driver: "rockchip"
-
-  igt-kms-tegra:
-    <<: *igt
-    params:
-      <<: *igt-kms-test-list
-      drm_driver: "tegra"
-
-  igt-kms-exynos:
-    <<: *igt
-    params:
-      <<: *igt-kms-test-list
-      drm_driver: "exynos"
 
   igt-gpu-i915:
     <<: *igt
@@ -185,6 +153,41 @@ test_plans:
         panfrost_get_param
         panfrost_prime
         panfrost_submit
+
+  igt-kms: &igt-kms
+    <<: *igt
+    params: &igt-kms-test-list
+      tests: >
+        core_auth
+        core_getclient
+        core_getstats
+        core_getversion
+        core_setmaster_vs_auth
+        drm_read
+        kms_addfb_basic
+        kms_atomic
+        kms_flip_event_leak
+        kms_prop_blob
+        kms_setmode
+        kms_vblank
+
+  igt-kms-exynos:
+    <<: *igt-kms
+    params:
+      <<: *igt-kms-test-list
+      drm_driver: "exynos"
+
+  igt-kms-rockchip:
+    <<: *igt-kms
+    params:
+      <<: *igt-kms-test-list
+      drm_driver: "rockchip"
+
+  igt-kms-tegra:
+    <<: *igt-kms
+    params:
+      <<: *igt-kms-test-list
+      drm_driver: "tegra"
 
   kselftest: &kselftest
     rootfs: debian_buster_kselftest
@@ -222,6 +225,12 @@ test_plans:
       job_timeout: '10'
       kselftest_collections: "seccomp"
 
+  lc-compliance:
+    rootfs: debian_buster-libcamera_nfs
+    pattern: 'lc-compliance/{category}-{method}-{protocol}-{rootfs}-lc-compliance-template.jinja2'
+    params:
+      job_timeout: '45'
+
   ltp: &ltp
     rootfs: debian_buster-ltp_nfs
     pattern: 'ltp/{category}-{method}-{protocol}-{rootfs}-ltp-template.jinja2'
@@ -243,12 +252,6 @@ test_plans:
           defconfig:
             - '+crypto'
 
-  ltp-ipc:
-    <<: *ltp
-    params:
-      <<: *ltp-params
-      tst_cmdfiles: "ipc"
-
   ltp-fcntl-locktests:
     <<: *ltp
     params:
@@ -264,6 +267,12 @@ test_plans:
       - passlist:
           defconfig:
             - '+ima'
+  ltp-ipc:
+    <<: *ltp
+    params:
+      <<: *ltp-params
+      tst_cmdfiles: "ipc"
+
   ltp-mm:
     <<: *ltp
     params:
@@ -323,12 +332,6 @@ test_plans:
           defconfig:
             - 'defconfig+virtualvideo'
             - 'multi_v7_defconfig+virtualvideo'
-
-  lc-compliance:
-    rootfs: debian_buster-libcamera_nfs
-    pattern: 'lc-compliance/{category}-{method}-{protocol}-{rootfs}-lc-compliance-template.jinja2'
-    params:
-      job_timeout: '45'
 
 device_default_filters:
 

--- a/kci_build
+++ b/kci_build
@@ -32,19 +32,13 @@ class cmd_validate(Command):
 
     def __call__(self, configs, args):
         # ToDo: Use jsonschema
-        err = kernelci.sort_check(configs['trees'].keys())
-        if err:
-            print("Trees broken order: '{}' before '{}".format(*err))
-            return False
 
-        err = kernelci.sort_check(configs['fragments'].keys())
+        entries = [
+            'trees', 'fragments', 'build_configs',
+        ]
+        err = kernelci.config.validate_yaml(opts.yaml_config, entries)
         if err:
-            print("Fragments broken order: '{}' before '{}'".format(*err))
-            return False
-
-        err = kernelci.sort_check(configs['build_configs'].keys())
-        if err:
-            print("Build configs broken order: '{}' before '{}'".format(*err))
+            print(err)
             return False
 
         return True

--- a/kci_data
+++ b/kci_data
@@ -33,6 +33,15 @@ class cmd_validate(Command):
 
     def __call__(self, configs, args):
         # ToDo: Use jsonschema
+
+        entries = [
+            'db_configs',
+        ]
+        err = kernelci.config.validate_yaml(opts.yaml_config, entries)
+        if err:
+            print(err)
+            return False
+
         return True
 
 

--- a/kci_test
+++ b/kci_test
@@ -42,19 +42,21 @@ class cmd_validate(Command):
 
     def __call__(self, configs, args):
         # ToDo: Use jsonschema
-        err = kernelci.sort_check(configs['device_types'].keys())
+
+        entries = [
+            'device_types',
+            'file_system_types',
+            'test_plans',
+            'labs',
+        ]
+        err = kernelci.config.validate_yaml(opts.yaml_config, entries)
         if err:
-            print("Device types broken order: '{}' before '{}'".format(*err))
+            print(err)
             return False
 
         test_config_devices = list(
             str(config.device_type) for config in configs['test_configs']
         )
-        err = kernelci.sort_check(test_config_devices)
-        if err:
-            print("Test configs broken order: '{}' before '{}'".format(*err))
-            return False
-
         for device_type in configs['device_types'].keys():
             if device_type not in test_config_devices:
                 print("Device type has no test config: {}".format(device_type))
@@ -66,11 +68,6 @@ class cmd_validate(Command):
                 print("Plans broken order for {}: '{}' before '{}'".format(
                     config.device_type, err[0], err[1]))
                 return False
-
-        err = kernelci.sort_check(configs['labs'].keys())
-        if err:
-            print("Labs broken order: '{}' before '{}'".format(*err))
-            return False
 
         return True
 


### PR DESCRIPTION
Validate each YAML file individually as top-level entries can now be merged from various separate files.  When this happens, the entries are put together in the order they appear in separate files, so the alphabetical check is irrelevant.