### PR TITLE
test-configs: Separate out selftests that don't have a config dependency

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -248,6 +248,12 @@ test_plans:
     filters:
       - passlist: {defconfig: ['kselftest']}
 
+  kselftest-basic: &kselftest-basic
+    rootfs: debian_bullseye-kselftest_nfs
+    pattern: 'kselftest/{category}-{method}-{protocol}-{rootfs}-kselftest-template.jinja2'
+    filters:
+      - blocklist: *kselftest_defconfig_filter
+
   kselftest-cpufreq:
     <<: *kselftest
     params:
@@ -255,13 +261,13 @@ test_plans:
       kselftest_collections: "cpufreq"
 
   kselftest-filesystems:
-    <<: *kselftest
+    <<: *kselftest-basic
     params:
       job_timeout: '10'
       kselftest_collections: "filesystems"
 
   kselftest-futex:
-    <<: *kselftest
+    <<: *kselftest-basic
     params:
       job_timeout: '10'
       kselftest_collections: "futex"
@@ -285,7 +291,7 @@ test_plans:
       kselftest_collections: "lkdtm"
 
   kselftest-rtc:
-    <<: *kselftest
+    <<: *kselftest-basic
     params:
       job_timeout: '10'
       kselftest_collections: "rtc"
@@ -297,7 +303,7 @@ test_plans:
       kselftest_collections: "seccomp"
 
   kselftest-tpm2:
-    <<: *kselftest
+    <<: *kselftest-basic
     params:
       job_timeout: '10'
       kselftest_collections: "tpm2"


### PR DESCRIPTION
There are a number of kselftest targets which do not require any extra
configuration, typically those that exercise core functionality that is
expected to always be enabled like futexes and those that test devices
like RTC which are expected to be part of the platform defconfig. Add a
separate kselftest-basic base class for those kselftests we already have
defined and use it.

This is useful on platforms that have problems with the kselftest
configuration fragment for whatever reason (eg, due to the extra memory
consumption) and lets these tests run in a more normal environment.

Signed-off-by: Mark Brown <broonie@kernel.org>