### PR TITLE
v4l2-compliance: Add support for capture and output format arguments

### DIFF
--- a/config/lava/v4l2-compliance/v4l2-compliance.jinja2
+++ b/config/lava/v4l2-compliance/v4l2-compliance.jinja2
@@ -1,6 +1,12 @@
 {% if v4l2_driver %}
     {% set v4l2_driver_arg = "-d " + v4l2_driver %}
 {% endif %}
+{% if v4l2_capture_format %}
+    {% set v4l2_capture_format_arg = "-f " + v4l2_capture_format %}
+{% endif %}
+{% if v4l2_output_format %}
+    {% set v4l2_output_format_arg = "-F " + v4l2_output_format %}
+{% endif %}
 - test:
     timeout:
       minutes: 10
@@ -16,7 +22,7 @@
           - functional
         run:
           steps:
-          - /usr/bin/v4l2-parser.sh {{ v4l2_driver_arg }}
+          - /usr/bin/v4l2-parser.sh {{ v4l2_driver_arg }} {{ v4l2_capture_format_arg }} {{ v4l2_output_format_arg }}
       from: inline
       name: {{ plan }}
       path: inline/{{ plan }}.yaml

--- a/config/lava/v4l2-compliance/v4l2-compliance.jinja2
+++ b/config/lava/v4l2-compliance/v4l2-compliance.jinja2
@@ -1,3 +1,6 @@
+{% if v4l2_driver %}
+    {% set v4l2_driver_arg = "-d " + v4l2_driver %}
+{% endif %}
 - test:
     timeout:
       minutes: 10
@@ -13,7 +16,7 @@
           - functional
         run:
           steps:
-          - /usr/bin/v4l2-parser.sh {{ v4l2_driver }}
+          - /usr/bin/v4l2-parser.sh {{ v4l2_driver_arg }}
       from: inline
       name: {{ plan }}
       path: inline/{{ plan }}.yaml

--- a/config/rootfs/debos/overlays/v4l2/usr/bin/v4l2-parser.sh
+++ b/config/rootfs/debos/overlays/v4l2/usr/bin/v4l2-parser.sh
@@ -19,33 +19,24 @@
 
 set -e
 
-# Video driver name
-driver_name="${1}"
-
-[ -z "$driver_name" ] && {
-    echo "No driver name provided"
-    echo "Usage: v4l2-parser.sh <DRIVER_NAME>"
-    exit 1
-}
-
-IFS=''
-
 # Test set name
 test_set=""
 
 # io index for streaming tests
 test_io=""
 
-device_path=$(v4l2-get-device -d $driver_name | head -n1)
+device_path=$(v4l2-get-device $@ | head -n1)
 
 [ -z "$device_path" ] && {
-    echo "No device found for driver $driver_name"
+    echo "No device found for arguments '$@'"
     lava-test-case device-presence --result fail
     exit 1
 }
 
 lava-test-case device-presence --result pass
 echo "device: $device_path"
+
+IFS=''
 
 v4l2-compliance -s -d $device_path | sed s/'\r'/'\n'/g | while read line; do
     # Skip noisy video capture progress messages


### PR DESCRIPTION
This PR changes the v4l2-parser.sh script and v4l2-compliance.jinja2 template in order to allow for two new parameters to be passed in v4l2-compliance test plans: `v4l2_capture_format` and `v4l2_output_format`. These allow a video node to be matched also based on its capture and/or output format. This is useful since there are some platforms (like mt8173) that have more than one codec device using the same driver, and the only difference between them is the capture/output format. So these arguments allow each of the codec on platforms like this to be tested independently.

The matching of the device node based on the format needs to be done in the v4l-get-device utility, so [a Merge Request](https://gitlab.collabora.com/gtucker/v4l2-get-device/-/merge_requests/1) was created adding this functionality to it. Hence, these two new arguments added in the third commit of this PR can only be used after that MR in v4l2-get-device is merged.

Example LAVA run: https://lava.collabora.co.uk/scheduler/job/5810811
It uses the updated v4l2-get-device and changed argument syntax in v4l2-parser to match `/dev/video2`, which uses the `mtk-vcodec-enc` driver and has the `VP80` capture format, through the command `/usr/bin/v4l2-parser.sh -d mtk-vcodec-enc -f VP80`. There's another `mtk-vcodec-enc` device at `/dev/video1` which is (successfully) not matched by these arguments.