### PR TITLE
config/k8s: generate fragments in the build job

### DIFF
--- a/config/k8s/job-build.jinja2
+++ b/config/k8s/job-build.jinja2
@@ -84,6 +84,9 @@ set -x; \
   --retries 3 \
   --delete; \
 \
+./kci_build generate_fragments \
+  --build-config=${BUILD_CONFIG}; \
+\
 ./kci_build init_bmeta \
   --build-config=${BUILD_CONFIG} \
   --commit=${COMMIT_ID} \


### PR DESCRIPTION
Generate config fragments as part of the build job instead of relying
on the tarball to already contain them.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>