### PR TITLE
kernelci.build: fix case when the boot directory doesn't exist

### DIFF
--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -1204,14 +1204,18 @@ class MakeKernel(Step):
 
     def _find_kernel_images(self, image):
         arch = self._meta.get('bmeta', 'environment', 'arch')
-        boot_dir = os.path.join(self._output_path, 'arch', arch, 'boot')
         kimage_names = KERNEL_IMAGE_NAMES[arch]
         kimages = dict()
 
         if image:
             kimage_names.add(image)
 
-        for path in boot_dir, self._output_path:
+        image_paths = [
+            os.path.join(self._output_path, 'arch', arch, 'boot'),
+            self._output_path
+        ]
+
+        for path in (p for p in image_paths if os.path.isdir(p)):
             files = set(os.listdir(path))
             image_files = files.intersection(kimage_names)
             kimages.update({im: os.path.join(path, im) for im in image_files})


### PR DESCRIPTION
When the kernel build fails, there may not be any boot output
directory at all (e.g. build/arch/arm/boot).  Calling os.listdir() on
a non-existent directory raises a Python exception, so check for the
presence of them first.

Fixes: a9d661b8c339 ("kernelci.build: implement MakeKernel.install()")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>