### PR TITLE
test-configs.yaml: enable kselftest-arm64 on hana Chromebook

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2459,6 +2459,7 @@ test_configs:
       - baseline-cip-nfs
       - baseline-nfs
       - cros-ec
+      - kselftest-arm64
       - kselftest-cpufreq
       - kselftest-filesystems
       - kselftest-futex


### PR DESCRIPTION
Enable kselftest-arm64 on mt8173-elm-hana.

Depends on #1089.