### PR TITLE
kernelci.lab.shell: add copyright header

### DIFF
--- a/kernelci/lab/shell.py
+++ b/kernelci/lab/shell.py
@@ -1,3 +1,20 @@
+# Copyright (C) 2021, 2022 Collabora Limited
+# Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+#
+# This module is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
 import os
 import subprocess
 from jinja2 import Environment, FileSystemLoader


### PR DESCRIPTION
Add missing copyright header in kernelci/lab/shell.py

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>