### PR TITLE
build-configs.yml: add clang-14 build env and replace clang-13

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -322,6 +322,12 @@ build_environments:
     arch_params:
       <<: *clang_12_arch_params
 
+  clang-14:
+    cc: clang
+    cc_version: 14
+    arch_params:
+      <<: *clang_12_arch_params
+
 # Default config with full build coverage
 build_configs_defaults:
   variants:
@@ -707,8 +713,8 @@ build_configs:
         architectures: *arch_clang_configs
 
       # Latest clang release
-      clang-13:
-        build_environment: clang-13
+      clang-14:
+        build_environment: clang-14
         architectures:
           <<: *arch_clang_configs
           riscv:


### PR DESCRIPTION
Add the latest clang version, clang-14 to the build-configs.yml. Replace
the clang-13 with clang-14 for builds.

Signed-off-by: Muhammad Usama Anjum <usama.anjum@collabora.com>