### PR TITLE
build-configs.yaml: update clang configs for mainline and next

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -651,8 +651,13 @@ build_configs:
     branch: 'master'
     variants:
       gcc-10: *default_gcc-10
+      # Minimum version
       clang-10:
         build_environment: clang-10
+        architectures: *arch_clang_configs
+      # Latest stable release
+      clang-13:
+        build_environment: clang-13
         architectures: *arch_clang_configs
 
   media:
@@ -704,11 +709,6 @@ build_configs:
               - 'multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y'
               - 'allnoconfig'
               - 'allmodconfig'
-
-      # clang-11 is the current minium clang version for -next
-      clang-11:
-        build_environment: clang-11
-        architectures: *arch_clang_configs
 
       # Latest clang release
       clang-13:


### PR DESCRIPTION
Drop clang-11 from linux-next to focus on the latest version instead,
and the minimum version may change from time to time so it's hard to
keep it enabled on linux-next (currently moving from 10 to 11).
Enable clang-13 as the latest stable release on mainline, and keep
clang-10 there as well.

This should result in little change in terms of build resources, with
clang-11 removed from linux-next and clang-13 added to mainline.  Once
a clang-14 Docker image is available, we can start using that with
linux-next to cover clang-11 (mainline), 13 (mainline) and 14 (next).

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>