### PR TITLE
rootfs-config: Remove mips architecture from bullseye config

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -22,7 +22,6 @@ rootfs_configs:
       - armel
       - armhf
       - i386
-      - mips
       - mips64el
       - mipsel
     extra_packages:


### PR DESCRIPTION
mips big-endian architecture is not supported in bullseye as per this
announcement: https://lists.debian.org/debian-devel-announce/2021/01/msg00002.html
'it is probably time to drop this architecture from bullseye and sid'

Signed-off-by: Lakshmipathi Ganapathi <lakshmipathi.ganapathi@collabora.com>