### PR TITLE
debos: Increase debos memory limit from 2G to 4G

### DIFF
--- a/kernelci/rootfs.py
+++ b/kernelci/rootfs.py
@@ -23,6 +23,7 @@ import os
 
 def _build_debos(name, config, data_path, arch):
     cmd = 'cd {data_path} && debos \
+--memory=4G \
 -t architecture:{arch} \
 -t suite:{release_name} \
 -t basename:{name}/{arch} \


### PR DESCRIPTION
bullseye-ltp rootfs creation requires more than
2GB memory, so we need to update debos configuration.

Signed-off-by: Lakshmipathi Ganapathi <lakshmipathi.ganapathi@collabora.com>