### PR TITLE
rootfs-configs: Trogdor: Add Adreno 630 and Venus-5.2 firmwares

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -151,6 +151,8 @@ rootfs_configs:
         - i915/bxt_dmc_ver1_07.bin
         - i915/kbl_dmc_ver1_04.bin
         - i915/glk_dmc_ver1_04.bin
+        - qcom/a630_gmu.bin
+        - qcom/a630_sqe.fw
     linux_fw_version: d526e044bddaa2c2ad855c7296147e49be0ab03c
     script: "scripts/bullseye-igt.sh"
     test_overlay: "overlays/igt"

--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -252,5 +252,12 @@ rootfs_configs:
       - bash
       - e2fslibs
       - e2fsprogs
+    extra_firmware:
+        - qcom/venus-5.4/venus.b00
+        - qcom/venus-5.4/venus.b01
+        - qcom/venus-5.4/venus.b02
+        - qcom/venus-5.4/venus.b03
+        - qcom/venus-5.4/venus.b04
+        - qcom/venus-5.4/venus.mdt
     script: "scripts/bullseye-v4l2.sh"
     test_overlay: "overlays/v4l2"


### PR DESCRIPTION
This patchset adds the required firmwares for GPU and hardware enc/decoder, necessary to run certain tests on Qualcomm sc7180-trogdor