### PR TITLE
kernelci.config.test: make TestPlan rootfs optional

### DIFF
--- a/kernelci/config/test.py
+++ b/kernelci/config/test.py
@@ -328,9 +328,10 @@ class TestPlan(YAMLObject):
 
     @classmethod
     def from_yaml(cls, name, test_plan, file_systems, default_filters=None):
+        rootfs_name = test_plan.get('rootfs')
         kw = {
             'name': name,
-            'rootfs': file_systems[test_plan['rootfs']],
+            'rootfs': file_systems[rootfs_name] if rootfs_name else None,
             'base_name': test_plan.get('base_name'),
             'filters': FilterFactory.from_data(test_plan, default_filters),
         }
@@ -364,8 +365,8 @@ class TestPlan(YAMLObject):
         return self._pattern.format(
             category=self._category,
             method=boot_method,
-            protocol=self.rootfs.boot_protocol,
-            rootfs=self.rootfs.root_type,
+            protocol=self.rootfs.boot_protocol if self.rootfs else None,
+            rootfs=self.rootfs.root_type if self.rootfs else None,
             plan=self.name)
 
     def match(self, config):

--- a/kernelci/test.py
+++ b/kernelci/test.py
@@ -113,7 +113,6 @@ def get_params(meta, target, plan_config, storage):
         if modules else None
     )
     modules_compression = _get_compression(modules_url)
-    rootfs = plan_config.rootfs
     defconfig_full = kernel['defconfig_full']
     defconfig = ''.join(defconfig_full.split('+')[:1])
     endian = 'big' if 'BIG_ENDIAN' in defconfig_full else 'little'
@@ -123,10 +122,6 @@ def get_params(meta, target, plan_config, storage):
         urllib.parse.urljoin(storage, '/'.join([url_px, kselftests]))
         if kselftests else None
     )
-    initrd_url = rootfs.get_url('ramdisk', arch, endian)
-    initrd_compression = _get_compression(initrd_url)
-    nfsroot_url = rootfs.get_url('nfs', arch, endian)
-    nfsroot_compression = _get_compression(nfsroot_url)
 
     params = {
         'name': job_name,
@@ -155,19 +150,28 @@ def get_params(meta, target, plan_config, storage):
         'git_commit': rev['commit'],
         'git_describe': describe,
         'git_url': rev['url'],
-        'initrd_url': initrd_url,
-        'initrd_compression': initrd_compression,
         'kernel_image': os.path.basename(kernel_img),
-        'nfsrootfs_url': nfsroot_url,
-        'nfsroot_compression': nfsroot_compression,
         'context': target.context,
-        'rootfs_prompt': rootfs.prompt,
         'file_server_resource': publish_path,
         'build_environment': meta.get('bmeta', 'environment', 'name'),
         'kselftests_url': kselftests_url,
     }
 
-    params.update(rootfs.params)
+    rootfs = plan_config.rootfs
+    if rootfs:
+        initrd_url = rootfs.get_url('ramdisk', arch, endian)
+        initrd_compression = _get_compression(initrd_url)
+        nfsroot_url = rootfs.get_url('nfs', arch, endian)
+        nfsroot_compression = _get_compression(nfsroot_url)
+        params.update({
+            'initrd_url': initrd_url,
+            'initrd_compression': initrd_compression,
+            'nfsrootfs_url': nfsroot_url,
+            'nfsroot_compression': nfsroot_compression,
+            'rootfs_prompt': rootfs.prompt,
+        })
+        params.update(rootfs.params)
+
     params.update(plan_config.params)
     params.update(target.params)
 


### PR DESCRIPTION
Make the rootfs attribute of the TestPlan configuration object
optional as some tests may not require any root file system image.
Tests that do require one will report any error when trying to run
them.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>