### PR TITLE
Run kselftest-tpm2 on grunt

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -268,6 +268,7 @@ fragments:
       - 'CONFIG_TCG_TIS_I2C_CR50=y'
       - 'CONFIG_SPI=y'
       - 'CONFIG_SPI_PXA2XX=y'
+      - 'CONFIG_PINCTRL_AMD=y'
 
   x86_kvm_guest:
     path: "kernel/configs/kvm_guest.config"

--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -159,6 +159,8 @@ rootfs_configs:
       - perl-modules-5.32
       - procps
       - publicsuffix
+      - python3-minimal
+      - python3-unittest2
       - wget
       - xz-utils
 

--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -161,6 +161,7 @@ rootfs_configs:
       - publicsuffix
       - python3-minimal
       - python3-unittest2
+      - tpm2-tools
       - wget
       - xz-utils
 

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1975,6 +1975,7 @@ test_configs:
       - kselftest-lkdtm
       - kselftest-rtc
       - kselftest-seccomp
+      - kselftest-tpm2
       - kselftest-vm
       - ltp-crypto
       - ltp-fcntl-locktests

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -293,6 +293,12 @@ test_plans:
       job_timeout: '10'
       kselftest_collections: "seccomp"
 
+  kselftest-tpm2:
+    <<: *kselftest
+    params:
+      job_timeout: '10'
+      kselftest_collections: "tpm2"
+
   kselftest-vm:
     <<: *kselftest
     params:


### PR DESCRIPTION
This PR gets kselftest-tpm2 running on grunt.

Lava log: https://lava.collabora.co.uk/scheduler/job/5608585

Basically the results are:
```
# selftests: tpm2: test_smoke.sh
# test_read_partial_overwrite (tpm2_tests.SmokeTest) ... ok
# test_read_partial_resp (tpm2_tests.SmokeTest) ... ok
# test_seal_with_auth (tpm2_tests.SmokeTest) ... ERROR
# test_seal_with_policy (tpm2_tests.SmokeTest) ... ERROR
# test_seal_with_too_long_auth (tpm2_tests.SmokeTest) ... FAIL
# test_send_two_cmds (tpm2_tests.SmokeTest) ... ok
# test_too_short_cmd (tpm2_tests.SmokeTest) ... ok
# test_unseal_with_wrong_auth (tpm2_tests.SmokeTest) ... ERROR
# test_unseal_with_wrong_policy (tpm2_tests.SmokeTest) ... ERROR

# test_async (tpm2_tests.AsyncTest) ... ok

# selftests: tpm2: test_space.sh
# test_flush_context (tpm2_tests.SpaceTest) ... /usr/lib/python3.7/unittest/case.py:615: ResourceWarning: unclosed file <_io.FileIO name='/dev/tpmrm0' mode='rb+' closefd=True>
#   testMethod()
# ResourceWarning: Enable tracemalloc to get the object allocation traceback
# ok
# test_get_handles (tpm2_tests.SpaceTest) ... ok
# test_invalid_cc (tpm2_tests.SpaceTest) ... ok
# test_make_two_spaces (tpm2_tests.SpaceTest) ... ok
```

The errors are caused by `tpm2.ProtocolError: TPM_RC_LOCKOUT: cc=0x00000153, rc=0x00000921`. There was [a commit](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=a9920d3bad40201ee8ab1da36bee4674f7e50d69) in the past fixing those, but [it was later reverted](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=5be206eaac9a68992fc3b06fb5dd5634e323de86). However the patch might make sense in KernelCI's usecase, where devices are there just for testing. That said, that patch requires the `tpm2_clear` tool, which is only available in bullseye.

I ran the tests using the `bullseye-kselftest` rootfs from #1024, with the addition of the `tpm2-tools` package, and that patch applied (although modified to clear before rather than after the tests are run), and the errors were gone:
https://lava.collabora.co.uk/scheduler/job/5616044. A single FAIL remained from one of the tests.

So one option would be to, after #1024 is merged, add the `tpm2-tools`  package and carry a patch in KernelCI for kselftest. Ideally the change would be merged upstream, but given that it was reverted already, a different approach would be needed for upstream, and I'm not sure what that would be.
