### PR TITLE
Support use of Debian armel port on systems that require it

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -22,6 +22,9 @@ file_system_types:
   debian: &debian
     url: 'http://storage.kernelci.org/images/rootfs/debian'
     arch_map:
+      armel: [{arch: arm, variant: v4t},
+              {arch: arm, variant: v5},
+              {arch: arm, variant: v6}]
       armhf: [{arch: arm}]
       amd64: [{arch: x86_64}]
 

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -616,6 +616,7 @@ device_types:
 
   at91sam9g20ek:
     mach: at91
+    variant: v5
     class: arm-dtb
     boot_method: uboot
 
@@ -1875,6 +1876,7 @@ test_configs:
   - device_type: at91sam9g20ek
     test_plans:
       - baseline
+      - baseline-nfs
 
   - device_type: bcm2711-rpi-4-b
     test_plans:

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -965,20 +965,20 @@ device_types:
 
   kirkwood-db-88f6282:
     mach: mvebu
+    variant: v5
     class: arm-dtb
     boot_method: uboot
     filters:
-        # To be removed once NFS is working with multi_v5_defconfig
-      - blocklist: {defconfig: ['allmodconfig', 'multi_v5_defconfig']}
+      - blocklist: {defconfig: ['allmodconfig']}
       - blocklist: {kernel: ['v3.']}
 
   kirkwood-openblocks_a7:
     mach: mvebu
+    variant: v5
     class: arm-dtb
     boot_method: uboot
     filters:
-        # To be removed once NFS is working with multi_v5_defconfig
-      - blocklist: {defconfig: ['allmodconfig', 'multi_v5_defconfig']}
+      - blocklist: {defconfig: ['allmodconfig']}
       - blocklist: {kernel: ['v3.']}
 
   kontron-kbox-a-230-ls:

--- a/kernelci/config/test.py
+++ b/kernelci/config/test.py
@@ -24,7 +24,8 @@ class DeviceType(YAMLObject):
     """Device type model."""
 
     def __init__(self, name, mach, arch, boot_method, dtb=None, base_name=None,
-                 flags=None, filters=None, context=None, params=None):
+                 flags=None, filters=None, context=None, params=None,
+                 variant=None):
         """A device type describes a category of equivalent hardware devices.
 
         *name* is unique for the device type, typically as used by LAVA.
@@ -38,10 +39,13 @@ class DeviceType(YAMLObject):
         *context* is an arbirary dictionary used when scheduling tests.
         *params* is a dictionary with parameters to pass to the test job
                  generator.
+        *variant* is the variant of the CPU architecture following the Linux
+                  kernel convention.
         """
         self._name = name
         self._mach = mach
         self._arch = arch
+        self._variant = variant
         self._boot_method = boot_method
         self._dtb = dtb
         self._base_name = base_name or name
@@ -70,6 +74,10 @@ class DeviceType(YAMLObject):
         return self._arch
 
     @property
+    def variant(self):
+        return self._variant
+
+    @property
     def boot_method(self):
         return self._boot_method
 
@@ -93,6 +101,7 @@ class DeviceType(YAMLObject):
         attrs = super()._get_attrs()
         attrs.update({
             'arch',
+            'variant',
             'base_name',
             'boot_method',
             'context',
@@ -159,7 +168,8 @@ class DeviceType_shell(DeviceType):
 
     def __init__(self, name, mach=None, arch=None, boot_method=None,
                  *args, **kwargs):
-        super().__init__(name, mach, arch, boot_method, *args, **kwargs)
+        super().__init__(name, mach, arch, boot_method,
+                         *args, **kwargs)
 
 
 class DeviceTypeFactory(YAMLObject):
@@ -182,7 +192,7 @@ class DeviceTypeFactory(YAMLObject):
             'filters': FilterFactory.from_data(device_type, default_filters),
         }
         kw.update(cls._kw_from_yaml(device_type, [
-            'mach', 'arch', 'boot_method',
+            'mach', 'arch', 'variant', 'boot_method',
             'dtb', 'flags', 'context', 'params',
         ]))
         cls_name = device_type.get('class')
@@ -232,10 +242,14 @@ class RootFSType(YAMLObject):
         attrs.update({'url', 'arch_map'})
         return attrs
 
-    def get_arch_name(self, arch, endian):
+    def get_arch_name(self, arch, variant, endian):
         arch_key = ('arch', arch)
+        variant_key = ('variant', variant)
         endian_key = ('endian', endian)
-        arch_name = (self._arch_dict.get((arch_key, endian_key)) or
+        arch_name = (self._arch_dict.get((arch_key, variant_key,
+                                          endian_key)) or
+                     self._arch_dict.get((arch_key, variant_key)) or
+                     self._arch_dict.get((arch_key, endian_key)) or
                      self._arch_dict.get((arch_key,), arch))
         return arch_name
 
@@ -319,7 +333,7 @@ class RootFS(YAMLObject):
     def get_url_format(self, fs_type):
         return self._url_format.get(fs_type)
 
-    def get_url(self, fs_type, arch, endian):
+    def get_url(self, fs_type, arch, variant, endian):
         """Get the URL of the file system for the given variant and arch.
 
         The *fs_type* should match one of the URL patterns known to this root
@@ -328,7 +342,7 @@ class RootFS(YAMLObject):
         fmt = self.get_url_format(fs_type)
         if not fmt:
             return None
-        arch_name = self._fs_type.get_arch_name(arch, endian)
+        arch_name = self._fs_type.get_arch_name(arch, variant, endian)
         return fmt.format(arch=arch_name)
 
 

--- a/kernelci/test.py
+++ b/kernelci/test.py
@@ -88,6 +88,7 @@ def get_params(meta, target, plan_config, storage):
 
     kernel, rev = (meta.get('bmeta', key) for key in ['kernel', 'revision'])
     arch = target.arch
+    variant = target.variant
     dtb = dtb_full = target.dtb
     if dtb:
         dtb_dir = meta.get_single_artifact('dtbs', attr='path')
@@ -159,9 +160,9 @@ def get_params(meta, target, plan_config, storage):
 
     rootfs = plan_config.rootfs
     if rootfs:
-        initrd_url = rootfs.get_url('ramdisk', arch, endian)
+        initrd_url = rootfs.get_url('ramdisk', arch, variant, endian)
         initrd_compression = _get_compression(initrd_url)
-        nfsroot_url = rootfs.get_url('nfs', arch, endian)
+        nfsroot_url = rootfs.get_url('nfs', arch, variant, endian)
         nfsroot_compression = _get_compression(nfsroot_url)
         params.update({
             'initrd_url': initrd_url,


### PR DESCRIPTION
This board has ethernet and can run NFS root (my own testing
includes something based on the KernelCI NFS tests as a regular
feature).

Signed-off-by: Mark Brown <broonie@kernel.org>