### PR TITLE
kernelci.build: add "chromeos" sub-directory for configs

### DIFF
--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -1100,11 +1100,15 @@ scripts/kconfig/merge_config.sh -O {output} '{base}' '{frag}' {redir}
         if not _download_file(url, cros_config):
             raise FileNotFoundError("Error reading {}".format(url))
         tar = tarfile.open(cros_config)
+        subdir = 'chromeos'
         with open(os.path.join(self._output_path, ".config"), 'wb') as f:
-            f.write(tar.extractfile("base.config").read())
-            f.write(tar.extractfile(os.path.join(os.path.dirname(config),
-                                    "common.config")).read())
-            f.write(tar.extractfile(config).read())
+            config_file_names = [
+                os.path.join(subdir, 'base.config'),
+                os.path.join(subdir, os.path.dirname(config), "common.config"),
+                os.path.join(subdir, config),
+            ]
+            for file_name in config_file_names:
+                f.write(tar.extractfile(file_name).read())
 
     def run(self, jopt=None, verbose=False, opts=None):
         """Make the kernel config


### PR DESCRIPTION
Update _create_cros_config() to look into a "chromeos" sub-directory
in the Chrome OS config tarball as the files appear to have now been
split between different categories.

Here's the contents of a sample config tarball:

https://chromium.googlesource.com/chromiumos/third_party/kernel/+archive/refs/heads/chromeos-5.10/chromeos/config.tar.gz

├── chromeos
│   ├── arm64
│   │   ├── chromiumos-arm64.flavour.config
│   │   ├── chromiumos-mediatek.flavour.config
│   │   ├── chromiumos-qualcomm.flavour.config
│   │   ├── chromiumos-rockchip64.flavour.config
│   │   └── common.config
│   ├── armel
│   │   ├── chromiumos-arm.flavour.config
│   │   ├── chromiumos-rockchip.flavour.config
│   │   └── common.config
│   ├── base.config
│   └── x86_64
│       ├── chromeos-amd-stoneyridge.flavour.config
│       ├── chromeos-intel-denverton.flavour.config
│       ├── chromeos-intel-pineview.flavour.config
│       ├── chromeos-x86_64-reven.flavour.config
│       ├── chromiumos-x86_64.flavour.config
│       └── common.config
├── manatee
│   ├── base.config
│   └── x86_64
│       ├── chromeos-intel-pineview.flavour.config
│       └── common.config
└── termina
    ├── arm64
    │   ├── common.config
    │   └── container-vm-arm64.flavour.config
    ├── base.config
    └── x86_64
        ├── common.config
        └── container-vm-x86_64.flavour.config

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>