### PR TITLE
CHROMEOS Use new flashing script

### DIFF
--- a/config/lava/chromeos/chromeos-flash-template.jinja2
+++ b/config/lava/chromeos/chromeos-flash-template.jinja2
@@ -75,7 +75,7 @@ actions:
           steps:
             - lsblk
             - ls -l /root
-            - IMAGE_NAME={{ chromeos_image }}  /bin/bash /usr/bin/chromeos-flash-modules.sh flash_chromeos enable_rw fixup_root
+            - IMAGE_NAME={{ chromeos_image }}  /bin/bash /opt/chromeos/flash
       lava-signal: kmsg
       from: inline
       name: chromeos-flash


### PR DESCRIPTION
  Use /opt/chromeos/flash script instead of the old /usr/bin/chromeos-flash-modules.sh.

Depends on #1105 
