### PR TITLE
T32412 kernelci.lab.LabAPI: add .save_file()

### DIFF
--- a/kci_test
+++ b/kci_test
@@ -209,18 +209,14 @@ class cmd_generate(Command):
         if args.output and not os.path.exists(args.output):
             os.makedirs(args.output)
         for target, plan in jobs_list:
-            params = kernelci.test.get_params(
-                meta, target, plan, args.storage)
+            params = kernelci.test.get_params(meta, target, plan, args.storage)
             job = api.generate(params, target, plan, callback_opts)
             if job is None:
                 print("Failed to generate the job definition")
                 return False
             if args.output:
-                file_name = api.job_file_name(params)
-                output_file = os.path.join(args.output, file_name)
+                output_file = api.save_file(job, args.output, params)
                 print(output_file)
-                with open(output_file, 'w') as output:
-                    output.write(job)
             else:
                 print("# Job: {}".format(params['name']))
                 print(job)

--- a/kernelci/lab/__init__.py
+++ b/kernelci/lab/__init__.py
@@ -17,6 +17,7 @@
 
 import importlib
 import json
+import os
 
 
 class LabAPI:
@@ -77,6 +78,21 @@ class LabAPI:
     def generate(self, params, target, plan, callback_opts):
         """Generate a test job definition."""
         raise NotImplementedError("Lab.generate() is required")
+
+    def save_file(self, job, output_path, params):
+        """Save a test job definition in a file.
+
+        *job* is the job definition data
+        *output_path* is the directory where the file should be saved
+        *params* is a dictionary with template parameters
+
+        Return the full path where the job definition file was saved.
+        """
+        file_name = self.job_file_name(params)
+        output_file = os.path.join(output_path, file_name)
+        with open(output_file, 'w') as output:
+            output.write(job)
+        return output_file
 
     def submit(self, job_path):
         """Submit a test job definition in a lab."""


### PR DESCRIPTION
Add LabAPI.save_file() method to let each lab implementation the
possibility to save job definition files in a particular way.  Move
the implementation from kci_test to the LabAPI base class to provide
the same generic default behaviour.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>