### PR TITLE
Enable kselftest on stable 5.14

### DIFF
--- a/config/core/build-configs-stable.yaml
+++ b/config/core/build-configs-stable.yaml
@@ -14,10 +14,10 @@ trees:
 
 # Build fewer kernel configs with stable branches
 stable_variants: &stable_variants
-  gcc-10:
+  gcc-10: &stable_gcc_10
     build_environment: gcc-10
-    fragments: ['tinyconfig']
-    architectures:
+    fragments: [tinyconfig]
+    architectures: &stable_architectures
       arc:
         base_defconfig: 'haps_hs_smp_defconfig'
         extra_configs: ['allnoconfig']
@@ -53,12 +53,33 @@ stable_variants: &stable_variants
         extra_configs: ['allnoconfig']
         fragments: [x86-chromebook]
 
+
+stable_variants_kselftest: &stable_variants_kselftest
+  gcc-10:
+    <<: *stable_gcc_10
+    architectures:
+      <<: *stable_architectures
+      arm:
+        base_defconfig: 'multi_v7_defconfig'
+        extra_configs: ['allnoconfig']
+        fragments: [kselftest]
+      arm64:
+        extra_configs: ['allnoconfig']
+        fragments: [kselftest]
+      x86_64:
+        base_defconfig: 'x86_64_defconfig'
+        extra_configs:
+          - 'allnoconfig'
+          - 'x86_64_defconfig+x86-chromebook+kselftest'
+        fragments: [x86-chromebook, kselftest]
+
+
 build_configs:
 
   kernelci:
     tree: kernelci
     branch: 'kernelci.org'
-    variants: *stable_variants
+    variants: *stable_variants_kselftest
 
   sashal_stable-next:
     tree: sashal
@@ -103,7 +124,7 @@ build_configs:
   stable_5.14:
     tree: stable
     branch: 'linux-5.14.y'
-    variants: *stable_variants
+    variants: *stable_variants_kselftest
 
   stable_5.15:
     tree: stable
@@ -194,7 +215,7 @@ build_configs:
   stable-rc_5.14:
     tree: stable-rc
     branch: 'linux-5.14.y'
-    variants: *stable_variants
+    variants: *stable_variants_kselftest
     reference:
       tree: stable
       branch: 'linux-5.14.y'
@@ -298,7 +319,7 @@ build_configs:
   stable-rc_queue-5.14:
     tree: stable-rc
     branch: 'queue/5.14'
-    variants: *stable_variants
+    variants: *stable_variants_kselftest
     reference:
       tree: stable
       branch: 'linux-5.14.y'

--- a/config/core/build-configs-stable.yaml
+++ b/config/core/build-configs-stable.yaml
@@ -1,3 +1,17 @@
+trees:
+
+  kernelci:
+    url: "https://github.com/kernelci/linux.git"
+
+  sashal:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/sashal/linux-stable.git"
+
+  stable:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git"
+
+  stable-rc:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git"
+
 # Build fewer kernel configs with stable branches
 stable_variants: &stable_variants
   gcc-10:

--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -55,9 +55,6 @@ trees:
   gtucker:
     url: 'https://gitlab.collabora.com/gtucker/linux.git'
 
-  kernelci:
-    url: "https://github.com/kernelci/linux.git"
-
   khilman:
     url: "https://git.kernel.org/pub/scm/linux/kernel/git/khilman/linux.git"
 
@@ -115,17 +112,8 @@ trees:
   samsung:
     url: "https://git.kernel.org/pub/scm/linux/kernel/git/kgene/linux-samsung.git"
 
-  sashal:
-    url: "https://git.kernel.org/pub/scm/linux/kernel/git/sashal/linux-stable.git"
-
   soc:
     url: "https://git.kernel.org/pub/scm/linux/kernel/git/soc/soc.git"
-
-  stable:
-    url: "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git"
-
-  stable-rc:
-    url: "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git"
 
   tegra:
     url: "https://git.kernel.org/pub/scm/linux/kernel/git/tegra/linux.git"


### PR DESCRIPTION
Enable kselftest on stable kernels based on linux-5.14.y as it should be working well enough.  Future stable branches may be enabled if this appears to be producing valid results.

Also move the stable trees definitions to the stable builds config file to keep it more self-contained.