### PR TITLE
Fixes rootfs undefined behaviour from issue #863

### DIFF
--- a/config/rootfs/debos/rootfs.yaml
+++ b/config/rootfs/debos/rootfs.yaml
@@ -143,9 +143,11 @@ actions:
   - action: run
     description: Move image to output directory
     command: mv ${ARTIFACTDIR}/rootfs.ext4 ${ARTIFACTDIR}/{{ $basename -}}/
+    postprocess: true
 
   - action: run
     command: xz -f ${ARTIFACTDIR}/{{ $basename -}}/rootfs.ext4
+    postprocess: true
 
   - action: run
     description: update-initramfs step


### PR DESCRIPTION
Tested locally, now the rootfs.ext4 image is without errors.