### PR TITLE
test-configs.yaml: update Debian rootfs URLs

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -48,38 +48,38 @@ file_systems:
 
   debian_buster_ramdisk:
     type: debian
-    ramdisk: 'buster/20211105.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'buster/20211112.0/{arch}/rootfs.cpio.gz'
 
   debian_buster_nfs:
     type: debian
-    ramdisk: 'buster/20211105.0/{arch}/initrd.cpio.gz'
-    nfs: 'buster/20211105.0/{arch}/full.rootfs.tar.xz'
+    ramdisk: 'buster/20211112.0/{arch}/initrd.cpio.gz'
+    nfs: 'buster/20211112.0/{arch}/full.rootfs.tar.xz'
     root_type: nfs
 
   debian_buster-cros-ec_ramdisk:
     type: debian
-    ramdisk: 'buster-cros-ec/20211105.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'buster-cros-ec/20211112.0/{arch}/rootfs.cpio.gz'
 
   debian_buster-igt_ramdisk:
     type: debian
-    ramdisk: 'buster-igt/20211105.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'buster-igt/20211112.0/{arch}/rootfs.cpio.gz'
 
   debian_buster_kselftest:
     type: debian
-    ramdisk: 'buster-kselftest/20211105.0/{arch}/initrd.cpio.gz'
-    nfs: 'buster-kselftest/20211105.0/{arch}/full.rootfs.tar.xz'
+    ramdisk: 'buster-kselftest/20211112.0/{arch}/initrd.cpio.gz'
+    nfs: 'buster-kselftest/20211112.0/{arch}/full.rootfs.tar.xz'
     root_type: nfs
     params:
       os_config: 'debian'
 
   debian_buster-v4l2_ramdisk:
     type: debian
-    ramdisk: 'buster-v4l2/20211105.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'buster-v4l2/20211112.0/{arch}/rootfs.cpio.gz'
 
   debian_buster-libcamera_nfs:
     type: debian
-    ramdisk: 'buster-libcamera/20211105.0/{arch}/initrd.cpio.gz'
-    nfs: 'buster-libcamera/20211105.0/{arch}/full.rootfs.tar.xz'
+    ramdisk: 'buster-libcamera/20211112.0/{arch}/initrd.cpio.gz'
+    nfs: 'buster-libcamera/20211112.0/{arch}/full.rootfs.tar.xz'
     root_type: nfs
 
   debian_buster-ltp_nfs:


### PR DESCRIPTION
Update all the Debian rootfs URLs except LTP which is _still_ failing
to build for arm64.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>