### PR TITLE
config/docker: add clang-15

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -337,6 +337,12 @@ build_environments:
     arch_params:
       <<: *clang_12_arch_params
 
+  clang-15:
+    cc: clang
+    cc_version: 15
+    arch_params:
+      <<: *clang_12_arch_params
+
 # Default config with full build coverage
 build_configs_defaults:
   variants:

--- a/config/docker/clang-15/Dockerfile
+++ b/config/docker/clang-15/Dockerfile
@@ -2,10 +2,10 @@ ARG PREFIX=kernelci/
 FROM ${PREFIX}clang-base
 
 RUN wget -q -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-RUN echo 'deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-14 main' \
+RUN echo 'deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye main' \
    >> /etc/apt/sources.list.d/clang.list
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
-    clang-14 lld-14 llvm-14
+    clang-15 lld-15 llvm-15
 
-ENV PATH=/usr/lib/llvm-14/bin:${PATH}
+ENV PATH=/usr/lib/llvm-15/bin:${PATH}


### PR DESCRIPTION
Update clang-14 Dockerfile and add new one for clang-15 now that the
main repository has moved to clang-15.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>