### PR TITLE
build-configs.yaml: enable clang-10 again for mainline

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -284,10 +284,10 @@ build_environments:
         name: 'riscv64'
         cross_compile: 'riscv64-linux-gnu-'
 
-  clang-11:
+  clang-10:
     cc: clang
-    cc_version: 11
-    arch_params: &clang_arch_params
+    cc_version: 10
+    arch_params: &clang_10_arch_params
       arm:
         <<: *arm_params
         name:
@@ -304,11 +304,16 @@ build_environments:
         <<: *x86_64_params
         name:
 
+  clang-11:
+    cc: clang
+    cc_version: 11
+    arch_params: *clang_10_arch_params
+
   clang-12:
     cc: clang
     cc_version: 12
     arch_params: &clang_12_arch_params
-      <<: *clang_arch_params
+      <<: *clang_10_arch_params
       riscv:
         <<: *riscv_params
         name:
@@ -319,8 +324,7 @@ build_environments:
   clang-13:
     cc: clang
     cc_version: 13
-    arch_params:
-      <<: *clang_12_arch_params
+    arch_params: *clang_12_arch_params
 
 # Default config with full build coverage
 build_configs_defaults:
@@ -647,8 +651,8 @@ build_configs:
     branch: 'master'
     variants:
       gcc-10: *default_gcc-10
-      clang-11:
-        build_environment: clang-11
+      clang-10:
+        build_environment: clang-10
         architectures: *arch_clang_configs
 
   media:


### PR DESCRIPTION
Add the clang-10 build environment again temporarily for mainline as
it's still the minimum supported version until the patch series to
change it to LLVM 11.0 is merged in the next release cycle.  The
clang-10 Docker image can stay unchanged as it was based on Debian
Buster and isn't supported any more, so the Dockerfile for clang-10
doesn't need to be added back.

Fixes: fc2dbb1615b5 ("build-configs.yaml: remove clang-10 and use clang-11")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>