### PR TITLE
test-configs.yaml: add arm64-chromebook to default filter

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -92,6 +92,7 @@ test_plan_default_filters:
       values:
         - ['arm', 'multi_v7_defconfig']
         - ['arm64', 'defconfig']
+        - ['arm64', 'defconfig+arm64-chromebook']
         - ['i386', 'i386_defconfig']
         - ['x86_64', 'x86_64_defconfig']
         - ['x86_64', 'x86_64_defconfig+x86-chromebook']


### PR DESCRIPTION
Add defconfig+arm64-chromebook to the default test plan filter so test
plans will be enabled by default on Chromebooks that rely on this
config fragment (mt8173-elm-hana at the moment).

Fixes: aeab1ef0cdc1 ("build-configs.yaml: add arm64-chromebook fragment")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>