### PR TITLE
test-configs: Enable arm64 kselftests

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2012,6 +2012,8 @@ test_configs:
   - device_type: bcm2711-rpi-4-b
     test_plans:
       - baseline
+      - baseline-nfs
+      - kselftest-arm64
 
   - device_type: bcm2836-rpi-2-b
     test_plans:
@@ -2366,6 +2368,8 @@ test_configs:
   - device_type: meson-g12b-odroid-n2
     test_plans:
       - baseline
+      - baseline-nfs
+      - kselftest-arm64
       - kselftest-lib
 
   - device_type: meson-gxbb-nanopi-k2
@@ -2401,6 +2405,7 @@ test_configs:
       - baseline
       - baseline-nfs
       - kselftest-alsa
+      - kselftest-arm64
       - kselftest-cpufreq
       - kselftest-futex
       - kselftest-lib
@@ -2761,6 +2766,7 @@ test_configs:
     test_plans:
       - baseline
       - baseline-nfs
+      - kselftest-arm64
       - kselftest-cpufreq
       - kselftest-filesystems
       - kselftest-futex


### PR DESCRIPTION
Provide a basic hookup for the arm64 kselftests and enable them for a bunch
of platforms. Other than qemu these platforms are picked mostly at random,
just to ensure that there's a selection of physical implementations. The
one it's most important to cover here is qemu since the arm64 kselftests
exercise bleeding edge architecture features which are generally supported
in emulation well before they are available in physical implementations.
The tests will detect missing features at runtime and cleanly skip tests
that don't apply to the current platform.

Signed-off-by: Mark Brown <broonie@kernel.org>