### PR TITLE
Enable rtc kselftest on mt8173-elm-hana

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2231,6 +2231,7 @@ test_configs:
       - kselftest-futex
       - kselftest-lib
       - kselftest-lkdtm
+      - kselftest-rtc
       - kselftest-seccomp
       - lc-compliance
       - ltp-crypto

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -257,6 +257,12 @@ test_plans:
       job_timeout: '10'
       kselftest_collections: "lkdtm"
 
+  kselftest-rtc:
+    <<: *kselftest
+    params:
+      job_timeout: '10'
+      kselftest_collections: "rtc"
+
   kselftest-seccomp:
     <<: *kselftest
     params:


### PR DESCRIPTION
This adds a new kselftest test plan for the rtc collection, and enables it to run on mt8173-elm-hana.

The test output log can be seen here: https://lava.collabora.co.uk/scheduler/job/5227298

As can be seen, 2 out of the 7 tests fail. Namely, `rtc.alarm_alm_set` and `rtc.alarm_alm_set_minute`. The reason behind this is that the MT6397 RTC driver doesn't implement the `alarm_irq_enable()` operation, which is required for the `RTC_AIE_ON/OFF` IOCTLs used in those tests.

That said, that doesn't seem to be a problem since the `wkalm` variants of those two tests pass, which use the `RTC_WKALM_*` IOCTLs instead, which are preferred over the `ALM` ones anyway. (According to `Documentation/ABI/testing/rtc-cdev` and `drivers/rtc/dev.c`)

To run this test, `CONFIG_RTC_DRV_MT6397` needs to be enabled (either as module or built-in). [A patch has been sent to the mailing list adding it to the defconfig](https://lore.kernel.org/all/20211217162445.876034-1-nfraprado@collabora.com/).