### PR TITLE
CHROMEOS build-configs-chromeos.yaml: enable arm64-chromebook fragment

### DIFF
--- a/config/core/build-configs-chromeos.yaml
+++ b/config/core/build-configs-chromeos.yaml
@@ -10,18 +10,19 @@ chromeos_variants: &chromeos-variants
           - regex: { defconfig: 'cros' }
       arm64:
         base_defconfig: 'cros://chromeos-5.10/arm64/chromiumos-arm64.flavour.config'
+        fragments: [arm64-chromebook]
         extra_configs:
-          - 'cros://chromeos-5.10/arm64/chromiumos-mediatek.flavour.config'
-          - 'cros://chromeos-5.10/arm64/chromiumos-qualcomm.flavour.config'
-          - 'cros://chromeos-5.10/arm64/chromiumos-rockchip64.flavour.config'
+          - 'cros://chromeos-5.10/arm64/chromiumos-mediatek.flavour.config+arm64-chromebook'
+          - 'cros://chromeos-5.10/arm64/chromiumos-qualcomm.flavour.config+arm64-chromebook'
+          - 'cros://chromeos-5.10/arm64/chromiumos-rockchip64.flavour.config+arm64-chromebook'
         filters: *cros-filters
       x86_64:
         base_defconfig: 'cros://chromeos-5.10/x86_64/chromiumos-x86_64.flavour.config'
+        fragments: [x86-chromebook]
         extra_configs:
           - 'cros://chromeos-5.10/x86_64/chromeos-amd-stoneyridge.flavour.config+x86-chromebook'
           - 'cros://chromeos-5.10/x86_64/chromeos-intel-denverton.flavour.config+x86-chromebook'
           - 'cros://chromeos-5.10/x86_64/chromeos-intel-pineview.flavour.config+x86-chromebook'
-        fragments: [x86-chromebook]
         filters: *cros-filters
 
   clang-13:


### PR DESCRIPTION
Add the arm64-chromebook fragment to all Chrome OS configs in the same
way that the x86-chromebook fragment was previously enabled.  This is
required to boot some Chromebook devices with serial console and other
tweaks that aren't in the upstream arm64 defconfig.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>