### PR TITLE
build-configs-cip.yaml: enable preempt_rt on rt cip kernels

### DIFF
--- a/config/core/build-configs-cip.yaml
+++ b/config/core/build-configs-cip.yaml
@@ -86,9 +86,10 @@ cip_variants_preempt_rt: &cip_variants_preempt_rt
         extra_configs:
           - 'defconfig+preempt_rt'
       x86_64:
-        fragments: [preempt_rt]
+        fragments: [preempt_rt, x86-chromebook]
         extra_configs:
           - 'x86_64_defconfig+preempt_rt'
+          - 'x86_64_defconfig+x86-chromebook+preempt_rt'
 
 
 build_configs:

--- a/config/core/build-configs-cip.yaml
+++ b/config/core/build-configs-cip.yaml
@@ -70,6 +70,27 @@ cip_variants_kselftest: &cip_variants_kselftest
           - 'allnoconfig'
           - 'x86_64_defconfig+x86-chromebook+kselftest'
 
+
+cip_variants_preempt_rt: &cip_variants_preempt_rt
+  gcc-10:
+    <<: *cip_gcc_10
+    fragments: [preempt_rt]
+    architectures:
+      <<: *cip_architectures
+      arm:
+        fragments: [preempt_rt]
+        extra_configs:
+          - 'multi_v7_defconfig+preempt_rt'
+      arm64:
+        fragments: [preempt_rt]
+        extra_configs:
+          - 'defconfig+preempt_rt'
+      x86_64:
+        fragments: [preempt_rt]
+        extra_configs:
+          - 'x86_64_defconfig+preempt_rt'
+
+
 build_configs:
   cip_4.4:
     tree: cip
@@ -84,7 +105,7 @@ build_configs:
   cip_4.4-rt:
     tree: cip
     branch: 'linux-4.4.y-cip-rt'
-    variants: *cip_variants
+    variants: *cip_variants_preempt_rt
 
   cip_4.19:
     tree: cip
@@ -118,7 +139,7 @@ build_configs:
   cip_4.19-rt:
     tree: cip
     branch: 'linux-4.19.y-cip-rt'
-    variants: *cip_variants
+    variants: *cip_variants_preempt_rt
 
   cip_5.10:
     tree: cip
@@ -133,7 +154,7 @@ build_configs:
   cip_5.10-rt:
     tree: cip
     branch: 'linux-5.10.y-cip-rt'
-    variants: *cip_variants_kselftest
+    variants: *cip_variants_preempt_rt
 
   cip_pavel-test:
     tree: cip-gitlab


### PR DESCRIPTION
Add build variants with the preempt_rt fragment enabled and use them
with the -rt kernel branches.

Signed-off-by: Alice Ferrazzi <alice.ferrazzi@miraclelinux.com>
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>