### PR TITLE
kernelci.lab.LabAPI: pass job_path to .submit()

### DIFF
--- a/kci_test
+++ b/kci_test
@@ -239,14 +239,12 @@ class cmd_submit(Command):
         for path in job_paths:
             if not os.path.isfile(path):
                 continue
-            with open(path, 'r') as job_file:
-                job = job_file.read()
-                try:
-                    job_id = lab_api.submit(job)
-                    print("{} {}".format(job_id, path))
-                except Exception as e:
-                    print("ERROR {}: {}".format(path, e))
-                    res = False
+            try:
+                job_id = lab_api.submit(path)
+                print("{} {}".format(job_id, path))
+            except Exception as e:
+                print("ERROR {}: {}".format(path, e))
+                res = False
         return res
 
 

--- a/kernelci/lab/__init__.py
+++ b/kernelci/lab/__init__.py
@@ -78,7 +78,7 @@ class LabAPI:
         """Generate a test job definition."""
         raise NotImplementedError("Lab.generate() is required")
 
-    def submit(self, job):
+    def submit(self, job_path):
         """Submit a test job definition in a lab."""
         raise NotImplementedError("Lab.submit() is required")
 

--- a/kernelci/lab/lava/__init__.py
+++ b/kernelci/lab/lava/__init__.py
@@ -25,6 +25,7 @@ from kernelci.lab import LabAPI
 
 
 class LavaAPI(LabAPI):
+
     def generate(self, params, target, plan, callback_opts):
         short_template_file = plan.get_template_path(target.boot_method)
         template_file = os.path.join('config/lava', short_template_file)
@@ -44,6 +45,12 @@ class LavaAPI(LabAPI):
         template = jinja2_env.get_template(short_template_file)
         data = template.render(params)
         return data
+
+    def submit(self, job_path):
+        with open(job_path, 'r') as job_file:
+            job = job_file.read()
+            job_id = self._submit(job)
+            return job_id
 
     def _add_callback_params(self, params, opts):
         callback_id = opts.get('id')

--- a/kernelci/lab/lava/lava_rest.py
+++ b/kernelci/lab/lava/lava_rest.py
@@ -100,10 +100,11 @@ class LavaRest(LavaAPI):
     def job_file_name(self, params):
         return '.'.join([params['name'], 'yaml'])
 
-    def submit(self, job):
+    def _submit(self, job):
         jobs_url = urljoin(self._server.url, 'jobs/')
-        job_data = {'definition': yaml.dump(yaml.load(job,
-                                                      Loader=yaml.CLoader))}
+        job_data = {
+            'definition': yaml.dump(yaml.load(job, Loader=yaml.CLoader)),
+        }
         resp = self._server.session.post(jobs_url, json=job_data,
                                          allow_redirects=False)
         resp.raise_for_status()

--- a/kernelci/lab/lava/lava_xmlrpc.py
+++ b/kernelci/lab/lava/lava_xmlrpc.py
@@ -94,7 +94,7 @@ class LAVA(LavaAPI):
     def job_file_name(self, params):
         return '.'.join([params['name'], 'yaml'])
 
-    def submit(self, job):
+    def _submit(self, job):
         return self._server.scheduler.submit_job(job)
 
 


### PR DESCRIPTION
Rather than passing a job definition object to LabAPI.submit(), pass
the path to a job definition file.  Then it's up to the implementation
code to open it and submit it.  All the current use-cases are based on
actual definition files; if being able to pass an object instead
becomes required at some point then the class can be adjusted
accoringly then.

Update kernelci.lab.lava and kci_test accordingly.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>