### PR TITLE
T32412 kernelci.config.test: allow no arch in TestConfig.match()

### DIFF
--- a/kernelci/config/test.py
+++ b/kernelci/config/test.py
@@ -414,7 +414,9 @@ class TestConfig(YAMLObject):
                 plan in self._test_plans and
                 self._test_plans[plan].match(config)
             )) and
-            self.device_type.arch == arch and
+            (self.device_type.arch is None or (
+                self.device_type.arch == arch
+            )) and
             self.device_type.match(flags, config) and
             all(f.match(**config) for f in self._filters)
         )


### PR DESCRIPTION
Adjust the logic in TestConfig.match() for when the device type has no
"arch" attribute.  This may be the case when running scripts on an
abstract platform without any particular kernel build rather than real
hardware.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>