### PR TITLE
kci_rootfs: Remove temporary files in strip.sh

### DIFF
--- a/config/rootfs/debos/scripts/strip.sh
+++ b/config/rootfs/debos/scripts/strip.sh
@@ -27,6 +27,9 @@ export DEBIAN_FRONTEND=noninteractive
 exec 3>&-
 exec 4>&-
 
+rm "$UNNEEDED_TEMP_FILE"
+rm "$EXTRA_TEMP_FILE"
+
 # Removing unused packages
 for PACKAGE in ${PACKAGES_TO_REMOVE}
 do


### PR DESCRIPTION
Remove temporary files after the descriptors are closed.