### PR TITLE
test-configs.yaml: update buildroot image URL

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -34,7 +34,7 @@ file_systems:
 
   buildroot-baseline_ramdisk:
     type: buildroot
-    ramdisk: 'buildroot-baseline/20220121.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'buildroot-baseline/20220211.1/{arch}/rootfs.cpio.gz'
 
   cip_nfs:
     type: cip


### PR DESCRIPTION
Update the URL for the buildroot images used with the baseline ramdisk
tests.  This contains updates to run TPM tests as part of bootrr.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>