### PR TITLE
Enable preempt_rt on rt enabled CIP kernels

### DIFF
--- a/config/core/build-configs-cip.yaml
+++ b/config/core/build-configs-cip.yaml
@@ -130,3 +130,8 @@ build_configs:
     tree: cip
     branch: 'linux-5.10.y-cip'
     variants: *cip_variants_kselftest
+
+  cip_5.10-rt:
+    tree: cip
+    branch: 'linux-5.10.y-cip-rt'
+    variants: *cip_variants_kselftest

--- a/config/core/build-configs-cip.yaml
+++ b/config/core/build-configs-cip.yaml
@@ -45,7 +45,6 @@ cip_variants: &cip_variants
         fragments: [x86-chromebook]
         extra_configs: ['allnoconfig']
 
-
 cip_variants_kselftest: &cip_variants_kselftest
   gcc-10:
     <<: *cip_gcc_10
@@ -67,6 +66,26 @@ cip_variants_kselftest: &cip_variants_kselftest
           - 'allnoconfig'
           - 'x86_64_defconfig+x86-chromebook+kselftest'
 
+cip_variants_preempt_rt: &cip_variants_preempt_rt
+  gcc-10:
+    <<: *cip_gcc_10
+    fragments: [preempt_rt]
+    architectures:
+      <<: *cip_architectures
+      arm:
+        fragments: [preempt_rt]
+        extra_configs:
+          - 'multi_v7_defconfig+preempt_rt'
+      arm64:
+        fragments: [preempt_rt]
+        extra_configs:
+          - 'defconfig+preempt_rt'
+      x86_64:
+        fragments: [preempt_rt]
+        extra_configs:
+          - 'x86_64_defconfig+preempt_rt'
+
+
 build_configs:
   cip_4.4:
     tree: cip
@@ -76,7 +95,7 @@ build_configs:
   cip_4.4-rt:
     tree: cip
     branch: 'linux-4.4.y-cip-rt'
-    variants: *cip_variants
+    variants: *cip_variants_preempt_rt
 
   cip_4.19:
     tree: cip
@@ -105,7 +124,7 @@ build_configs:
   cip_4.19-rt:
     tree: cip
     branch: 'linux-4.19.y-cip-rt'
-    variants: *cip_variants
+    variants: *cip_variants_preempt_rt
 
   cip_5.10:
     tree: cip


### PR DESCRIPTION
This pr depends on https://github.com/kernelci/kernelci-core/pull/898