### PR TITLE
test-configs.yaml: update bullseye-v4l2 rootfs URLs

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -89,8 +89,8 @@ file_systems:
     ramdisk: 'bullseye-rt/20220228.1/{arch}/rootfs.cpio.gz'
 
   debian_bullseye-v4l2_ramdisk:
-    type: debian
-    ramdisk: 'bullseye-v4l2/20220228.1/{arch}/rootfs.cpio.gz'
+    type: debian-staging
+    ramdisk: 'bullseye-v4l2/20220309.1/{arch}/rootfs.cpio.gz'
 
 
 


### PR DESCRIPTION
Update the bullseye-v4l2 rootfs URLs with the new builds with a fix to
actually use Debian Bullseye as well as support for capture / output
format options for v4l2-compliance by passing arguments directly in
the v4l2-parser.sh script.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>