### PR TITLE
Run QEMU LAVA tests only in Docker containers

### DIFF
--- a/config/core/lab-configs.yaml
+++ b/config/core/lab-configs.yaml
@@ -85,7 +85,6 @@ labs:
     filters: &collabora-filters
       - blocklist:
           tree: [android]
-          plan: [baseline-qemu-docker]
 
   lab-collabora-staging:
     lab_type: lava.lava_rest
@@ -133,7 +132,6 @@ labs:
       - passlist:
           plan:
             - baseline
-      - blocklist: {plan: [baseline-qemu-docker]}
 
   lab-pengutronix:
     lab_type: lava.lava_rest
@@ -142,7 +140,6 @@ labs:
       - passlist:
           plan:
             - baseline
-      - blocklist: {plan: [baseline-qemu-docker]}
 
   lab-theobroma-systems:
     lab_type: lava.lava_xmlrpc
@@ -151,7 +148,6 @@ labs:
       - passlist:
           plan:
             - baseline
-      - blocklist: {plan: [baseline-qemu-docker]}
 
   shell:
     lab_type: shell

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -153,12 +153,6 @@ test_plans:
     filters:
       - blocklist: *kselftest_defconfig_filter
 
-  baseline-qemu-docker:
-    rootfs: buildroot-baseline_ramdisk
-    pattern: 'baseline/generic-qemu-baseline-docker-template.jinja2'
-    filters:
-      - blocklist: *kselftest_defconfig_filter
-
   cros-ec:
     rootfs: debian_bullseye-cros-ec_ramdisk
 
@@ -2318,7 +2312,6 @@ test_configs:
   - device_type: qemu_arm-virt-gicv3
     test_plans:
       - baseline_qemu
-      - baseline-qemu-docker
       - smc
       - v4l2-compliance-vivid
 
@@ -2337,7 +2330,6 @@ test_configs:
   - device_type: qemu_arm64-virt-gicv3
     test_plans:
       - baseline_qemu
-      - baseline-qemu-docker
       - smc
       - v4l2-compliance-vivid
 
@@ -2348,7 +2340,6 @@ test_configs:
   - device_type: qemu_i386
     test_plans:
       - baseline_qemu
-      - baseline-qemu-docker
 
   - device_type: qemu_i386-uefi
     test_plans:
@@ -2356,12 +2347,11 @@ test_configs:
 
   - device_type: qemu_riscv64
     test_plans:
-      - baseline-qemu-docker
+      - baseline_qemu
 
   - device_type: qemu_x86_64
     test_plans:
       - baseline_qemu
-      - baseline-qemu-docker
       - ltp-timers_qemu
       - smc
       - v4l2-compliance-vivid

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -152,6 +152,8 @@ test_plans:
     pattern: 'baseline/generic-qemu-baseline-template.jinja2'
     filters:
       - blocklist: *kselftest_defconfig_filter
+      - passlist: &qemu_labs_filter
+          lab: ['lab-baylibre', 'lab-collabora-staging']
 
   cros-ec:
     rootfs: debian_bullseye-cros-ec_ramdisk
@@ -369,6 +371,10 @@ test_plans:
       <<: *ltp-params
       grp_test: "TMR"
       job_timeout: '30'
+    filters:
+      - combination: *arch_defconfig_filter
+      - blocklist: *kselftest_defconfig_filter
+      - passlist: *qemu_labs_filter
 
   preempt-rt:
     rootfs: debian_bullseye-rt_ramdisk
@@ -389,6 +395,15 @@ test_plans:
 
   smc:
     rootfs: buildroot-baseline_ramdisk
+
+  smc_qemu:
+    base_name: smc
+    rootfs: buildroot-baseline_ramdisk
+    pattern: 'smc/{category}-{method}-{protocol}-{rootfs}-smc-template.jinja2'
+    filters:
+      - combination: *arch_defconfig_filter
+      - blocklist: *kselftest_defconfig_filter
+      - passlist: *qemu_labs_filter
 
   usb:
     rootfs: debian_bullseye_ramdisk
@@ -2312,7 +2327,7 @@ test_configs:
   - device_type: qemu_arm-virt-gicv3
     test_plans:
       - baseline_qemu
-      - smc
+      - smc_qemu
       - v4l2-compliance-vivid
 
   - device_type: qemu_arm-virt-gicv3-uefi
@@ -2330,7 +2345,7 @@ test_configs:
   - device_type: qemu_arm64-virt-gicv3
     test_plans:
       - baseline_qemu
-      - smc
+      - smc_qemu
       - v4l2-compliance-vivid
 
   - device_type: qemu_arm64-virt-gicv3-uefi
@@ -2353,7 +2368,7 @@ test_configs:
     test_plans:
       - baseline_qemu
       - ltp-timers_qemu
-      - smc
+      - smc_qemu
       - v4l2-compliance-vivid
 
   - device_type: qemu_x86_64-uefi

--- a/config/lava/baseline/generic-qemu-baseline-docker-template.jinja2
+++ b/config/lava/baseline/generic-qemu-baseline-docker-template.jinja2
@@ -1,2 +1,0 @@
-{% set qemu_docker = True %}
-{% include 'baseline/generic-qemu-baseline-template.jinja2' %}

--- a/config/lava/boot/generic-qemu-boot-template.jinja2
+++ b/config/lava/boot/generic-qemu-boot-template.jinja2
@@ -58,11 +58,9 @@ actions:
       minutes: 5
     method: qemu
     media: tmpfs
-{%- if qemu_docker %}
     docker:
       image: kernelci/qemu
       binary: {{ qemu_binary }}
-{%- endif %}
     prompts:
       - '{{ rootfs_prompt }}'
 {% endblock %}


### PR DESCRIPTION
Convert configuration and LAVA job templates to always use Docker when running QEMU tests.

Fixes #1014