### PR TITLE
build-configs.yaml: add INTERCONNECT_QCOM_SC7180 to arm64-chromebook

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -145,6 +145,9 @@ fragments:
       - 'CONFIG_REGULATOR_DA9211=y'
       - 'CONFIG_ARM_MEDIATEK_CPUFREQ=y'
       - 'CONFIG_RTC_DRV_MT6397=y'
+      # This is required for sc7180-trogdor-lazor-limozeen and it hasn't been
+      # merged upstream yet.
+      - 'CONFIG_INTERCONNECT_QCOM_SC7180=y'
 
   crypto:
     path: "kernel/configs/crypto.config"


### PR DESCRIPTION
Add CONFIG_INTERCONNECT_QCOM_SC7180=y to the arm64-chromebook fragment which is needed for sc7180-trogdor-lazor-limozeen.