### PR TITLE
config/docker: Use a current version of qemu

### DIFF
--- a/config/docker/qemu/Dockerfile
+++ b/config/docker/qemu/Dockerfile
@@ -1,7 +1,10 @@
 FROM debian:bullseye
 
-RUN apt-get update && \
-	apt-get install --yes --no-install-recommends \
+RUN echo deb http://deb.debian.org/debian bullseye-backports main \
+	> /etc/apt/sources.list.d/backports.list
+
+RUN apt-get update && apt-get install -t bullseye-backports --yes
+	--no-install-recommends \
 	qemu-system \
 	qemu-system-arm \
 	qemu-system-mips \


### PR DESCRIPTION
Half the point of running all docker jobs in qemu is to allow us
to make use of features of and get coverage of architecture
emulation in current versions of qemu. Unfortunately we're just
using the default version from Debian which is v5.2, already more
than a year old and only going to get futher and further behind.
Change the container to pick up the verison of qemu from
backports which should be a lot more current - at time of writing
it's got the latest release.

Signed-off-by: Mark Brown <broonie@kernel.org>