### PR TITLE
Add ChromiumOS image building functionality as rootfs option

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -255,6 +255,13 @@ rootfs_configs:
       - wget
       - xz-utils
 
+  chromiumos-amd64-generic:
+    rootfs_type: chromiumos
+    board: amd64-generic
+    branch: release-R99-14469.B
+    arch_list:
+      - amd64
+
   sid:
     rootfs_type: debos
     debian_release: sid

--- a/config/docker/build-and-push.sh
+++ b/config/docker/build-and-push.sh
@@ -60,6 +60,7 @@ debos \
 dt-validation \
 k8s \
 qemu \
+chromiumos \
 "
 
 if [ -n "$*" ]; then

--- a/config/docker/chromiumos/Dockerfile
+++ b/config/docker/chromiumos/Dockerfile
@@ -1,0 +1,37 @@
+# syntax=docker/dockerfile:1
+FROM debian:bullseye-slim
+MAINTAINER "KernelCI TSC" <kernelci-tsc@groups.io>
+
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends \
+        sudo \
+        ca-certificates \
+        netbase \
+	git \
+	build-essential \
+	python3 \
+	curl \
+	wget \
+	ssh \
+    && apt-get clean \
+    && apt-get autoremove \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN useradd -u 1000 -ms /bin/sh user && adduser user sudo && echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+RUN mkdir -p /home/user/chromiumos && chown -R user /home/user/chromiumos
+
+# Extra packages needed by kernelCI
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    python3.9 \
+    python3-requests \
+    python3-yaml
+
+USER user
+ENV HOME=/home/user
+WORKDIR $HOME/chromiumos
+
+RUN git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
+ENV PATH="/home/user/chromiumos/depot_tools:${PATH}"
+
+WORKDIR /kernelci-core

--- a/config/rootfs/chromiumos/scripts/build_board.sh
+++ b/config/rootfs/chromiumos/scripts/build_board.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+set -e
+BOARD=$1
+BRANCH=$2
+DATA_DIR=$(pwd)
+
+# Building SDK itself
+if [ ! -d chromiumos-sdk ]; then
+  sudo mkdir chromiumos-sdk
+  sudo chown user chromiumos-sdk
+  cd chromiumos-sdk
+  git config --global user.email "bot@kernelci.org"
+  git config --global user.name "KernelCI Bot"
+  git config --global color.ui false
+  repo init --repo-url https://chromium.googlesource.com/external/repo --manifest-url https://chromium.googlesource.com/chromiumos/manifest --manifest-name default.xml --manifest-branch ${BRANCH} --depth=1
+  repo sync -j$(nproc)
+  cros_sdk --create
+else
+  cd chromiumos-sdk
+  # We might have different branch
+  repo init --repo-url https://chromium.googlesource.com/external/repo --manifest-url https://chromium.googlesource.com/chromiumos/manifest --manifest-name default.xml --manifest-branch ${BRANCH} --depth=1
+  repo sync -j$(nproc)
+  cros_sdk --create
+fi
+
+# Compiling ChromiumOS image
+# Future possible option --profile=x, for example kernel-5_15, profiles are at /mnt/host/source/src/overlays/overlay-${BOARD}/profiles/
+cros_sdk setup_board --board=${BOARD} --force
+# Add serial support
+cros_sdk USE=pcserial ./build_packages --board=${BOARD}
+cros_sdk USE="tty_console_ttyS0" emerge-${BOARD} chromeos-base/tty
+cros_sdk ./build_image --enable_serial ttyS0 --board=${BOARD} --boot_args "earlyprintk=serial,keep console=tty0" --noenable_rootfs_verification test
+
+# Create artifacts dir and copy generated image and tast files
+sudo mkdir -p ${DATA_DIR}/${BOARD}
+sudo cp src/build/images/${BOARD}/latest/chromiumos_test_image.bin ${DATA_DIR}/${BOARD}
+sudo cp ./chroot/usr/bin/remote_test_runner ${DATA_DIR}/${BOARD}
+sudo cp ./chroot/usr/bin/tast ${DATA_DIR}/${BOARD}
+
+# Delete build directory
+[ -d "${DATA_DIR}/chromiumos-sdk/chroot/build" ] && sudo rm -rf ${DATA_DIR}/chromiumos-sdk/chroot/build && echo Build directory deleted

--- a/doc/kci_rootfs.md
+++ b/doc/kci_rootfs.md
@@ -22,7 +22,7 @@ You will be using `kernelci/debos` docker image for this purpose.
    ```
    sudo docker run -itd \
      -v $(pwd)/kernelci-core:/kernelci-core \
-     --device /dev/kvm \
+     --device /dev/kvm -v /dev:/dev \
      --privileged kernelci/debos
    sudo docker exec -it <container_id> bash
    cd /kernelci-core/

--- a/kernelci/cli.py
+++ b/kernelci/cli.py
@@ -263,7 +263,7 @@ class Args:
         'name': '--rootfs-type',
         'help': "Rootfs type",
         'type': str,
-        'choices': ('debos', 'buildroot')
+        'choices': ('debos', 'buildroot', 'chromiumos')
     }
 
     storage = {

--- a/kernelci/config/rootfs.py
+++ b/kernelci/config/rootfs.py
@@ -159,10 +159,42 @@ class RootFS_Buildroot(RootFS):
         return list(self._arch_list)
 
 
+class RootFS_ChromiumOS(RootFS):
+    def __init__(self, name, rootfs_type, arch_list=None, board=None,
+                 branch=None):
+        super().__init__(name, rootfs_type)
+        self._arch_list = arch_list or list()
+        self._board = board
+        self._branch = branch
+
+    @classmethod
+    def from_yaml(cls, config, name):
+        kw = {
+            'name': name,
+        }
+        kw.update(cls._kw_from_yaml(config, [
+            'rootfs_type', 'arch_list', 'board', 'branch'
+        ]))
+        return cls(**kw)
+
+    @property
+    def arch_list(self):
+        return list(self._arch_list)
+
+    @property
+    def board(self):
+        return self._board
+
+    @property
+    def branch(self):
+        return self._branch
+
+
 class RootFSFactory(YAMLObject):
     _rootfs_types = {
         'debos': RootFS_Debos,
         'buildroot': RootFS_Buildroot,
+        'chromiumos': RootFS_ChromiumOS,
     }
 
     @classmethod
@@ -203,6 +235,8 @@ def validate(configs):
             return _validate_debos(name, config)
         elif config.rootfs_type == 'buildroot':
             return _validate_buildroot(name, config)
+        elif config.rootfs_type == 'chromiumos':
+            return _validate_chromiumos(name, config)
         else:
             print('Invalid rootfs type {} for config name {}'
                   .format(config.rootfs_type, name))
@@ -242,6 +276,15 @@ def _validate_buildroot(name, config):
     return True
 
 
+def _validate_chromiumos(name, config):
+    err = sort_check(config.arch_list)
+    if err:
+        print("Arch order broken for {}: '{}' before '{}".format(
+            name, err[0], err[1]))
+        return False
+    return True
+
+
 def dump_configs(configs):
     """Prints rootfs configs to stdout
 
@@ -252,6 +295,8 @@ def dump_configs(configs):
             _dump_config_debos(config_name, config)
         elif config.rootfs_type == 'buildroot':
             _dump_config_buildroot(config_name, config)
+        elif config.rootfs_type == 'chromiumos':
+            _dump_config_chromiumos(config_name, config)
 
 
 def _dump_config_debos(config_name, config):
@@ -279,3 +324,11 @@ def _dump_config_buildroot(config_name, config):
     print('\trootfs_type: {}'.format(config.rootfs_type))
     print('\tarch_list: {}'.format(config.arch_list))
     print('\tfrags: {}'.format(config.frags))
+
+
+def _dump_config_chromiumos(config_name, config):
+    print(config_name)
+    print('\trootfs_type: {}'.format(config.rootfs_type))
+    print('\tarch_list: {}'.format(config.arch_list))
+    print('\board: {}'.format(config.board))
+    print('\branch: {}'.format(config.branch))

--- a/kernelci/rootfs.py
+++ b/kernelci/rootfs.py
@@ -65,6 +65,15 @@ def _build_buildroot(name, config, data_path, arch, frag='baseline'):
     return shell_cmd(cmd, True)
 
 
+def _build_chromiumos(name, config, data_path, arch):
+    cmd = 'cd {data_path} && ./scripts/build_board.sh {board} {branch}'.format(
+        data_path=data_path,
+        board=config.board,
+        branch=config.branch
+    )
+    return shell_cmd(cmd, True)
+
+
 def build(name, config, data_path, arch):
     """Build rootfs images.
 
@@ -77,6 +86,8 @@ def build(name, config, data_path, arch):
         return _build_debos(name, config, data_path, arch)
     elif config.rootfs_type == "buildroot":
         return _build_buildroot(name, config, data_path, arch)
+    elif config.rootfs_type == "chromiumos":
+        return _build_chromiumos(name, config, data_path, arch)
     else:
         raise ValueError("rootfs_type not supported: {}"
                          .format(config.rootfs_type))


### PR DESCRIPTION
With just:

docker run -itd -v $(pwd):/kernelci-core --device /dev/kvm -v /dev:/dev --privileged kernelci/chromiumos
./kci_rootfs build --rootfs-config chromiumos --data-path config/rootfs/chromiumos --arch amd64-generic
(And several hours of build time)
I can get qemu bootable image:
config/rootfs/chromiumos/amd64-generic/chromiumos_test_image.bin
(Must be used with USB storage disk, if we use libvirt)

As ChromiumOS dont have strictly speaking "architecture", in our case it means ChromiumOS board name.
So it can be amd64-generic, hatch, etc. 

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>
