### PR TITLE
Enable various kselftests

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -299,6 +299,13 @@ test_plans:
       kselftest_collections: "kcmp"
     filters: *kselftest_no_fragment
 
+  kselftest-kvm:
+    <<: *kselftest
+    params:
+      job_timeout: '10'
+      kselftest_collections: "kvm"
+    filters: *kselftest_no_fragment
+
   kselftest-lib:
     <<: *kselftest
     params:

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -303,6 +303,12 @@ test_plans:
       job_timeout: '10'
       kselftest_collections: "lkdtm"
 
+  kselftest-net:
+    <<: *kselftest
+    params:
+      job_timeout: '10'
+      kselftest_collections: "net"
+
   kselftest-openat2:
     <<: *kselftest
     params:

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -265,6 +265,13 @@ test_plans:
       kselftest_collections: "capabilities"
     filters: *kselftest_no_fragment
 
+  kselftest-cgroup:
+    <<: *kselftest
+    params:
+      job_timeout: '10'
+      kselftest_collections: "cgroup"
+    filters: *kselftest_no_fragment
+
   kselftest-clone3:
     <<: *kselftest
     params:

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -258,6 +258,13 @@ test_plans:
     filters: &kselftest_no_fragment
       - combination: *arch_defconfig_filter
 
+  kselftest-capabilities:
+    <<: *kselftest
+    params:
+      job_timeout: '10'
+      kselftest_collections: "capabilities"
+    filters: *kselftest_no_fragment
+
   kselftest-cpufreq:
     <<: *kselftest
     params:

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -292,6 +292,13 @@ test_plans:
       kselftest_collections: "futex"
     filters: *kselftest_no_fragment
 
+  kselftest-kcmp:
+    <<: *kselftest
+    params:
+      job_timeout: '10'
+      kselftest_collections: "kcmp"
+    filters: *kselftest_no_fragment
+
   kselftest-lib:
     <<: *kselftest
     params:

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -310,6 +310,13 @@ test_plans:
       job_timeout: '10'
       kselftest_collections: "lkdtm"
 
+  kselftest-mincore:
+    <<: *kselftest
+    params:
+      job_timeout: '10'
+      kselftest_collections: "mincore"
+    filters: *kselftest_no_fragment
+
   kselftest-net:
     <<: *kselftest
     params:

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -258,6 +258,13 @@ test_plans:
     filters: &kselftest_no_fragment
       - combination: *arch_defconfig_filter
 
+  kselftest-arm64:
+    <<: *kselftest
+    params:
+      job_timeout: '10'
+      kselftest_collections: "arm64"
+    filters: *kselftest_no_fragment
+
   kselftest-capabilities:
     <<: *kselftest
     params:

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -336,6 +336,13 @@ test_plans:
       job_timeout: '10'
       kselftest_collections: "seccomp"
 
+  kselftest-timers:
+    <<: *kselftest
+    params:
+      job_timeout: '15'
+      kselftest_collections: "timers"
+    filters: *kselftest_no_fragment
+
   kselftest-tpm2:
     <<: *kselftest
     params:

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -310,6 +310,13 @@ test_plans:
       job_timeout: '10'
       kselftest_collections: "lkdtm"
 
+  kselftest-membarrier:
+    <<: *kselftest
+    params:
+      job_timeout: '10'
+      kselftest_collections: "membarrier"
+    filters: *kselftest_no_fragment
+
   kselftest-mincore:
     <<: *kselftest
     params:

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -265,6 +265,13 @@ test_plans:
       kselftest_collections: "capabilities"
     filters: *kselftest_no_fragment
 
+  kselftest-clone3:
+    <<: *kselftest
+    params:
+      job_timeout: '10'
+      kselftest_collections: "clone3"
+    filters: *kselftest_no_fragment
+
   kselftest-cpufreq:
     <<: *kselftest
     params:

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -278,6 +278,13 @@ test_plans:
       job_timeout: '10'
       kselftest_collections: "cpufreq"
 
+  kselftest-exec:
+    <<: *kselftest
+    params:
+      job_timeout: '10'
+      kselftest_collections: "exec"
+    filters: *kselftest_no_fragment
+
   kselftest-filesystems:
     <<: *kselftest
     params:

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -303,6 +303,13 @@ test_plans:
       job_timeout: '10'
       kselftest_collections: "lkdtm"
 
+  kselftest-openat2:
+    <<: *kselftest
+    params:
+      job_timeout: '10'
+      kselftest_collections: "openat2"
+    filters: *kselftest_no_fragment
+
   kselftest-rtc:
     <<: *kselftest
     params:


### PR DESCRIPTION
This series adds just the basic stanzas for some reasonably reliable kselftests which seem useful and which I've been using to have more kselftest fragments to work with for other development. 

It doesn't include any board enabements due to the concerns about picking systems to run things on, I will turn them on for AT91SAM9G20-EK once https://github.com/kernelci/kernelci-core/pull/1097 is in (and there's some overlap with https://github.com/kernelci/kernelci-core/pull/1116 too). 