### PR TITLE
build-configs: Add fixes branches for my trees

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -567,17 +567,33 @@ build_configs:
     tree: broonie-regmap
     branch: 'for-next'
 
+  broonie-regmap-fixes:
+    tree: broonie-regmap
+    branch: 'for-linus'
+
   broonie-regulator:
     tree: broonie-regulator
     branch: 'for-next'
+
+  broonie-regulator-fixes:
+    tree: broonie-regulator
+    branch: 'for-linus'
 
   broonie-sound:
     tree: broonie-sound
     branch: 'for-next'
 
+  broonie-sound-fixes:
+    tree: broonie-sound
+    branch: 'for-next-linus'
+
   broonie-spi:
     tree: broonie-spi
     branch: 'for-next'
+
+  broonie-spi-fixes:
+    tree: broonie-spi
+    branch: 'for-linus'
 
   chrome-platform:
     tree: chrome-platform


### PR DESCRIPTION
Add coverage for the fixes branches for my trees, these are no longer
merged into my -next branches and it's useful to check that they don't
have any dependencies on -next material. They are generally updated less
often than the -next branches.

Signed-off-by: Mark Brown <broonie@kernel.org>