### PR TITLE
CHROMEOS Add LAVA template for QEMU tast tests

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -163,6 +163,18 @@ test_plans:
       docker_image: 'kernelci/chromeos-tast'
       cros_tast_tarball: 'http://172.17.0.1/chromeos/autotest_server_package_octopus_R92_13981.0.0.tar.bz2'
 
+  chromiumosvm-tast-fixed-kernel:
+    pattern: 'chromeos/chromiumosvm-tast-template.jinja2'
+    filters:
+      - blocklist: *kselftest_defconfig_filter
+      - passlist: &qemu_chromiumos_labs_filter
+          lab: ['lab-collabora-staging', 'lab-collabora']
+    params:
+      job_timeout: '60'
+      docker_image: 'kernelci/chromeos-tast'
+      rootfs_url: 'https://storage.chromeos.kernelci.org/images/rootfs/chromeos/crostest006/chromiumos-amd64-generic/amd64/'
+      fixed_kernel: true
+
   cros-ec:
     rootfs: debian_bullseye-cros-ec_ramdisk
 
@@ -1382,6 +1394,31 @@ device_types:
     params: &uefi_x86_64
       bios_url: 'http://storage.kernelci.org/images/uefi/edk2-stable202005/x86_64/OVMF.fd'
 
+  qemu_x86_64-uefi-chromiumos:
+    base_name: qemu
+    mach: qemu
+    arch: x86_64
+    boot_method: qemu
+    params:
+      bios_url: 'http://storage.kernelci.org/images/uefi/edk2-stable202005/x86_64/OVMF.fd'
+    context:
+      arch: x86_64
+      cpu: 'qemu64'
+      guestfs_interface: 'virtio'
+      extra_options:
+        - '-device pcie-root-port,port=0x10,chassis=1,id=pci.1,bus=pcie.0,multifunction=on,addr=0x2'
+        - '-device pcie-root-port,port=0x15,chassis=6,id=pci.6,bus=pcie.0,addr=0x2.0x5'
+        - '-device qemu-xhci,p2=15,p3=15,id=usb,bus=pci.6,addr=0x0'
+        - '-device usb-storage,bus=usb.0,drive=lavatest2'
+        - '-m 2048'
+        - '-device usb-tablet,id=input0,bus=usb.0,port=2'
+        - '-device pcie-root-port,port=0x11,chassis=2,id=pci.2,bus=pcie.0,addr=0x2.0x1'
+        - '-device virtio-vga,id=video0,virgl=on,max_outputs=1,bus=pcie.0,addr=0x3'
+        - '-device ich9-intel-hda,id=sound0,bus=pcie.0,addr=0x1b'
+        - '-machine pc-q35-5.2,accel=kvm,usb=off,vmport=off,dump-guest-core=off'
+    filters:
+      - passlist: {}
+
   qemu_x86_64-uefi-mixed:
     <<: *qemu_x86_64
     params: *uefi_i386
@@ -2417,6 +2454,10 @@ test_configs:
   - device_type: qemu_x86_64-uefi-mixed
     test_plans:
       - baseline_qemu
+
+  - device_type: qemu_x86_64-uefi-chromiumos
+    test_plans:
+      - chromiumosvm-tast-fixed-kernel
 
   - device_type: r8a774a1-hihope-rzg2m-ex
     test_plans:

--- a/config/lava/chromeos/chromeos-tast-template.jinja2
+++ b/config/lava/chromeos/chromeos-tast-template.jinja2
@@ -5,7 +5,7 @@
 {% endblock %}
 {% block actions %}
 actions:
-  - deploy:
+- deploy:
       timeout:
         minutes: {{ job_timeout }}
       to: tftp
@@ -13,7 +13,7 @@ actions:
         url: {{ kernel_url }}
       os: oe
 
-  - boot:
+- boot:
       timeout:
         minutes: 30
       method: depthcharge
@@ -21,28 +21,6 @@ actions:
       prompts:
         - {{ prompt_command }}
 
-  - test:
-      timeout:
-        minutes: 45
-      docker:
-        image: {{ docker_image }}
-        wait:
-          device: true
-      results:
-          location: /home/cros-tast/lava
-      definitions:
-      - repository:
-          metadata:
-            format: Lava-Test Test Definition 1.0
-            name: docker-chromeos-tast
-          run:
-            steps:
-              - 'cd /home/cros-tast; curl -s {{cros_tast_tarball}} | tar xjf -'
-              - 'chown -R cros-tast: /home/cros-tast'
-              - 'ls -l /home/cros-tast'
-              - 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /home/cros-tast/.ssh/id_rsa root@$(lava-target-ip) whoami'
-              - 'cd /home/cros-tast/tast; ./tast list -build=false root@$(lava-target-ip)'
-        from: inline
-        name: docker-chromeos-tast
-        path: inline/docker-chromeos-tast.yaml
+{% include 'chromeos/tast.jinja2' %}
+
 {% endblock %}

--- a/config/lava/chromeos/chromiumosvm-tast-template.jinja2
+++ b/config/lava/chromeos/chromiumosvm-tast-template.jinja2
@@ -1,0 +1,37 @@
+{% extends 'base/kernel-ci-base.jinja2' %}
+{% block main %}
+{{ super () }}
+{% endblock %}
+
+{% block actions %}
+{{ super () }}
+
+actions:
+- deploy:
+    images:
+      bios:
+        image_arg: -bios {bios}
+        url: http://storage.kernelci.org/images/uefi/edk2-stable202005/x86_64/OVMF.fd
+      rootfs:
+        image_arg: -drive format=raw,file={rootfs},id=lavatest2,if=none
+        url: {{ rootfs_url }}chromiumos_test_image.bin.gz
+        compression: gz
+{% if fixed_kernel is not defined %}
+# FIXME not supported yet
+{% endif %}
+    os: oe
+    timeout:
+      minutes: {{ job_timeout }}
+    to: tmpfs
+
+- boot:
+    method: qemu
+    media: tmpfs
+    timeout:
+      minutes: 5
+    prompts:
+    - "login:"
+
+{% include 'chromeos/tast.jinja2' %}
+
+{% endblock %}

--- a/config/lava/chromeos/tast.jinja2
+++ b/config/lava/chromeos/tast.jinja2
@@ -1,0 +1,30 @@
+- test:
+      timeout:
+        minutes: 45
+      docker:
+        image: {{ docker_image }}
+        wait:
+          device: true
+      results:
+          location: /home/cros-tast/lava
+      definitions:
+      - repository:
+          metadata:
+            format: Lava-Test Test Definition 1.0
+            name: tast-tests
+          run:
+            steps:
+              - 'cd /home/cros-tast'
+{%- if cros_tast_tarball %}
+              - 'curl -s {{cros_tast_tarball}} | tar xjf -'
+{% endif %}
+{%- if rootfs_url %}
+              - 'curl -s {{rootfs_url}}tast.tgz | tar xzf -'
+              - 'cp remote_test_runner /usr/bin/remote_test_runner'
+{% endif %}
+              - 'while ! ping -c 1 -w 1 $(lava-target-ip); do sleep 1; done'
+              - 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /home/cros-tast/.ssh/id_rsa root@$(lava-target-ip) whoami'
+              - './tast-parser.py example.ARCFixture example.ManyParams.arc_state example.Param.dog example.Pass example.Fail'
+        from: inline
+        name: docker-tast-tests
+        path: inline/docker-tast-tests.yaml


### PR DESCRIPTION
As QEMU version of ChromiumOS have slightly different boot
sequence and uses tast built from ChromiumOS sources, it require separate LAVA template.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>