### PR TITLE
kernelci_api.py: Add KernelCI_API.get_root_node function

### DIFF
--- a/kernelci/data/kernelci_api.py
+++ b/kernelci/data/kernelci_api.py
@@ -83,6 +83,10 @@ class KernelCI_API(Database):
     def get_node_from_event(self, event):
         return self.get_node(event.data['id'])
 
+    def get_root_node(self, node_id):
+        resp = self._get('/'.join(['get_root_node', node_id]))
+        return json.loads(resp.text)
+
     def submit(self, data, verbose=False):
         obj_list = []
         for path, item in data.items():


### PR DESCRIPTION
Add function to call 'get_root_node/' endpoint of
kernelci-api.

Signed-off-by: Jeny Sadadia <jeny.sadadia@gmail.com>