### PR TITLE
build-configs.yaml: add RTC_DRV_MT6397 to arm64-chromebook

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -141,6 +141,7 @@ fragments:
     configs:
       - 'CONFIG_REGULATOR_DA9211=y'
       - 'CONFIG_ARM_MEDIATEK_CPUFREQ=y'
+      - 'CONFIG_RTC_DRV_MT6397=y'
 
   crypto:
     path: "kernel/configs/crypto.config"


### PR DESCRIPTION
Add CONFIG_RTC_DRV_MT6397=y to the arm64-chromebook config fragment to
enable kselftest-rtc tests on mt8173-elm-hana.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>