### PR TITLE
CHROMEOS Modify LAVA template: add modules into rootfs

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -196,8 +196,19 @@ test_plans:
     params:
       job_timeout: '60'
       docker_image: 'kernelci/chromeos-tast'
-      rootfs_url: 'https://storage.chromeos.kernelci.org/images/rootfs/chromeos/crostest006/chromiumos-amd64-generic/amd64/'
+      rootfs_url: 'https://storage.chromeos.kernelci.org/images/rootfs/chromeos/20220429.0/chromiumos-amd64-generic/amd64/'
       fixed_kernel: true
+
+  chromiumosvm-tast-upstream-kernel:
+    pattern: 'chromeos/chromiumosvm-tast-template.jinja2'
+    filters:
+      - blocklist: *kselftest_defconfig_filter
+      - passlist:
+          lab: ['lab-collabora-staging', 'lab-collabora']
+    params:
+      job_timeout: '60'
+      docker_image: 'kernelci/chromeos-tast'
+      rootfs_url: 'https://storage.chromeos.kernelci.org/images/rootfs/chromeos/20220429.0/chromiumos-amd64-generic/amd64/'
 
   cros-ec:
     rootfs: debian_bullseye-cros-ec_ramdisk
@@ -2544,6 +2555,7 @@ test_configs:
   - device_type: qemu_x86_64-uefi-chromiumos
     test_plans:
       - chromiumosvm-tast-fixed-kernel
+      - chromiumosvm-tast-upstream-kernel
 
   - device_type: r8a774a1-hihope-rzg2m-ex
     test_plans:

--- a/config/lava/chromeos/chromiumosvm-tast-template.jinja2
+++ b/config/lava/chromeos/chromiumosvm-tast-template.jinja2
@@ -7,6 +7,31 @@
 {{ super () }}
 
 actions:
+
+- deploy:
+    to: downloads
+    images:
+        rootfs:
+             url: {{ rootfs_url }}chromiumos_test_image.bin.gz
+             compression: gz
+        kernel:
+{% if fixed_kernel is not defined %}
+             url: {{ kernel_url }}
+{% else %}
+             url: {{ rootfs_url }}bzImage
+{% endif %}
+        modules:
+{% if fixed_kernel is not defined %}
+             url: {{ modules_url }}
+{% else %}
+             url: {{ rootfs_url }}modules.tar.xz
+{% endif %}
+             compression: xz
+    postprocess:
+        docker:
+            image: kernelci/chromeos-lavapost
+            steps:
+                - /add_modules.sh
 - deploy:
     images:
       bios:
@@ -14,11 +39,10 @@ actions:
         url: http://storage.kernelci.org/images/uefi/edk2-stable202005/x86_64/OVMF.fd
       rootfs:
         image_arg: -drive format=raw,file={rootfs},id=lavatest2,if=none
-        url: {{ rootfs_url }}chromiumos_test_image.bin.gz
-        compression: gz
-{% if fixed_kernel is not defined %}
-# FIXME not supported yet
-{% endif %}
+        url: downloads://chromiumos_test_image.bin
+      kernel:
+        image_arg: -kernel {kernel} --append 'init=/sbin/init boot=local rootwait ro noresume noswap loglevel=7 earlyprintk=serial,keep console=tty0 console=ttyS0 i915.modeset=1 cros_efi cros_debug root=/dev/sda3 tsc=unstable'
+        url: downloads://./bzImage
     os: oe
     timeout:
       minutes: {{ job_timeout }}


### PR DESCRIPTION
LAVA capable to add upstream modules into ChromiumOS rootfs image
using libguestfs, and this way we can test upstream kernels.

First tests:
"Fixed kernel" https://lava.collabora.co.uk/scheduler/job/6015601
Upstream kernel https://lava.collabora.co.uk/scheduler/job/6015641

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>