### PR TITLE
igt-parser.sh: Add amdgpu binaries directory to path

### DIFF
--- a/config/rootfs/debos/overlays/igt/usr/bin/igt-parser.sh
+++ b/config/rootfs/debos/overlays/igt/usr/bin/igt-parser.sh
@@ -30,7 +30,7 @@ LC_ALL=C type lava-test-set > /dev/null || alias lava-test-set='echo - '
 LC_ALL=C type lava-test-case > /dev/null || alias lava-test-case='echo --- '
 
 # Standard installation path for i-g-t test binaries
-export PATH=/usr/libexec/igt-gpu-tools:$PATH
+export PATH=/usr/libexec/igt-gpu-tools:/usr/libexec/igt-gpu-tools/amdgpu:$PATH
 
 # See lib/igt_core.h
 IGT_EXIT_SUCCESS=0


### PR DESCRIPTION
The amdgpu igt binaries are installed in a subdirectory of the usual
path where other igt binaries are installed. Add this subdirectory to
the PATH variable as well so we can execute the amdgpu igt tests.

Signed-off-by: Nícolas F. R. A. Prado <nfraprado@collabora.com>