### PR TITLE
Enable kselftest-tpm2 on sona

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1954,6 +1954,7 @@ test_configs:
       - baseline
       - baseline-nfs
       - cros-ec
+      - kselftest-tpm2
 
   - device_type: hp-x360-12b-n4000-octopus
     test_plans:


### PR DESCRIPTION
This PR depends on #1025 and #823. Marking as draft for now until they're merged.

The test runs exactly the same as on grunt, #1025, although a different driver is used.

LAVA log run: https://lava.collabora.co.uk/scheduler/job/5655738