### PR TITLE
build-configs-stable.yaml: move kselftest from 5.14 to 5.15

### DIFF
--- a/config/core/build-configs-stable.yaml
+++ b/config/core/build-configs-stable.yaml
@@ -124,12 +124,12 @@ build_configs:
   stable_5.14:
     tree: stable
     branch: 'linux-5.14.y'
-    variants: *stable_variants_kselftest
+    variants: *stable_variants
 
   stable_5.15:
     tree: stable
     branch: 'linux-5.15.y'
-    variants: *stable_variants
+    variants: *stable_variants_kselftest
 
   stable_5.16:
     tree: stable


### PR DESCRIPTION
The next LTS will be based on 5.15, so move the kselftest fragment
from 5.14 to 5.15.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>