### PR TITLE
Enable baseline-qemu-docker test plan on lab-collabora-staging

### DIFF
--- a/config/core/lab-configs.yaml
+++ b/config/core/lab-configs.yaml
@@ -55,7 +55,9 @@ labs:
     lab_type: lava
     url: 'https://staging.lava.collabora.dev/RPC2/'
     priority: '45'
-    filters: *collabora-filters
+    filters:
+      - blocklist:
+          tree: [android]
 
   lab-kontron:
     lab_type: lava


### PR DESCRIPTION
This one is to enable temporarily baseline-qemu-docker on lab-collabora-staging