### PR TITLE
Add cmd to install firmware in rootfs

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -66,6 +66,8 @@ rootfs_configs:
       - e2fslibs
       - e2fsprogs
       - libext2fs2
+    extra_firmware:
+      - rtl_nic/rtl8153b-2.fw
     script: "scripts/buster-cros-ec-tests.sh"
     test_overlay: ""
 
@@ -109,6 +111,9 @@ rootfs_configs:
         - dir
         - partx
         - find
+    extra_firmware:
+        - i915/kbl_dmc_ver1_04.bin
+        - i915/glk_dmc_ver1_04.bin
     script: "scripts/buster-igt.sh"
     test_overlay: "overlays/igt"
 

--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -67,7 +67,11 @@ rootfs_configs:
       - e2fsprogs
       - libext2fs2
     extra_firmware:
+      - mrvl/pcieusb8997_combo_v4.bin
+      - mrvl/sd8897_uapsta.bin
+      - qca/rampatch_00440302.bin
       - rtl_nic/rtl8153b-2.fw
+      - rockchip/dptx.bin
     script: "scripts/buster-cros-ec-tests.sh"
     test_overlay: ""
 
@@ -112,6 +116,7 @@ rootfs_configs:
         - partx
         - find
     extra_firmware:
+        - i915/bxt_dmc_ver1_07.bin
         - i915/kbl_dmc_ver1_04.bin
         - i915/glk_dmc_ver1_04.bin
     script: "scripts/buster-igt.sh"

--- a/config/rootfs/debos/rootfs.yaml
+++ b/config/rootfs/debos/rootfs.yaml
@@ -1,6 +1,7 @@
 {{- $architecture := or .architecture "arm64" -}}
 {{- $basename := or .basename "." -}}
 {{- $extra_packages := or .extra_packages "" -}}
+{{- $extra_firmware := or .extra_firmware "" -}}
 {{- $suite := or .suite "stretch" -}}
 {{- $script := or .script "scripts/nothing.sh" -}}
 {{- $test_overlay := .test_overlay -}}
@@ -53,6 +54,13 @@ actions:
     description: Install extra packages
     chroot: true
     command: apt-get update && apt-get -y install --no-install-recommends {{ $extra_packages }}
+
+{{ if $extra_firmware }}
+  - action: run
+    description: add firmware files
+    chroot: false
+    script: scripts/install-firmware.sh {{ $extra_firmware }}
+{{ end }}
 
   - action: run
     description: Set hostname

--- a/config/rootfs/debos/scripts/install-firmware.sh
+++ b/config/rootfs/debos/scripts/install-firmware.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+set -e
+FIRMWARE_SITE=https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git
+FIRMWARE_VERSION=d526e044bddaa2c2ad855c7296147e49be0ab03c
+
+DEST=${ROOTDIR}/lib/firmware
+mkdir -p $DEST
+
+# Because the linux-firmware repo is very big, we use the following
+# git init hack to fetch a single shallow commit to minimize time,
+# space and network bandwidth
+TMP_REPO=/tmp/linux-firmware
+mkdir -p $TMP_REPO && cd $TMP_REPO
+git init
+git remote add origin $FIRMWARE_SITE
+git fetch --depth 1 origin $FIRMWARE_VERSION
+git checkout FETCH_HEAD
+
+for fw_file in "$@"
+do
+    cp --parents "$fw_file" $DEST
+done
+
+########################################################################
+# Cleanup: remove downloaded firmware files
+########################################################################
+rm -rf $TMP_REPO

--- a/doc/kci_rootfs.md
+++ b/doc/kci_rootfs.md
@@ -138,6 +138,7 @@ Now you know how to build default `kci_rootfs` images. Let's look at how to add 
   | script                | Custom script to be executed during rootfs image creation. |
   | test_overlay          | Create a directory layout on final rootfs image as provided. |
   | extra_packages        | Installs specified packages on rootfs image. |
+  | extra_firmware        | Installs specified linux-firmware files into rootfs image. |
   | extra_files_remove    | Removes specified files from rootfs image. |
 
   Please note at the moment, only `debos` is supported as `rootfs_type` and above options are debos specific.

--- a/kernelci/config/rootfs.py
+++ b/kernelci/config/rootfs.py
@@ -42,7 +42,7 @@ class RootFS(YAMLObject):
 
 class RootFS_Debos(RootFS):
     def __init__(self, name, rootfs_type, debian_release=None,
-                 arch_list=None, extra_packages=None,
+                 arch_list=None, extra_packages=None, extra_firmware=None,
                  extra_packages_remove=None,
                  extra_files_remove=None, script="",
                  test_overlay="", crush_image_options=None, debian_mirror="",
@@ -52,6 +52,7 @@ class RootFS_Debos(RootFS):
         self._arch_list = arch_list or list()
         self._extra_packages = extra_packages or list()
         self._extra_packages_remove = extra_packages_remove or list()
+        self._extra_firmware = extra_firmware or list()
         self._extra_files_remove = extra_files_remove or list()
         self._script = script
         self._test_overlay = test_overlay
@@ -68,7 +69,8 @@ class RootFS_Debos(RootFS):
                      'extra_packages', 'extra_packages_remove',
                      'extra_files_remove', 'script', 'test_overlay',
                      'crush_image_options', 'debian_mirror',
-                     'keyring_package', 'keyring_file']))
+                     'keyring_package', 'keyring_file',
+                     'extra_firmware']))
         return cls(**kw)
 
     @property
@@ -90,6 +92,10 @@ class RootFS_Debos(RootFS):
     @property
     def extra_files_remove(self):
         return list(self._extra_files_remove)
+
+    @property
+    def extra_firmware(self):
+        return list(self._extra_firmware)
 
     @property
     def script(self):
@@ -248,6 +254,7 @@ def _dump_config_debos(config_name, config):
         config.extra_packages_remove))
     print('\textra_files_remove: {}'.format(
         config.extra_files_remove))
+    print('\textra_firmware: {}'.format(config.extra_firmware))
     print('\tscript: {}'.format(config.script))
     print('\ttest_overlay: {}'.format(config.test_overlay))
     print('\tcrush_image_options: {}'.format(

--- a/kernelci/rootfs.py
+++ b/kernelci/rootfs.py
@@ -29,6 +29,7 @@ def _build_debos(name, config, data_path, arch):
 -t extra_packages:"{extra_packages}" \
 -t extra_packages_remove:"{extra_packages_remove}" \
 -t extra_files_remove:"{extra_files_remove}" \
+-t extra_firmware:"{extra_firmware}" \
 -t script:"{script}" \
 -t test_overlay:"{test_overlay}" \
 -t crush_image_options:"{crush_image_options}" \
@@ -43,6 +44,7 @@ rootfs.yaml'.format(
             extra_packages=" ".join(config.extra_packages),
             extra_packages_remove=" ".join(config.extra_packages_remove),
             extra_files_remove=" ".join(config.extra_files_remove),
+            extra_firmware=" ".join(config.extra_firmware),
             script=config.script,
             test_overlay=config.test_overlay,
             crush_image_options=" ".join(config.crush_image_options),


### PR DESCRIPTION
The first commit adds the mechanism then the second commit adds some example firmware required for `mt8173-elm-hana-next-2021-05-27` and `asus-C433TA-AJ0005-rammus`.

Fixes: #698 