### PR TITLE
test-configs.yaml: update Debian Buster rootfs URLs

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -67,8 +67,8 @@ file_systems:
 
   debian_buster-libcamera_nfs:
     type: debian
-    ramdisk: 'buster-libcamera/20211008.0/{arch}/initrd.cpio.gz'
-    nfs: 'buster-libcamera/20211008.0/{arch}/full.rootfs.tar.xz'
+    ramdisk: 'buster-libcamera/20211014.0/{arch}/initrd.cpio.gz'
+    nfs: 'buster-libcamera/20211014.0/{arch}/full.rootfs.tar.xz'
     root_type: nfs
 
   debian_buster-ltp_nfs:


### PR DESCRIPTION
Update the Debian Buster rootfs URLs except for libcamera and ltp as
they failed to build for various reasons.  These rootfs images were
built with the new Bullseye version of the kernelci/debos Docker
image.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>