### PR TITLE
test-configs.yaml: Add a machine type for Juno with U-Boot firmware

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -967,6 +967,12 @@ device_types:
       - blocklist: *device_config_filter
       - blocklist: {defconfig: ['multi_v7_defconfig+kselftest']}
 
+  juno-uboot:
+    mach: vexpress
+    class: arm64-dtb
+    dtb: 'arm/juno.dtb'
+    boot_method: uboot
+
   kirkwood-db-88f6282:
     mach: mvebu
     class: arm-dtb
@@ -2170,6 +2176,24 @@ test_configs:
     test_plans:
       - baseline
       - baseline-nfs
+
+  - device_type: juno-uboot
+    test_plans:
+      - baseline
+      - baseline-nfs
+      - kselftest-cpufreq
+      - kselftest-futex
+      - kselftest-lib
+      - kselftest-lkdtm
+      - kselftest-rtc
+      - kselftest-seccomp
+      - ltp-crypto
+      - ltp-fcntl-locktests
+      - ltp-ipc
+      # ltp-mm - runs system out of memory
+      - ltp-pty
+      - ltp-timers
+      - smc
 
   - device_type: kirkwood-db-88f6282
     test_plans:


### PR DESCRIPTION
The standard LAVA interpretation of Juno includes support for rewriting
the firmware as part of the test job but not all labs will want to do
that since it makes jobs take longer to run and be more hassle to
specify. Add a separate device type for Juno r0 systems with fixed
u-boot firmware.

Signed-off-by: Mark Brown <broonie@kernel.org>