### PR TITLE
test-configs: Don't use KVM acceleration for arm64 virtual platforms

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1307,7 +1307,7 @@ device_types:
       arch: arm64
       cpu: 'max'
       guestfs_interface: 'virtio'
-      machine: 'virt,gic-version=2,mte=on,accel=kvm:tcg'
+      machine: 'virt,gic-version=2,mte=on,accel=tcg'
     filters:
       - regex: { defconfig: 'defconfig' }
 
@@ -1325,7 +1325,7 @@ device_types:
       arch: arm64
       cpu: 'max'
       guestfs_interface: 'virtio'
-      machine: 'virt,gic-version=3,mte=on,accel=kvm:tcg'
+      machine: 'virt,gic-version=3,mte=on,accel=tcg'
     filters:
       - passlist: {defconfig: ['defconfig']}
 


### PR DESCRIPTION
Using KVM acceleration means that when running natively instead
of emulating whatever qemu supports we directly virtualise
whatever CPU the host has. This results in a less consistent
target platform between test runs and means we miss coverage of
new features only available in emulation which is one of the
benefits of using qemu. It's reasonable to want to test
virtualisation but we should specifically do so as a separate
target.

This is unlikely to have had any effect at present since
currently I think all our host systems are x86 based.

Signed-off-by: Mark Brown <broonie@kernel.org>