### PR TITLE
config/docker: set MAINTAINER to kernelci-tsc@groups.io

### DIFF
--- a/config/docker/build-base/Dockerfile
+++ b/config/docker/build-base/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:bullseye
-MAINTAINER "Matt Hart" <matt@mattface.org>
+MAINTAINER "KernelCI TSC" <kernelci-tsc@groups.io>
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/config/docker/k8s/Dockerfile
+++ b/config/docker/k8s/Dockerfile
@@ -3,7 +3,7 @@
 #
 ARG PREFIX=kernelci/
 FROM ${PREFIX}build-base
-MAINTAINER "Kevin Hilman <khilmnan@baylibre.com>"
+MAINTAINER "KernelCI TSC" <kernelci-tsc@groups.io>
 
 #
 # Install gcloud-sdk


### PR DESCRIPTION
Set the MAINTAINER attribute to kernelci-tsc@groups.io in all the
Dockerfiles instead of individuals.  This is so that the Technical
Steering Committee of the project becomes the owner of such things to
ensure continuity.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>