### PR TITLE
config/core: move Chrome OS build configs to separate file

### DIFF
--- a/config/core/build-configs-chromeos.yaml
+++ b/config/core/build-configs-chromeos.yaml
@@ -1,0 +1,33 @@
+chromeos_variants: &chromeos-variants
+  clang-13:
+    build_environment: clang-13
+    architectures:
+      arm:
+        base_defconfig: 'cros://chromeos-5.10/armel/chromiumos-arm.flavour.config'
+        extra_configs:
+          - 'cros://chromeos-5.10/armel/chromiumos-rockchip.flavour.config'
+        filters: &cros-filters
+          - regex: { defconfig: 'cros' }
+      arm64:
+        base_defconfig: 'cros://chromeos-5.10/arm64/chromiumos-arm64.flavour.config'
+        extra_configs:
+          - 'cros://chromeos-5.10/arm64/chromiumos-mediatek.flavour.config'
+          - 'cros://chromeos-5.10/arm64/chromiumos-qualcomm.flavour.config'
+          - 'cros://chromeos-5.10/arm64/chromiumos-rockchip64.flavour.config'
+        filters: *cros-filters
+      x86_64:
+        base_defconfig: 'cros://chromeos-5.10/x86_64/chromiumos-x86_64.flavour.config'
+        extra_configs:
+          - 'cros://chromeos-5.10/x86_64/chromeos-amd-stoneyridge.flavour.config+x86-chromebook'
+          - 'cros://chromeos-5.10/x86_64/chromeos-intel-denverton.flavour.config+x86-chromebook'
+          - 'cros://chromeos-5.10/x86_64/chromeos-intel-pineview.flavour.config+x86-chromebook'
+        fragments: [x86-chromebook]
+        filters: *cros-filters
+
+
+build_configs:
+
+  chromeos-next:
+    tree: next
+    branch: 'master'
+    variants: *chromeos-variants

--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -485,33 +485,6 @@ preempt_rt_variants: &preempt_rt_variants
     fragments: [preempt_rt]
 
 
-chromeos_variants:
-  clang-13: &chromeos-configs
-    build_environment: clang-13
-    architectures:
-      arm:
-        base_defconfig: 'cros://chromeos-5.10/armel/chromiumos-arm.flavour.config'
-        extra_configs:
-          - 'cros://chromeos-5.10/armel/chromiumos-rockchip.flavour.config'
-        filters: &cros-filters
-          - regex: { defconfig: 'cros' }
-      arm64:
-        base_defconfig: 'cros://chromeos-5.10/arm64/chromiumos-arm64.flavour.config'
-        extra_configs:
-          - 'cros://chromeos-5.10/arm64/chromiumos-mediatek.flavour.config'
-          - 'cros://chromeos-5.10/arm64/chromiumos-qualcomm.flavour.config'
-          - 'cros://chromeos-5.10/arm64/chromiumos-rockchip64.flavour.config'
-        filters: *cros-filters
-      x86_64:
-        base_defconfig: 'cros://chromeos-5.10/x86_64/chromiumos-x86_64.flavour.config'
-        extra_configs:
-          - 'cros://chromeos-5.10/x86_64/chromeos-amd-stoneyridge.flavour.config+x86-chromebook'
-          - 'cros://chromeos-5.10/x86_64/chromeos-intel-denverton.flavour.config+x86-chromebook'
-          - 'cros://chromeos-5.10/x86_64/chromeos-intel-pineview.flavour.config+x86-chromebook'
-        fragments: [x86-chromebook]
-        filters: *cros-filters
-
-
 build_configs:
 
   agross:
@@ -729,10 +702,6 @@ build_configs:
             filters:
               - passlist:
                   defconfig: *riscv_clang_configs
-
-      # ChromeOS configs
-      chromeos-configs:
-        <<: *chromeos-configs
 
   next_pending-fixes:
     tree: next


### PR DESCRIPTION
Move all the Chrome OS build configuration to a new file
build-configs-chromeos.yaml.  This reduces the scope for merge
conflicts and makes it easier to maintain on a separate branch.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>