### PR TITLE
T32412 Add Shell lab type

### DIFF
--- a/config/core/lab-configs.yaml
+++ b/config/core/lab-configs.yaml
@@ -137,3 +137,6 @@ labs:
           plan:
             - baseline
       - blocklist: {plan: [baseline-qemu-docker]}
+
+  shell:
+    lab_type: shell

--- a/kci_test
+++ b/kci_test
@@ -177,28 +177,28 @@ class cmd_generate(Command):
         if meta.get('bmeta', 'build', 'status') != "PASS":
             return True
 
-        lab = configs['labs'][args.lab_config]
-        api = kernelci.lab.get_api(
-            lab, args.user, args.lab_token, args.lab_json)
+        lab_config = configs['labs'][args.lab_config]
+        lab_api = kernelci.lab.get_api(
+            lab_config, args.user, args.lab_token, args.lab_json)
 
         if args.target and args.plan:
-            target = configs['device_types'][args.target]
-            plan = configs['test_plans'][args.plan]
-            jobs_list = [(target, plan)]
+            device_config = configs['device_types'][args.target]
+            plan_config = configs['test_plans'][args.plan]
+            jobs_list = [(device_config, plan_config)]
         else:
             jobs_list = []
-            configs = kernelci.test.match_configs(
-                configs['test_configs'], meta, lab)
-            for device_type, plan in configs:
-                if not api.device_type_online(device_type):
+            test_configs = kernelci.test.match_configs(
+                configs['test_configs'], meta, lab_config)
+            for device_config, plan_config in test_configs:
+                if not lab_api.device_type_online(device_config):
                     continue
-                if args.target and device_type.name != args.target:
+                if args.target and device_config.name != args.target:
                     continue
-                if args.plan and plan.name != args.plan:
+                if args.plan and plan_config.name != args.plan:
                     continue
-                if args.mach and device_type.mach != args.mach:
+                if args.mach and device_config.mach != args.mach:
                     continue
-                jobs_list.append((device_type, plan))
+                jobs_list.append((device_config, plan_config))
 
         callback_opts = {
             'id': args.callback_id,
@@ -208,14 +208,16 @@ class cmd_generate(Command):
         }
         if args.output and not os.path.exists(args.output):
             os.makedirs(args.output)
-        for target, plan in jobs_list:
-            params = kernelci.test.get_params(meta, target, plan, args.storage)
-            job = api.generate(params, target, plan, callback_opts)
+        for device_config, plan_config in jobs_list:
+            params = kernelci.test.get_params(
+                meta, device_config, plan_config, args.storage)
+            job = lab_api.generate(params, device_config, plan_config,
+                                   callback_opts)
             if job is None:
                 print("Failed to generate the job definition")
                 return False
             if args.output:
-                output_file = api.save_file(job, args.output, params)
+                output_file = lab_api.save_file(job, args.output, params)
                 print(output_file)
             else:
                 print("# Job: {}".format(params['name']))

--- a/kci_test
+++ b/kci_test
@@ -206,13 +206,16 @@ class cmd_generate(Command):
             'type': args.callback_type or 'kernelci',
             'url': args.callback_url,
         }
+        db_config = (
+            configs['db_configs'][args.db_config] if args.db_config else None
+        )
         if args.output and not os.path.exists(args.output):
             os.makedirs(args.output)
         for device_config, plan_config in jobs_list:
             params = kernelci.test.get_params(
                 meta, device_config, plan_config, args.storage)
             job = lab_api.generate(params, device_config, plan_config,
-                                   callback_opts)
+                                   callback_opts, db_config=db_config)
             if job is None:
                 print("Failed to generate the job definition")
                 return False

--- a/kernelci/config/lab.py
+++ b/kernelci/config/lab.py
@@ -89,6 +89,7 @@ class LabFactory(YAMLObject):
     _lab_types = {
         'lava.lava_xmlrpc': Lab_LAVA,
         'lava.lava_rest': Lab_LAVA,
+        'shell': Lab,
     }
 
     @classmethod

--- a/kernelci/config/lab.py
+++ b/kernelci/config/lab.py
@@ -23,18 +23,16 @@ from kernelci.config.base import FilterFactory, YAMLObject
 class Lab(YAMLObject):
     """Test lab model."""
 
-    def __init__(self, name, lab_type, url, filters=None):
+    def __init__(self, name, lab_type, filters=None):
         """A lab object contains all the information relative to a test lab.
 
         *name* is the name used to refer to the lab in meta-data.
         *lab_type* is the name of the type of lab, essentially indicating the
                    type of software used by the lab.
-        *url* is the URL to reach the lab API.
         *filters* is a list of Filter objects associated with this lab.
         """
         self._name = name
         self._lab_type = lab_type
-        self._url = url
         self._filters = filters or list()
 
     @classmethod
@@ -49,15 +47,25 @@ class Lab(YAMLObject):
     def lab_type(self):
         return self._lab_type
 
-    @property
-    def url(self):
-        return self._url
-
     def match(self, data):
         return all(f.match(**data) for f in self._filters)
 
 
-class Lab_LAVA(Lab):
+class LabAPI(Lab):
+
+    def __init__(self, url, *args, **kwargs):
+        """
+        *url* is the URL to reach the lab API.
+        """
+        super().__init__(*args, **kwargs)
+        self._url = url
+
+    @property
+    def url(self):
+        return self._url
+
+
+class Lab_LAVA(LabAPI):
 
     def __init__(self, priority='medium', *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/kernelci/lab/__init__.py
+++ b/kernelci/lab/__init__.py
@@ -76,7 +76,7 @@ class LabAPI:
         return self.config.match(filter_data)
 
     def generate(self, params, device_config, plan_config,
-                 callback_opts=None, templates_path=None):
+                 callback_opts=None, templates_path=None, db_config=None):
         """Generate a test job definition.
 
         *params* is a dictionary with the test parameters which can be used
@@ -92,6 +92,9 @@ class LabAPI:
 
         *templates_path* is an optional argument to specify the path where the
             template files should be found, when not in the standard location
+
+        *db_config* is a Database configuration object for the database or API
+            where the results should be sent
         """
         raise NotImplementedError("Lab.generate() is required")
 

--- a/kernelci/lab/__init__.py
+++ b/kernelci/lab/__init__.py
@@ -75,8 +75,24 @@ class LabAPI:
         """Apply filters and return True if they match, False otherwise."""
         return self.config.match(filter_data)
 
-    def generate(self, params, target, plan, callback_opts):
-        """Generate a test job definition."""
+    def generate(self, params, device_config, plan_config,
+                 callback_opts=None, templates_path=None):
+        """Generate a test job definition.
+
+        *params* is a dictionary with the test parameters which can be used
+             when generating a job definition using templates
+
+        *device_config* is a DeviceType configuration object for the target
+             device type
+
+        *plan_config* is a TestPlan configuration object for the target test
+             plan
+
+        *callback_opts* is a dictionary with extra options used for callbacks
+
+        *templates_path* is an optional argument to specify the path where the
+            template files should be found, when not in the standard location
+        """
         raise NotImplementedError("Lab.generate() is required")
 
     def save_file(self, job, output_path, params):

--- a/kernelci/lab/lava/__init__.py
+++ b/kernelci/lab/lava/__init__.py
@@ -27,7 +27,7 @@ from kernelci.lab import LabAPI
 class LavaAPI(LabAPI):
 
     def generate(self, params, device_config, plan_config, callback_opts=None,
-                 templates_path='config/lava'):
+                 templates_path='config/lava', db_config=None):
         short_template_file = plan_config.get_template_path(
             device_config.boot_method)
         template_file = os.path.join(templates_path, short_template_file)

--- a/kernelci/lab/lava/__init__.py
+++ b/kernelci/lab/lava/__init__.py
@@ -26,9 +26,11 @@ from kernelci.lab import LabAPI
 
 class LavaAPI(LabAPI):
 
-    def generate(self, params, target, plan, callback_opts):
-        short_template_file = plan.get_template_path(target.boot_method)
-        template_file = os.path.join('config/lava', short_template_file)
+    def generate(self, params, device_config, plan_config, callback_opts=None,
+                 templates_path='config/lava'):
+        short_template_file = plan_config.get_template_path(
+            device_config.boot_method)
+        template_file = os.path.join(templates_path, short_template_file)
         if not os.path.exists(template_file):
             print("Template not found: {}".format(template_file))
             return None
@@ -39,7 +41,8 @@ class LavaAPI(LabAPI):
             'lab_name': self.config.name,
             'base_device_type': self._alias_device_type(base_name),
         })
-        self._add_callback_params(params, callback_opts)
+        if callback_opts:
+            self._add_callback_params(params, callback_opts)
         jinja2_env = Environment(loader=FileSystemLoader('config/lava'),
                                  extensions=["jinja2.ext.do"])
         template = jinja2_env.get_template(short_template_file)

--- a/kernelci/lab/shell.py
+++ b/kernelci/lab/shell.py
@@ -1,0 +1,29 @@
+import os
+import subprocess
+from jinja2 import Environment, FileSystemLoader
+from kernelci.lab import LabAPI
+
+
+class Shell(LabAPI):
+
+    def generate(self, params, device_config, plan_config,
+                 callback_opts=None, templates_path='config/scripts'):
+        jinja2_env = Environment(loader=FileSystemLoader(
+            templates_path or self.TEMPLATES_PATH
+        ))
+        template_path = plan_config.get_template_path(None)
+        template = jinja2_env.get_template(template_path)
+        return template.render(params)
+
+    def save_file(self, *args, **kwargs):
+        output_file = super().save_file(*args, **kwargs)
+        os.chmod(output_file, 0o775)
+        return output_file
+
+    def submit(self, job_path):
+        return subprocess.call(job_path)
+
+
+def get_api(lab, **kwargs):
+    """Get a Shell object"""
+    return Shell(lab, **kwargs)

--- a/kernelci/lab/shell.py
+++ b/kernelci/lab/shell.py
@@ -20,8 +20,9 @@ class Shell(LabAPI):
         os.chmod(output_file, 0o775)
         return output_file
 
-    def submit(self, job_path):
-        return subprocess.call(job_path)
+    def submit(self, job_path, get_process=False):
+        process = subprocess.Popen(job_path)
+        return process if get_process else process.pid
 
 
 def get_api(lab, **kwargs):

--- a/kernelci/lab/shell.py
+++ b/kernelci/lab/shell.py
@@ -7,7 +7,8 @@ from kernelci.lab import LabAPI
 class Shell(LabAPI):
 
     def generate(self, params, device_config, plan_config,
-                 callback_opts=None, templates_path='config/scripts'):
+                 callback_opts=None, templates_path='config/scripts',
+                 db_config=None):
         jinja2_env = Environment(loader=FileSystemLoader(
             templates_path or self.TEMPLATES_PATH
         ))

--- a/kernelci/lab/shell.py
+++ b/kernelci/lab/shell.py
@@ -14,6 +14,8 @@ class Shell(LabAPI):
         ))
         template_path = plan_config.get_template_path(None)
         template = jinja2_env.get_template(template_path)
+        if db_config:
+            params['db_config_yaml'] = db_config.to_yaml()
         return template.render(params)
 
     def save_file(self, *args, **kwargs):


### PR DESCRIPTION
Add `kernelci.lab.shell` to run tests in a local process. Update `kci_test` accordingly to be able to use it.

Note: The script templates are not part of this PR as they are instead being added to [`kernelci-pipeline`](https://github.com/kernelci/kernelci-pipeline).