### PR TITLE
test-configs.yaml: fix buster-libcamera URL

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -74,8 +74,8 @@ file_systems:
 
   debian_buster-libcamera_nfs:
     type: debian
-    ramdisk: 'buster-libcamera/20211126.0/{arch}/initrd.cpio.gz'
-    nfs: 'buster-libcamera/20211126.0/{arch}/full.rootfs.tar.xz'
+    ramdisk: 'buster-libcamera/20211112.0/{arch}/initrd.cpio.gz'
+    nfs: 'buster-libcamera/20211112.0/{arch}/full.rootfs.tar.xz'
     root_type: nfs
 
   debian_buster-ltp_nfs:


### PR DESCRIPTION
Fix buster-libcamera URL as the 20211126.0 revision failed to build on
arm64.  Revert to the previous revision that built on all
architectures (20211112.0).

Fixes: eae1f11042ae ("test-configs.yaml: update Debian rootfs URLs")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>