### PR TITLE
config/docker: Factor out common elements of clang containers

### DIFF
--- a/config/docker/build-and-push.sh
+++ b/config/docker/build-and-push.sh
@@ -87,6 +87,7 @@ docker_build_and_tag() {
 
 for target in $targets; do
     if [ "$target" = "compilers" ]; then
+        docker_build_and_tag clang-base
         for cc in {gcc,clang}-*
         do
             docker_build_and_tag "$cc"

--- a/config/docker/clang-11/Dockerfile
+++ b/config/docker/clang-11/Dockerfile
@@ -1,43 +1,7 @@
 ARG PREFIX=kernelci/
-FROM ${PREFIX}build-base
+FROM ${PREFIX}clang-base
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
-    software-properties-common \
-    gnupg2
-
-RUN apt-get update && apt-get install --no-install-recommends -y \
-    binutils-aarch64-linux-gnu \
-    binutils-arm-linux-gnueabihf \
-    binutils-riscv64-linux-gnu \
-    binutils \
     clang-11 lld-11 llvm-11
 
 ENV PATH=/usr/lib/llvm-11/bin:${PATH}
-
-# kselftest x86
-RUN apt-get update && apt-get install --no-install-recommends -y \
-   libc6-dev \
-   libcap-dev \
-   libcap-ng-dev \
-   libelf-dev \
-   libpopt-dev
-
-# kselftest arm64
-RUN dpkg --add-architecture arm64
-RUN apt-get update && apt-get install --no-install-recommends -y \
-   libc6-dev:arm64 \
-   libcap-dev:arm64 \
-   libcap-ng-dev:arm64 \
-   libelf-dev:arm64 \
-   libpopt-dev:arm64
-
-# kselftest arm
-RUN dpkg --add-architecture armhf
-RUN apt-get update && apt-get install --no-install-recommends -y \
-   libc6-dev:armhf \
-   libcap-dev:armhf \
-   libcap-ng-dev:armhf \
-   libelf-dev:armhf \
-   libpopt-dev:armhf
-
-RUN apt-get autoremove -y gcc

--- a/config/docker/clang-12/Dockerfile
+++ b/config/docker/clang-12/Dockerfile
@@ -1,47 +1,11 @@
 ARG PREFIX=kernelci/
-FROM ${PREFIX}build-base
-
-RUN apt-get update && apt-get install --no-install-recommends -y \
-    software-properties-common \
-    gnupg2
+FROM ${PREFIX}clang-base
 
 RUN wget -q -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 RUN echo 'deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-12 main' \
    >> /etc/apt/sources.list.d/clang.list
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
-    binutils-aarch64-linux-gnu \
-    binutils-arm-linux-gnueabihf \
-    binutils-riscv64-linux-gnu \
-    binutils \
     clang-12 lld-12 llvm-12
 
 ENV PATH=/usr/lib/llvm-12/bin:${PATH}
-
-# kselftest x86
-RUN apt-get update && apt-get install --no-install-recommends -y \
-   libc6-dev \
-   libcap-dev \
-   libcap-ng-dev \
-   libelf-dev \
-   libpopt-dev
-
-# kselftest arm64
-RUN dpkg --add-architecture arm64
-RUN apt-get update && apt-get install --no-install-recommends -y \
-   libc6-dev:arm64 \
-   libcap-dev:arm64 \
-   libcap-ng-dev:arm64 \
-   libelf-dev:arm64 \
-   libpopt-dev:arm64
-
-# kselftest arm
-RUN dpkg --add-architecture armhf
-RUN apt-get update && apt-get install --no-install-recommends -y \
-   libc6-dev:armhf \
-   libcap-dev:armhf \
-   libcap-ng-dev:armhf \
-   libelf-dev:armhf \
-   libpopt-dev:armhf
-
-RUN apt-get autoremove -y gcc

--- a/config/docker/clang-13/Dockerfile
+++ b/config/docker/clang-13/Dockerfile
@@ -1,47 +1,11 @@
 ARG PREFIX=kernelci/
-FROM ${PREFIX}build-base
-
-RUN apt-get update && apt-get install --no-install-recommends -y \
-    software-properties-common \
-    gnupg2
+FROM ${PREFIX}clang-base
 
 RUN wget -q -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 RUN echo 'deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-13 main' \
    >> /etc/apt/sources.list.d/clang.list
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
-    binutils-aarch64-linux-gnu \
-    binutils-arm-linux-gnueabihf \
-    binutils-riscv64-linux-gnu \
-    binutils \
     clang-13 lld-13 llvm-13
 
 ENV PATH=/usr/lib/llvm-13/bin:${PATH}
-
-# kselftest x86
-RUN apt-get update && apt-get install --no-install-recommends -y \
-   libc6-dev \
-   libcap-dev \
-   libcap-ng-dev \
-   libelf-dev \
-   libpopt-dev
-
-# kselftest arm64
-RUN dpkg --add-architecture arm64
-RUN apt-get update && apt-get install --no-install-recommends -y \
-   libc6-dev:arm64 \
-   libcap-dev:arm64 \
-   libcap-ng-dev:arm64 \
-   libelf-dev:arm64 \
-   libpopt-dev:arm64
-
-# kselftest arm
-RUN dpkg --add-architecture armhf
-RUN apt-get update && apt-get install --no-install-recommends -y \
-   libc6-dev:armhf \
-   libcap-dev:armhf \
-   libcap-ng-dev:armhf \
-   libelf-dev:armhf \
-   libpopt-dev:armhf
-
-RUN apt-get autoremove -y gcc

--- a/config/docker/clang-base/Dockerfile
+++ b/config/docker/clang-base/Dockerfile
@@ -1,0 +1,40 @@
+ARG PREFIX=kernelci/
+FROM ${PREFIX}build-base
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    software-properties-common \
+    gnupg2
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    binutils-aarch64-linux-gnu \
+    binutils-arm-linux-gnueabihf \
+    binutils-riscv64-linux-gnu \
+    binutils
+
+# kselftest x86
+RUN apt-get update && apt-get install --no-install-recommends -y \
+   libc6-dev \
+   libcap-dev \
+   libcap-ng-dev \
+   libelf-dev \
+   libpopt-dev
+
+# kselftest arm64
+RUN dpkg --add-architecture arm64
+RUN apt-get update && apt-get install --no-install-recommends -y \
+   libc6-dev:arm64 \
+   libcap-dev:arm64 \
+   libcap-ng-dev:arm64 \
+   libelf-dev:arm64 \
+   libpopt-dev:arm64
+
+# kselftest arm
+RUN dpkg --add-architecture armhf
+RUN apt-get update && apt-get install --no-install-recommends -y \
+   libc6-dev:armhf \
+   libcap-dev:armhf \
+   libcap-ng-dev:armhf \
+   libelf-dev:armhf \
+   libpopt-dev:armhf
+
+RUN apt-get autoremove -y gcc


### PR DESCRIPTION
The clang docker containers contain a lot of duplicated content installing
utlilities used in the clang build, runtime dependencies for the kernel
build system and removing GCC. This means that any updates to those shared
elements need to touch multiple Dockerfiles. Simplify this by creating a
clang-base container which has everything except the actual clang packages
and basing the version specific clang packages on that.

Since clang-10 is now deprecated and the containers for it are based on
an older Debian release which isn't quite the same as the rest it is not
updated.

Signed-off-by: Mark Brown <broonie@kernel.org>