### PR TITLE
rootfs: libcamera: Move build out of /tmp to avoid out-of-memory issues

### DIFF
--- a/config/rootfs/debos/scripts/buster-libcamera.sh
+++ b/config/rootfs/debos/scripts/buster-libcamera.sh
@@ -41,7 +41,7 @@ echo '{  "tests_suites": [' >> $BUILDFILE
 ########################################################################
 
 LIBCAMERA_URL=https://git.linuxtv.org/libcamera.git
-mkdir -p /tmp/tests/libcamera && cd /tmp/tests/libcamera
+mkdir -p /var/tests/libcamera && cd /var/tests/libcamera
 
 git clone --depth=1 $LIBCAMERA_URL .
 
@@ -55,7 +55,7 @@ echo '  ]}' >> $BUILDFILE
 ########################################################################
 # Cleanup: remove files and packages we don't want in the images       #
 ########################################################################
-rm -rf /tmp/tests
+rm -rf /var/tests
 
 apt-get remove --purge -y ${BUILD_DEPS}
 apt-get remove --purge -y libgtest-dev


### PR DESCRIPTION
/tmp has a lower size limit by default, which was causing out-of-memory
issues when building libcamera inside of it. Move the build out of the
/tmp directory to avoid this.

Signed-off-by: Nícolas F. R. A. Prado <nfraprado@collabora.com>