### PR TITLE
test-configs.yaml: update Debian rootfs URLs

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -48,33 +48,33 @@ file_systems:
 
   debian_bullseye_ramdisk:
     type: debian
-    ramdisk: 'bullseye/20211203.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'bullseye/20211210.0/{arch}/rootfs.cpio.gz'
 
   debian_bullseye_nfs:
     type: debian
-    ramdisk: 'bullseye/20211203.0/{arch}/initrd.cpio.gz'
-    nfs: 'bullseye/20211203.0/{arch}/full.rootfs.tar.xz'
+    ramdisk: 'bullseye/20211210.0/{arch}/initrd.cpio.gz'
+    nfs: 'bullseye/20211210.0/{arch}/full.rootfs.tar.xz'
     root_type: nfs
 
   debian_buster-cros-ec_ramdisk:
     type: debian
-    ramdisk: 'buster-cros-ec/20211203.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'buster-cros-ec/20211210.0/{arch}/rootfs.cpio.gz'
 
   debian_bullseye-igt_ramdisk:
     type: debian
-    ramdisk: 'bullseye-igt/20211203.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'bullseye-igt/20211210.0/{arch}/rootfs.cpio.gz'
 
   debian_buster_kselftest:
     type: debian
-    ramdisk: 'buster-kselftest/20211203.0/{arch}/initrd.cpio.gz'
-    nfs: 'buster-kselftest/20211203.0/{arch}/full.rootfs.tar.xz'
+    ramdisk: 'buster-kselftest/20211210.0/{arch}/initrd.cpio.gz'
+    nfs: 'buster-kselftest/20211210.0/{arch}/full.rootfs.tar.xz'
     root_type: nfs
     params:
       os_config: 'debian'
 
   debian_buster-v4l2_ramdisk:
     type: debian
-    ramdisk: 'buster-v4l2/20211203.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'buster-v4l2/20211210.0/{arch}/rootfs.cpio.gz'
 
   debian_buster-libcamera_nfs:
     type: debian
@@ -84,8 +84,8 @@ file_systems:
 
   debian_buster-ltp_nfs:
     type: debian
-    ramdisk: 'buster-ltp/20211203.0/{arch}/initrd.cpio.gz'
-    nfs: 'buster-ltp/20211203.0/{arch}/full.rootfs.tar.xz'
+    ramdisk: 'buster-ltp/20211210.0/{arch}/initrd.cpio.gz'
+    nfs: 'buster-ltp/20211210.0/{arch}/full.rootfs.tar.xz'
     root_type: nfs
 
 


### PR DESCRIPTION
Update the Debian rootfs URLs except for buster-libcamera which is
still failing to build.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>