### PR TITLE
kernelci.lab: drop db_config from .generate()

### DIFF
--- a/kci_test
+++ b/kci_test
@@ -256,7 +256,7 @@ class cmd_generate(Command):
             params = kernelci.test.get_params(
                 meta, device_config, plan_config, args.storage)
             job = lab_api.generate(params, device_config, plan_config,
-                                   callback_opts, db_config=db_config)
+                                   callback_opts)
             if job is None:
                 print("Failed to generate the job definition")
                 return False

--- a/kernelci/lab/__init__.py
+++ b/kernelci/lab/__init__.py
@@ -76,8 +76,7 @@ class LabAPI:
         return self.config.match(filter_data)
 
     def generate(self, params, device_config, plan_config,
-                 callback_opts=None, templates_path=None, db_config=None,
-                 lab_config=None):
+                 callback_opts=None, templates_path=None, lab_config=None):
         """Generate a test job definition.
 
         *params* is a dictionary with the test parameters which can be used
@@ -93,9 +92,6 @@ class LabAPI:
 
         *templates_path* is an optional argument to specify the path where the
             template files should be found, when not in the standard location
-
-        *db_config* is a Database configuration object for the database or API
-            where the results should be sent
 
         *lab_config* is a configuration object for the API
             where the tests should be run

--- a/kernelci/lab/lava/__init__.py
+++ b/kernelci/lab/lava/__init__.py
@@ -27,7 +27,7 @@ from kernelci.lab import LabAPI
 class LavaAPI(LabAPI):
 
     def generate(self, params, device_config, plan_config, callback_opts=None,
-                 templates_path='config/lava', db_config=None):
+                 templates_path='config/lava'):
         short_template_file = plan_config.get_template_path(
             device_config.boot_method)
         template_file = os.path.join(templates_path, short_template_file)

--- a/kernelci/lab/shell.py
+++ b/kernelci/lab/shell.py
@@ -7,13 +7,10 @@ from kernelci.lab import LabAPI
 class Shell(LabAPI):
 
     def generate(self, params, device_config, plan_config,
-                 callback_opts=None, templates_path='config/scripts',
-                 db_config=None):
+                 callback_opts=None, templates_path='config/scripts'):
         jinja2_env = Environment(loader=FileSystemLoader(templates_path))
         template_path = plan_config.get_template_path(None)
         template = jinja2_env.get_template(template_path)
-        if db_config:
-            params['db_config_yaml'] = db_config.to_yaml()
         return template.render(params)
 
     def save_file(self, *args, **kwargs):


### PR DESCRIPTION
Drop the db_config argument from LabAPI.generate() as extra parameters
such as the db config YAML dump should be added to the parameters
before calling the method.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>