### PR TITLE
config/docker: update buildroot to Debian Bullseye

### DIFF
--- a/config/docker/buildroot/Dockerfile
+++ b/config/docker/buildroot/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -31,6 +31,6 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 
 # Extra packages needed by kernelCI
 RUN apt-get update && apt-get install --no-install-recommends -y \
-    python3.7 \
+    python3.9 \
     python3-requests \
     python3-yaml


### PR DESCRIPTION
Update the buildroot Docker image to Debian Bullseye and Python 3.9.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>