### PR TITLE
Add kci_test validate_rootfs_urls

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -76,7 +76,7 @@ file_systems:
     type: debian
     ramdisk: 'bullseye-rt/20211216.0/{arch}/rootfs.cpio.gz'
 
-  debian_buster_kselftest:
+  debian_buster-kselftest_nfs:
     type: debian
     ramdisk: 'buster-kselftest/20211224.2/{arch}/initrd.cpio.gz'
     nfs: 'buster-kselftest/20211224.2/{arch}/full.rootfs.tar.xz'
@@ -240,7 +240,7 @@ test_plans:
       drm_driver: "tegra"
 
   kselftest: &kselftest
-    rootfs: debian_buster_kselftest
+    rootfs: debian_buster-kselftest_nfs
     pattern: 'kselftest/{category}-{method}-{protocol}-{rootfs}-kselftest-template.jinja2'
     filters:
       - passlist: {defconfig: ['kselftest']}

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -32,7 +32,7 @@ file_system_types:
 
 file_systems:
 
-  buildroot_baseline_ramdisk:
+  buildroot-baseline_ramdisk:
     type: buildroot
     ramdisk: 'buildroot-baseline/20211210.0/{arch}/rootfs.cpio.gz'
 
@@ -120,7 +120,7 @@ default_filters:
 test_plans:
 
   baseline:
-    rootfs: buildroot_baseline_ramdisk
+    rootfs: buildroot-baseline_ramdisk
     filters:
       - blocklist: *kselftest_defconfig_filter
 
@@ -131,7 +131,7 @@ test_plans:
       - blocklist: *kselftest_defconfig_filter
 
   baseline-fastboot:
-    rootfs: buildroot_baseline_ramdisk
+    rootfs: buildroot-baseline_ramdisk
     pattern: 'baseline/generic-fastboot-baseline-template.jinja2'
     params:
       job_timeout: '50'
@@ -144,13 +144,13 @@ test_plans:
 
   baseline_qemu:
     base_name: baseline
-    rootfs: buildroot_baseline_ramdisk
+    rootfs: buildroot-baseline_ramdisk
     pattern: 'baseline/generic-qemu-baseline-template.jinja2'
     filters:
       - blocklist: *kselftest_defconfig_filter
 
   baseline-qemu-docker:
-    rootfs: buildroot_baseline_ramdisk
+    rootfs: buildroot-baseline_ramdisk
     pattern: 'baseline/generic-qemu-baseline-docker-template.jinja2'
     filters:
       - blocklist: *kselftest_defconfig_filter
@@ -374,7 +374,7 @@ test_plans:
       sleep_params: mem
 
   smc:
-    rootfs: buildroot_baseline_ramdisk
+    rootfs: buildroot-baseline_ramdisk
 
   usb:
     rootfs: debian_bullseye_ramdisk

--- a/kci_test
+++ b/kci_test
@@ -21,6 +21,7 @@ import argparse
 import glob
 import json
 import os
+import requests
 import sys
 
 from kernelci.cli import Args, Command, parse_opts
@@ -81,15 +82,30 @@ class cmd_validate_rootfs_urls(Command):
         rootfs_configs = config_data['rootfs_configs']
         for fs, fs_config in file_systems_config.items():
             fs_parts = fs.split('_')
-            print(fs_parts)
             if fs_parts[0] == 'debian':
                 fs_name = fs_parts[1]
+                root_type = fs_parts[2]
             elif fs_parts[0].startswith('buildroot'):
                 fs_name = fs_parts[0]
+                root_type = fs_parts[1]
             else:
                 continue
-            fs_config = rootfs_configs.get(fs_name)
-            print(fs_config)
+            rootfs_config = rootfs_configs.get(fs_name)
+            url_formats = list(
+                url_fmt for url_fmt in (
+                    fs_config.get_url_format(fmt_type)
+                    for fmt_type in set({root_type}).union({'nfs', 'ramdisk'})
+                ) if url_fmt
+            )
+            if args.verbose:
+                print(fs)
+            for arch in rootfs_config.arch_list:
+                for url_format in url_formats:
+                    url = url_format.format(arch=arch)
+                    resp = requests.head(url)
+                    if args.verbose:
+                        print(f"  {resp.status_code} {url}")
+                    resp.raise_for_status()
         return True
 
 

--- a/kci_test
+++ b/kci_test
@@ -72,6 +72,27 @@ class cmd_validate(Command):
         return True
 
 
+class cmd_validate_rootfs_urls(Command):
+    help = "Check that all the rootfs URLs are valid"
+    opt_args = [Args.verbose]
+
+    def __call__(self, config_data, args, **kwargs):
+        file_systems_config = config_data['file_systems']
+        rootfs_configs = config_data['rootfs_configs']
+        for fs, fs_config in file_systems_config.items():
+            fs_parts = fs.split('_')
+            print(fs_parts)
+            if fs_parts[0] == 'debian':
+                fs_name = fs_parts[1]
+            elif fs_parts[0].startswith('buildroot'):
+                fs_name = fs_parts[0]
+            else:
+                continue
+            fs_config = rootfs_configs.get(fs_name)
+            print(fs_config)
+        return True
+
+
 class cmd_list_jobs(Command):
     help = "List all the jobs that need to be run for a given build and lab"
     args = [Args.lab_config]

--- a/kernelci/config/test.py
+++ b/kernelci/config/test.py
@@ -316,13 +316,16 @@ class RootFS(YAMLObject):
         })
         return attrs
 
+    def get_url_format(self, fs_type):
+        return self._url_format.get(fs_type)
+
     def get_url(self, fs_type, arch, endian):
         """Get the URL of the file system for the given variant and arch.
 
         The *fs_type* should match one of the URL patterns known to this root
         file system.
         """
-        fmt = self._url_format.get(fs_type)
+        fmt = self.get_url_format(fs_type)
         if not fmt:
             return None
         arch_name = self._fs_type.get_arch_name(arch, endian)


### PR DESCRIPTION
Add a `kci_test validate_rootfs_urls` command to verify all the rootfs URLs in `test-configs.yaml` are valid.  Fix a few loose ends in `test-configs.yaml` to keep the rootfs config names consistent.