### PR TITLE
CHROMEOS Add chromebook definitions, extract kernel and modules from rootfs

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -247,3 +247,23 @@ rootfs_configs:
     arch_list:
       - amd64
 
+  chromiumos-grunt:
+    rootfs_type: chromiumos
+    board: grunt
+    branch: release-R100-14526.B
+    arch_list:
+      - amd64
+
+  chromiumos-hatch:
+    rootfs_type: chromiumos
+    board: hatch
+    branch: release-R100-14526.B
+    arch_list:
+      - amd64
+
+  chromiumos-octopus:
+    rootfs_type: chromiumos
+    board: octopus
+    branch: release-R100-14526.B
+    arch_list:
+      - amd64

--- a/config/rootfs/chromiumos/scripts/build_board.sh
+++ b/config/rootfs/chromiumos/scripts/build_board.sh
@@ -45,7 +45,7 @@ fi
 
 # Add serial support
 echo Add serial support
-cros_sdk USE=pcserial ./build_packages --board=${BOARD}
+cros_sdk USE=pcserial build_packages --board=${BOARD}
 cros_sdk USE="tty_console_ttyS0" emerge-"${BOARD}" chromeos-base/tty
 echo Building image
 cros_sdk ./build_image --enable_serial ttyS0 --board="${BOARD}" --boot_args "earlyprintk=serial,keep console=tty0" --noenable_rootfs_verification test

--- a/config/rootfs/chromiumos/scripts/build_board.sh
+++ b/config/rootfs/chromiumos/scripts/build_board.sh
@@ -32,6 +32,17 @@ echo Board ${BOARD} setup
 # Compiling ChromiumOS image
 # Future possible option --profile=x, for example kernel-5_15, profiles are at /mnt/host/source/src/overlays/overlay-${BOARD}/profiles/
 cros_sdk setup_board --board=${BOARD}
+
+# Without workarounds hatch and octopus build failing
+if [ "${BOARD}" == "hatch" ]; then
+echo Patching hatch specific issue
+sed -i 's/EC_BOARDS=()/EC_BOARDS=(hatch)/' src/third_party/chromiumos-overlay/eclass/cros-ec-board.eclass
+fi
+if [ "${BOARD}" == "octopus" ]; then
+echo Patching octopus specific issue
+sed -i s,'use fuzzer || die',"#use fuzzer || die", src/third_party/chromiumos-overlay/eclass/cros-ec-board.eclass
+fi
+
 # Add serial support
 echo Add serial support
 cros_sdk USE=pcserial ./build_packages --board=${BOARD}

--- a/config/rootfs/chromiumos/scripts/build_board.sh
+++ b/config/rootfs/chromiumos/scripts/build_board.sh
@@ -57,6 +57,8 @@ sudo cp "src/build/images/${BOARD}/latest/chromiumos_test_image.bin" "${DATA_DIR
 sudo tar -czf "${DATA_DIR}/${BOARD}/tast.tgz" -C ./chroot/usr/bin/ remote_test_runner tast
 sudo chown -R "${USERNAME}" "${DATA_DIR}/${BOARD}"
 gzip -1 "${DATA_DIR}/${BOARD}/chromiumos_test_image.bin"
+sudo tar -cJf "${DATA_DIR}/${BOARD}/modules.tar.xz" -C ./chroot/build/${BOARD} lib/modules
+sudo cp "./chroot/build/${BOARD}/boot/vmlinuz" "${DATA_DIR}/${BOARD}/bzImage"
 
 # Probably redundant, but better safe than sorry
 cleanup


### PR DESCRIPTION
Manually built and tested rootfs of octopus, grunt, hatch.
hatch require small patch (workaround) at current moment, otherwise build fail with error:

    No boards found; assuming we're building for a fuzzer.
    ERROR: chromeos-base/chromeos-ec-0.0.2-r12066::chromiumos failed (compile phase):
    No EC boards found.

Also add extraction of kernel and modules, as LAVA depthcharge method require them for booting.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>