### PR TITLE
rootfs-configs.yaml: bullseye-igt: Add firmware for amdgpu

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -90,6 +90,14 @@ rootfs_configs:
         - partx
         - find
     extra_firmware:
+        - amdgpu/stoney_ce.bin
+        - amdgpu/stoney_me.bin
+        - amdgpu/stoney_mec.bin
+        - amdgpu/stoney_pfp.bin
+        - amdgpu/stoney_rlc.bin
+        - amdgpu/stoney_sdma.bin
+        - amdgpu/stoney_uvd.bin
+        - amdgpu/stoney_vce.bin
         - i915/bxt_dmc_ver1_07.bin
         - i915/kbl_dmc_ver1_04.bin
         - i915/glk_dmc_ver1_04.bin


### PR DESCRIPTION
Add firmware used by the amdgpu driver in the bullseye-igt rootfs. This
will allow amdgpu igt tests to be run later.

Fixes #853. Since the `bullseye-igt` rootfs has been added in the meantime, I added the firmware to that rootfs instead of the `buster-igt` originally mentioned in the issue. 

Signed-off-by: Nícolas F. R. A. Prado <nfraprado@collabora.com>