### PR TITLE
build-configs.yaml: bump mainline to clang-11

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -296,10 +296,10 @@ build_environments:
         name: 'riscv64'
         cross_compile: 'riscv64-linux-gnu-'
 
-  clang-10:
+  clang-11:
     cc: clang
-    cc_version: 10
-    arch_params: &clang_10_arch_params
+    cc_version: 11
+    arch_params: &clang_11_arch_params
       arm:
         <<: *arm_params
         name:
@@ -316,16 +316,11 @@ build_environments:
         <<: *x86_64_params
         name:
 
-  clang-11:
-    cc: clang
-    cc_version: 11
-    arch_params: *clang_10_arch_params
-
   clang-12:
     cc: clang
     cc_version: 12
     arch_params: &clang_12_arch_params
-      <<: *clang_10_arch_params
+      <<: *clang_11_arch_params
       riscv:
         <<: *riscv_params
         name:
@@ -728,8 +723,8 @@ build_configs:
     variants:
       gcc-10: *default_gcc-10
       # Minimum version
-      clang-10:
-        build_environment: clang-10
+      clang-11:
+        build_environment: clang-11
         architectures: *arch_clang_configs
       # Latest stable release
       clang-13:


### PR DESCRIPTION
Bump mainline builds from clang-10 to clang-11 as it is now the
minimal version supported.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>