### PR TITLE
Pine64+ kselftests

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2622,6 +2622,12 @@ test_configs:
     test_plans:
       - baseline
       - baseline-nfs
+      - kselftest-cpufreq
+      - kselftest-filesystems
+      - kselftest-futex
+      - kselftest-lib
+      - kselftest-rtc
+      - kselftest-seccomp
       - ltp-crypto
       - ltp-fcntl-locktests
       - ltp-ima


### PR DESCRIPTION
This builds on top of https://github.com/kernelci/kernelci-core/pull/1121, adding the kselftests on top. At time of submission the lab configurations need updating to support the larger kernel that the kselftest fragments generate (though some will start working once https://github.com/kernelci/kernelci-core/pull/1116 goes in), the lab config for at least my lab will hopefully be updated in the next day or two when I find a quiet period in my lab.