### PR TITLE
config/docker: Add packages for kselftest/alsa

### DIFF
--- a/config/docker/clang-base/Dockerfile
+++ b/config/docker/clang-base/Dockerfile
@@ -17,7 +17,9 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
    libcap-dev \
    libcap-ng-dev \
    libelf-dev \
-   libpopt-dev
+   libpopt-dev \
+   libasound2-dev \
+   pkg-config
 
 # kselftest arm64
 RUN dpkg --add-architecture arm64
@@ -26,7 +28,9 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
    libcap-dev:arm64 \
    libcap-ng-dev:arm64 \
    libelf-dev:arm64 \
-   libpopt-dev:arm64
+   libpopt-dev:arm64 \
+   libasound2-dev:arm64 \
+   pkg-config:arm64
 
 # kselftest arm
 RUN dpkg --add-architecture armhf
@@ -35,6 +39,8 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
    libcap-dev:armhf \
    libcap-ng-dev:armhf \
    libelf-dev:armhf \
-   libpopt-dev:armhf
+   libpopt-dev:armhf \
+   libasound2-dev:armhf \
+   pkg-config:armhf
 
 RUN apt-get autoremove -y gcc

--- a/config/docker/gcc-10_arm/Dockerfile
+++ b/config/docker/gcc-10_arm/Dockerfile
@@ -25,4 +25,6 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
    libhugetlbfs-dev:armhf \
    libmnl-dev:armhf \
    libnuma-dev:armhf \
-   libpopt-dev:armhf
+   libpopt-dev:armhf \
+   libasound2-dev:armhf \
+   pkg-config:armhf

--- a/config/docker/gcc-10_arm64/Dockerfile
+++ b/config/docker/gcc-10_arm64/Dockerfile
@@ -36,4 +36,6 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
    libhugetlbfs-dev:arm64 \
    libmnl-dev:arm64 \
    libnuma-dev:arm64 \
-   libpopt-dev:arm64
+   libpopt-dev:arm64 \
+   libasound2-dev:arm64 \
+   pkg-config:arm64

--- a/config/docker/gcc-10_x86/Dockerfile
+++ b/config/docker/gcc-10_x86/Dockerfile
@@ -17,4 +17,6 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
    libhugetlbfs-dev \
    libmnl-dev \
    libnuma-dev \
-   libpopt-dev
+   libpopt-dev \
+   libasound2-dev \
+   pkg-config


### PR DESCRIPTION
Alsa test needs alsa library which comes from libasound2-dev package.
pkg-config package is being used in Makefile of the test. Add both
packages.

Signed-off-by: Muhammad Usama Anjum <usama.anjum@collabora.com>