### PR TITLE
CHROMEOS Add ping to docker image

### DIFF
--- a/config/docker/chromeos-tast/Dockerfile
+++ b/config/docker/chromeos-tast/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 RUN apt-get update && apt-get install -y \
     curl \
     git \
+    inetutils-ping \
     python3 \
     python-pkg-resources \
     vim \


### PR DESCRIPTION
As qemu chromiumos need time to bring network up,
it is much easier and faster to wait it with ping.

Tested with https://lava.collabora.co.uk/scheduler/job/5827818

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>