### PR TITLE
test-configs: Add at91sam9g20ek

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -610,7 +610,6 @@ device_types:
 
   at91sam9g20ek:
     mach: at91
-    arch: armel
     class: arm-dtb
     boot_method: uboot
 

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -608,6 +608,12 @@ device_types:
     class: arm-dtb
     boot_method: uboot
 
+  at91sam9g20ek:
+    mach: at91
+    arch: armel
+    class: arm-dtb
+    boot_method: uboot
+
   bcm2711-rpi-4-b:
     mach: broadcom
     class: arm64-dtb
@@ -1857,6 +1863,10 @@ test_configs:
       - baseline
 
   - device_type: at91-sama5d4_xplained
+    test_plans:
+      - baseline
+
+  - device_type: at91sam9g20ek
     test_plans:
       - baseline
 


### PR DESCRIPTION
This board (a very old out of production AT91 reference system) is in my
lab.

The board only has 64M of RAM so is very restricted in terms of what it can
run from ramdisk but it has ethernet and is quite capable with NFS and is
a useful example of it's generation of audio hardware. With our current
setup it struggles to boot a multi_v5_defconfig in an initramfs due to the
size of the modules causing us to run out of memory, we may need to
explicitly block that.

Signed-off-by: Mark Brown <broonie@kernel.org>