### PR TITLE
test-configs: Enable more tests for Pine64+

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2587,6 +2587,7 @@ test_configs:
       # ltp-mm - runs system out of memory
       - ltp-pty
       - ltp-timers
+      - smc
 
   - device_type: sun50i-h5-libretech-all-h3-cc
     test_plans:

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2580,6 +2580,13 @@ test_configs:
     test_plans:
       - baseline
       - baseline-nfs
+      - ltp-crypto
+      - ltp-fcntl-locktests
+      - ltp-ima
+      - ltp-ipc
+      # ltp-mm - runs system out of memory
+      - ltp-pty
+      - ltp-timers
 
   - device_type: sun50i-h5-libretech-all-h3-cc
     test_plans:


### PR DESCRIPTION
The board has suitable hardware to support the cpufreq and RTC tests and has built in ethernet so can NFS boot.

This builds on top of https://github.com/kernelci/kernelci-core/pull/1119 which is in the history, hopefully github handles that well...