### PR TITLE
build-configs.yaml: drop the ardb_arm-kaslr-latest config

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -661,25 +661,6 @@ build_configs:
     tree: ardb
     branch: 'for-kernelci'
 
-  ardb_arm-kaslr-latest:
-    tree: ardb
-    branch: 'arm-kaslr-latest'
-    variants:
-      gcc-10:
-        build_environment: gcc-10
-        architectures:
-          x86_64: *x86_64_arch
-          arm64: *arm64_arch
-          arm:
-            base_defconfig: 'multi_v7_defconfig'
-            extra_configs:
-              - 'multi_v7_defconfig+CONFIG_CPU_BIG_ENDIAN=y'
-              - 'multi_v7_defconfig+CONFIG_SMP=n'
-              - 'multi_v7_defconfig+CONFIG_EFI=y+CONFIG_ARM_LPAE=y'
-              - 'multi_v7_defconfig+CONFIG_RANDOMIZE_BASE=y'
-              - 'multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y+CONFIG_RANDOMIZE_BASE=y'
-              - 'omap2plus_defconfig+CONFIG_RANDOMIZE_BASE=y'
-
   arm64:
     tree: arm64
     branch: 'for-kernelci'


### PR DESCRIPTION
Drop the arm-kaslr-latest branch from ardb's tree as it is now stale
and not used any more.

Suggested-by: Ard Biesheuvel <ardb@kernel.org>
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>