### PR TITLE
config/docker: add 32-bit support to gcc-10 x86

### DIFF
--- a/config/docker/gcc-10_x86/Dockerfile
+++ b/config/docker/gcc-10_x86/Dockerfile
@@ -20,3 +20,9 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
    libpopt-dev \
    libasound2-dev \
    pkg-config
+
+# 32-bit support for kselftest
+RUN apt-get update && apt-get install --no-install-recommends -y \
+   gcc-multilib \
+   libc6-i386 \
+   libc6-dev-i386


### PR DESCRIPTION
Add support for building 32-bit binaries to the gcc-10 x86 Docker
image.  This is useful for some kselftests (x86 and vm) which build
both 64-bit and 32-bit variants of some test programs.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>