### PR TITLE
lab-configs: Add a timeout for the LKFT lab

### DIFF
--- a/config/core/lab-configs.yaml
+++ b/config/core/lab-configs.yaml
@@ -115,6 +115,8 @@ labs:
     lab_type: lava.lava_rest
     url: 'https://lkft.validation.linaro.org/'
     priority: low
+    queue_timeout:
+      days: 1
     filters:
       - passlist:
           plan:


### PR DESCRIPTION
The LKFT lab has a current enough version of LAVA to do queue
timeouts so let's enable a timeout of one day which is probably
sensible enough for standard testing.

This should help us catch up with the backlog due to the QDF2400
being slow to boot.

Signed-off-by: Mark Brown <broonie@kernel.org>