### PR TITLE
CHROMEOS Add LAVA postprocessing docker image

### DIFF
--- a/config/docker/build-and-push.sh
+++ b/config/docker/build-and-push.sh
@@ -62,6 +62,7 @@ k8s \
 qemu \
 chromiumos \
 chromeos-flash \
+chromeos-lavapost \
 "
 
 if [ -n "$*" ]; then

--- a/config/docker/chromeos-lavapost/Dockerfile
+++ b/config/docker/chromeos-lavapost/Dockerfile
@@ -1,0 +1,15 @@
+FROM debian:bullseye-slim
+MAINTAINER "KernelCI TSC" <kernelci-tsc@groups.io>
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+          libguestfs-tools \
+          linux-image-generic \
+          qemu-utils 
+
+ENV LIBGUESTFS_BACKEND=direct \
+    HOME=/root
+
+ADD add_modules.sh /add_modules.sh

--- a/config/docker/chromeos-lavapost/add_modules.sh
+++ b/config/docker/chromeos-lavapost/add_modules.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# In case you experience any problems with guestfish,
+# you can enable extended debug:
+#export LIBGUESTFS_DEBUG=1 LIBGUESTFS_TRACE=1
+guestfish <<_EOF_
+add chromiumos_test_image.bin
+run
+mount /dev/sda3 /
+tar-in modules.tar /
+umount-all
+_EOF_


### PR DESCRIPTION
LAVA require special docker image with libguestfs installed,
as libguestfs used to modify binary disk images with multiple
partitions and filesystems.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>