### PR TITLE
T31627 - create lava job for chrome os

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -157,6 +157,11 @@ test_plans:
 
   chromeos-tast:
     pattern: 'chromeos/chromeos-tast-template.jinja2'
+    params:
+      job_timeout: '60'
+      prompt_command: 'sof-audio-pci'
+      docker_image: 'kernelci/chromeos-tast'
+      cros_tast_tarball: 'http://172.17.0.1/chromeos/autotest_server_package_octopus_R92_13981.0.0.tar.bz2'
 
   cros-ec:
     rootfs: debian_bullseye-cros-ec_ramdisk

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -155,6 +155,9 @@ test_plans:
       - passlist: &qemu_labs_filter
           lab: ['lab-baylibre', 'lab-collabora-staging']
 
+  chromeos-tast:
+    pattern: 'chromeos/chromeos-tast-template.jinja2'
+
   cros-ec:
     rootfs: debian_bullseye-cros-ec_ramdisk
 
@@ -1992,6 +1995,7 @@ test_configs:
       - baseline
       - baseline-cip-nfs
       - baseline-nfs
+      - chromeos-tast
       - cros-ec
       - igt-gpu-i915
       - kselftest-filesystems

--- a/config/lava/base/kernel-ci-base.jinja2
+++ b/config/lava/base/kernel-ci-base.jinja2
@@ -23,9 +23,15 @@ metadata:
   job.name: {{ name }}
   job.kernel_url: {{ kernel_url }}
   job.kernel_image: {{ kernel_image }}
+{%- if modules_url %}
   job.modules_url: {{ modules_url }}
+{% endif %}
+{%- if initrd_url %}
   job.initrd_url: {{ initrd_url }}
+{% endif %}
+{%- if nfsrootfs_url %}
   job.nfsrootfs_url: {{ nfsrootfs_url }}
+{% endif %}
   job.dtb_url: {{ dtb_url }}
   job.file_server_resource: {{ file_server_resource }}
   job.build_environment: {{ build_environment }}

--- a/config/lava/chromeos/chromeos-tast-template.jinja2
+++ b/config/lava/chromeos/chromeos-tast-template.jinja2
@@ -1,0 +1,48 @@
+{% extends 'base/kernel-ci-base.jinja2' %}
+{% block main %}
+{% do context.update({"extra_kernel_args": "console_msg_format=syslog earlycon cros_debug cros_secure root=/dev/mmcblk0p3" }) %}
+{{ super() }}
+{% endblock %}
+{% block actions %}
+actions:
+  - deploy:
+      timeout:
+        minutes: {{ job_timeout }}
+      to: tftp
+      kernel:
+        url: {{ kernel_url }}
+      os: oe
+
+  - boot:
+      timeout:
+        minutes: 30
+      method: depthcharge
+      commands: emmc
+      prompts:
+        - {{ prompt_command }}
+
+  - test:
+      timeout:
+        minutes: 45
+      docker:
+        image: {{ docker_image }}
+        wait:
+          device: true
+      results:
+          location: /home/cros-tast/lava
+      definitions:
+      - repository:
+          metadata:
+            format: Lava-Test Test Definition 1.0
+            name: docker-chromeos-tast
+          run:
+            steps:
+              - 'cd /home/cros-tast; curl -s {{cros_tast_tarball}} | tar xjf -'
+              - 'chown -R cros-tast: /home/cros-tast'
+              - 'ls -l /home/cros-tast'
+              - 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /home/cros-tast/.ssh/id_rsa root@$(lava-target-ip) whoami'
+              - 'cd /home/cros-tast/tast; ./tast list -build=false root@$(lava-target-ip)'
+        from: inline
+        name: docker-chromeos-tast
+        path: inline/docker-chromeos-tast.yaml
+{% endblock %}


### PR DESCRIPTION
Add a new lava job template to be used by chrome OS at this first step to run Tast tests.