### PR TITLE
New device: Add sc7180-trogdor-lazor-limozeen with basic tests

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1402,6 +1402,7 @@ device_types:
     mach: qcom
     class: arm64-dtb
     boot_method: depthcharge
+    filters: *arm64-chromebook-filters
 
   snow:
     mach: exynos

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1399,8 +1399,8 @@ device_types:
       - blocklist: {kernel: ['v3.', 'v4.4', 'v4.9']}
 
   sc7180-trogdor-lazor-limozeen:
-    mach: qcom-dtb
-    class: arm64
+    mach: qcom
+    class: arm64-dtb
     boot_method: depthcharge
     dtb: 'sc7180-trogdor-lazor-limozeen-nots-r5.dtb'
     filters: *arm64-chromebook-filters

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1399,9 +1399,10 @@ device_types:
       - blocklist: {kernel: ['v3.', 'v4.4', 'v4.9']}
 
   sc7180-trogdor-lazor-limozeen:
-    mach: qcom
-    class: arm64-dtb
+    mach: qcom-dtb
+    class: arm64
     boot_method: depthcharge
+    dtb: 'sc7180-trogdor-lazor-limozeen-nots-r5.dtb'
     filters: *arm64-chromebook-filters
 
   snow:

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1402,7 +1402,7 @@ device_types:
     mach: qcom
     class: arm64-dtb
     boot_method: depthcharge
-    dtb: 'sc7180-trogdor-lazor-limozeen-nots-r5.dtb'
+    dtb: 'qcom/sc7180-trogdor-lazor-limozeen-nots-r5.dtb'
     filters: *arm64-chromebook-filters
 
   snow:

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2418,6 +2418,7 @@ test_configs:
   - device_type: sc7180-trogdor-lazor-limozeen
     test_plans:
       - baseline
+      - cros-ec
 
   - device_type: snow
     test_plans:

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1398,6 +1398,11 @@ device_types:
       - blocklist: *allmodconfig_filter
       - blocklist: {kernel: ['v3.', 'v4.4', 'v4.9']}
 
+  sc7180-trogdor-lazor-limozeen:
+    mach: qcom
+    class: arm64-dtb
+    boot_method: depthcharge
+
   snow:
     mach: exynos
     class: arm-dtb
@@ -2407,6 +2412,10 @@ test_configs:
       - blocklist: {kernel: ['v3.', 'v4.4', 'v4.9', 'v4.14']}
 
   - device_type: rk3399-puma-haikou
+    test_plans:
+      - baseline
+
+  - device_type: sc7180-trogdor-lazor-limozeen
     test_plans:
       - baseline
 


### PR DESCRIPTION
This patchset adds Trogdor to the test-configs and enables baseline and cros-ec tests to be run on it.

The baseline-nfs and other tests requiring nfs support haven't been added because of an issue with USB: it's probing slow (it's a module), the usb ethernet adapter comes up too late and this produces the unability to assign an IP address and mount the NFS rootfs.

Please note: in order to be able to run these tests, it is required to have this kernel patch merged in https://lore.kernel.org/lkml/20211011154003.904355-1-angelogioacchino.delregno@collabora.com
...or the device will hang.