### PR TITLE
test-configs.yaml: add lenovo-hr330a-7x33cto1ww-emag

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -926,6 +926,11 @@ device_types:
     dtb: 'freescale/fsl-ls1028a-kontron-sl28-var3-ads2.dtb'
     boot_method: uboot
 
+  lenovo-hr330a-7x33cto1ww-emag:
+    mach: arm64
+    arch: arm64
+    boot_method: grub
+
   meson-g12a-sei510:
     mach: amlogic
     class: arm64-dtb
@@ -2056,6 +2061,10 @@ test_configs:
   - device_type: kontron-sl28-var3-ads2
     test_plans:
       - baseline
+      - baseline-nfs
+
+  - device_type: lenovo-hr330a-7x33cto1ww-emag
+    test_plans:
       - baseline-nfs
 
   - device_type: meson-g12a-sei510

--- a/config/lava/sleep/generic-grub-tftp-ramdisk-sleep-template.jinja2
+++ b/config/lava/sleep/generic-grub-tftp-ramdisk-sleep-template.jinja2
@@ -1,0 +1,7 @@
+{% extends 'boot/generic-grub-tftp-ramdisk-boot-template.jinja2' %}
+{% block actions %}
+{{ super () }}
+
+{% include 'sleep/sleep.jinja2' %}
+
+{% endblock %}


### PR DESCRIPTION
Add the lenovo-hr330a-7x33cto1ww-emag arm64 server device type and
enable only baseline-nfs on it as it takes a very long time to boot
with the current setup.  It relies entirely on UEFI and doesn't use
any dtb file.