### PR TITLE
test-configs.yaml: replace buster-v4l2 with bullseye-v4l2

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -76,6 +76,10 @@ file_systems:
     type: debian
     ramdisk: 'bullseye-rt/20211216.0/{arch}/rootfs.cpio.gz'
 
+  debian_bullseye-v4l2_ramdisk:
+    type: debian
+    ramdisk: 'bullseye-v4l2/20220112.0/{arch}/rootfs.cpio.gz'
+
   debian_buster-kselftest_nfs:
     type: debian
     ramdisk: 'buster-kselftest/20211224.2/{arch}/initrd.cpio.gz'
@@ -83,10 +87,6 @@ file_systems:
     root_type: nfs
     params:
       os_config: 'debian'
-
-  debian_buster-v4l2_ramdisk:
-    type: debian
-    ramdisk: 'buster-v4l2/20211224.3/{arch}/rootfs.cpio.gz'
 
 
 
@@ -386,13 +386,13 @@ test_plans:
     rootfs: debian_bullseye_ramdisk
 
   v4l2-compliance-uvc:
-    rootfs: debian_buster-v4l2_ramdisk
+    rootfs: debian_bullseye-v4l2_ramdisk
     # FIXME - this is not very sustainable, improve template naming scheme
     pattern: 'v4l2-compliance/{category}-{method}-{protocol}-{rootfs}-v4l2-compliance-template.jinja2'
     params: {v4l2_driver: "uvcvideo"}
 
   v4l2-compliance-vivid:
-    rootfs: debian_buster-v4l2_ramdisk
+    rootfs: debian_bullseye-v4l2_ramdisk
     pattern: 'v4l2-compliance/generic-qemu-v4l2-compliance-template.jinja2'
     params: {v4l2_driver: "vivid"}
     filters:


### PR DESCRIPTION
Replace the buster-v4l2 rootfs images with the new bullseye-v4l2 ones.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>