### PR TITLE
test-configs.yaml: drop LTP on sun50i-h6-pine-h64

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2520,9 +2520,6 @@ test_configs:
   - device_type: sun50i-h6-pine-h64
     test_plans:
       - baseline
-      - ltp-crypto
-      - ltp-ipc
-      - ltp-mm
 
   - device_type: sun50i-h6-pine-h64-model-b
     test_plans:


### PR DESCRIPTION
The sun50i-h6-pine-h64 device type doesn't have enough online
instances in the current labs to cover LTP test cases, so reduce the
load to only baseline.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>