### PR TITLE
config/docker: add jenkins user to debos image

### DIFF
--- a/config/docker/debos/Dockerfile
+++ b/config/docker/debos/Dockerfile
@@ -50,3 +50,6 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     python3-yaml \
     ssh \
     xz-utils
+
+# Jenkins hacks
+RUN useradd -u 996 -ms /bin/sh jenkins


### PR DESCRIPTION
Add jenkins user to debos container. It's needed for some jobs to have a `jenkins` user inside the container.

