### PR TITLE
Enable cpufreq kselftest on mt8173-elm-hana

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -140,6 +140,7 @@ fragments:
     path: "kernel/configs/arm64-chromebook.config"
     configs:
       - 'CONFIG_REGULATOR_DA9211=y'
+      - 'CONFIG_ARM_MEDIATEK_CPUFREQ=y'
 
   crypto:
     path: "kernel/configs/crypto.config"

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -227,6 +227,12 @@ test_plans:
     filters:
       - passlist: {defconfig: ['kselftest']}
 
+  kselftest-cpufreq:
+    <<: *kselftest
+    params:
+      job_timeout: '10'
+      kselftest_collections: "cpufreq"
+
   kselftest-filesystems:
     <<: *kselftest
     params:

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2227,6 +2227,7 @@ test_configs:
       - baseline-cip-nfs
       - baseline-nfs
       - cros-ec
+      - kselftest-cpufreq
       - kselftest-filesystems
       - kselftest-futex
       - kselftest-lib


### PR DESCRIPTION
This adds a new kselftest test plan for the cpufreq collection, and enables it to run on mt8173-elm-hana.

The test output log can be seen here: https://lava.collabora.co.uk/scheduler/job/5242522

To run this test, `CONFIG_ARM_MEDIATEK_CPUFREQ` needs to be enabled as built-in. [A patch has been sent to the mailing list adding it to the defconfig](https://lore.kernel.org/linux-mediatek/20211217154452.868419-1-nfraprado@collabora.com/T/#u).

After that patch gets merged, we will still either need to block this test on older kernel branches tested by KernelCI or have a config fragment anyway for those, right?