### PR TITLE
Enable preempt-rt on Deptcharge devices

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1832,6 +1832,7 @@ test_configs:
       - ltp-mm
       - ltp-pty
       - ltp-timers
+      - preempt-rt
       - sleep_mem
       - smc
 
@@ -1963,6 +1964,7 @@ test_configs:
       - ltp-mm
       - ltp-pty
       - ltp-timers
+      - preempt-rt
       - sleep
       - smc
 
@@ -2233,6 +2235,7 @@ test_configs:
       - ltp-mm
       - ltp-pty
       - ltp-timers
+      - preempt-rt
       - sleep
       - v4l2-compliance-uvc
 

--- a/config/lava/preempt-rt/generic-depthcharge-tftp-ramdisk-preempt-rt-template.jinja2
+++ b/config/lava/preempt-rt/generic-depthcharge-tftp-ramdisk-preempt-rt-template.jinja2
@@ -1,0 +1,7 @@
+{% extends 'boot/generic-depthcharge-tftp-ramdisk-boot-template.jinja2' %}
+{% block actions %}
+{{ super () }}
+
+{% include 'preempt-rt/preempt-rt.jinja2' %}
+
+{% endblock %}


### PR DESCRIPTION
Add a LAVA template to run `preempt-rt` on Depthcharge devices and enable it on several x86 and arm64 Chromebooks.