### PR TITLE
cvehound: add a script to convert reports to kernelci format

### DIFF
--- a/test-suites/cvehound
+++ b/test-suites/cvehound
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2022 Denis Efremov
+# Author: Denis Efremov <efremov@linux.com>
+#
+# This module is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+import os
+import sys
+import json
+from optparse import OptionParser
+
+def convert(bmeta, report):
+    rev = bmeta['revision']
+    env = bmeta['environment']
+    kernel = bmeta['kernel']
+    kernelci = {
+        'job': 'mainline',
+        'git_branch': rev['branch'],
+        'git_commit': rev['commit'],
+        'kernel': rev['describe_verbose'],
+
+        'build_environment': env['name'],
+        'arch': env['arch'],
+        'defconfig': kernel['defconfig'],
+        'defconfig_full': kernel['defconfig_full'],
+
+        'lab_name': 'manual',
+        'device_type': 'shell',
+
+        'name': 'cvehound',
+    }
+
+    cves = {}
+    for cve in report['args']['cve']:
+        cves[cve] = 'PASS'
+    for cve in report['results']:
+        cves[cve] = 'FAIL'
+    if cves:
+        kernelci['test_cases'] = []
+        for name, status in cves.items():
+            kernelci['test_cases'].append({'name': name, 'status': status})
+    return kernelci
+
+def main():
+    parser = OptionParser()
+    parser.add_option('-b', '--bmeta',
+                      dest="bmeta", help="kernelci's bmeta", metavar="FILE")
+    parser.add_option('-r', '--report',
+                      dest="report", help="cvehound report", metavar="FILE")
+    parser.add_option('-o', '--output',
+                      dest="output", help="cvehound report suitable for kernelci", metavar="FILE")
+    (options, args) = parser.parse_args()
+    if args:
+        print("Unknown arguments:", args, file=sys.stderr)
+        sys.exit(1)
+
+    if not options.bmeta:
+        print("Please, specify path to kernelci's bmeta with --bmeta", file=sys.stderr)
+        sys.exit(2)
+    if not options.report:
+        print("Please, specify path to cvehound's report with --report", file=sys.stderr)
+        sys.exit(2)
+    if not options.output:
+        print("Please, specify --output", file=sys.stderr)
+        sys.exit(2)
+
+    if not os.path.isfile(options.bmeta):
+        print("Can't find file", options.bmeta, file=sys.stderr)
+        sys.exit(3)
+    if not os.path.isfile(options.report):
+        print("Can't find file", options.report, file=sys.stderr)
+        sys.exit(3)
+    if os.path.isfile(options.output):
+        print("File", options.output, "already exists", file=sys.stderr)
+        sys.exit(3)
+
+    with open(options.bmeta, 'rt') as fh:
+        bmeta = json.load(fh)
+    with open(options.report, 'rt') as fh:
+        report = json.load(fh)
+
+    output = convert(bmeta, report)
+
+    with open(options.output, 'wt') as fh:
+        json.dump(output, fh, sort_keys=True, indent=4)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
The script converts cvehound reports to kernelci tests format.

How to use:
$ cvehound --kernel /root/linux --report report.json
$ ./test-suites/cvehound --bmeta bmeta.json --report report.json --output kernelci-results.json
$ kci_data submit_test --data-file=kernelci-results.json --db-config=...

This is a part of #803.

Signed-off-by: Denis Efremov <denis.e.efremov@oracle.com>