### PR TITLE
rootfs: parameterize the linux-firmware repo version

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -74,6 +74,7 @@ rootfs_configs:
       - qca/rampatch_00440302.bin
       - rtl_nic/rtl8153b-2.fw
       - rockchip/dptx.bin
+    linux_fw_version: d526e044bddaa2c2ad855c7296147e49be0ab03c
     script: "scripts/bullseye-cros-ec-tests.sh"
     test_overlay: ""
 
@@ -128,6 +129,7 @@ rootfs_configs:
         - i915/bxt_dmc_ver1_07.bin
         - i915/kbl_dmc_ver1_04.bin
         - i915/glk_dmc_ver1_04.bin
+    linux_fw_version: d526e044bddaa2c2ad855c7296147e49be0ab03c
     script: "scripts/bullseye-igt.sh"
     test_overlay: "overlays/igt"
 

--- a/config/rootfs/debos/rootfs.yaml
+++ b/config/rootfs/debos/rootfs.yaml
@@ -60,11 +60,7 @@ actions:
   - action: run
     description: add firmware files
     chroot: false
-    {{ if $linux_fw_version }}
-    script: scripts/install-firmware.sh -v {{ $linux_fw_version }} -f {{ $extra_firmware }}
-    {{ else}}
-    script: scripts/install-firmware.sh -f {{ $extra_firmware }}
-    {{ end }}
+    script: scripts/install-firmware.sh -f {{ $extra_firmware }} {{ if $linux_fw_version }} -v {{ $linux_fw_version }} {{ end }}
 {{ end }}
 
   - action: run

--- a/config/rootfs/debos/rootfs.yaml
+++ b/config/rootfs/debos/rootfs.yaml
@@ -2,6 +2,7 @@
 {{- $basename := or .basename "." -}}
 {{- $extra_packages := or .extra_packages "" -}}
 {{- $extra_firmware := or .extra_firmware "" -}}
+{{- $linux_fw_version := or .linux_fw_version "" -}}
 {{- $suite := or .suite "buster" -}}
 {{- $script := or .script "scripts/nothing.sh" -}}
 {{- $test_overlay := .test_overlay -}}
@@ -59,7 +60,11 @@ actions:
   - action: run
     description: add firmware files
     chroot: false
-    script: scripts/install-firmware.sh {{ $extra_firmware }}
+    {{ if $linux_fw_version }}
+    script: scripts/install-firmware.sh -v {{ $linux_fw_version }} -f {{ $extra_firmware }}
+    {{ else}}
+    script: scripts/install-firmware.sh -f {{ $extra_firmware }}
+    {{ end }}
 {{ end }}
 
   - action: run

--- a/config/rootfs/debos/scripts/install-firmware.sh
+++ b/config/rootfs/debos/scripts/install-firmware.sh
@@ -1,8 +1,37 @@
-#!/bin/sh
+#!/bin/bash
+
+# Usage:
+# install-firmware.sh [OPTIONS]
+#
+#     -v <version>                  version (tag, branch or commit) of the
+#                                   linux-firmware repo to fetch
+#     -f <file_1> ... <file_n>      files to install
 
 set -e
+
 FIRMWARE_SITE=https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git
-FIRMWARE_VERSION=d526e044bddaa2c2ad855c7296147e49be0ab03c
+FIRMWARE_DEFAULT_VERSION=d526e044bddaa2c2ad855c7296147e49be0ab03c
+
+version=""
+files=()
+
+while getopts ":v:f:" opt
+do
+    case $opt in
+        v ) version=$OPTARG
+            ;;
+        f ) files=("$OPTARG")
+            until [[ $(eval "echo \${$OPTIND}") =~ ^-.* ]] || [ -z $(eval "echo \${$OPTIND}") ]; do
+                files+=($(eval "echo \${$OPTIND}"))
+                OPTIND=$((OPTIND + 1))
+            done
+            ;;
+    esac
+done
+
+if [[ "$version" == "" ]]; then
+    version=$FIRMWARE_DEFAULT_VERSION
+fi
 
 DEST=${ROOTDIR}/lib/firmware
 mkdir -p $DEST
@@ -14,10 +43,10 @@ TMP_REPO=/tmp/linux-firmware
 mkdir -p $TMP_REPO && cd $TMP_REPO
 git init
 git remote add origin $FIRMWARE_SITE
-git fetch --depth 1 origin $FIRMWARE_VERSION
+git fetch --depth 1 origin $version
 git checkout FETCH_HEAD
 
-for fw_file in "$@"
+for fw_file in "${files[@]}"
 do
     cp --parents "$fw_file" $DEST
 done

--- a/config/rootfs/debos/scripts/install-firmware.sh
+++ b/config/rootfs/debos/scripts/install-firmware.sh
@@ -10,7 +10,7 @@
 set -e
 
 FIRMWARE_SITE=https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git
-FIRMWARE_DEFAULT_VERSION=d526e044bddaa2c2ad855c7296147e49be0ab03c
+FIRMWARE_DEFAULT_VERSION=HEAD
 
 version=""
 files=()

--- a/doc/kci_rootfs.md
+++ b/doc/kci_rootfs.md
@@ -167,6 +167,7 @@ Now you know how to build default `kci_rootfs` images. Let's look at how to add 
   | test_overlay          | Create a directory layout on final rootfs image as provided. |
   | extra_packages        | Installs specified packages on rootfs image. |
   | extra_firmware        | Installs specified linux-firmware files into rootfs image. |
+  | linux_fw_version      | If `extra_firmware` is specified, selects the linux-firmware version to fetch. |
   | extra_files_remove    | Removes specified files from rootfs image. |
 
   Please note at the moment, only `debos` is supported as `rootfs_type` and above options are debos specific.

--- a/kernelci/config/rootfs.py
+++ b/kernelci/config/rootfs.py
@@ -43,6 +43,7 @@ class RootFS(YAMLObject):
 class RootFS_Debos(RootFS):
     def __init__(self, name, rootfs_type, debian_release=None,
                  arch_list=None, extra_packages=None, extra_firmware=None,
+                 linux_fw_version="",
                  extra_packages_remove=None,
                  extra_files_remove=None, script="",
                  test_overlay="", crush_image_options=None, debian_mirror="",
@@ -53,6 +54,7 @@ class RootFS_Debos(RootFS):
         self._extra_packages = extra_packages or list()
         self._extra_packages_remove = extra_packages_remove or list()
         self._extra_firmware = extra_firmware or list()
+        self._linux_fw_version = linux_fw_version
         self._extra_files_remove = extra_files_remove or list()
         self._script = script
         self._test_overlay = test_overlay
@@ -79,6 +81,7 @@ class RootFS_Debos(RootFS):
             'extra_packages_remove',
             'extra_files_remove',
             'extra_firmware',
+            'linux_fw_version',
             'script',
             'test_overlay',
             'crush_image_options',
@@ -108,6 +111,10 @@ class RootFS_Debos(RootFS):
     @property
     def extra_firmware(self):
         return list(self._extra_firmware)
+
+    @property
+    def linux_fw_version(self):
+        return self._linux_fw_version
 
     @property
     def script(self):
@@ -287,6 +294,7 @@ def _dump_config_debos(config_name, config):
     print('\textra_files_remove: {}'.format(
         config.extra_files_remove))
     print('\textra_firmware: {}'.format(config.extra_firmware))
+    print('\tlinux_fw_version: {}'.format(config.linux_fw_version))
     print('\tscript: {}'.format(config.script))
     print('\ttest_overlay: {}'.format(config.test_overlay))
     print('\tcrush_image_options: {}'.format(

--- a/kernelci/rootfs.py
+++ b/kernelci/rootfs.py
@@ -62,6 +62,7 @@ class DebosBuilder(RootfsBuilder):
             'extra_packages_remove': ' '.join(config.extra_packages_remove),
             'extra_files_remove':  ' '.join(config.extra_files_remove),
             'extra_firmware': ' '.join(config.extra_firmware),
+            'linux_fw_version': config.linux_fw_version,
             'script': config.script,
             'test_overlay': config.test_overlay,
             'crush_image_options': ' '.join(config.crush_image_options),


### PR DESCRIPTION
The config/rootfs/debos/scripts/install-firmware.sh script hardcodes the
commit to fetch from the linux-firmare repo. This changeset implements a
"linux_fw_version" key for rootfs configs that define
"extra_firmware". If defined (as a commit hash, tag or branch), it
overrides the commit originally defined in the script.

Signed-off-by: Ricardo Cañuelo <ricardo.canuelo@collabora.com>