### PR TITLE
rootfs-configs.yaml: add libnuma to bullseye-kselftest

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -148,6 +148,7 @@ rootfs_configs:
       - libgdbm6
       - libhugetlbfs0
       - libmnl0
+      - libnuma1
       - libpam-cap
       - libpcre2-8-0
       - libperl5.32


### PR DESCRIPTION
Some vm kselftests are failing due to missing libnuma.so.1:

```
# -------------------------------------------------------
# running KSM MADV_MERGEABLE test with 10 identical pages
# -------------------------------------------------------
# ./ksm_tests: error while loading shared libraries: libnuma.so.1: cannot open shared object file: No such file or directory
# [FAIL]
```

Add the libnuma1 package to the rootfs config to fix this.
