### PR TITLE
test-configs.yaml: disable kselftest on mt8183-kukui-jacuzzi

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2207,11 +2207,6 @@ test_configs:
     test_plans:
       - baseline
       - baseline-nfs
-      - kselftest-filesystems
-      - kselftest-futex
-      - kselftest-lib
-      - kselftest-lkdtm
-      - kselftest-seccomp
 
   - device_type: mustang
     test_plans:


### PR DESCRIPTION
Disable all kselftest on mt8183-kukui-jacuzzi-juniper-sku16 as the
hack to set a custom ip=::: kernel command line argument is breaking
other use-cases on this device type in Collabora's LAVA lab.  This is
a temporary measure until the issue is fixed properly in the LAVA
device type templates or elsewhere.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>