### PR TITLE
test-configs.yaml: use latest bullseye-ltp for QEMU

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -74,7 +74,7 @@ file_systems:
 
   debian_bullseye-ltp_ramdisk:
     type: debian
-    ramdisk: 'bullseye-ltp/20211221.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'bullseye-ltp/20220121.0/{arch}/rootfs.cpio.gz'
 
   debian_bullseye-rt_ramdisk:
     type: debian


### PR DESCRIPTION
Update the URL of the newly defined bullseye-ltp ramdisk which is used
on QEMU.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>