### PR TITLE
config/lava: add earlycon to kernel command line

### DIFF
--- a/config/lava/base/kernel-ci-base.jinja2
+++ b/config/lava/base/kernel-ci-base.jinja2
@@ -1,4 +1,4 @@
-{% set extra_kernel_args = "console_msg_format=syslog" %}
+{% set extra_kernel_args = "console_msg_format=syslog earlycon" %}
 
 {%- block metadata %}
 metadata:


### PR DESCRIPTION
Add "earlycon" to the default kernel command line as it should just
work on platforms with stdout-path set in their device tree.

Suggested-by: Rob Herring <robh@kernel.org>
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>