### PR TITLE
lava-v2-callback.py: look for job result in login test case

### DIFF
--- a/scripts/lava-v2-callback.py
+++ b/scripts/lava-v2-callback.py
@@ -73,8 +73,9 @@ def handle_boot(cb, verbose):
 def _add_login_case(results, tests):
     tests_map = {t['name']: t for t in tests}
     login = tests_map.get('auto-login-action') or tests_map.get('login-action')
-    if login:
-        results['login'] = login['result']
+    job_result = tests_map['job']['result']
+    result = login and login['result'] == 'pass' and job_result == 'pass'
+    results['login'] = 'pass' if result else 'fail'
 
 
 def _add_test_results(results, tests, suite_name):


### PR DESCRIPTION
Fix how the login test case is being created to produce the same
pass/fail result as the kernelci-backend implementation.  If the login
action passed but the overall job failed, then set the login test case
as "failed".

Fixes: 07b9a0ae3c99 ("lava-v2-callback.py: add support for login test case")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>