### PR TITLE
test-configs.yaml: add hp-x360-14-G1-sona

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -704,6 +704,13 @@ device_types:
     boot_method: depthcharge
     filters: *x86-chromebook-filters
 
+  # Alphabetical order exception: 14 is an int but 12b is a string
+  hp-x360-14-G1-sona:
+    mach: x86
+    arch: x86_64
+    boot_method: depthcharge
+    filters: *x86-chromebook-filters
+
   hp-x360-12b-n4000-octopus:
     mach: x86
     arch: x86_64
@@ -1902,6 +1909,12 @@ test_configs:
       - preempt-rt
       - sleep
       - smc
+
+  - device_type: hp-x360-14-G1-sona
+    test_plans:
+      - baseline
+      - baseline-nfs
+      - cros-ec
 
   - device_type: hp-x360-12b-n4000-octopus
     test_plans:


### PR DESCRIPTION
Add the hp-x360-14-G1-sona x86_64 Chromebook device type which is
present in lab-collabora and enable baseline and cros-ec test plans on
it for now.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>