### PR TITLE
kernelci.config.base: fix default filters

### DIFF
--- a/kernelci/config/base.py
+++ b/kernelci/config/base.py
@@ -190,5 +190,5 @@ class FilterFactory(YAMLObject):
 def default_filters_from_yaml(data):
     return {
         entry_type: FilterFactory.from_yaml(filters_data)
-        for entry_type, filters_data in data.get('default_filters').items()
+        for entry_type, filters_data in data.get('default_filters', {}).items()
     }


### PR DESCRIPTION
Fix default filters when they're not defined in YAML using an empty
dictionary.

Fixes: 6374126064e3 ("kernelci.config: group default filters under default_filters")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>