### PR TITLE
T31087 lava rest support

### DIFF
--- a/config/core/lab-configs.yaml
+++ b/config/core/lab-configs.yaml
@@ -2,8 +2,8 @@ labs:
 
   # ToDo: also run jobs with callbacks sent to BayLibre's KernelCI backend
   lab-baylibre:
-    lab_type: lava
-    url: 'https://lava.baylibre.com/'
+    lab_type: lava.lava_xmlrpc
+    url: 'https://lava.baylibre.com/RPC2'
     filters:
       - blocklist: {tree: [drm-tip]}
       - passlist:
@@ -13,13 +13,13 @@ labs:
             - preempt-rt
 
   lab-broonie:
-    lab_type: lava_rest
-    url: 'https://lava.sirena.org.uk/'
+    lab_type: lava.lava_xmlrpc
+    url: 'https://lava.sirena.org.uk/RPC2'
     priority: low
 
   lab-cip:
-    lab_type: lava_rest
-    url: 'https://lava.ciplatform.org/'
+    lab_type: lava.lava_xmlrpc
+    url: 'https://lava.ciplatform.org/RPC2'
     filters:
       - blocklist: {tree: [android]}
       - passlist:
@@ -28,8 +28,8 @@ labs:
             - smc
 
   lab-clabbe:
-    lab_type: lava
-    url: 'https://lava.montjoie.ovh/'
+    lab_type: lava.lava_xmlrpc
+    url: 'https://lava.montjoie.ovh/RPC2'
     filters:
       - passlist:
           plan:
@@ -43,7 +43,7 @@ labs:
             - stable
 
   lab-collabora:
-    lab_type: lava_rest
+    lab_type: lava.lava_rest
     url: 'https://lava.collabora.co.uk/'
     priority: '45'
     filters: &collabora-filters
@@ -52,13 +52,13 @@ labs:
           plan: [baseline-qemu-docker]
 
   lab-collabora-staging:
-    lab_type: lava_rest
+    lab_type: lava.lava_rest
     url: 'https://staging.lava.collabora.dev/'
     priority: '45'
     filters: *collabora-filters
 
   lab-kontron:
-    lab_type: lava_rest
+    lab_type: lava.lava_rest
     url: 'https://lavalab.kontron.com/'
     filters:
       - passlist:
@@ -66,7 +66,7 @@ labs:
             - baseline
 
   lab-linaro-lkft:
-    lab_type: lava_rest
+    lab_type: lava.lava_rest
     url: 'https://lkft.validation.linaro.org/'
     priority: low
     filters:
@@ -80,8 +80,8 @@ labs:
             - stable
 
   lab-mhart:
-    lab_type: lava
-    url: 'http://lava.streamtester.net/'
+    lab_type: lava.lava_xmlrpc
+    url: 'http://lava.streamtester.net/RPC2'
     filters:
       - blocklist: {tree: ['android', 'drm-tip', 'linaro-android']}
       - passlist:
@@ -89,7 +89,7 @@ labs:
             - baseline
 
   lab-nxp:
-    lab_type: lava_rest
+    lab_type: lava.lava_rest
     url: 'https://lavalab.nxp.com/'
     filters:
       - passlist:
@@ -98,7 +98,7 @@ labs:
       - blocklist: {plan: [baseline-qemu-docker]}
 
   lab-pengutronix:
-    lab_type: lava_rest
+    lab_type: lava.lava_rest
     url: 'https://hekla.openlab.pengutronix.de/'
     filters:
       - passlist:
@@ -107,8 +107,8 @@ labs:
       - blocklist: {plan: [baseline-qemu-docker]}
 
   lab-theobroma-systems:
-    lab_type: lava
-    url: 'https://lava.theobroma-systems.com/'
+    lab_type: lava.lava_xmlrpc
+    url: 'https://lava.theobroma-systems.com/RPC2'
     filters:
       - passlist:
           plan:

--- a/kernelci/config/lab.py
+++ b/kernelci/config/lab.py
@@ -81,6 +81,7 @@ class LabFactory(YAMLObject):
     _lab_types = {
         'lava_rest': Lab_LAVA,
         'lava.lava_xmlrpc': Lab_LAVA,
+        'lava.lava_rest': Lab_LAVA,
     }
 
     @classmethod

--- a/kernelci/config/lab.py
+++ b/kernelci/config/lab.py
@@ -79,8 +79,8 @@ class LabFactory(YAMLObject):
     """Factory to create lab objects from YAML data."""
 
     _lab_types = {
-        'lava': Lab_LAVA,
         'lava_rest': Lab_LAVA,
+        'lava.lava_xmlrpc': Lab_LAVA,
     }
 
     @classmethod

--- a/kernelci/lab/__init__.py
+++ b/kernelci/lab/__init__.py
@@ -17,20 +17,18 @@
 
 import importlib
 import json
-import urllib.parse
-import xmlrpc.client
 
 
 class LabAPI:
     """Remote API to a test lab"""
 
-    def __init__(self, config):
+    def __init__(self, config, **kwargs):
         """A test lab API object can be used to remotely interact with a lab
 
         *config* is a kernelci.config.lab.Lab object
         """
         self._config = config
-        self._server = None
+        self._server = self._connect(**kwargs)
         self._devices = None
 
     @property
@@ -46,20 +44,8 @@ class LabAPI:
     def _get_devices(self):
         return list()
 
-    def connect(self, user=None, token=None):
-        """Connect to the remote server API
-
-        *user* is the name of the user to connect to the lab
-        *token* is the token associated with the user to connect to the lab
-        """
-        if user and token:
-            url = urllib.parse.urlparse(self.config.url)
-            api_url = "{scheme}://{user}:{token}@{loc}{path}RPC2/".format(
-                scheme=url.scheme, user=user, token=token,
-                loc=url.netloc, path=url.path)
-        else:
-            api_url = self.config.url
-        self._server = xmlrpc.client.ServerProxy(api_url)
+    def _connect(self, *args, **kwargs):
+        return None
 
     def import_devices(self, data):
         """Import devices information
@@ -106,11 +92,9 @@ def get_api(lab, user=None, token=None, lab_json=None):
     *lab_json* is the path to a JSON file with cached lab information
     """
     m = importlib.import_module('.'.join(['kernelci', 'lab', lab.lab_type]))
-    api = m.get_api(lab)
+    api = m.get_api(lab, user=user, token=token)
     if lab_json:
         with open(lab_json) as json_file:
             devices = json.load(json_file)['devices']
             api.import_devices(devices)
-    if user and token:
-        api.connect(user, token)
     return api

--- a/kernelci/lab/lava/__init__.py
+++ b/kernelci/lab/lava/__init__.py
@@ -1,0 +1,62 @@
+# Copyright (C) 2019,2021 Collabora Limited
+# Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+# Author: Michal Galka <michal.galka@coll
+#
+# Copyright (C) 2019 Linaro Limited
+# Author: Dan Rue <dan.rue@linaro.org>
+#
+# This module is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+from jinja2 import Environment, FileSystemLoader
+import os
+from kernelci.lab import LabAPI
+
+
+class LavaAPI(LabAPI):
+    def generate(self, params, target, plan, callback_opts):
+        short_template_file = plan.get_template_path(target.boot_method)
+        template_file = os.path.join('config/lava', short_template_file)
+        if not os.path.exists(template_file):
+            print("Template not found: {}".format(template_file))
+            return None
+        base_name = params['base_device_type']
+        params.update({
+            'template_file': template_file,
+            'priority': self.config.priority,
+            'lab_name': self.config.name,
+            'base_device_type': self._alias_device_type(base_name),
+        })
+        self._add_callback_params(params, callback_opts)
+        jinja2_env = Environment(loader=FileSystemLoader('config/lava'),
+                                 extensions=["jinja2.ext.do"])
+        template = jinja2_env.get_template(short_template_file)
+        data = template.render(params)
+        return data
+
+    def _add_callback_params(self, params, opts):
+        callback_id = opts.get('id')
+        if not callback_id:
+            return
+        callback_type = opts.get('type')
+        if callback_type == 'kernelci':
+            lava_cb = 'boot' if params['plan'] == 'boot' else 'test'
+            # ToDo: consolidate this to just have to pass the callback_url
+            params['callback_name'] = '/'.join(['lava', lava_cb])
+        params.update({
+            'callback': callback_id,
+            'callback_url': opts['url'],
+            'callback_dataset': opts['dataset'],
+            'callback_type': callback_type,
+        })

--- a/kernelci/lab/lava/lava_rest.py
+++ b/kernelci/lab/lava/lava_rest.py
@@ -1,0 +1,115 @@
+# Copyright (C) 2021 Collabora Limited
+# Author: Michal Galka <michal.galka@collabora.com>
+#
+# This module is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+from collections import namedtuple
+import json
+import requests
+from urllib.parse import urljoin
+import yaml
+from kernelci.lab.lava import LavaAPI
+
+RestAPIServer = namedtuple('RestAPIServer', ['url', 'session'])
+
+
+class LavaRest(LavaAPI):
+    """Interface to a LAVA lab
+
+    This implementation of kernelci.lab.LabAPI is to communicate with LAVA
+    labs.  It can retrieve some information such as the list of devices and
+    their online status, generate and submit jobs with callback parameters.
+    One special thing it can deal with is job priorities, which is only
+    available in kernelci.config.lab.lab_LAVA objects.
+    """
+    API_VERSION = 'v0.2'
+
+    def _get_response(self, url):
+        resp = self._server.session.get(url)
+        resp.raise_for_status()
+        return resp.json()
+
+    def _get_all(self, url):
+        resp = self._get_response(url)
+        results = resp['results']
+        while resp['next']:
+            resp = self._get_response(resp['next'])
+            results.extend(resp['results'])
+        return results
+
+    def _get_devices(self):
+        devices_url = urljoin(self._server.url, 'devices')
+        aliases_url = urljoin(self._server.url, 'aliases')
+        all_devices = self._get_all(devices_url)
+        all_aliases = {item['name']: item['device_type']
+                       for item in self._get_all(aliases_url)}
+        device_types = {}
+        for device in all_devices:
+            device_list = device_types.setdefault(
+                device['device_type'], list())
+            device_list.append({
+                'name': device['hostname'],
+                'online': device['health'] == 'Good',
+            })
+        online_status = {
+            device_type: any(device['online'] for device in devices)
+            for device_type, devices in device_types.items()
+        }
+
+        return {
+            'online_status': online_status,
+            'aliases': all_aliases,
+        }
+
+    def _alias_device_type(self, device_type):
+        aliases = self.devices.get('aliases', dict())
+        return aliases.get(device_type, device_type)
+
+    def _connect(self, token=None, **kwargs):
+        """Connect to the remote server API
+
+        *token* is the token associated with the user to connect to the lab
+        """
+        rest_headers = {
+            'authorization': f'Token {token}',
+            'content-type': 'application/json'
+        }
+        rest_url = f'{self.config.url}/api/{self.API_VERSION}/'
+        rest_api = RestAPIServer(rest_url, requests.Session())
+        rest_api.session.params = {'format': 'json', 'limit': '256'}
+        rest_api.session.headers = rest_headers
+        return rest_api
+
+    def device_type_online(self, device_type_config):
+        device_type = self._alias_device_type(device_type_config.base_name)
+        online_status = self.devices.get('online_status', dict())
+        return online_status.get(device_type, False)
+
+    def job_file_name(self, params):
+        return '.'.join([params['name'], 'yaml'])
+
+    def submit(self, job):
+        jobs_url = urljoin(self._server.url, 'jobs/')
+        job_data = {'definition': yaml.dump(yaml.load(job,
+                                                      Loader=yaml.CLoader))}
+        resp = self._server.session.post(jobs_url, json=job_data,
+                                         allow_redirects=False)
+        resp.raise_for_status()
+        return resp.json()['job_ids'][0]
+
+
+def get_api(lab, **kwargs):
+    """Get a LAVA lab API object"""
+    return LavaRest(lab, **kwargs)


### PR DESCRIPTION
- Extract common parts from the LAVA API implementation.
- Create kernelci.lab.lava package
- Move XMLRPC based communication to lab.lava.lava_xmlrpc.
The redesign is a preparation for another implementing other means of  communication with LAVA labs.
- Add lava.lava_rest lab type
- Add hadnling LAVA jobs with LAVA REST API v0.2
