### PR TITLE
kernelci.build: don't convert publish path to lower-case

### DIFF
--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -1121,7 +1121,7 @@ scripts/kconfig/merge_config.sh -O {output} '{base}' '{frag}' {redir}
         bmeta = self._meta.get('bmeta')
         rev, env = (bmeta[cat] for cat in ('revision', 'environment'))
         publish_path = '/'.join((
-            re.sub(r'[\/:]', '-', item).lower() for item in [
+            re.sub(r'[\/:]', '-', item) for item in [
                 rev['tree'],
                 rev['branch'],
                 rev['describe'],


### PR DESCRIPTION
Stop converting all the elements in the publish path to lower case as
the config string with e.g. +CONFIG_SOMETHING=y needs to remain in
capital letters.  This was most likely introduced by mistake as
there's no apparent reason for using lower-case, even with Chrome OS
config names which the breaking change was originally required for.

Fixes: 2eccce7ab993 ("kernelci.build: replace more characters in publish path")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>