### PR TITLE
lab-configs.yaml: Enable testing for Renesas trees in lab-cip

### DIFF
--- a/config/core/lab-configs.yaml
+++ b/config/core/lab-configs.yaml
@@ -49,6 +49,8 @@ labs:
             - ['mainline', 'master']
             - ['next', 'master']
             - ['next', 'pending-fixes']
+            - ['renesas', 'master']
+            - ['renesas-next', 'next']
             - ['stable', 'linux-4.4.y']
             - ['stable', 'linux-4.19.y']
             - ['stable', 'linux-5.10.y']


### PR DESCRIPTION
Given that there are a lot of Renesas boards in lab-cip (specifically lab-cip-renesas) it would be good to expand upstream Renesas tree testing to test them.

Thanks