### PR TITLE
Allow selftests to run without the kselftest fragment

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -255,6 +255,8 @@ test_plans:
     params:
       job_timeout: '10'
       kselftest_collections: "alsa"
+    filters: &kselftest_no_fragment
+      - combination: *arch_defconfig_filter
 
   kselftest-cpufreq:
     <<: *kselftest
@@ -267,12 +269,14 @@ test_plans:
     params:
       job_timeout: '10'
       kselftest_collections: "filesystems"
+    filters: *kselftest_no_fragment
 
   kselftest-futex:
     <<: *kselftest
     params:
       job_timeout: '10'
       kselftest_collections: "futex"
+    filters: *kselftest_no_fragment
 
   kselftest-lib:
     <<: *kselftest
@@ -297,6 +301,7 @@ test_plans:
     params:
       job_timeout: '10'
       kselftest_collections: "rtc"
+    filters: *kselftest_no_fragment
 
   kselftest-seccomp:
     <<: *kselftest
@@ -309,6 +314,7 @@ test_plans:
     params:
       job_timeout: '10'
       kselftest_collections: "tpm2"
+    filters: *kselftest_no_fragment
 
   kselftest-vm:
     <<: *kselftest

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -1454,16 +1454,6 @@ class MakeSelftests(Step):
     def name(self):
         return 'kselftest'
 
-    def is_enabled(self):
-        """Check whether the kselftest fragment is enabled
-
-        Return True if the kselftest config fragment is enabled in the build
-        meta-data, or False otherwise.
-        """
-        return 'kselftest' in self._meta.get(
-            'bmeta', 'kernel', 'defconfig_extras'
-        )
-
     def run(self, jopt=None, verbose=False, opts=None):
         """Make the kernel selftests
 


### PR DESCRIPTION
Many kselfests have no dependency on the kselftest fragment, such as those for core kernel features which are always enabled and those for drivers which require very device specific configuration expected to come from the defconfg. Even where there is a need for a config fragment the tests should handle it being missing gracefully at runtime. Remove the dependency on building kselftests and remove the runtime dependency from those selftests where it isn't needed.