### PR TITLE
Add support for queue timeout

### DIFF
--- a/config/core/lab-configs.yaml
+++ b/config/core/lab-configs.yaml
@@ -4,6 +4,8 @@ labs:
   lab-baylibre:
     lab_type: lava.lava_xmlrpc
     url: 'https://lava.baylibre.com/RPC2/'
+    queue_timeout:
+      days: 1
     filters:
       - blocklist: {tree: [drm-tip]}
       - passlist:
@@ -69,6 +71,8 @@ labs:
   lab-clabbe:
     lab_type: lava.lava_xmlrpc
     url: 'https://lava.montjoie.ovh/RPC2/'
+    queue_timeout:
+      hours: 24
     filters:
       - passlist:
           plan:

--- a/config/lava/base/kernel-ci-base.jinja2
+++ b/config/lava/base/kernel-ci-base.jinja2
@@ -64,6 +64,15 @@ timeouts:
   actions:
     power-off:
       seconds: 30
+{%- if queue_timeout %}
+  queue:
+    {%- if queue_timeout.hours %}
+    hours: {{ queue_timeout.hours }}
+    {% endif %}
+    {%- if queue_timeout.days %}
+    days: {{ queue_timeout.days }}
+    {% endif %}
+{% endif %}
 priority: {{ priority }}
 visibility: public
 {% endblock %}

--- a/kernelci/config/lab.py
+++ b/kernelci/config/lab.py
@@ -67,19 +67,27 @@ class LabAPI(Lab):
 
 class Lab_LAVA(LabAPI):
 
-    def __init__(self, priority='medium', *args, **kwargs):
+    def __init__(self, priority='medium', queue_timeout=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._priority = priority
+        self._queue_timeout = queue_timeout
 
     @property
     def priority(self):
         return self._priority
+
+    @property
+    def queue_timeout(self):
+        return self._queue_timeout
 
     @classmethod
     def from_yaml(cls, lab, kw):
         priority = lab.get('priority')
         if priority:
             kw['priority'] = priority
+        queue_timeout = lab.get('queue_timeout')
+        if queue_timeout:
+            kw['queue_timeout'] = queue_timeout
         return cls(**kw)
 
 

--- a/kernelci/lab/lava/__init__.py
+++ b/kernelci/lab/lava/__init__.py
@@ -38,6 +38,7 @@ class LavaAPI(LabAPI):
         params.update({
             'template_file': template_file,
             'priority': self.config.priority,
+            'queue_timeout': self.config.queue_timeout,
             'lab_name': self.config.name,
             'base_device_type': self._alias_device_type(base_name),
         })


### PR DESCRIPTION
Since 2021.08, LAVA supports queue timeout.
Let's adds support for it in kernelCI.
Since my lab is recent enough, enable queue_timout in my lab.

Closes: 1086

Signed-off-by: Corentin LABBE <clabbe@baylibre.com>