### PR TITLE
kernelci.data.kernelci_api: fix PUT requests when udating documents

### DIFF
--- a/kernelci/data/kernelci_api.py
+++ b/kernelci/data/kernelci_api.py
@@ -79,8 +79,9 @@ class KernelCI_API(Database):
         obj_list = []
         for path, item in data.items():
             try:
-                if 'id' in item.keys():
-                    resp = self._put(path, json.dumps(item))
+                node_id = item.get('_id')
+                if node_id:
+                    resp = self._put(f"{path}/{node_id}", json.dumps(item))
                 else:
                     resp = self._post(path, json.dumps(item))
             except requests.exceptions.HTTPError as ex:


### PR DESCRIPTION
Fix how the PUT requests are used when updating documents by checking
whether the data contains an '_id' rather than 'id', and if there is
one then use it in the URL path as it's required for PUT requests.

Fixes: 63774f174681 ("kernelci/data/kernelci_api.py: Add logic to use PUT in submit()")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>