### PR TITLE
add lc-compliance test to rockpi4

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -222,6 +222,13 @@ fragments:
       - 'CONFIG_PREEMPT_RT=y'
       - 'CONFIG_PREEMPT_RT_FULL=y' # <= v4.19
 
+  rockpi4_nfs:
+    path: "kernel/configs/rockpi4_nfs.config"
+    configs:
+    - 'CONFIG_STMMAC_ETH=y'
+    - 'CONFIG_STMMAC_PLATFORM=y'
+    - 'CONFIG_DWMAC_ROCKCHIP=y'
+
   tinyconfig:
     path: "kernel/configs/tiny.config"
     defconfig: 'tinyconfig'
@@ -840,6 +847,16 @@ build_configs:
   krzysztof:
     tree: krzysztof
     branch: 'for-next'
+
+  lc-compliance-rockpi4:
+    tree: media
+    branch: 'master'
+    variants:
+      gcc-10:
+        build_environment: gcc-10
+        fragments: [rockpi4_nfs]
+        architectures:
+          arm64: *arm64_arch
 
   lee_android_3.18:
     tree: lee

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -231,6 +231,14 @@ test_plans:
     params:
       job_timeout: '45'
 
+  lc-compliance-rockpi4:
+    rootfs: debian_buster-libcamera_nfs
+    pattern: 'lc-compliance/{category}-{method}-{protocol}-{rootfs}-lc-compliance-template.jinja2'
+    params:
+      job_timeout: '45'
+    filters:
+      - passlist: {defconfig: ['rockpi4_nfs']}
+
   ltp: &ltp
     rootfs: debian_buster-ltp_nfs
     pattern: 'ltp/{category}-{method}-{protocol}-{rootfs}-ltp-template.jinja2'
@@ -1398,6 +1406,13 @@ device_types:
       - blocklist: *allmodconfig_filter
       - blocklist: {kernel: ['v3.', 'v4.4', 'v4.9']}
 
+  rockpi4:
+    mach: mediatek
+    class: arm64-dtb
+    boot_method: depthcharge
+    filters:
+      - passlist: {defconfig: ['rockpi4_nfs']}
+
   snow:
     mach: exynos
     class: arm-dtb
@@ -2409,6 +2424,10 @@ test_configs:
   - device_type: rk3399-puma-haikou
     test_plans:
       - baseline
+
+  - device_type: rockpi4
+    test_plans:
+      - lc-compliance-rockpi4
 
   - device_type: snow
     test_plans:


### PR DESCRIPTION
There are rock pi 4 boards with imx219 cameras attached available on collabora's LAVA lab now. This PR drafts the KernelCI configs needed to run the lc-compliance tests on rock pi 4 boards.

One issue is that the defconfig for arm64 isn't suitable to load the rootfs through nfs in the rockpi4. For this to be possible, a few configs need to be enabled builtin. So this PR also adds kernel builds with these configs enabled.

Signed-off-by: Nícolas F. R. A. Prado <nfraprado@collabora.com>