### PR TITLE
Add kselftest-rtc on two x86 chromebooks

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1910,6 +1910,7 @@ test_configs:
       - kselftest-lib
       - kselftest-livepatch
       - kselftest-lkdtm
+      - kselftest-rtc
       - kselftest-seccomp
       - ltp-crypto
       - ltp-fcntl-locktests

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1763,6 +1763,7 @@ test_configs:
       - baseline-nfs
       - kselftest-filesystems
       - kselftest-futex
+      - kselftest-rtc
       - ltp-ipc
       - ltp-mm
       - ltp-timers


### PR DESCRIPTION
The x86 chromebook devices chosen to run the test were hp-11A-G6-EE-grunt and asus-C436FA-Flip-hatch, due to having a lot of them available at the LAVA lab, and them being from different platforms (Stoney Ridge/AMD vs Cometlake-U/Intel).

Lava log for grunt: https://lava.collabora.co.uk/scheduler/job/5453615
Lava log for hatch: https://lava.collabora.co.uk/scheduler/job/5453691

Both devices use the same RTC driver, so their logs and results are similar. The intent in adding both devices is to have some redundancy and achieving the goal of having two devices for each architecture running each kselftest.

All 7 tests pass, although given the rtc kselftest timeout bug, the whole rtc kselftest suite might fail sometimes due to the timeout. That bug should be fixed in the next kernel release (5.17): https://lore.kernel.org/all/20220112194142.3276385-1-nfraprado@collabora.com/. This might cause KernelCI to detect it as a regression, in which case might make more sense to merge this PR after 5.17.