### PR TITLE
rootfs-configs: Enable armel kselftest builds

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -163,6 +163,7 @@ rootfs_configs:
     arch_list:
       - amd64
       - arm64
+      - armel
       - armhf
     extra_packages:
       - bc


### PR DESCRIPTION
With the pending addition of AT91SAM9G20-EK which is ARMv5 based we need
an armel build of kselftest in order to allow us to run kselftests on
that platform.

Signed-off-by: Mark Brown <broonie@kernel.org>