### PR TITLE
test-configs: Enable baseline-nfs for Pine64+

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2579,6 +2579,7 @@ test_configs:
   - device_type: sun50i-a64-pine64-plus
     test_plans:
       - baseline
+      - baseline-nfs
 
   - device_type: sun50i-h5-libretech-all-h3-cc
     test_plans:


### PR DESCRIPTION
The board has built in ethernet which is well supported by the kernel.

Signed-off-by: Mark Brown <broonie@kernel.org>