### PR TITLE
Add libnuma-dev package to enable additional ltp-mm test cases

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -135,6 +135,8 @@ rootfs_configs:
       - amd64
       - arm64
       - armhf
+    extra_packages:
+      - libnuma-dev
     script: "scripts/buster-ltp.sh"
 
   buster-v4l2:

--- a/config/rootfs/debos/scripts/buster-ltp.sh
+++ b/config/rootfs/debos/scripts/buster-ltp.sh
@@ -16,6 +16,7 @@ BUILD_DEPS="\
     flex \
     m4 \
     libc6-dev \
+    libnuma-dev \
 "
 
 apt-get install --no-install-recommends -y  ${BUILD_DEPS}


### PR DESCRIPTION
This PR includes patch by @padovan from kernelci/kernelci-core#706 to enable following ltp-mm test cases:
- oom03
- oom04
- oom05
- vma02
- vma04