### PR TITLE
kernelci.lab: add trailing slash to RPC2/ for LAVA labs

### DIFF
--- a/kernelci/lab/__init__.py
+++ b/kernelci/lab/__init__.py
@@ -54,7 +54,7 @@ class LabAPI:
         """
         if user and token:
             url = urllib.parse.urlparse(self.config.url)
-            api_url = "{scheme}://{user}:{token}@{loc}{path}RPC2".format(
+            api_url = "{scheme}://{user}:{token}@{loc}{path}RPC2/".format(
                 scheme=url.scheme, user=user, token=token,
                 loc=url.netloc, path=url.path)
         else:


### PR DESCRIPTION
Add a trailing slash to the RPC2/ URL as this appears to be required
at least for some labs (e.g. lab-clabbe).

Fixes: aea6ab3a37e6 ("kernelci.lab: move RPC2 suffix to implementation")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>