### PR TITLE
Add bullseye-cros-ec rootfs image

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -50,6 +50,31 @@ rootfs_configs:
     script: "scripts/install-bootrr.sh"
     test_overlay: "overlays/baseline"
 
+  bullseye-cros-ec:
+    rootfs_type: debos
+    debian_release: bullseye
+    arch_list:
+      - amd64
+      - arm64
+      - armhf
+    extra_packages:
+      - python3-minimal
+      - python3-unittest2
+      - tzdata
+    extra_packages_remove:
+      - bash
+      - e2fslibs
+      - e2fsprogs
+      - libext2fs2
+    extra_firmware:
+      - mrvl/pcieusb8997_combo_v4.bin
+      - mrvl/sd8897_uapsta.bin
+      - qca/rampatch_00440302.bin
+      - rtl_nic/rtl8153b-2.fw
+      - rockchip/dptx.bin
+    script: "scripts/bullseye-cros-ec-tests.sh"
+    test_overlay: ""
+
   bullseye-igt:
     rootfs_type: debos
     debian_release: bullseye

--- a/config/rootfs/debos/rootfs.yaml
+++ b/config/rootfs/debos/rootfs.yaml
@@ -160,7 +160,7 @@ actions:
 
   - action: run
     chroot: true
-    script: scripts/strip.sh
+    script: scripts/strip.sh "{{ $extra_packages }}"
 
 {{ if $extra_packages_remove }}
   - action: run

--- a/config/rootfs/debos/scripts/bullseye-cros-ec-tests.sh
+++ b/config/rootfs/debos/scripts/bullseye-cros-ec-tests.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -x
+
+# Important: This script is run under QEMU
+
+set -e
+
+# Build-depends needed to build the test suites, they'll be removed later
+BUILD_DEPS="\
+    git \
+    python3-setuptools \
+    python3-pip
+"
+
+apt-get install --no-install-recommends -y ${BUILD_DEPS}
+apt-mark manual python3 libpython3-stdlib libpython3.9-stdlib python3.9
+
+########################################################################
+# Build tests                                                          #
+########################################################################
+
+BUILDFILE=/test_suites.json
+echo '{  "tests_suites": [' >> $BUILDFILE
+
+########################################################################
+# Build and install tests                                              #
+########################################################################
+
+CROS_URL="https://git.kernel.org/pub/scm/linux/kernel/git/chrome-platform/cros-ec-tests.git"
+CROS_SHA=$(git ls-remote ${CROS_URL} | head -n 1 | cut -f 1)
+
+pip3 install git+${CROS_URL}@${CROS_SHA}
+
+echo '    {"name": "cros-ec-tests", "git_url": "'$CROS_URL'", "git_commit": "'$CROS_SHA'" }' >> $BUILDFILE
+echo '  ]}' >> $BUILDFILE
+
+########################################################################
+# Cleanup: remove files and packages we don't want in the images       #
+########################################################################
+
+rm -fr /src/cros-ec-tests
+
+apt-get remove --purge -y ${BUILD_DEPS} perl-modules-5.32
+apt-get autoremove --purge -y
+apt-get clean
+

--- a/config/rootfs/debos/scripts/strip.sh
+++ b/config/rootfs/debos/scripts/strip.sh
@@ -9,14 +9,26 @@ set -e
 rm -rf /etc/localtime
 cp /usr/share/zoneinfo/Etc/UTC /etc/localtime
 
+EXTRA_PACKAGES=$(echo "${1}" | xargs -n1)
+EXTRA_TEMP_FILE=$(mktemp strip_extra_packages.XXXXXX)
+exec 3>"$EXTRA_TEMP_FILE"
+echo "$EXTRA_PACKAGES" | sort | uniq >&3
 
-UNNEEDED_PACKAGES=" libfdisk1"\
-" tzdata"\
+UNNEEDED_PACKAGES=" libfdisk1 \
+tzdata"
+UNNEEDED_TEMP_FILE=$(mktemp strip_unneeded_packages.XXXXXX)
+exec 4>"$UNNEEDED_TEMP_FILE"
+echo "$UNNEEDED_PACKAGES" | xargs -n1 | sort | uniq >&4
+
+PACKAGES_TO_REMOVE=$(comm  -23  "$UNNEEDED_TEMP_FILE" "$EXTRA_TEMP_FILE")
 
 export DEBIAN_FRONTEND=noninteractive
 
+exec 3>&-
+exec 4>&-
+
 # Removing unused packages
-for PACKAGE in ${UNNEEDED_PACKAGES}
+for PACKAGE in ${PACKAGES_TO_REMOVE}
 do
 	echo ${PACKAGE}
 	if ! apt-get remove --purge --yes "${PACKAGE}"


### PR DESCRIPTION
Add Debian bullseye based image configuration for cros-ec tests.

Depends on https://github.com/kernelci/kernelci-core/pull/995