### PR TITLE
kernelci.config: make all YAML config optional

### DIFF
--- a/kernelci/config/build.py
+++ b/kernelci/config/build.py
@@ -400,7 +400,7 @@ class BuildConfig(YAMLObject):
 def from_yaml(data):
     trees = {
         name: Tree.from_yaml(config, name)
-        for name, config in data['trees'].items()
+        for name, config in data.get('trees', {}).items()
     }
 
     fragments = {
@@ -410,7 +410,7 @@ def from_yaml(data):
 
     build_environments = {
         name: BuildEnvironment.from_yaml(config, name)
-        for name, config in data['build_environments'].items()
+        for name, config in data.get('build_environments', {}).items()
     }
 
     defaults = data.get('build_configs_defaults', {})
@@ -418,14 +418,12 @@ def from_yaml(data):
     build_configs = {
         name: BuildConfig.from_yaml(config, name, trees, fragments,
                                     build_environments, defaults)
-        for name, config in data['build_configs'].items()
+        for name, config in data.get('build_configs', {}).items()
     }
 
-    config_data = {
+    return {
         'trees': trees,
         'fragments': fragments,
         'build_environments': build_environments,
         'build_configs': build_configs,
     }
-
-    return config_data

--- a/kernelci/config/data.py
+++ b/kernelci/config/data.py
@@ -79,10 +79,9 @@ class DatabaseFactory(YAMLObject):
 def from_yaml(data):
     db_configs = {
         name: DatabaseFactory.from_yaml(name, db)
-        for name, db in data['db_configs'].items()
+        for name, db in data.get('db_configs', {}).items()
     }
 
-    config_data = {
+    return {
         'db_configs': db_configs,
     }
-    return config_data

--- a/kernelci/config/lab.py
+++ b/kernelci/config/lab.py
@@ -102,11 +102,9 @@ class LabFactory(YAMLObject):
 def from_yaml(data):
     labs = {
         name: LabFactory.from_yaml(name, lab)
-        for name, lab in data['labs'].items()
+        for name, lab in data.get('labs', {}).items()
     }
 
-    config_data = {
+    return {
         'labs': labs,
     }
-
-    return config_data

--- a/kernelci/config/rootfs.py
+++ b/kernelci/config/rootfs.py
@@ -181,14 +181,12 @@ class RootFSFactory(YAMLObject):
 def from_yaml(data):
     rootfs_configs = {
         name: RootFSFactory.from_yaml(name, rootfs)
-        for name, rootfs in data['rootfs_configs'].items()
+        for name, rootfs in data.get('rootfs_configs', {}).items()
     }
 
-    config_data = {
+    return {
         'rootfs_configs': rootfs_configs,
     }
-
-    return config_data
 
 
 def validate(configs):

--- a/kernelci/config/test.py
+++ b/kernelci/config/test.py
@@ -426,38 +426,40 @@ class TestConfig(YAMLObject):
 def from_yaml(data):
     fs_types = {
         name: RootFSType.from_yaml(fs_type)
-        for name, fs_type in data['file_system_types'].items()
+        for name, fs_type in data.get('file_system_types', {}).items()
     }
 
     file_systems = {
         name: RootFS.from_yaml(fs_types, rootfs)
-        for name, rootfs in data['file_systems'].items()
+        for name, rootfs in data.get('file_systems', {}).items()
     }
 
-    plan_filters = FilterFactory.from_yaml(data['test_plan_default_filters'])
+    plan_filters = FilterFactory.from_yaml(
+        data.get('test_plan_default_filters', {})
+    )
 
     test_plans = {
         name: TestPlan.from_yaml(name, test_plan, file_systems, plan_filters)
-        for name, test_plan in data['test_plans'].items()
+        for name, test_plan in data.get('test_plans', {}).items()
     }
 
-    device_filters = FilterFactory.from_yaml(data['device_default_filters'])
+    device_filters = FilterFactory.from_yaml(
+        data.get('device_default_filters', {})
+    )
 
     device_types = {
         name: DeviceTypeFactory.from_yaml(name, device_type, device_filters)
-        for name, device_type in data['device_types'].items()
+        for name, device_type in data.get('device_types', {}).items()
     }
 
     test_configs = [
         TestConfig.from_yaml(test_config, device_types, test_plans)
-        for test_config in data['test_configs']
+        for test_config in data.get('test_configs', [])
     ]
 
-    config_data = {
+    return {
         'file_systems': file_systems,
         'test_plans': test_plans,
         'device_types': device_types,
         'test_configs': test_configs,
     }
-
-    return config_data


### PR DESCRIPTION
Add empty dictionaries by default when loading all the YAML
configurations as some command line tools may be run without all the
types of configurations defined.  This won't cause any side-effects as
it's the same as when trying to access a YAML configuration that
doesn't exist, so error handling for that is the same too.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>