### PR TITLE
test-config: distribute core kernel kselftests

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2025,6 +2025,12 @@ test_configs:
   - device_type: imx6q-sabrelite
     test_plans:
       - baseline
+      - kselftest-filesystems
+      - kselftest-futex
+      - kselftest-lib
+      - kselftest-livepatch
+      - kselftest-lkdtm
+      - kselftest-seccomp
 
   - device_type: imx6q-sabrelite
     test_plans:
@@ -2146,6 +2152,9 @@ test_configs:
     test_plans:
       - baseline
       - baseline-nfs
+      - kselftest-filesystems
+      - kselftest-futex
+      - kselftest-lib
 
   - device_type: meson-g12b-odroid-n2
     test_plans:
@@ -2227,6 +2236,7 @@ test_configs:
       - kselftest-filesystems
       - kselftest-futex
       - kselftest-lib
+      - kselftest-livepatch
       - kselftest-lkdtm
       - kselftest-rtc
       - kselftest-seccomp
@@ -2245,6 +2255,8 @@ test_configs:
     test_plans:
       - baseline
       - baseline-nfs
+      - kselftest-lkdtm
+      - kselftest-seccomp
 
   - device_type: mustang
     test_plans:
@@ -2443,7 +2455,6 @@ test_configs:
       - cros-ec
       - igt-gpu-panfrost
       - igt-kms-rockchip
-      - kselftest-lib
       - ltp-timers
       - sleep
       - usb


### PR DESCRIPTION
Distribute core kernel kselftests on all available devices per
architecture. One kselftest should run on at least two different
devices of same architecture when there is no capacity issue. Add or
remove kselftests to different devices to make this normalization.
These changes have been done after doing analysis that how many devices
devices are available of certain architecture.

Signed-off-by: Muhammad Usama Anjum <usama.anjum@collabora.com>

---
The latest proposal, "Proposal - 2" can be seen in the [spreadsheet](https://docs.google.com/spreadsheets/d/1ffrb_zP1WqKNaLx3W6eOdp39CbXzvpUKBwiWtgtxfwM/edit#gid=0).
