### PR TITLE
build-configs.yaml: add arm config CONFIG_THUMB2_KERNEL

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -363,6 +363,7 @@ build_configs_defaults:
             - 'multi_v7_defconfig+CONFIG_CPU_BIG_ENDIAN=y'
             - 'multi_v7_defconfig+CONFIG_SMP=n'
             - 'multi_v7_defconfig+CONFIG_EFI=y+CONFIG_ARM_LPAE=y'
+            - 'multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y'
           fragments: [crypto, ima]
 
         arm64: &arm64_arch
@@ -915,6 +916,7 @@ build_configs:
               - 'multi_v7_defconfig+CONFIG_CPU_BIG_ENDIAN=y'
               - 'multi_v7_defconfig+CONFIG_SMP=n'
               - 'multi_v7_defconfig+CONFIG_EFI=y+CONFIG_ARM_LPAE=y'
+              - 'multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y'
               - 'allnoconfig'
               - 'allmodconfig'
 


### PR DESCRIPTION
Add an extra arm config with CONFIG_THUMB2_KERNEL enabled to the
default list of configs and linux-next.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>

Fixes #845 