### PR TITLE
build-configs: use clang-13 for linux-next

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -924,8 +924,8 @@ build_configs:
         architectures: *arch_clang_configs
 
       # Latest clang release
-      clang-12:
-        build_environment: clang-12
+      clang-13:
+        build_environment: clang-13
         architectures:
           <<: *arch_clang_configs
           riscv:


### PR DESCRIPTION
Upgrade from LLVM/Clang 12 to 13 to build linux-next as LLVM 13.0 just
got released.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>