### PR TITLE
test-configs.yaml: update Debian URLs

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -48,33 +48,33 @@ file_systems:
 
   debian_buster_ramdisk:
     type: debian
-    ramdisk: 'buster/20211112.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'buster/20211118.0/{arch}/rootfs.cpio.gz'
 
   debian_buster_nfs:
     type: debian
-    ramdisk: 'buster/20211112.0/{arch}/initrd.cpio.gz'
-    nfs: 'buster/20211112.0/{arch}/full.rootfs.tar.xz'
+    ramdisk: 'buster/20211118.0/{arch}/initrd.cpio.gz'
+    nfs: 'buster/20211118.0/{arch}/full.rootfs.tar.xz'
     root_type: nfs
 
   debian_buster-cros-ec_ramdisk:
     type: debian
-    ramdisk: 'buster-cros-ec/20211112.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'buster-cros-ec/20211118.0/{arch}/rootfs.cpio.gz'
 
   debian_buster-igt_ramdisk:
     type: debian
-    ramdisk: 'buster-igt/20211112.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'buster-igt/20211118.0/{arch}/rootfs.cpio.gz'
 
   debian_buster_kselftest:
     type: debian
-    ramdisk: 'buster-kselftest/20211112.0/{arch}/initrd.cpio.gz'
-    nfs: 'buster-kselftest/20211112.0/{arch}/full.rootfs.tar.xz'
+    ramdisk: 'buster-kselftest/20211118.0/{arch}/initrd.cpio.gz'
+    nfs: 'buster-kselftest/20211118.0/{arch}/full.rootfs.tar.xz'
     root_type: nfs
     params:
       os_config: 'debian'
 
   debian_buster-v4l2_ramdisk:
     type: debian
-    ramdisk: 'buster-v4l2/20211112.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'buster-v4l2/20211118.0/{arch}/rootfs.cpio.gz'
 
   debian_buster-libcamera_nfs:
     type: debian


### PR DESCRIPTION
Update all the Debian rootfs URLs to 20211118.0 except buster-ltp and
buster-libcamera which had some build failures on arm64.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>