### PR TITLE
Upgrade debos Docker image to Bullseye

### DIFF
--- a/config/docker/debos/Dockerfile
+++ b/config/docker/debos/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -45,7 +45,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 
 # Extra packages needed by kernelCI
 RUN apt-get update && apt-get install --no-install-recommends -y \
-    python3.7 \
+    python3.9 \
     python3-requests \
     python3-yaml \
     xz-utils

--- a/config/rootfs/debos/scripts/crush.sh
+++ b/config/rootfs/debos/scripts/crush.sh
@@ -48,7 +48,8 @@ package_management()  {
    remove_packages "${UNNEEDED_PACKAGES}"
 
    # Show what's left package-wise before dropping dpkg itself
-   COLUMNS=300 dpkg -l
+   # ToDo: Investigate why it's hanging with Debian Bullseye as host
+   # COLUMNS=300 dpkg -l
 
    # Drop dpkg
    dpkg --purge --force-remove-essential --force-depends  dpkg


### PR DESCRIPTION
Upgrade the debos Docker image to Bullseye and work around an issue with `dpkg -l` in `crush.sh`.