### PR TITLE
test-configs.yaml: Add rk3399-rock-pi-4b

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1414,6 +1414,11 @@ device_types:
       - blocklist: *device_config_filter
       - blocklist: {kernel: ['v3.', 'v4.4', 'v4.9']}
 
+  rk3399-rock-pi-4b:
+    mach: rockchip
+    class: arm64-dtb
+    boot_method: uboot
+
   sc7180-trogdor-lazor-limozeen:
     mach: qcom
     class: arm64-dtb
@@ -2450,6 +2455,11 @@ test_configs:
   - device_type: rk3399-puma-haikou
     test_plans:
       - baseline
+
+  - device_type: rk3399-rock-pi-4b
+    test_plans:
+      - baseline
+      - baseline-nfs
 
   - device_type: sc7180-trogdor-lazor-limozeen
     test_plans:


### PR DESCRIPTION
Add the rk3399-rock-pi-4b device and enable the baseline tests on it.

Lava run for baseline OK: https://lava.collabora.co.uk/scheduler/job/5486817
Lava run for baseline-nfs OK: https://lava.collabora.co.uk/scheduler/job/5486703

The device tree used by this specific device variant, rk3399-rock-pi-4b.dts, was created only in 5.9. Before that a single generic dt was used for all RockPi4's. So a blocklist or allowlist needs to be added to ensure that only 5.10+ kernels run on this device. @gctucker how could that be done? I've seen the other examples, but I haven't been able to find the list of kernel releases that are run in KernelCI, so that I can block all the ones below 5.10.