### PR TITLE
Lab priority ranges

### DIFF
--- a/config/core/lab-configs.yaml
+++ b/config/core/lab-configs.yaml
@@ -17,7 +17,8 @@ labs:
   lab-broonie:
     lab_type: lava.lava_xmlrpc
     url: 'https://lava.sirena.org.uk/RPC2/'
-    priority: low
+    priority_min: 0
+    priority_max: 40
     filters:
       - passlist:
           plan:

--- a/config/core/lab-configs.yaml
+++ b/config/core/lab-configs.yaml
@@ -115,7 +115,8 @@ labs:
   lab-linaro-lkft:
     lab_type: lava.lava_rest
     url: 'https://lkft.validation.linaro.org/'
-    priority: low
+    priority_min: 0
+    priority_max: 25
     queue_timeout:
       days: 1
     filters:

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -125,6 +125,8 @@ test_plans:
 
   baseline:
     rootfs: buildroot-baseline_ramdisk
+    params:
+      priority: 90
     filters:
       - blocklist: *kselftest_defconfig_filter
 

--- a/kernelci/config/lab.py
+++ b/kernelci/config/lab.py
@@ -67,14 +67,20 @@ class LabAPI(Lab):
 
 class Lab_LAVA(LabAPI):
 
-    def __init__(self, priority='medium', queue_timeout=None, *args, **kwargs):
+    def __init__(self, priority_min=50, priority_max=50,
+                 queue_timeout=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._priority = priority
+        self._priority_min = priority_min
+        self._priority_max = priority_max
         self._queue_timeout = queue_timeout
 
     @property
-    def priority(self):
-        return self._priority
+    def priority_min(self):
+        return self._priority_min
+
+    @property
+    def priority_max(self):
+        return self._priority_max
 
     @property
     def queue_timeout(self):
@@ -84,7 +90,27 @@ class Lab_LAVA(LabAPI):
     def from_yaml(cls, lab, kw):
         priority = lab.get('priority')
         if priority:
-            kw['priority'] = priority
+            if priority == 'low':
+                priority = 0
+            elif priority == 'medium':
+                priority = 50
+            elif priority == 'high':
+                priority = 100
+            else:
+                priority = int(priority)
+
+            # If min/max are specified these will be overridden
+            kw['priority_min'] = priority
+            kw['priority_max'] = priority
+
+        # 0 is a valid value so explicitly check for None
+        priority_min = lab.get('priority_min')
+        if priority_min is not None:
+            kw['priority_min'] = int(priority_min)
+        priority_max = lab.get('priority_max')
+        if priority_max is not None:
+            kw['priority_max'] = int(priority_max)
+
         queue_timeout = lab.get('queue_timeout')
         if queue_timeout:
             kw['queue_timeout'] = queue_timeout

--- a/kernelci/lab/__init__.py
+++ b/kernelci/lab/__init__.py
@@ -76,7 +76,8 @@ class LabAPI:
         return self.config.match(filter_data)
 
     def generate(self, params, device_config, plan_config,
-                 callback_opts=None, templates_path=None, db_config=None):
+                 callback_opts=None, templates_path=None, db_config=None,
+                 lab_config=None):
         """Generate a test job definition.
 
         *params* is a dictionary with the test parameters which can be used
@@ -95,6 +96,9 @@ class LabAPI:
 
         *db_config* is a Database configuration object for the database or API
             where the results should be sent
+
+        *lab_config* is a configuration object for the API
+            where the tests should be run
         """
         raise NotImplementedError("Lab.generate() is required")
 

--- a/kernelci/lab/lava/__init__.py
+++ b/kernelci/lab/lava/__init__.py
@@ -35,12 +35,26 @@ class LavaAPI(LabAPI):
             print("Template not found: {}".format(template_file))
             return None
         base_name = params['base_device_type']
+
+        # Scale the job priority (from 0-100) within the available levels
+        # for the lab, or use the lowest by default.
+        if 'priority' in plan_config.params:
+            priority = plan_config.params['priority']
+            if priority > 100:
+                priority = 100
+        else:
+            priority = 0
+
+        prio_range = self.config._priority_max - self.config._priority_min
+        priority = int(((priority * prio_range) / 100) +
+                       self.config._priority_min)
+
         params.update({
             'template_file': template_file,
-            'priority': self.config.priority,
             'queue_timeout': self.config.queue_timeout,
             'lab_name': self.config.name,
             'base_device_type': self._alias_device_type(base_name),
+            'priority': priority,
         })
         if callback_opts:
             self._add_callback_params(params, callback_opts)


### PR DESCRIPTION
LAVA supports numerical priorities for jobs from 0 to 100. Currently we only allow a single priority to be configured for all KernelCI jobs in a lab, in order to allow labs to give us more flexibility in how we schedule jobs allow a minimum and maximum priority to be configured within which we can schedule jobs.

We then map this range onto a percentage priority configurable in each test plan, defaulting to 0 so all jobs are assigned the lowest priority allowed by the lab.

For robustness if only one of minimum or maximum is specified we set both minimum and maximum to a single value. For simplicity and robustness with people updating their configurations if the existing priority field is configured then we still retain it, if no range is specified it will be the minimum and maximum. The string based priorities low, medium and high map onto 0, 50 and 100 respectively as they do in LAVA.

It is likely to be desirable to extend this in future to allow more prioritisation based on the tree being tested as well, and possibly to make more dynamic use of the priority range (eg, favoring tests that have recently been unstable to make sure they get covered). Hopefully other lab types will also be able to map the percentage based prioritisation onto any similar features they have.