### PR TITLE
Fix pkg-config

### DIFF
--- a/config/docker/clang-base/Dockerfile
+++ b/config/docker/clang-base/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
    libhugetlbfs-dev:arm64 \
    libpopt-dev:arm64 \
    libasound2-dev:arm64 \
-   pkg-config:arm64
+   pkg-config
 
 # kselftest arm
 RUN dpkg --add-architecture armhf
@@ -44,6 +44,6 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
    libhugetlbfs-dev:armhf \
    libpopt-dev:armhf \
    libasound2-dev:armhf \
-   pkg-config:armhf
+   pkg-config
 
 RUN apt-get autoremove -y gcc

--- a/config/docker/gcc-10_arm/Dockerfile
+++ b/config/docker/gcc-10_arm/Dockerfile
@@ -27,4 +27,4 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
    libnuma-dev:armhf \
    libpopt-dev:armhf \
    libasound2-dev:armhf \
-   pkg-config:armhf
+   pkg-config

--- a/config/docker/gcc-10_arm/Dockerfile
+++ b/config/docker/gcc-10_arm/Dockerfile
@@ -27,4 +27,5 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
    libnuma-dev:armhf \
    libpopt-dev:armhf \
    libasound2-dev:armhf \
+   libasound2-dev \
    pkg-config

--- a/config/docker/gcc-10_arm64/Dockerfile
+++ b/config/docker/gcc-10_arm64/Dockerfile
@@ -38,4 +38,5 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
    libnuma-dev:arm64 \
    libpopt-dev:arm64 \
    libasound2-dev:arm64 \
+   libasound2-dev \
    pkg-config

--- a/config/docker/gcc-10_arm64/Dockerfile
+++ b/config/docker/gcc-10_arm64/Dockerfile
@@ -38,4 +38,4 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
    libnuma-dev:arm64 \
    libpopt-dev:arm64 \
    libasound2-dev:arm64 \
-   pkg-config:arm64
+   pkg-config


### PR DESCRIPTION
This installs a copy of pkg-config we can actually use and ensures it finds libasound2 in cross builds.