### PR TITLE
CHROMEOS Clean workspace on error or exit, compress image

### DIFF
--- a/config/rootfs/chromiumos/scripts/build_board.sh
+++ b/config/rootfs/chromiumos/scripts/build_board.sh
@@ -1,32 +1,52 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 BOARD=$1
 BRANCH=$2
 DATA_DIR=$(pwd)
+USERNAME=$(/usr/bin/id -run)
 
-# Delete old SDK if present
-[ -d "${DATA_DIR}/chromiumos-sdk" ] && sudo rm -rf ${DATA_DIR}/chromiumos-sdk && echo Old SDK deleted
+function cleanup()
+{
+  rc=$?
+  echo Cleanup on exit
+  # Delete old SDK directory to not waste space
+  [ -d "${DATA_DIR}/chromiumos-sdk" ] && sudo rm -rf ${DATA_DIR}/chromiumos-sdk && echo Old SDK deleted
+  exit $rc
+}
 
+trap cleanup EXIT
+
+echo Preparing environment, branch ${BRANCH}
 sudo mkdir chromiumos-sdk
 sudo chown user chromiumos-sdk
 cd chromiumos-sdk
 git config --global user.email "bot@kernelci.org"
 git config --global user.name "KernelCI Bot"
 git config --global color.ui false
-repo init --repo-url https://chromium.googlesource.com/external/repo --manifest-url https://chromium.googlesource.com/chromiumos/manifest --manifest-name default.xml --manifest-branch ${BRANCH} --depth=1
+repo init --repo-url https://chromium.googlesource.com/external/repo --manifest-url https://chromium.googlesource.com/chromiumos/manifest --manifest-name default.xml --manifest-branch ${BRANCH}
 repo sync -j$(nproc)
+echo Building SDK
 cros_sdk --create
 
+echo Board ${BOARD} setup
 # Compiling ChromiumOS image
 # Future possible option --profile=x, for example kernel-5_15, profiles are at /mnt/host/source/src/overlays/overlay-${BOARD}/profiles/
-cros_sdk setup_board --board=${BOARD} --force
+cros_sdk setup_board --board=${BOARD}
 # Add serial support
+echo Add serial support
 cros_sdk USE=pcserial ./build_packages --board=${BOARD}
-cros_sdk USE="tty_console_ttyS0" emerge-${BOARD} chromeos-base/tty
-cros_sdk ./build_image --enable_serial ttyS0 --board=${BOARD} --boot_args "earlyprintk=serial,keep console=tty0" --noenable_rootfs_verification test
+cros_sdk USE="tty_console_ttyS0" emerge-"${BOARD}" chromeos-base/tty
+echo Building image
+cros_sdk ./build_image --enable_serial ttyS0 --board="${BOARD}" --boot_args "earlyprintk=serial,keep console=tty0" --noenable_rootfs_verification test
 
+echo Moving artifacts
 # Create artifacts dir and copy generated image and tast files
-sudo mkdir -p ${DATA_DIR}/${BOARD}
-sudo cp src/build/images/${BOARD}/latest/chromiumos_test_image.bin ${DATA_DIR}/${BOARD}
-sudo cp ./chroot/usr/bin/remote_test_runner ${DATA_DIR}/${BOARD}
-sudo cp ./chroot/usr/bin/tast ${DATA_DIR}/${BOARD}
+sudo mkdir -p "${DATA_DIR}/${BOARD}"
+sudo cp "src/build/images/${BOARD}/latest/chromiumos_test_image.bin" "${DATA_DIR}/${BOARD}"
+sudo cp ./chroot/usr/bin/remote_test_runner "${DATA_DIR}/${BOARD}"
+sudo cp ./chroot/usr/bin/tast "${DATA_DIR}/${BOARD}"
+sudo chown -R "${USERNAME}" "${DATA_DIR}/${BOARD}"
+gzip -1 "${DATA_DIR}/${BOARD}/chromiumos_test_image.bin"
+
+# Probably redundant, but better safe than sorry
+cleanup


### PR DESCRIPTION
Use trap function, so it will clean not only on exit, but
also if script quit early due error.
This resolve problems with jenkins.
Also compress image, as it shrink image from 6GB to approx 2GB.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>