### PR TITLE
Enable cr50 tpm drivers

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -263,6 +263,13 @@ fragments:
       - 'CONFIG_IIO_CROS_EC_SENSORS=m'
       - 'CONFIG_MFD_CROS_EC_DEV=m'
       - 'CONFIG_I2C_DESIGNWARE_PLATFORM=y'
+      - 'CONFIG_TCG_TPM=y'
+      - 'CONFIG_TCG_TIS=y'
+      - 'CONFIG_TCG_TIS_SPI=y'
+      - 'CONFIG_TCG_TIS_SPI_CR50=y'
+      - 'CONFIG_TCG_TIS_I2C_CR50=y'
+      - 'CONFIG_SPI=y'
+      - 'CONFIG_SPI_PXA2XX=y'
 
   x86_kvm_guest:
     path: "kernel/configs/kvm_guest.config"


### PR DESCRIPTION
HI,

This is the kernelci-core counterpart to the [bootrr PR #12](https://github.com/kernelci/bootrr/pull/12).

[Here is an example run](https://lava.collabora.co.uk/results/testcase/170445026) of the bootrr test with these configs and tpm2-tools on my dev setup.