### PR TITLE
kernelci.build: Make each build step overwrite its meta-data when re-run

### DIFF
--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -538,12 +538,21 @@ class Metadata:
                 break
         return value
 
-    def add_step(self, data):
-        """Add meta-data for a build step
+    def update_step(self, data):
+        """Update meta-data for a build step
+
+        Update meta-data for a build step so that if there is already a step
+        with the same name, the new data overwrites the old one, otherwise the
+        data is appended at the end.
 
         *data* is the data for the step, following the schema
         """
-        self._steps.append(data)
+        for i, item in enumerate(self._steps):
+            if item['name'] == data['name']:
+                self._steps[i] = data
+                break
+        else:
+            self._steps.append(data)
         total_duration = sum(s['duration'] for s in self._steps)
         all_status = set(s['status'] for s in self._steps)
         self._bmeta['build'] = {
@@ -745,7 +754,7 @@ class Step:
         if self._log_path and os.path.exists(self._log_path):
             run_data['log_file'] = self._log_file
         run_data['status'] = "PASS" if status is True else "FAIL"
-        self._meta.add_step(run_data)
+        self._meta.update_step(run_data)
         self._meta.save(save_artifacts=False)
         return status
 

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -547,9 +547,10 @@ class Metadata:
 
         *data* is the data for the step, following the schema
         """
-        for i, item in enumerate(self._steps):
-            if item['name'] == data['name']:
-                self._steps[i] = data
+        for step in self._steps:
+            if step['name'] == data['name']:
+                step.clear()
+                step.update(data)
                 break
         else:
             self._steps.append(data)


### PR DESCRIPTION
Currently, each build step always appends its meta-data to steps.json.
This works well for automated building, where all steps are always run
in the same sequence. However when kci_build is used manually to build
an image, multiple runs of the same step may happen as part of the
iterative development process. Since the overall build status is the
aggregation of the individual steps' status, a previous failed build can
keep the overall status as FAIL in bmeta.json, preventing the usage of
kci_test.

This could be worked around by the user always running init_bmeta before
starting each build, but a better alternative is to make each step
overwrite the meta-data from a previous run of the same step. This
improves the usability from manual usage while not affecting the
automated usecase.

Signed-off-by: Nícolas F. R. A. Prado <nfraprado@collabora.com>