### PR TITLE
rootfs-configs.yaml: Fix bullseye-v4l2 release

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -206,7 +206,7 @@ rootfs_configs:
 
   bullseye-v4l2:
     rootfs_type: debos
-    debian_release: buster
+    debian_release: bullseye
     arch_list:
       - amd64
       - arm64

--- a/config/rootfs/debos/scripts/bullseye-v4l2.sh
+++ b/config/rootfs/debos/scripts/bullseye-v4l2.sh
@@ -70,7 +70,7 @@ cd /tmp
 rm -rf /tmp/tests
 
 apt-get remove --purge -y ${BUILD_DEPS}
-apt-get remove --purge -y perl-modules-5.28
+apt-get remove --purge -y perl-modules-5.32
 apt-get autoremove --purge -y
 apt-get clean
 


### PR DESCRIPTION
Set debian release for bullseye-v4l2 to bullseye.

Signed-off-by: Laura Nao <laura.nao@collabora.com>