### PR TITLE
T32412 kernelci.config.test: add DeviceType_shell

### DIFF
--- a/kernelci/config/test.py
+++ b/kernelci/config/test.py
@@ -155,6 +155,13 @@ class DeviceType_riscv(DeviceType):
         super().__init__(name, mach, arch, *args, **kw)
 
 
+class DeviceType_shell(DeviceType):
+
+    def __init__(self, name, mach=None, arch=None, boot_method=None,
+                 *args, **kwargs):
+        super().__init__(name, mach, arch, boot_method, *args, **kwargs)
+
+
 class DeviceTypeFactory(YAMLObject):
     """Factory to create device types from YAML data."""
 
@@ -164,6 +171,7 @@ class DeviceTypeFactory(YAMLObject):
         'arm-dtb': DeviceType_arm,
         'arm64-dtb': DeviceType_arm64,
         'riscv-dtb': DeviceType_riscv,
+        'shell': DeviceType_shell,
     }
 
     @classmethod


### PR DESCRIPTION
Add kernelci.config.test.DeviceType_shell which will be used to run
scripts in a local shell.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>