### PR TITLE
build-configs.yaml: add kselftest tree with fixes and next branches

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -655,6 +655,12 @@ build_configs:
             <<: *x86_64_defconfig
             fragments: [x86-chromebook]
             extra_configs: ['x86_64+defconfig+kselftest+x86-chromebook']
+      clang-14:
+        build_environment: clang-14
+        fragments: [kselftest]
+        architectures:
+          arm64: *arm64_defconfig
+          x86_64: *x86_64_defconfig
 
   lee_android_3.18:
     tree: lee

--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -637,7 +637,7 @@ build_configs:
     tree: krzysztof
     branch: 'for-next'
 
-  kselftest_fixes:
+  kselftest_fixes: &kselftest-tree
     tree: kselftest
     branch: 'fixes'
     variants:
@@ -645,22 +645,33 @@ build_configs:
         build_environment: gcc-10
         fragments: [kselftest]
         architectures:
-          arm: *arm_defconfig
-          arm64:
+          arm:
+            <<: *arm_defconfig
+            filters: &kselftest-only
+              - regex: { defconfig: '.*kselftest.*' }
+          arm64: &arm64-kselftest
             <<: *arm64_defconfig
             fragments: [arm64-chromebook]
             extra_configs: ['defconfig+kselftest+arm64-chromebook']
-          i386: *i386_defconfig
-          x86_64:
+            filters: *kselftest-only
+          i386:
+            <<: *i386_defconfig
+            filters: *kselftest-only
+          x86_64: &x86_64-kselftest
             <<: *x86_64_defconfig
             fragments: [x86-chromebook]
             extra_configs: ['x86_64+defconfig+kselftest+x86-chromebook']
+            filters: *kselftest-only
       clang-14:
         build_environment: clang-14
         fragments: [kselftest]
         architectures:
-          arm64: *arm64_defconfig
-          x86_64: *x86_64_defconfig
+          arm64: *arm64-kselftest
+          x86_64: *x86_64-kselftest
+
+  kselftest_next:
+    <<: *kselftest-tree
+    branch: 'next'
 
   lee_android_3.18:
     tree: lee

--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -58,6 +58,9 @@ trees:
   krzysztof:
     url: "https://git.kernel.org/pub/scm/linux/kernel/git/krzk/linux.git"
 
+  kselftest:
+    url: 'https://git.kernel.org/pub/scm/linux/kernel/git/shuah/linux-kselftest.git'
+
   lee:
     url: "https://git.kernel.org/pub/scm/linux/kernel/git/lee/linux.git"
 
@@ -633,6 +636,25 @@ build_configs:
   krzysztof:
     tree: krzysztof
     branch: 'for-next'
+
+  kselftest_fixes:
+    tree: kselftest
+    branch: 'fixes'
+    variants:
+      gcc-10:
+        build_environment: gcc-10
+        fragments: [kselftest]
+        architectures:
+          arm: *arm_defconfig
+          arm64:
+            <<: *arm64_defconfig
+            fragments: [arm64-chromebook]
+            extra_configs: ['defconfig+kselftest+arm64-chromebook']
+          i386: *i386_defconfig
+          x86_64:
+            <<: *x86_64_defconfig
+            fragments: [x86-chromebook]
+            extra_configs: ['x86_64+defconfig+kselftest+x86-chromebook']
 
   lee_android_3.18:
     tree: lee


### PR DESCRIPTION
Add the linux-kselftest tree with a build config for the "fixes" and "next" branches including a small set of builds to cover all the kselftest currently being run on actual hardware.

Link: https://lore.kernel.org/lkml/5fd1a35c-f84e-1c6a-4a3a-be76dda97ca3@collabora.com/