### PR TITLE
kernelci.data: add missing verbose argument to _print_http_error()

### DIFF
--- a/kernelci/data/__init__.py
+++ b/kernelci/data/__init__.py
@@ -71,7 +71,7 @@ class Database:
         """
         raise NotImplementedError("Database.submit_test() not implemented")
 
-    def _print_http_error(self, http_error):
+    def _print_http_error(self, http_error, verbose=False):
         print(http_error)
         if verbose:
             errors = json.loads(http_error.response.content).get("errors", [])


### PR DESCRIPTION
Add the missing verbose argument to Database._print_http_error().

Fixes: 0618a1a3de47 ("kernelci.data: add Database._print_http_error()")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>