### PR TITLE
build-configs-chromeos.yaml: add file with Chrome OS build configs

### DIFF
--- a/config/core/build-configs-chromeos.yaml
+++ b/config/core/build-configs-chromeos.yaml
@@ -1,5 +1,5 @@
 chromeos_variants: &chromeos-variants
-  clang-13:
+  chromeos-clang-13:
     build_environment: clang-13
     architectures:
       arm:
@@ -24,6 +24,19 @@ chromeos_variants: &chromeos-variants
         fragments: [x86-chromebook]
         filters: *cros-filters
 
+  clang-13:
+    build_environment: clang-13
+    architectures:
+      arm64: &arm64_defconfig
+        base_defconfig: 'defconfig'
+        fragments: [arm64-chromebook]
+        filters:
+          - passlist: { defconfig: ['arm64-chromebook'] }
+      x86_64: &x86_64_defconfig
+        base_defconfig: 'x86_64_defconfig'
+        fragments: [x86-chromebook]
+        filters:
+          - passlist: { defconfig: ['x86-chromebook'] }
 
 build_configs:
 

--- a/config/core/build-configs-chromeos.yaml
+++ b/config/core/build-configs-chromeos.yaml
@@ -10,18 +10,19 @@ chromeos_variants: &chromeos-variants
           - regex: { defconfig: 'cros' }
       arm64:
         base_defconfig: 'cros://chromeos-5.10/arm64/chromiumos-arm64.flavour.config'
+        fragments: [arm64-chromebook]
         extra_configs:
-          - 'cros://chromeos-5.10/arm64/chromiumos-mediatek.flavour.config'
-          - 'cros://chromeos-5.10/arm64/chromiumos-qualcomm.flavour.config'
-          - 'cros://chromeos-5.10/arm64/chromiumos-rockchip64.flavour.config'
+          - 'cros://chromeos-5.10/arm64/chromiumos-mediatek.flavour.config+arm64-chromebook'
+          - 'cros://chromeos-5.10/arm64/chromiumos-qualcomm.flavour.config+arm64-chromebook'
+          - 'cros://chromeos-5.10/arm64/chromiumos-rockchip64.flavour.config+arm64-chromebook'
         filters: *cros-filters
       x86_64:
         base_defconfig: 'cros://chromeos-5.10/x86_64/chromiumos-x86_64.flavour.config'
+        fragments: [x86-chromebook]
         extra_configs:
           - 'cros://chromeos-5.10/x86_64/chromeos-amd-stoneyridge.flavour.config+x86-chromebook'
           - 'cros://chromeos-5.10/x86_64/chromeos-intel-denverton.flavour.config+x86-chromebook'
           - 'cros://chromeos-5.10/x86_64/chromeos-intel-pineview.flavour.config+x86-chromebook'
-        fragments: [x86-chromebook]
         filters: *cros-filters
 
   clang-13:

--- a/config/core/build-configs-chromeos.yaml
+++ b/config/core/build-configs-chromeos.yaml
@@ -1,0 +1,33 @@
+chromeos_variants: &chromeos-variants
+  clang-13:
+    build_environment: clang-13
+    architectures:
+      arm:
+        base_defconfig: 'cros://chromeos-5.10/armel/chromiumos-arm.flavour.config'
+        extra_configs:
+          - 'cros://chromeos-5.10/armel/chromiumos-rockchip.flavour.config'
+        filters: &cros-filters
+          - regex: { defconfig: 'cros' }
+      arm64:
+        base_defconfig: 'cros://chromeos-5.10/arm64/chromiumos-arm64.flavour.config'
+        extra_configs:
+          - 'cros://chromeos-5.10/arm64/chromiumos-mediatek.flavour.config'
+          - 'cros://chromeos-5.10/arm64/chromiumos-qualcomm.flavour.config'
+          - 'cros://chromeos-5.10/arm64/chromiumos-rockchip64.flavour.config'
+        filters: *cros-filters
+      x86_64:
+        base_defconfig: 'cros://chromeos-5.10/x86_64/chromiumos-x86_64.flavour.config'
+        extra_configs:
+          - 'cros://chromeos-5.10/x86_64/chromeos-amd-stoneyridge.flavour.config+x86-chromebook'
+          - 'cros://chromeos-5.10/x86_64/chromeos-intel-denverton.flavour.config+x86-chromebook'
+          - 'cros://chromeos-5.10/x86_64/chromeos-intel-pineview.flavour.config+x86-chromebook'
+        fragments: [x86-chromebook]
+        filters: *cros-filters
+
+
+build_configs:
+
+  chromeos-next:
+    tree: next
+    branch: 'master'
+    variants: *chromeos-variants

--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -525,33 +525,6 @@ preempt_rt_variants: &preempt_rt_variants
           - 'x86_64_defconfig+preempt_rt+x86-chromebook'
 
 
-chromeos_variants:
-  clang-13: &chromeos-configs
-    build_environment: clang-13
-    architectures:
-      arm:
-        base_defconfig: 'cros://chromeos-5.10/armel/chromiumos-arm.flavour.config'
-        extra_configs:
-          - 'cros://chromeos-5.10/armel/chromiumos-rockchip.flavour.config'
-        filters: &cros-filters
-          - regex: { defconfig: 'cros' }
-      arm64:
-        base_defconfig: 'cros://chromeos-5.10/arm64/chromiumos-arm64.flavour.config'
-        extra_configs:
-          - 'cros://chromeos-5.10/arm64/chromiumos-mediatek.flavour.config'
-          - 'cros://chromeos-5.10/arm64/chromiumos-qualcomm.flavour.config'
-          - 'cros://chromeos-5.10/arm64/chromiumos-rockchip64.flavour.config'
-        filters: *cros-filters
-      x86_64:
-        base_defconfig: 'cros://chromeos-5.10/x86_64/chromiumos-x86_64.flavour.config'
-        extra_configs:
-          - 'cros://chromeos-5.10/x86_64/chromeos-amd-stoneyridge.flavour.config+x86-chromebook'
-          - 'cros://chromeos-5.10/x86_64/chromeos-intel-denverton.flavour.config+x86-chromebook'
-          - 'cros://chromeos-5.10/x86_64/chromeos-intel-pineview.flavour.config+x86-chromebook'
-        fragments: [x86-chromebook]
-        filters: *cros-filters
-
-
 build_configs:
 
   agross:
@@ -821,10 +794,6 @@ build_configs:
             filters:
               - passlist:
                   defconfig: *riscv_clang_configs
-
-      # ChromeOS configs
-      chromeos-configs:
-        <<: *chromeos-configs
 
   next_pending-fixes:
     tree: next

--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -731,6 +731,26 @@ build_configs:
       clang-13:
         build_environment: clang-13
         architectures: *arch_clang_configs
+      chromeos-configs: &chromeos_configs
+        build_environment: clang-13
+        architectures:
+            arm:
+              base_defconfig: 'cros://chromeos-5.10/armel/chromiumos-arm.flavour.config'
+              extra_configs:
+                - 'cros://chromeos-5.10/armel/chromiumos-rockchip.flavour.config'
+            arm64:
+              base_defconfig: 'cros://chromeos-5.10/arm64/chromiumos-arm64.flavour.config'
+              extra_configs:
+                - 'cros://chromeos-5.10/arm64/chromiumos-mediatek.flavour.config'
+                - 'cros://chromeos-5.10/arm64/chromiumos-qualcomm.flavour.config'
+                - 'cros://chromeos-5.10/arm64/chromiumos-rockchip64.flavour.config'
+            x86_64:
+              base_defconfig: 'cros://chromeos-5.10/x86_64/chromiumos-x86_64.flavour.config'
+              extra_configs:
+                - 'cros://chromeos-5.10/x86_64/chromeos-amd-stoneyridge.flavour.config'
+                - 'cros://chromeos-5.10/x86_64/chromeos-intel-denverton.flavour.config'
+                - 'cros://chromeos-5.10/x86_64/chromeos-intel-pineview.flavour.config'
+
 
   media:
     tree: media
@@ -794,6 +814,10 @@ build_configs:
             filters:
               - passlist:
                   defconfig: *riscv_clang_configs
+
+      # ChromeOS configs
+      chromeos_configs:
+        <<: *chromeos_configs
 
   next_pending-fixes:
     tree: next

--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -525,7 +525,6 @@ preempt_rt_variants: &preempt_rt_variants
           - 'x86_64_defconfig+preempt_rt+x86-chromebook'
 
 
-
 chromeos_variants:
   clang-13: &chromeos-configs
     build_environment: clang-13
@@ -546,9 +545,10 @@ chromeos_variants:
       x86_64:
         base_defconfig: 'cros://chromeos-5.10/x86_64/chromiumos-x86_64.flavour.config'
         extra_configs:
-          - 'cros://chromeos-5.10/x86_64/chromeos-amd-stoneyridge.flavour.config'
-          - 'cros://chromeos-5.10/x86_64/chromeos-intel-denverton.flavour.config'
-          - 'cros://chromeos-5.10/x86_64/chromeos-intel-pineview.flavour.config'
+          - 'cros://chromeos-5.10/x86_64/chromeos-amd-stoneyridge.flavour.config+x86-chromebook'
+          - 'cros://chromeos-5.10/x86_64/chromeos-intel-denverton.flavour.config+x86-chromebook'
+          - 'cros://chromeos-5.10/x86_64/chromeos-intel-pineview.flavour.config+x86-chromebook'
+        fragments: [x86-chromebook]
         filters: *cros-filters
 
 

--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -525,6 +525,33 @@ preempt_rt_variants: &preempt_rt_variants
           - 'x86_64_defconfig+preempt_rt+x86-chromebook'
 
 
+
+chromeos_variants:
+  clang-13: &chromeos-configs
+    build_environment: clang-13
+    architectures:
+      arm:
+        base_defconfig: 'cros://chromeos-5.10/armel/chromiumos-arm.flavour.config'
+        extra_configs:
+          - 'cros://chromeos-5.10/armel/chromiumos-rockchip.flavour.config'
+        filters: &cros-filters
+          - regex: { defconfig: 'cros' }
+      arm64:
+        base_defconfig: 'cros://chromeos-5.10/arm64/chromiumos-arm64.flavour.config'
+        extra_configs:
+          - 'cros://chromeos-5.10/arm64/chromiumos-mediatek.flavour.config'
+          - 'cros://chromeos-5.10/arm64/chromiumos-qualcomm.flavour.config'
+          - 'cros://chromeos-5.10/arm64/chromiumos-rockchip64.flavour.config'
+        filters: *cros-filters
+      x86_64:
+        base_defconfig: 'cros://chromeos-5.10/x86_64/chromiumos-x86_64.flavour.config'
+        extra_configs:
+          - 'cros://chromeos-5.10/x86_64/chromeos-amd-stoneyridge.flavour.config'
+          - 'cros://chromeos-5.10/x86_64/chromeos-intel-denverton.flavour.config'
+          - 'cros://chromeos-5.10/x86_64/chromeos-intel-pineview.flavour.config'
+        filters: *cros-filters
+
+
 build_configs:
 
   agross:
@@ -731,26 +758,6 @@ build_configs:
       clang-13:
         build_environment: clang-13
         architectures: *arch_clang_configs
-      chromeos-configs: &chromeos_configs
-        build_environment: clang-13
-        architectures:
-            arm:
-              base_defconfig: 'cros://chromeos-5.10/armel/chromiumos-arm.flavour.config'
-              extra_configs:
-                - 'cros://chromeos-5.10/armel/chromiumos-rockchip.flavour.config'
-            arm64:
-              base_defconfig: 'cros://chromeos-5.10/arm64/chromiumos-arm64.flavour.config'
-              extra_configs:
-                - 'cros://chromeos-5.10/arm64/chromiumos-mediatek.flavour.config'
-                - 'cros://chromeos-5.10/arm64/chromiumos-qualcomm.flavour.config'
-                - 'cros://chromeos-5.10/arm64/chromiumos-rockchip64.flavour.config'
-            x86_64:
-              base_defconfig: 'cros://chromeos-5.10/x86_64/chromiumos-x86_64.flavour.config'
-              extra_configs:
-                - 'cros://chromeos-5.10/x86_64/chromeos-amd-stoneyridge.flavour.config'
-                - 'cros://chromeos-5.10/x86_64/chromeos-intel-denverton.flavour.config'
-                - 'cros://chromeos-5.10/x86_64/chromeos-intel-pineview.flavour.config'
-
 
   media:
     tree: media
@@ -816,8 +823,8 @@ build_configs:
                   defconfig: *riscv_clang_configs
 
       # ChromeOS configs
-      chromeos_configs:
-        <<: *chromeos_configs
+      chromeos-configs:
+        <<: *chromeos-configs
 
   next_pending-fixes:
     tree: next


### PR DESCRIPTION
Add a `build-configs-chromeos.yaml` file with the Chrome OS build configuration used on chromeos.kernelci.org.  Depends on #1102. 