### PR TITLE
test-configs.yaml: Enable kselftest-cpufreq on sona

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1963,6 +1963,7 @@ test_configs:
       - baseline
       - baseline-nfs
       - cros-ec
+      - kselftest-cpufreq
 
   - device_type: hp-x360-12b-n4000-octopus
     test_plans:


### PR DESCRIPTION
sona is an intel x86-64 platform and uses the intel_pstate CPU frequency
scaling driver. Enable kselftest-cpufreq on sona to extend the coverage
to this platform and driver.

Lava run: https://lava.collabora.co.uk/scheduler/job/5696445

Note that the output written by kselftest-cpufreq is only shown on stdout starting with 5.17-rc2, [due to this commit](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=40d70d4d60974c28054a60316f2aec8810833526). Previous versions work the same, there's just no test output.