### PR TITLE
test-configs: Add multi_v5_defconfig as a defconfig for 32 bit arm

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -101,6 +101,7 @@ default_filters:
     - combination: &arch_defconfig_filter
         keys: ['arch', 'defconfig']
         values:
+          - ['arm', 'multi_v5_defconfig']
           - ['arm', 'multi_v7_defconfig']
           - ['arm64', 'defconfig']
           - ['arm64', 'defconfig+arm64-chromebook']


### PR DESCRIPTION
The arm port has two main defconfigs - multi_v7_defconfig for the more
modern hardware and multi_v5_defconfig for older system. Currently we
only consider the former where we need a list of defconfigs but we do
have some older platforms so consider multi_v5_defconfig part of our
standard architecture defconfig list.

Signed-off-by: Mark Brown <broonie@kernel.org>