### PR TITLE
build-configs.yaml: add arm64-chromebook fragment

### DIFF
--- a/config/core/build-configs-stable.yaml
+++ b/config/core/build-configs-stable.yaml
@@ -35,6 +35,7 @@ stable_variants: &stable_variants
         extra_configs: ['allnoconfig']
       arm64:
         extra_configs: ['allnoconfig']
+        fragments: [arm64-chromebook]
       i386:
         base_defconfig: 'i386_defconfig'
         extra_configs: ['allnoconfig']
@@ -64,8 +65,10 @@ stable_variants_kselftest: &stable_variants_kselftest
         extra_configs: ['allnoconfig']
         fragments: [kselftest]
       arm64:
-        extra_configs: ['allnoconfig']
-        fragments: [kselftest]
+        extra_configs:
+          - 'allnoconfig'
+          - 'defconfig+arm64-chromebook+kselftest'
+        fragments: [arm64-chromebook, kselftest]
       x86_64:
         base_defconfig: 'x86_64_defconfig'
         extra_configs:

--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -139,6 +139,11 @@ fragments:
       - 'CONFIG_DRM_AMDGPU=y'
       - 'CONFIG_DRM_AMDGPU_USERPTR=y'
 
+  arm64-chromebook:
+    path: "kernel/configs/arm64-chromebook.config"
+    configs:
+      - 'CONFIG_REGULATOR_DA9211=y'
+
   crypto:
     path: "kernel/configs/crypto.config"
     configs:
@@ -363,7 +368,8 @@ build_configs_defaults:
             - 'allnoconfig'
             - 'defconfig+CONFIG_CPU_BIG_ENDIAN=y'
             - 'defconfig+CONFIG_RANDOMIZE_BASE=y'
-          fragments: [crypto, ima]
+            - 'defconfig+arm64-chromebook+kselftest'
+          fragments: [arm64-chromebook, crypto, ima]
 
         i386: &i386_arch
           base_defconfig: 'i386_defconfig'
@@ -556,7 +562,9 @@ build_configs:
         build_environment: gcc-10
         architectures:
           arm: *arm_defconfig
-          arm64: *arm64_defconfig
+          arm64:
+            <<: *arm64_defconfig
+            fragments: [arm64-chromebook]
           x86_64:
             <<: *x86_64_defconfig
             fragments: [x86-chromebook]
@@ -733,6 +741,7 @@ build_configs:
               - 'defconfig+CONFIG_ARM64_64K_PAGES=y'
               - 'defconfig+CONFIG_CPU_BIG_ENDIAN=y'
               - 'defconfig+CONFIG_RANDOMIZE_BASE=y'
+              - 'defconfig+arm64-chromebook+kselftest'
           arm:
             base_defconfig: 'multi_v7_defconfig'
             extra_configs:

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1100,6 +1100,8 @@ device_types:
     mach: mediatek
     class: arm64-dtb
     boot_method: depthcharge
+    filters:
+      - passlist: {defconfig: ['arm64-chromebook']}
 
   mt8183-kukui-jacuzzi-juniper-sku16:
     mach: mediatek


### PR DESCRIPTION
Add a new fragment arm64-chromebook with missing config options to
boot on some arm64 Chromebooks.  In particular, this is required for
the mt8173-elm-hana platform until the following patch gets merged in
mainline kernel:

  https://lkml.org/lkml/2021/10/11/489

Update test-configs.yaml accordingly.