### PR TITLE
Fix how templates_path is used in kernelci.lab

### DIFF
--- a/kernelci/lab/lava/__init__.py
+++ b/kernelci/lab/lava/__init__.py
@@ -43,7 +43,7 @@ class LavaAPI(LabAPI):
         })
         if callback_opts:
             self._add_callback_params(params, callback_opts)
-        jinja2_env = Environment(loader=FileSystemLoader('config/lava'),
+        jinja2_env = Environment(loader=FileSystemLoader(templates_path),
                                  extensions=["jinja2.ext.do"])
         template = jinja2_env.get_template(short_template_file)
         data = template.render(params)

--- a/kernelci/lab/shell.py
+++ b/kernelci/lab/shell.py
@@ -9,9 +9,7 @@ class Shell(LabAPI):
     def generate(self, params, device_config, plan_config,
                  callback_opts=None, templates_path='config/scripts',
                  db_config=None):
-        jinja2_env = Environment(loader=FileSystemLoader(
-            templates_path or self.TEMPLATES_PATH
-        ))
+        jinja2_env = Environment(loader=FileSystemLoader(templates_path))
         template_path = plan_config.get_template_path(None)
         template = jinja2_env.get_template(template_path)
         if db_config:


### PR DESCRIPTION
Fix a couple of places where the `templates_path` was not being used correctly.