### PR TITLE
config/docker: Update clang-14 packcages location

### DIFF
--- a/config/docker/clang-14/Dockerfile
+++ b/config/docker/clang-14/Dockerfile
@@ -2,7 +2,7 @@ ARG PREFIX=kernelci/
 FROM ${PREFIX}clang-base
 
 RUN wget -q -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-RUN echo 'deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye main' \
+RUN echo 'deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-14 main' \
    >> /etc/apt/sources.list.d/clang.list
 
 RUN apt-get update && apt-get install --no-install-recommends -y \


### PR DESCRIPTION
Clang-14 packages location has been chanegd as it is still in
development. Update its location.

Signed-off-by: Muhammad Usama Anjum <usama.anjum@collabora.com>