### PR TITLE
build-configs.yaml: add rt-stable 5.10 and 5.15 branches

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -794,6 +794,16 @@ build_configs:
     branch: 'v5.4-rt'
     variants: *preempt_rt_variants
 
+  rt-stable_v5.10-rt:
+    tree: rt-stable
+    branch: 'v5.10-rt'
+    variants: *preempt_rt_variants
+
+  rt-stable_v5.15-rt:
+    tree: rt-stable
+    branch: 'v5.15-rt'
+    variants: *preempt_rt_variants
+
   samsung:
     tree: samsung
     branch: 'for-next'


### PR DESCRIPTION
Add the v5.10-rt and v5.15-rt branches to the rt-stable tree.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>