### PR TITLE
config/docker: add ssh to debos docker image

### DIFF
--- a/config/docker/debos/Dockerfile
+++ b/config/docker/debos/Dockerfile
@@ -48,4 +48,5 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     python3.9 \
     python3-requests \
     python3-yaml \
+    ssh \
     xz-utils


### PR DESCRIPTION
Add ssh to debos docker image which is necessary to upload images with
scp.
