### PR TITLE
WIP: Create a new lava job template to be used by Chromebook

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -14,6 +14,11 @@ file_system_types:
       x86:     [{arch: i386}, {arch: x86_64}]
       mipsel:  [{arch: mips}]
 
+  chrome-os:
+    url: 'to be defined'
+    arch_map:
+      amd64: [{arch: x86_64}]
+
   cip:
     url: 'https://storage.kernelci.org/images/rootfs/cip/20211105'
     arch_map:
@@ -41,6 +46,12 @@ file_systems:
     ramdisk: 'qemu-{arch}/cip-core-image-kernelci-cip-core-buster-qemu-{arch}-initrd.img.gz'
     nfs: 'qemu-{arch}/cip-core-image-kernelci-cip-core-buster-qemu-{arch}.tar.gz'
     root_type: nfs
+
+  chrome_version:
+    type: chrome-os
+    ramdisk: 'to be defined'
+    emmc: 'to be defined'
+    root_type: emmc
 
   debian_bullseye_ramdisk:
     type: debian
@@ -356,6 +367,12 @@ test_plans:
 
   smc:
     rootfs: buildroot_baseline_ramdisk
+
+  tast:
+    rootfs: chrome_version
+    pattern: 'chromeos/{category}-{method}-{protocol}-{rootfs}-chromeos-template.jinja2'
+    filters:
+      - passlist: {defconfig: ['x86_64_defconfig+x86-chromebook']}
 
   usb:
     rootfs: debian_bullseye_ramdisk
@@ -1988,6 +2005,7 @@ test_configs:
       - ltp-mm
       - sleep_mem
       - smc
+      - tast
 
   - device_type: hsdk
     test_plans:

--- a/config/lava/boot/generic-emmc-tftp-chromebook-boot-template.jinja2
+++ b/config/lava/boot/generic-emmc-tftp-chromebook-boot-template.jinja2
@@ -1,0 +1,20 @@
+{% extends 'base/kernel-ci-base-tftp-deploy.jinja2' %}
+
+tags: ['cbg-0']
+
+{% block actions %}
+{%- block deploy %}
+{{ super () }}
+{%- endblock %}
+{% block kernel_image_type %}
+{%- endblock %}
+
+- boot:
+    timeout:
+      minutes: 30
+    method: depthcharge
+    commands: emmc
+    prompts:
+      - 'sof-audio-pci'
+
+{% endblock %}

--- a/config/lava/chromeos/chromeos.jinja2
+++ b/config/lava/chromeos/chromeos.jinja2
@@ -1,0 +1,35 @@
+- test:
+    timeout:
+      minutes: 45
+    docker:
+      image: kernelci/chromeos-tast
+      volumes:
+        - /tmp/octupos:/home/cros-tast/octupos
+      wait:
+        device: true
+    results:
+      location: /home/cros-tast/lava
+    definitions:
+      repository:
+        metadata:
+          format: Lava-Test Test Definition 1.0
+          name: docker-ping
+          description: "chromeos-flash"
+        run:
+          steps:
+            - uname -a
+            - pwd
+            - ls -l
+            - ls -l /home/cros-tast
+#             - 'cd /home/cros-tast; curl -s http://172.17.0.1/chromeos/autotest_server_package_octopus_R92_13981.0.0.tar.bz2 | tar xjf -'
+#             - 'chown -R cros-tast: /home/cros-tast'
+            - ls -l /home/cros-tast
+            - ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /home/cros-tast/.ssh/id_rsa root@$(lava-target-ip) whoami
+#             - 'cd /home/cros-tast/tast; ./tast list -build=false root@$(lava-target-ip)'
+#             - while true; do date; sleep 15; done
+      from: inline
+      name: docker-ping-inline
+      path: inline/docker-ping.yaml
+
+    - repository: tast tarball?
+      name: {{ specific_tast_test }}

--- a/config/lava/chromeos/generic-depthcharge-tftp-emmc-chromeos-template.jinja2
+++ b/config/lava/chromeos/generic-depthcharge-tftp-emmc-chromeos-template.jinja2
@@ -1,0 +1,8 @@
+{% extends 'boot/generic-emmc-tftp-chromebook-boot-template.jinja2' %}
+
+{% block actions %}
+{{ super () }}
+
+{% include 'chromeos/chromeos.jinja2' %}
+
+{% endblock %}


### PR DESCRIPTION
config/core/test.yaml: add test_plan, file_system and buildroot hypothetical entries to be used in Chromebook devices and their lava job template.

lava/chrome: include basic jinja2 template for Chromebook devices.

Signed-off-by: Alexandra Pereira <alexandra.pereira@collabora.com>