### PR TITLE
build-configs-android: Enable clang-14 builds for more android branches

### DIFF
--- a/config/core/build-configs-android.yaml
+++ b/config/core/build-configs-android.yaml
@@ -138,27 +138,37 @@ build_configs:
   android_mainline:
     tree: android
     branch: 'android-mainline'
-    variants: *android_variants
+    variants:
+      <<: *android_variants
+      <<: *clang_android_variants
 
   android_mainline_tracking:
     tree: android
     branch: 'android-mainline-tracking'
-    variants: *android_variants
+    variants:
+      <<: *android_variants
+      <<: *clang_android_variants
 
   android11-5.4:
     tree: android
     branch: 'android11-5.4'
-    variants: *android_variants
+    variants:
+      <<: *android_variants
+      <<: *clang_android_variants
 
   android12-5.4:
     tree: android
     branch: 'android12-5.4'
-    variants: *android_variants
+    variants:
+      <<: *android_variants
+      <<: *clang_android_variants
 
   android12-5.4-lts:
     tree: android
     branch: 'android12-5.4-lts'
-    variants: *android_variants
+    variants:
+      <<: *android_variants
+      <<: *clang_android_variants
 
   android12-5.10:
     tree: android


### PR DESCRIPTION
Enable clang-14 builds for android-mainline, android-mainline-tracking,
android11-5.4, android12-5.4 and android12-5.4-lts branches.

Signed-off-by: Muhammad Usama Anjum <usama.anjum@collabora.com>