### PR TITLE
kci_rootfs: Add --output option

### DIFF
--- a/kci_rootfs
+++ b/kci_rootfs
@@ -95,7 +95,7 @@ class cmd_list_variants(Command):
 
 class cmd_build(Command):
     help = "Build a rootfs image"
-    args = [Args.rootfs_config, Args.arch]
+    args = [Args.rootfs_config, Args.arch, Args.output]
     opt_args = [Args.data_path]
 
     def __call__(self, config_data, args, **kwargs):
@@ -108,7 +108,8 @@ class cmd_build(Command):
         data_path = (
             args.data_path or 'config/rootfs/{}'.format(config.rootfs_type)
         )
-        return kernelci.rootfs.build(config_name, config, data_path, args.arch)
+        return kernelci.rootfs.build(config_name, config, data_path,
+                                     args.arch, args.output)
 
 
 class cmd_upload(Command):


### PR DESCRIPTION
At current moment kci_rootfs generate artifacts in random, option specific directories,
which increase complexity of build configuration.

This patch adds mandatory --output option for directory, where artifacts generated.

Also it adds git clone option for buildroot, otherwise without it
buildroot rootfs option is incomplete and doesnt work "standalone".

Additionally it will have predictable structure for output:
{output_directory}/{config_name}/{arch}

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>