### PR TITLE
config/lava/kselftest: add missing parameters to template

### DIFF
--- a/config/lava/kselftest/kselftest.jinja2
+++ b/config/lava/kselftest/kselftest.jinja2
@@ -24,3 +24,5 @@
         SKIPFILE: skipfile-lkft.yaml
         TST_CMDFILES: {{ kselftest_collections }}
         TST_CASENAME: {{ kselftest_tests }}
+        BOARD: {{ device_type }}
+        BRANCH: {{ tree }}


### PR DESCRIPTION
Add the BOARD and BRANCH parameters to the kselftest.jinja2 template
as they will then be passed to the skiplist and used to correctly
compute the skipfile.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>