### PR TITLE
T31651 detached process

### DIFF
--- a/config/scripts/base-python.jinja2
+++ b/config/scripts/base-python.jinja2
@@ -3,11 +3,45 @@
 {%- extends 'base.jinja2' %}
 
 {% block script_init -%}
+import os
 import sys
+import yaml
+
+import kernelci.data
+import kernelci.config
+
+DB_CONFIG_YAML = """
+{{ db_config_yaml }}"""
+NODE_ID = "{{ node_id }}"
 {% endblock %}
 
 {% block script_exit -%}
+def _get_db():
+    if not DB_CONFIG_YAML:
+        return None
+
+    db_config = kernelci.config.data.DatabaseFactory.from_yaml(
+        'db', yaml.load(DB_CONFIG_YAML, Loader=yaml.CLoader)
+    )
+    if not db_config:
+        return None
+
+    api_token = os.getenv('API_TOKEN')
+    if not api_token:
+        return None
+
+    return kernelci.data.get_db(db_config, api_token)
+
+
 if __name__ == '__main__':
-    ret = main(sys.argv)
-    sys.exit(0 if ret is True else 1)
+    res = main(sys.argv)
+
+    if NODE_ID:
+        db = _get_db()
+        if db:
+            node = db.get_node(NODE_ID)
+            node['status'] = res
+            db.submit({'node': node})
+
+    sys.exit(0 if res is True else 1)
 {% endblock %}

--- a/kernelci/lab/shell.py
+++ b/kernelci/lab/shell.py
@@ -7,13 +7,15 @@ from kernelci.lab import LabAPI
 class Shell(LabAPI):
     BASE_PATH = 'config/scripts'
 
-    def generate(self, params, target, plan,
-                 callback_opts=None, base_path=None):
+    def generate(self, params, target_config, plan_config, callback_opts=None,
+                 db_config=None, base_path=None):
         jinja2_env = Environment(loader=FileSystemLoader(
             base_path or self.BASE_PATH
         ))
-        template_path = plan.get_template_path(None)
+        template_path = plan_config.get_template_path(None)
         template = jinja2_env.get_template(template_path)
+        if db_config:
+            params['db_config_yaml'] = db_config.to_yaml()
         return template.render(params)
 
     def save_file(self, *args, **kwargs):

--- a/kernelci/lab/shell.py
+++ b/kernelci/lab/shell.py
@@ -18,6 +18,9 @@ class Shell(LabAPI):
             params['db_config_yaml'] = db_config.to_yaml()
         return template.render(params)
 
+    def job_file_name(self, params):
+        return '-'.join([params['node_id'], params['name']])
+
     def save_file(self, *args, **kwargs):
         output_file = super().save_file(*args, **kwargs)
         os.chmod(output_file, 0o775)

--- a/kernelci/lab/shell.py
+++ b/kernelci/lab/shell.py
@@ -22,7 +22,8 @@ class Shell(LabAPI):
         return output_file
 
     def submit(self, job_path):
-        return subprocess.call(job_path)
+        process = subprocess.Popen(job_path, shell=True)
+        return process.pid
 
 
 def get_api(lab, **kwargs):


### PR DESCRIPTION
Run scripts in `kernelci.lab.Shell` as detached processes and pass the YAML configuration for the remote API to the template so they can send the results directly.