### PR TITLE
kernelci.lab.lava: move job_file_name() to base class

### DIFF
--- a/kernelci/lab/lava/__init__.py
+++ b/kernelci/lab/lava/__init__.py
@@ -70,6 +70,9 @@ class LavaAPI(LabAPI):
             job_id = self._submit(job)
             return job_id
 
+    def job_file_name(self, params):
+        return '.'.join([params['name'], 'yaml'])
+
     def _add_callback_params(self, params, opts):
         callback_id = opts.get('id')
         if not callback_id:

--- a/kernelci/lab/lava/lava_rest.py
+++ b/kernelci/lab/lava/lava_rest.py
@@ -97,9 +97,6 @@ class LavaRest(LavaAPI):
         online_status = self.devices.get('online_status', dict())
         return online_status.get(device_type, False)
 
-    def job_file_name(self, params):
-        return '.'.join([params['name'], 'yaml'])
-
     def _submit(self, job):
         jobs_url = urljoin(self._server.url, 'jobs/')
         job_data = {

--- a/kernelci/lab/lava/lava_xmlrpc.py
+++ b/kernelci/lab/lava/lava_xmlrpc.py
@@ -91,9 +91,6 @@ class LAVA(LavaAPI):
         online_status = self.devices.get('online_status', dict())
         return online_status.get(device_type, False)
 
-    def job_file_name(self, params):
-        return '.'.join([params['name'], 'yaml'])
-
     def _submit(self, job):
         return self._server.scheduler.submit_job(job)
 


### PR DESCRIPTION
Move the .job_file_name() method to the base LavaAPI class as it's
common to XMLRPC and Rest API variants.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>