### PR TITLE
build-configs.yaml: Add to fragment support of NVMe to Chromebooks

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -271,6 +271,8 @@ fragments:
       - 'CONFIG_SPI=y'
       - 'CONFIG_SPI_PXA2XX=y'
       - 'CONFIG_PINCTRL_AMD=y'
+      - 'CONFIG_NVME_CORE=y'
+      - 'CONFIG_BLK_DEV_NVME=y'
 
   x86_kvm_guest:
     path: "kernel/configs/kvm_guest.config"


### PR DESCRIPTION
Without NVMe support it is not possible to flash such Chromebooks.
Tested at: https://lava.collabora.co.uk/scheduler/job/6090176

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>