### PR TITLE
kernelci.test: derive compression type from URLs

### DIFF
--- a/config/lava/base/kernel-ci-base-tftp-deploy.jinja2
+++ b/config/lava/base/kernel-ci-base-tftp-deploy.jinja2
@@ -19,17 +19,23 @@ actions:
 {%- if nfsrootfs_url %}
     nfsrootfs:
       url: {{ nfsrootfs_url }}
-      compression: xz
+      {%- if nfsroot_compression %}
+      compression: {{ nfsroot_compression }}
+      {%- endif %}
 {%- endif %}
 {%- if initrd_url %}
     ramdisk:
       url: {{ initrd_url }}
-      compression: gz
+      {%- if initrd_compression %}
+      compression: {{ initrd_compression }}
+      {%- endif %}
 {%- endif %}
 {%- if modules_url %}
     modules:
       url: {{ modules_url }}
-      compression: xz
+      {%- if modules_compression %}
+      compression: {{ modules_compression }}
+      {%- endif %}
 {%- endif %}
 {%- if dtb_url %}
     dtb:


### PR DESCRIPTION
Rather than hard-coding the compression type in the LAVA base
template, derive it from the rootfs and modules URLs and pass it as
template arguments.  This allows more flexibility by relying on the
convention with usual file extensions i.e. .gz, .bz2 and .xz.  If the
end of the URL doesn't match any of these (say, .tar), the compression
attribute is left empty and not defined in the LAVA template.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>
Signed-off-by: Alice Ferrazzi <alice.ferrazzi@miraclelinux.com>