### PR TITLE
test-configs: Enable MTE for virtual arm64 platforms

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1257,7 +1257,7 @@ device_types:
       arch: arm64
       cpu: 'max'
       guestfs_interface: 'virtio'
-      machine: 'virt,gic-version=2,accel=kvm:tcg'
+      machine: 'virt,gic-version=2,mte=on,accel=kvm:tcg'
     filters:
       - regex: { defconfig: 'defconfig' }
 
@@ -1275,7 +1275,7 @@ device_types:
       arch: arm64
       cpu: 'max'
       guestfs_interface: 'virtio'
-      machine: 'virt,gic-version=3,accel=kvm:tcg'
+      machine: 'virt,gic-version=3,mte=on,accel=kvm:tcg'
     filters:
       - passlist: {defconfig: ['defconfig']}
 


### PR DESCRIPTION
The arm64 Memory Tagging Extension (FEAT_MTE) is supported by qemu but is
not enabled, even with cpu=max. Get some test coverage for it by enabling
it for our virtual arm64 platforms when the built kernel supports it. There
is some specific coverage for it in kselftest too which will be exercised
when this is enabled.

Signed-off-by: Mark Brown <broonie@kernel.org>