### PR TITLE
Add igt amdgpu test plan and enable it on grunt

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -148,6 +148,25 @@ test_plans:
     rootfs: debian_buster-igt_ramdisk
     pattern: 'igt/{category}-{method}-{protocol}-{rootfs}-igt.jinja2'
 
+  igt-gpu-amd:
+    <<: *igt
+    params:
+      drm_driver: "amdgpu"
+      tests: >
+        core_auth
+        core_getclient
+        core_getstats
+        core_getversion
+        core_setmaster_vs_auth
+        amd_basic
+        amd_bypass
+        amd_color
+        amd_cs_nop
+        amd_info
+        amd_link_settings
+    filters:
+      - passlist: {defconfig: ['amdgpu']}
+
   igt-gpu-i915:
     <<: *igt
     params:

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1965,6 +1965,7 @@ test_configs:
       - baseline-cip-nfs
       - baseline-nfs
       - cros-ec
+      - igt-gpu-amd
       - kselftest-filesystems
       - kselftest-futex
       - kselftest-lib


### PR DESCRIPTION
Add a test plan to run IGT tests, both Core and AMD specific, on the AMDGPU driver, and enable it to run on hp-11A-G6-EE-grunt (aka grunt). This relies on the igt rootfs containing the firmware required by AMDGPU, which will get added by #884.

Fixes #883.

At the moment some tests still fail:

```
amd_bypass.8bpc-bypass-mode
amd_color.crtc-lut-accuracy
amd_info.query-timestamp
amd_info.query-timestamp-while-idle
```

Some more in-depth debugging will be needed to try and find out why, since just enabling the other amdgpu config symbols didn't solve it. If it's not possible to get all tests working then we could disable them.