### PR TITLE
rootfs-configs.yaml: Add firmware rootfs

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -51,6 +51,25 @@ rootfs_configs:
     script: "scripts/install-bootrr.sh"
     test_overlay: "overlays/baseline"
 
+  bullseye-firmware:
+    rootfs_type: debos
+    debian_release: bullseye
+    arch_list:
+      - amd64
+      - arm64
+      - armhf
+    extra_packages:
+      - wireless-regdb
+    extra_packages_remove:
+      - bash
+      - e2fslibs
+      - e2fsprogs
+      - libext2fs2
+    extra_firmware:
+      - mrvl/pcieusb8997_combo_v4.bin
+      - rockchip/dptx.bin
+    test_overlay: "overlays/firmware"
+
   bullseye-igt:
     rootfs_type: debos
     debian_release: bullseye

--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -66,8 +66,14 @@ rootfs_configs:
       - e2fsprogs
       - libext2fs2
     extra_firmware:
+      - i915/bxt_dmc_ver1_07.bin
+      - i915/glk_dmc_ver1_04.bin
+      - i915/kbl_dmc_ver1_04.bin
+      - imx/sdma/sdma-imx6q.bin
       - mrvl/pcieusb8997_combo_v4.bin
+      - qca/rampatch_00440302.bin
       - rockchip/dptx.bin
+      - rtl_nic/rtl8153b-2.fw
     test_overlay: "overlays/firmware"
 
   bullseye-igt:

--- a/config/rootfs/debos/overlays/firmware/usr/bin/check-missing-firmware.sh
+++ b/config/rootfs/debos/overlays/firmware/usr/bin/check-missing-firmware.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+lava-test-set start no-missing-firmware
+
+ignore_regex="maxtouch\.cfg|rockchip/dptx\.bin"
+
+dmesg -l alert,crit,err,warn | grep firmware | grep -Ev "$ignore_regex" \
+	&& lava-test-case no-missing-firmware --result fail \
+	|| lava-test-case no-missing-firmware --result pass
+
+lava-test-set stop


### PR DESCRIPTION
Add a rootfs containing the firmware to boot devices and the overlay
script that will be used to check which firmwares are missing.

For now, only the firmwares used by rk3399-gru-kevin are present.

Signed-off-by: Nícolas F. R. A. Prado <nfraprado@collabora.com>