### PR TITLE
CHROMEOS config/docker: add chromeos-tast image

### DIFF
--- a/config/docker/chromeos-tast/Dockerfile
+++ b/config/docker/chromeos-tast/Dockerfile
@@ -1,0 +1,43 @@
+FROM debian:bullseye-slim
+MAINTAINER "KernelCI TSC" <kernelci-tsc@groups.io>
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    apt-transport-https \
+    bzip2 \
+    ca-certificates strace \
+    ssh
+
+RUN apt-get update && apt-get install -y \
+    curl \
+    git \
+    python3 \
+    python-pkg-resources \
+    vim \
+    xz-utils
+
+RUN \
+  mkdir -p /home/cros-tast && \
+  useradd cros-tast -d /home/cros-tast && \
+  chown cros-tast: -R /home/cros-tast && \
+  adduser cros-tast sudo && \
+  echo "cros-tast ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+USER cros-tast
+ENV HOME=/home/cros-tast
+WORKDIR $HOME
+
+RUN mkdir -p $HOME/trunk
+RUN git clone \
+    https://chromium.googlesource.com/chromiumos/chromite \
+    $HOME/trunk/chromite
+ENV PATH=$PATH:$HOME/trunk/chromite/scripts
+RUN yes | gsutil update
+
+# This SSH key is only used with Chrome OS test images.
+RUN mkdir "$HOME/.ssh"
+RUN cp "$HOME/trunk/chromite/ssh_keys/testing_rsa" "$HOME/.ssh/id_rsa"
+RUN chmod 0600 "$HOME/.ssh/id_rsa"
+
+# Needed by LAVA to install the overlay
+USER root


### PR DESCRIPTION
Add a kernelci/chromeos-tast Docker image to run the host tools for
Chrome OS Tast tests.  This is intended to be used on LAVA dispatchers
to run tests on Chromebook devices running Chrome OS user-space.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>