### PR TITLE
test-configs.yaml: add lab-broonie to QEMU passlist

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -153,7 +153,10 @@ test_plans:
     filters:
       - blocklist: *kselftest_defconfig_filter
       - passlist: &qemu_labs_filter
-          lab: ['lab-baylibre', 'lab-collabora-staging']
+          lab:
+            - 'lab-baylibre'
+            - 'lab-broonie'
+            - 'lab-collabora-staging'
 
   cros-ec:
     rootfs: debian_bullseye-cros-ec_ramdisk


### PR DESCRIPTION
Add lab-broonie to the passlist for QEMU tests which now requires
Docker support.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>