### PR TITLE
CHROMEOS config/lava/chromeos: Add chromeos-install-modules-template

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -61,6 +61,8 @@ rootfs_configs:
       - wget
       - openssh-server
       - parted
+      - xz-utils
+      - bzip2
     test_overlay: "overlays/chromeos-flash"
 
   bullseye-cros-ec:

--- a/config/core/test-configs-chromeos.yaml
+++ b/config/core/test-configs-chromeos.yaml
@@ -1,5 +1,9 @@
 test_plans:
 
+  chromeos-boot:
+    pattern: 'chromeos/chromeos-boot-chromebook-template.jinja2'
+    prompt_command: 'NETDEV_UP'
+
   chromeos-flash:
     pattern: 'chromeos/chromeos-flash-template.jinja2'
     params:

--- a/config/lava/chromeos/chromeos-boot-chromebook-template.jinja2
+++ b/config/lava/chromeos/chromeos-boot-chromebook-template.jinja2
@@ -1,0 +1,30 @@
+{% extends 'base/kernel-ci-base.jinja2' %}
+{% block main %}
+{{ super () }}
+context:
+  extra_kernel_args: console_msg_format=syslog cros_secure cros_debug boot=/dev/{{ flashing_device }}p3
+{% endblock %}
+
+{% block actions %}
+{{ super () }}
+
+actions:
+- deploy:
+      namespace: boot_chromeos
+      timeout:
+        minutes: 60
+      to: tftp
+      kernel:
+        url: {{ kernel_url }}
+      os: oe
+
+- boot:
+      namespace: boot_chromeos
+      timeout:
+        minutes: 30
+      method: depthcharge
+      commands: emmc
+      prompts:
+        - {{ prompt_command }}
+
+{% endblock %}

--- a/config/lava/chromeos/chromeos-install-modules-template.jinja2
+++ b/config/lava/chromeos/chromeos-install-modules-template.jinja2
@@ -1,0 +1,66 @@
+{% extends 'base/kernel-ci-base.jinja2' %}
+{% block main %}
+{{ super () }}
+context:
+  extra_kernel_args: console_msg_format=syslog cros_secure cros_debug
+{% endblock %}
+
+{% block actions %}
+{{ super () }}
+
+actions:
+- deploy:
+    namespace: install_modules
+    kernel:
+      url: {{ flashing_kernel }}
+    modules:
+      url: {{ flashing_modules }}
+      compression: xz
+    nfsrootfs:
+      url: {{ flashing_rootfs }}
+      compression: xz
+    ramdisk:
+      url: {{ flashing_ramdisk }}
+      compression: gz
+    os: oe
+    timeout:
+      minutes: 60
+    to: tftp
+
+
+- boot:
+    namespace: install_modules
+    timeout:
+      minutes: 60
+    method: depthcharge
+    commands: nfs
+    prompts:
+      - '/ #'
+
+- test:
+    namespace: install_modules
+    timeout:
+      minutes: 60
+    definitions:
+    - repository:
+        metadata:
+          format: Lava-Test Test Definition 1.0
+          name: chromeos-install-modules
+          description: "Install Chrome OS kernel modules"
+          os:
+            - debian
+          scope:
+            - functional
+          environment:
+            - lava-test-shell
+        run:
+          steps:
+            - lsblk
+            - ls -l /root
+            - MODULES_URL="{{ modules_url }}"  /bin/bash /opt/chromeos/install-modules
+      lava-signal: kmsg
+      from: inline
+      name: chromeos-install-modules
+      path: inline/chromeos-install-modules.yaml
+
+{% endblock %}

--- a/config/rootfs/debos/overlays/chromeos-flash/opt/chromeos/install-modules
+++ b/config/rootfs/debos/overlays/chromeos-flash/opt/chromeos/install-modules
@@ -18,7 +18,7 @@ install_modules()
     cd "$mount_dir"
     ls -l lib/modules
     rm -rf lib/modules
-    tar xzf "$root_path/$modules_tarball"
+    tar xf "$root_path/$modules_tarball"
     chown root: -R lib
     ls -l lib/modules
     cd "$root_path"


### PR DESCRIPTION
Add LAVA job template for installing chromeos modules and a accompanying test-configs.yaml configuration.