### PR TITLE
kernelci.data: add missing json import

### DIFF
--- a/kernelci/data/__init__.py
+++ b/kernelci/data/__init__.py
@@ -17,6 +17,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 import importlib
+import json
 
 
 class Database:

--- a/kernelci/data/kernelci_backend.py
+++ b/kernelci/data/kernelci_backend.py
@@ -16,7 +16,6 @@
 # along with this library; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-import json
 import requests
 import urllib
 from kernelci.data import Database


### PR DESCRIPTION
Import missing json package which is needed for
Database._print_http_error().  Also remove it from
kernelci.data.kernelci_backend as it's not needed there any more.

Fixes: 0618a1a3de47 ("kernelci.data: add Database._print_http_error()")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>