### PR TITLE
test-configs.yaml: upgrade bullseye-igt to 20211124.0

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -62,7 +62,7 @@ file_systems:
 
   debian_bullseye-igt_ramdisk:
     type: debian
-    ramdisk: 'bullseye-igt/20211118.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'bullseye-igt/20211124.0/{arch}/rootfs.cpio.gz'
 
   debian_buster_kselftest:
     type: debian


### PR DESCRIPTION
Upgrade the bullseye-igt rootfs image to 20211124.0 which contains all
the firmware files for amdgpu and i915 as well as the fix to include
amdgpu tests in $PATH.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>