### PR TITLE
test-configs.yaml: enable QEMU Docker in lab-collabora

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -174,6 +174,7 @@ test_plans:
           lab:
             - 'lab-baylibre'
             - 'lab-broonie'
+            - 'lab-collabora'
             - 'lab-collabora-staging'
 
   cros-ec:


### PR DESCRIPTION
Enable QEMU Docker jobs in lab-collabora now that is has been upgraded
to LAVA 2021.01.3.

Depends on #1245 which in turn depends on some extra LAVA changes to be merged and deployed in the lab.