### PR TITLE
test-configs.yaml: update rootfs URLs

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -44,26 +44,26 @@ file_systems:
 
   debian_bullseye_ramdisk:
     type: debian
-    ramdisk: 'bullseye/20220121.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'bullseye/20220128.0/{arch}/rootfs.cpio.gz'
 
   debian_bullseye_nfs:
     type: debian
-    ramdisk: 'bullseye/20220121.0/{arch}/initrd.cpio.gz'
-    nfs: 'bullseye/20220121.0/{arch}/full.rootfs.tar.xz'
+    ramdisk: 'bullseye/20220128.0/{arch}/initrd.cpio.gz'
+    nfs: 'bullseye/20220128.0/{arch}/full.rootfs.tar.xz'
     root_type: nfs
 
   debian_bullseye-cros-ec_ramdisk:
     type: debian
-    ramdisk: 'bullseye-cros-ec/20220127.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'bullseye-cros-ec/20220128.0/{arch}/rootfs.cpio.gz'
 
   debian_bullseye-igt_ramdisk:
     type: debian
-    ramdisk: 'bullseye-igt/20220121.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'bullseye-igt/20220128.0/{arch}/rootfs.cpio.gz'
 
   debian_bullseye-libcamera_nfs:
     type: debian
-    ramdisk: 'bullseye-libcamera/20220121.0/{arch}/initrd.cpio.gz'
-    nfs: 'bullseye-libcamera/20220121.0/{arch}/full.rootfs.tar.xz'
+    ramdisk: 'bullseye-libcamera/20220128.0/{arch}/initrd.cpio.gz'
+    nfs: 'bullseye-libcamera/20220128.0/{arch}/full.rootfs.tar.xz'
     root_type: nfs
 
   debian_bullseye-ltp_nfs:
@@ -78,16 +78,16 @@ file_systems:
 
   debian_bullseye-rt_ramdisk:
     type: debian
-    ramdisk: 'bullseye-rt/20220121.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'bullseye-rt/20220128.0/{arch}/rootfs.cpio.gz'
 
   debian_bullseye-v4l2_ramdisk:
     type: debian
-    ramdisk: 'bullseye-v4l2/20220121.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'bullseye-v4l2/20220128.0/{arch}/rootfs.cpio.gz'
 
   debian_buster-kselftest_nfs:
     type: debian
-    ramdisk: 'buster-kselftest//20220121.0/{arch}/initrd.cpio.gz'
-    nfs: 'buster-kselftest//20220121.0/{arch}/full.rootfs.tar.xz'
+    ramdisk: 'buster-kselftest//20220128.0/{arch}/initrd.cpio.gz'
+    nfs: 'buster-kselftest//20220128.0/{arch}/full.rootfs.tar.xz'
     root_type: nfs
     params:
       os_config: 'debian'


### PR DESCRIPTION
Update rootfs URLs to 20220128.0. Buildroot and bullseye-ltp rootfs
images failed to build and are not updated.