### PR TITLE
kci_bisect: add get_mbox command

### DIFF
--- a/kci_bisect
+++ b/kci_bisect
@@ -44,9 +44,16 @@ class cmd_get_recipients(Command):
 class cmd_get_mbox(Command):
     help = "Get an mbox email for a given commit"
     args = [Args.kdir, Args.commit]
+    opt_args = [
+        {
+            'name': '--base-url',
+            'default': 'https://lore.kernel.org/all/?',
+            'help': "Skip git pull",
+        },
+    ]
 
     def __call__(self, configs, args):
-        mbox = kernelci.bisect.get_mbox(args.kdir, args.commit)
+        mbox = kernelci.bisect.get_mbox(args.kdir, args.commit, args.base_url)
         if not mbox:
             return False
         print(mbox)

--- a/kci_bisect
+++ b/kci_bisect
@@ -41,6 +41,18 @@ class cmd_get_recipients(Command):
         return True
 
 
+class cmd_get_mbox(Command):
+    help = "Get an mbox email for a given commit"
+    args = [Args.kdir, Args.commit]
+
+    def __call__(self, configs, args):
+        mbox = kernelci.bisect.get_mbox(args.kdir, args.commit)
+        if not mbox:
+            return False
+        print(mbox)
+        return True
+
+
 if __name__ == '__main__':
     opts = parse_opts("kci_bisect", globals())
     configs = kernelci.config.load(opts.yaml_config)

--- a/kernelci/bisect.py
+++ b/kernelci/bisect.py
@@ -131,9 +131,9 @@ def get_recipients(kdir, commit, to=set(), cc=set()):
     return {'to': list(to), 'cc': list(cc)}
 
 
-def _lore_atom_query(subject):
+def _lore_atom_query(subject, base_url):
     query = urllib.parse.urlencode({'x': 'A', 'q': subject})
-    url = 'https://lore.kernel.org/lkml/?' + query
+    url = base_url + query
     resp = requests.get(url)
     resp.raise_for_status()
     return xml.dom.minidom.parseString(resp.text)
@@ -183,9 +183,9 @@ def _lore_mbox(url):
     return resp.text
 
 
-def get_mbox(kdir, commit):
+def get_mbox(kdir, commit, base_url):
     subject = _git_show_fmt(kdir, commit, '%s')
-    dom = _lore_atom_query(subject)
+    dom = _lore_atom_query(subject, base_url)
     entries = _lore_get_entries(dom)
     if not entries:
         return None


### PR DESCRIPTION
Add `kci_bisect get_mbox` command to get a Mailbox email from
lore.kernel.org that matches a given git commit number.  This is not
guaranteed to succeed as not all commits have an email in lore, and
some heuristics are used to determine which email to use when there
are several with a matching subject.  It's mostly a shortcut for
reporting an issue manually (typically, bisection results).

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>