### PR TITLE
T31651 shell scripts

### DIFF
--- a/config/core/lab-configs.yaml
+++ b/config/core/lab-configs.yaml
@@ -137,3 +137,6 @@ labs:
           plan:
             - baseline
       - blocklist: {plan: [baseline-qemu-docker]}
+
+  shell:
+    lab_type: shell

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -141,6 +141,9 @@ test_plans:
     filters:
       - blocklist: *kselftest_defconfig_filter
 
+  check-describe:
+    pattern: 'check-describe.jinja2'
+
   cros-ec:
     rootfs: debian_buster-cros-ec_ramdisk
 
@@ -1435,6 +1438,12 @@ device_types:
       - blocklist: *allmodconfig_filter
       - blocklist: {kernel: ['v3.', 'v4.4', 'v4.9']}
 
+  shell_python:
+    base_name: shell
+    class: shell
+    params:
+      shebang: '/usr/bin/env python3'
+
   snow:
     mach: exynos
     class: arm-dtb
@@ -2464,6 +2473,10 @@ test_configs:
   - device_type: rk3399-puma-haikou
     test_plans:
       - baseline
+
+  - device_type: shell_python
+    test_plans:
+      - check-describe
 
   - device_type: snow
     test_plans:

--- a/config/scripts/base-python.jinja2
+++ b/config/scripts/base-python.jinja2
@@ -1,4 +1,6 @@
-{% extends 'base.jinja2' %}
+{# -*- mode: Python -*- #}
+
+{%- extends 'base.jinja2' %}
 
 {% block script_init -%}
 import sys

--- a/config/scripts/base-python.jinja2
+++ b/config/scripts/base-python.jinja2
@@ -1,0 +1,11 @@
+{% extends 'base.jinja2' %}
+
+{% block script_init -%}
+import sys
+{% endblock %}
+
+{% block script_exit -%}
+if __name__ == '__main__':
+    ret = main(sys.argv)
+    sys.exit(0 if ret is True else 1)
+{% endblock %}

--- a/config/scripts/base.jinja2
+++ b/config/scripts/base.jinja2
@@ -1,3 +1,5 @@
+{# -*- mode: sh -*- -#}
+
 #!{{ shebang|default("/bin/sh") }}
 
 {% block script_init -%}

--- a/config/scripts/base.jinja2
+++ b/config/scripts/base.jinja2
@@ -1,0 +1,11 @@
+#!{{ shebang|default("/bin/sh") }}
+
+{% block script_init -%}
+set -e
+{% endblock -%}
+
+{%- block commands %}{% endblock %}
+
+{% block script_exit -%}
+exit 0
+{%- endblock %}

--- a/config/scripts/check-describe.jinja2
+++ b/config/scripts/check-describe.jinja2
@@ -1,4 +1,6 @@
-{% extends 'base-python.jinja2' %}
+{# -*- mode: Python -*- #}
+
+{%- extends 'base-python.jinja2' %}
 
 {% block script_init -%}
 {{ super() }}

--- a/config/scripts/check-describe.jinja2
+++ b/config/scripts/check-describe.jinja2
@@ -1,0 +1,74 @@
+{% extends 'base-python.jinja2' %}
+
+{% block script_init -%}
+{{ super() }}
+import requests
+{% endblock %}
+
+{% block commands %}
+GIT_URL = '{{ git_url }}'
+GIT_COMMIT = '{{ git_commit}}'
+GIT_DESCRIBE = '{{ git_describe }}'
+
+
+def _get_makefile(base_url, commit):
+    url = f'{base_url}/plain/Makefile/?id={commit}'
+    print(url)
+    resp = requests.get(url)
+    resp.raise_for_status()
+    return resp
+
+
+def _get_makefile_rev(makefile):
+    makefile_rev = {
+        'VERSION': None,
+        'PATCHLEVEL': None,
+        'SUBLEVEL': None,
+    }
+    for line_n, line_raw in enumerate(makefile.iter_lines()):
+        line = line_raw.decode()
+        value = list(val.strip() for val in line.split('='))
+        for key in makefile_rev.keys():
+            if value[0] == key:
+                makefile_rev[key] = int(value[1])
+                res = [val is not None for val in makefile_rev.values()]
+                if all(res):
+                    return makefile_rev
+        if line_n == 10:
+            return None
+    return None
+
+
+def _check_describe(makefile, describe):
+    try:
+        makefile_rev = _get_makefile_rev(makefile)
+    except Exception as e:
+        print(e)
+        makefile_rev = None
+    finally:
+        if makefile_rev is None:
+            return False
+
+    makefile_version = "v{version}.{patch}{dot}{sub}".format(
+        version=makefile_rev['VERSION'],
+        patch=makefile_rev['PATCHLEVEL'],
+        dot='.' if makefile_rev['SUBLEVEL'] else '',
+        sub=makefile_rev['SUBLEVEL'] if makefile_rev['SUBLEVEL'] else '',
+    )
+    return describe.startswith(makefile_version)
+
+
+def main(argv):
+    if not GIT_URL.startswith('https://git.kernel.org'):
+        print("Only git.kernel.org URLs are supported")
+        return False
+
+    print("Getting Makefile")
+    makefile = _get_makefile(GIT_URL, GIT_COMMIT)
+
+    print("Checking git describe")
+    res = _check_describe(makefile, GIT_DESCRIBE)
+    print("Result: {}".format("PASS" if res is True else "FAIL"))
+
+    return res
+{% endblock %}

--- a/kernelci/config/lab.py
+++ b/kernelci/config/lab.py
@@ -89,6 +89,7 @@ class LabFactory(YAMLObject):
     _lab_types = {
         'lava.lava_xmlrpc': Lab_LAVA,
         'lava.lava_rest': Lab_LAVA,
+        'shell': Lab,
     }
 
     @classmethod

--- a/kernelci/config/lab.py
+++ b/kernelci/config/lab.py
@@ -23,18 +23,16 @@ from kernelci.config.base import FilterFactory, YAMLObject
 class Lab(YAMLObject):
     """Test lab model."""
 
-    def __init__(self, name, lab_type, url, filters=None):
+    def __init__(self, name, lab_type, filters=None):
         """A lab object contains all the information relative to a test lab.
 
         *name* is the name used to refer to the lab in meta-data.
         *lab_type* is the name of the type of lab, essentially indicating the
                    type of software used by the lab.
-        *url* is the URL to reach the lab API.
         *filters* is a list of Filter objects associated with this lab.
         """
         self._name = name
         self._lab_type = lab_type
-        self._url = url
         self._filters = filters or list()
 
     @classmethod
@@ -49,15 +47,25 @@ class Lab(YAMLObject):
     def lab_type(self):
         return self._lab_type
 
-    @property
-    def url(self):
-        return self._url
-
     def match(self, data):
         return all(f.match(**data) for f in self._filters)
 
 
-class Lab_LAVA(Lab):
+class LabAPI(Lab):
+
+    def __init__(self, url, *args, **kwargs):
+        """
+        *url* is the URL to reach the lab API.
+        """
+        super().__init__(*args, **kwargs)
+        self._url = url
+
+    @property
+    def url(self):
+        return self._url
+
+
+class Lab_LAVA(LabAPI):
 
     def __init__(self, priority='medium', *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/kernelci/config/test.py
+++ b/kernelci/config/test.py
@@ -155,6 +155,13 @@ class DeviceType_riscv(DeviceType):
         super().__init__(name, mach, arch, *args, **kw)
 
 
+class DeviceType_shell(DeviceType):
+
+    def __init__(self, name, mach=None, arch=None, boot_method=None,
+                 *args, **kwargs):
+        super().__init__(name, mach, arch, boot_method, *args, **kwargs)
+
+
 class DeviceTypeFactory(YAMLObject):
     """Factory to create device types from YAML data."""
 
@@ -164,6 +171,7 @@ class DeviceTypeFactory(YAMLObject):
         'arm-dtb': DeviceType_arm,
         'arm64-dtb': DeviceType_arm64,
         'riscv-dtb': DeviceType_riscv,
+        'shell': DeviceType_shell,
     }
 
     @classmethod

--- a/kernelci/lab/shell.py
+++ b/kernelci/lab/shell.py
@@ -1,0 +1,30 @@
+import os
+import subprocess
+from jinja2 import Environment, FileSystemLoader
+from kernelci.lab import LabAPI
+
+
+class Shell(LabAPI):
+    BASE_PATH = 'config/scripts'
+
+    def generate(self, params, target, plan,
+                 callback_opts=None, base_path=None):
+        jinja2_env = Environment(loader=FileSystemLoader(
+            base_path or self.BASE_PATH
+        ))
+        template_path = plan.get_template_path(None)
+        template = jinja2_env.get_template(template_path)
+        return template.render(params)
+
+    def save_file(self, *args, **kwargs):
+        output_file = super().save_file(*args, **kwargs)
+        os.chmod(output_file, 0o775)
+        return output_file
+
+    def submit(self, job_path):
+        return subprocess.call(job_path)
+
+
+def get_api(lab, **kwargs):
+    """Get a Shell object"""
+    return Shell(lab, **kwargs)


### PR DESCRIPTION
Add initial support for running tests in shell scripts:
* add configuration for a "shell" lab type and "shell_python" device type
* add basic test plan "check-describe" with a Python script

The exit code will then tell whether the test passed or failed.  The next step is to make the test process self-contain and let it send the result to the API directly.