### PR TITLE
kci_rootfs: Preserve extra packes in the image

### DIFF
--- a/config/rootfs/debos/rootfs.yaml
+++ b/config/rootfs/debos/rootfs.yaml
@@ -160,7 +160,7 @@ actions:
 
   - action: run
     chroot: true
-    script: scripts/strip.sh
+    script: scripts/strip.sh "{{ $extra_packages }}"
 
 {{ if $extra_packages_remove }}
   - action: run

--- a/config/rootfs/debos/scripts/strip.sh
+++ b/config/rootfs/debos/scripts/strip.sh
@@ -9,14 +9,26 @@ set -e
 rm -rf /etc/localtime
 cp /usr/share/zoneinfo/Etc/UTC /etc/localtime
 
+EXTRA_PACKAGES=$(echo "${1}" | xargs -n1)
+EXTRA_TEMP_FILE=$(mktemp strip_extra_packages.XXXXXX)
+exec 3>"$EXTRA_TEMP_FILE"
+echo "$EXTRA_PACKAGES" | sort | uniq >&3
 
-UNNEEDED_PACKAGES=" libfdisk1"\
-" tzdata"\
+UNNEEDED_PACKAGES=" libfdisk1 \
+tzdata"
+UNNEEDED_TEMP_FILE=$(mktemp strip_unneeded_packages.XXXXXX)
+exec 4>"$UNNEEDED_TEMP_FILE"
+echo "$UNNEEDED_PACKAGES" | xargs -n1 | sort | uniq >&4
+
+PACKAGES_TO_REMOVE=$(comm  -23  "$UNNEEDED_TEMP_FILE" "$EXTRA_TEMP_FILE")
 
 export DEBIAN_FRONTEND=noninteractive
 
+exec 3>&-
+exec 4>&-
+
 # Removing unused packages
-for PACKAGE in ${UNNEEDED_PACKAGES}
+for PACKAGE in ${PACKAGES_TO_REMOVE}
 do
 	echo ${PACKAGE}
 	if ! apt-get remove --purge --yes "${PACKAGE}"


### PR DESCRIPTION
Remove packages listed in extra_packages section from the list of
packages to remove in the strip.sh script. This prevents kci_rootfs from
accidentally removing packages needed by tests.
