### PR TITLE
Add Git URL and branch YAML config for buildroot

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -1,6 +1,8 @@
 rootfs_configs:
   buildroot-baseline:
     rootfs_type: buildroot
+    git_url: https://github.com/kernelci/buildroot
+    git_branch: main
     arch_list:
       - arc
       - arm64

--- a/kernelci/config/rootfs.py
+++ b/kernelci/config/rootfs.py
@@ -139,6 +139,7 @@ class RootFS_Buildroot(RootFS):
         super().__init__(name, rootfs_type)
         self._arch_list = arch_list or list()
         self._frags = frags or list()
+        self._attrs = set()
 
     @classmethod
     def from_yaml(cls, config, name):
@@ -148,7 +149,9 @@ class RootFS_Buildroot(RootFS):
         kw.update(cls._kw_from_yaml(config, [
             'rootfs_type', 'arch_list', 'frags',
         ]))
-        return cls(**kw)
+        obj = cls(**kw)
+        obj._set_attrs(kw.keys())
+        return obj
 
     @property
     def frags(self):
@@ -157,6 +160,14 @@ class RootFS_Buildroot(RootFS):
     @property
     def arch_list(self):
         return list(self._arch_list)
+
+    def _set_attrs(self, attrs):
+        self._attrs = set(attrs)
+
+    def _get_attrs(self):
+        attrs = super()._get_attrs()
+        attrs.update(self._attrs)
+        return attrs
 
 
 class RootFSFactory(YAMLObject):

--- a/kernelci/config/rootfs.py
+++ b/kernelci/config/rootfs.py
@@ -135,8 +135,11 @@ class RootFS_Debos(RootFS):
 
 
 class RootFS_Buildroot(RootFS):
-    def __init__(self, name, rootfs_type, arch_list=None, frags=None):
+    def __init__(self, name, rootfs_type, git_url, git_branch,
+                 arch_list=None, frags=None):
         super().__init__(name, rootfs_type)
+        self._git_url = git_url
+        self._git_branch = git_branch
         self._arch_list = arch_list or list()
         self._frags = frags or list()
         self._attrs = set()
@@ -147,11 +150,19 @@ class RootFS_Buildroot(RootFS):
             'name': name,
         }
         kw.update(cls._kw_from_yaml(config, [
-            'rootfs_type', 'arch_list', 'frags',
+            'rootfs_type', 'arch_list', 'git_url', 'git_branch', 'frags',
         ]))
         obj = cls(**kw)
         obj._set_attrs(kw.keys())
         return obj
+
+    @property
+    def git_url(self):
+        return self._git_url
+
+    @property
+    def git_branch(self):
+        return self._git_branch
 
     @property
     def frags(self):

--- a/kernelci/rootfs.py
+++ b/kernelci/rootfs.py
@@ -94,26 +94,22 @@ class BuildrootBuilder(RootfsBuilder):
                                     self.name, arch)
         repo_dir = os.path.join(absoutput_dir, 'buildroot')
 
-        # Hard-coded here for now, should eventually be in YAML config
-        git_url = 'https://github.com/kernelci/buildroot'
-        git_branch = "main"
-
         if not os.path.exists(repo_dir):
             shell_cmd(f"""
 set -ex
-git clone {git_url} {repo_dir}
+git clone {config.git_url} {repo_dir}
 cd {repo_dir}
-git checkout -q origin/{git_branch}
+git checkout -q origin/{config.git_branch}
 """)
         else:
             shell_cmd(f"""
 set -ex
 cd {repo_dir}
-if [ $(git remote get-url origin) != "{git_url}" ]; then
-  git remote set-url origin {git_url}
+if [ $(git remote get-url origin) != "{config.git_url}" ]; then
+  git remote set-url origin {config.git_url}
 fi
 git remote update origin
-git checkout -q origin/{git_branch}
+git checkout -q origin/{config.git_branch}
 git clean -fd
 """)
 


### PR DESCRIPTION
Add YAML config for the Git URL and branch name to initialise the buildroot source tree.  Also reuse any existing clone to avoid recreating a fresh one every time.