### PR TITLE
test-configs: Use implementation defined FEAT_PAUTH with qemu on arm64

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1273,7 +1273,7 @@ device_types:
     boot_method: qemu
     context:
       arch: arm64
-      cpu: 'max'
+      cpu: 'max,pauth-impdef=on'
       guestfs_interface: 'virtio'
       machine: 'virt,gic-version=2'
     filters:
@@ -1291,7 +1291,7 @@ device_types:
     boot_method: qemu
     context:
       arch: arm64
-      cpu: 'max'
+      cpu: 'max,pauth-impdef=on'
       guestfs_interface: 'virtio'
       machine: 'virt,gic-version=3'
     filters:


### PR DESCRIPTION
The implementation of the architected pointer authentication implementation
in qemu is very slow so qemu provides optional support for an additional
implementation defined algorithm which runs much faster. This is not so
noticeable when userspace doesn't make use of pointer authentication but
once it does the performance improvement is dramatic. Switch our virtual
arm64 targets over to this, there's no real coverage impact for the kernel.

Signed-off-by: Mark Brown <broonie@kernel.org>