### PR TITLE
test-configs.yaml: Enable kselftest-rtc test plan on rk3399-gru-kevin

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2411,6 +2411,7 @@ test_configs:
       - baseline
       - baseline-nfs
       - cros-ec
+      - kselftest-rtc
       - ltp-fcntl-locktests
       - ltp-pty
       - ltp-timers


### PR DESCRIPTION
The rk3399-gru-kevin device uses the rtc-cros-ec driver for RTC. This PR adds the kselftest-rtc test on kevin to exercise this driver. The config needed to enable the driver is already part of the arm64 defconfig.

LAVA run: https://lava.collabora.co.uk/scheduler/job/5409783

As can be seen from the LAVA output, the `alarm_alm_set_minute` test, which sets an alarm, is failing with timeout. From a first look it seems like a bug in the `rtc-cros-ec` driver.