### PR TITLE
T31651 config to yaml

### DIFF
--- a/kernelci/config/base.py
+++ b/kernelci/config/base.py
@@ -16,6 +16,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 import re
+import yaml
 
 
 # -----------------------------------------------------------------------------
@@ -39,6 +40,31 @@ class YAMLObject:
         return {
             k: v for k, v in ((k, data.get(k)) for k in args) if v
         } if data else dict()
+
+    def _get_attrs(self):
+        """Return a set of attribute names for .to_dict() and .to_yaml()"""
+        return set()
+
+    def to_dict(self):
+        """Create a dictionary with the configuration data
+
+        Create a Python dictionary object with key-values representing the
+        configuration data originally imported from YAML.  This may not include
+        non-serialisable objects such as Filters.
+        """
+        return {
+            attr: getattr(self, attr) for attr in self._get_attrs()
+        }
+
+    def to_yaml(self):
+        """Recreate a YAML representation of the configuration data
+
+        Recreate a YAML text representation of the key-values made available
+        via the .to_dict() method.  This can be used to serialise a
+        configuration object and load it again without access to the full
+        original YAML files.
+        """
+        return yaml.dump(self.to_dict())
 
 
 class Filter:

--- a/kernelci/config/data.py
+++ b/kernelci/config/data.py
@@ -37,6 +37,11 @@ class Database(YAMLObject):
     def db_type(self):
         return self._db_type
 
+    def _get_attrs(self):
+        attrs = super()._get_attrs()
+        attrs.update({'name', 'db_type'})
+        return attrs
+
 
 class DatabaseAPI(Database):
     def __init__(self, name, db_type, url):
@@ -56,6 +61,11 @@ class DatabaseAPI(Database):
     @property
     def url(self):
         return self._url
+
+    def _get_attrs(self):
+        attrs = super()._get_attrs()
+        attrs.update({'url'})
+        return attrs
 
 
 class DatabaseFactory(YAMLObject):

--- a/kernelci/config/test.py
+++ b/kernelci/config/test.py
@@ -82,8 +82,27 @@ class DeviceType(YAMLObject):
         return dict(self._params)
 
     @property
+    def flags(self):
+        return list(self._flags)
+
+    @property
     def context(self):
         return self._context
+
+    def _get_attrs(self):
+        attrs = super()._get_attrs()
+        attrs.update({
+            'arch',
+            'base_name',
+            'boot_method',
+            'context',
+            'dtb',
+            'flags',
+            'mach',
+            'name',
+            'params',
+        })
+        return attrs
 
     def get_flag(self, name):
         return name in self._flags
@@ -200,6 +219,11 @@ class RootFSType(YAMLObject):
     def url(self):
         return self._url
 
+    def _get_attrs(self):
+        attrs = super()._get_attrs()
+        attrs.update({'url', 'arch_map'})
+        return attrs
+
     def get_arch_name(self, arch, endian):
         arch_key = ('arch', arch)
         endian_key = ('endian', endian)
@@ -272,6 +296,17 @@ class RootFS(YAMLObject):
     @property
     def params(self):
         return dict(self._params)
+
+    def _get_attrs(self):
+        attrs = super()._get_attrs()
+        attrs.update({
+            'boot_protocol',
+            'params',
+            'prompt',
+            'root_type',
+            'type',
+        })
+        return attrs
 
     def get_url(self, fs_type, arch, endian):
         """Get the URL of the file system for the given variant and arch.
@@ -354,6 +389,18 @@ class TestPlan(YAMLObject):
     @property
     def params(self):
         return dict(self._params)
+
+    def _get_attrs(self):
+        attrs = super()._get_attrs()
+        attrs.update({
+            'base_name',
+            'category'
+            'name',
+            'params',
+            'pattern',
+            'rootfs',
+        })
+        return attrs
 
     def get_template_path(self, boot_method):
         """Get the path to the template file for the given *boot_method*


### PR DESCRIPTION
Add support for recreating some YAML configuration from a `YAMLObject`.  This will be useful when running self-contained test scripts in their own environment without access to the full YAML configuration used by the pipeline.