### PR TITLE
core/build-configs-android.yaml: drop old android branches

### DIFF
--- a/config/core/build-configs-android.yaml
+++ b/config/core/build-configs-android.yaml
@@ -48,24 +48,9 @@ clang_android_variants: &clang_android_variants
 
 build_configs:
 
-  android_4.4-p:
-    tree: android
-    branch: 'android-4.4-p'
-    variants: *android_variants
-
-  android_4.4-p-release:
-    tree: android
-    branch: 'android-4.4-p-release'
-    variants: *android_variants
-
   android_4.9-p:
     tree: android
     branch: 'android-4.9-p'
-    variants: *android_variants
-
-  android_4.9-p-release:
-    tree: android
-    branch: 'android-4.9-p-release'
     variants: *android_variants
 
   android_4.9-q:
@@ -81,11 +66,6 @@ build_configs:
   android_4.14-p:
     tree: android
     branch: 'android-4.14-p'
-    variants: *android_variants
-
-  android_4.14-p-release:
-    tree: android
-    branch: 'android-4.14-p-release'
     variants: *android_variants
 
   android_4.14-q:


### PR DESCRIPTION
Remove old android branches listed as requested by Todd:
android-4.4-p
android-4.4-p-release
android-4.9-p-release
android-4.14-p-release

Signed-off-by: Alexandra Pereira <alexandra.pereira@collabora.com>

https://groups.io/g/kernelci/message/1344