### PR TITLE
T34835 lab config path

### DIFF
--- a/config/core/lab-configs.yaml
+++ b/config/core/lab-configs.yaml
@@ -3,6 +3,7 @@ labs:
   # ToDo: also run jobs with callbacks sent to BayLibre's KernelCI backend
   lab-baylibre:
     lab_type: lava.lava_xmlrpc
+    config_path: 'lava'
     url: 'https://lava.baylibre.com/RPC2/'
     queue_timeout:
       days: 1
@@ -16,6 +17,7 @@ labs:
 
   lab-broonie:
     lab_type: lava.lava_xmlrpc
+    config_path: 'lava'
     url: 'https://lava.sirena.org.uk/RPC2/'
     priority_min: 0
     priority_max: 40
@@ -31,6 +33,7 @@ labs:
 
   lab-cip:
     lab_type: lava.lava_xmlrpc
+    config_path: 'lava'
     url: 'https://lava.ciplatform.org/RPC2/'
     priority: low
     filters:
@@ -71,6 +74,7 @@ labs:
 
   lab-clabbe:
     lab_type: lava.lava_xmlrpc
+    config_path: 'lava'
     url: 'https://lava.montjoie.ovh/RPC2/'
     queue_timeout:
       hours: 24
@@ -88,6 +92,7 @@ labs:
 
   lab-collabora:
     lab_type: lava.lava_rest
+    config_path: 'lava'
     url: 'https://lava.collabora.co.uk/'
     priority: '45'
     queue_timeout:
@@ -98,6 +103,7 @@ labs:
 
   lab-collabora-staging:
     lab_type: lava.lava_rest
+    config_path: 'lava'
     url: 'https://staging.lava.collabora.dev/'
     priority: '45'
     queue_timeout:
@@ -106,6 +112,7 @@ labs:
 
   lab-kontron:
     lab_type: lava.lava_rest
+    config_path: 'lava'
     url: 'https://lavalab.kontron.com/'
     filters:
       - passlist:
@@ -114,6 +121,7 @@ labs:
 
   lab-linaro-lkft:
     lab_type: lava.lava_rest
+    config_path: 'lava'
     url: 'https://lkft.validation.linaro.org/'
     priority_min: 0
     priority_max: 25
@@ -133,6 +141,7 @@ labs:
 
   lab-mhart:
     lab_type: lava.lava_xmlrpc
+    config_path: 'lava'
     url: 'http://lava.streamtester.net/RPC2/'
     filters:
       - blocklist: {tree: ['android', 'drm-tip', 'linaro-android']}
@@ -142,6 +151,7 @@ labs:
 
   lab-nxp:
     lab_type: lava.lava_rest
+    config_path: 'lava'
     url: 'https://lavalab.nxp.com/'
     filters:
       - passlist:
@@ -150,6 +160,7 @@ labs:
 
   lab-pengutronix:
     lab_type: lava.lava_rest
+    config_path: 'lava'
     url: 'https://hekla.openlab.pengutronix.de/'
     filters:
       - passlist:
@@ -158,6 +169,7 @@ labs:
 
   lab-theobroma-systems:
     lab_type: lava.lava_xmlrpc
+    config_path: 'lava'
     url: 'https://lava.theobroma-systems.com/RPC2/'
     filters:
       - passlist:
@@ -166,3 +178,4 @@ labs:
 
   shell:
     lab_type: shell
+    config_path: 'scripts'

--- a/kernelci/config/lab.py
+++ b/kernelci/config/lab.py
@@ -23,16 +23,19 @@ from kernelci.config.base import FilterFactory, YAMLObject
 class Lab(YAMLObject):
     """Test lab model."""
 
-    def __init__(self, name, lab_type, filters=None):
+    def __init__(self, name, lab_type, config_path=None, filters=None):
         """A lab object contains all the information relative to a test lab.
 
         *name* is the name used to refer to the lab in meta-data.
         *lab_type* is the name of the type of lab, essentially indicating the
                    type of software used by the lab.
+        *config_path* is the relative path where config files for the lab type
+                      are stored
         *filters* is a list of Filter objects associated with this lab.
         """
         self._name = name
         self._lab_type = lab_type
+        self._config_path = config_path
         self._filters = filters or list()
 
     @classmethod
@@ -46,6 +49,10 @@ class Lab(YAMLObject):
     @property
     def lab_type(self):
         return self._lab_type
+
+    @property
+    def config_path(self):
+        return self._config_path
 
     def match(self, data):
         return all(f.match(**data) for f in self._filters)
@@ -135,7 +142,7 @@ class LabFactory(YAMLObject):
             'filters': FilterFactory.from_data(lab),
         }
         kw.update(cls._kw_from_yaml(lab, [
-            'url',
+            'url', 'config_path',
         ]))
         lab_cls = cls._lab_types[lab_type] if lab_type else Lab
         return lab_cls.from_yaml(lab, kw)


### PR DESCRIPTION
Add `config_path` attribute to the lab configuration to know where to find things such as Jinja2 templates. Also populate the attribute with all the existing lab configs.