### PR TITLE
Add amdgpu fragment for the AMDGPU driver

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -387,6 +387,7 @@ build_configs_defaults:
             - 'allmodconfig'
             - 'allnoconfig'
             - 'x86_64_defconfig+x86-chromebook+kselftest'
+            - 'x86_64_defconfig+x86-chromebook+amdgpu'
           fragments: [amdgpu, crypto, ima, x86_kvm_guest, x86-chromebook]
 
   reference:

--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -137,6 +137,7 @@ fragments:
     path: "kernel/configs/amdgpu.config"
     configs:
       - 'CONFIG_DRM_AMDGPU=y'
+      - 'CONFIG_DRM_AMDGPU_USERPTR=y'
 
   crypto:
     path: "kernel/configs/crypto.config"

--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -133,6 +133,11 @@ trees:
 
 fragments:
 
+  amdgpu:
+    path: "kernel/configs/amdgpu.config"
+    configs:
+      - 'CONFIG_DRM_AMDGPU=y'
+
   crypto:
     path: "kernel/configs/crypto.config"
     configs:
@@ -381,7 +386,7 @@ build_configs_defaults:
             - 'allmodconfig'
             - 'allnoconfig'
             - 'x86_64_defconfig+x86-chromebook+kselftest'
-          fragments: [crypto, ima, x86_kvm_guest, x86-chromebook]
+          fragments: [amdgpu, crypto, ima, x86_kvm_guest, x86-chromebook]
 
   reference:
     tree: mainline


### PR DESCRIPTION
Add a new amdgpu config fragment that enables the AMDGPU driver.

Fixes #854.

This fragment was tested in grunt: https://lava.collabora.co.uk/scheduler/job/5023017

As can be seen in the LAVA log, the following tests fail still:
```
amd_bypass.8bpc-bypass-mode
amd_color.crtc-lut-accuracy
amd_info.query-timestamp
amd_info.query-timestamp-while-idle
```

Enabling further amdgpu configs didn't improve the results, so only the configs that improved results were kept in the fragment.

For record purposes, the full fragment tested was:
```
      - 'CONFIG_DRM_AMDGPU=y'
      - 'CONFIG_DRM_AMDGPU_USERPTR=y'
      - 'CONFIG_DRM_AMDGPU_SI=y'
      - 'CONFIG_DRM_AMDGPU_CIK=y'
      - 'CONFIG_DRM_AMD_ACP=y'
      - 'CONFIG_DRM_AMD_DC=y'
      - 'CONFIG_DRM_AMD_DC_DCN=y'
      - 'CONFIG_DRM_AMD_DC_HDCP=y'
      - 'CONFIG_DRM_AMD_DC_SI=y'
      - 'CONFIG_KGDB=y'
      - 'CONFIG_DEBUG_KERNEL_DC=y'
      - 'CONFIG_DRM_AMD_SECURE_DISPLAY=y'
      - 'CONFIG_HSA_AMD=y'
      - 'CONFIG_HSA_AMD_SVM=y'
      - 'CONFIG_ZONE_DEVICE=y'
      - 'CONFIG_DEVICE_PRIVATE=y'
      - 'CONFIG_MEMORY_HOTPLUG=y'
      - 'CONFIG_MEMORY_HOTREMOVE=y'
```
And the logs were: https://lava.collabora.co.uk/scheduler/job/5024084 . The same failing tests were present.