### PR TITLE
test-configs: Raise priorities of all baseline jobs

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -133,6 +133,8 @@ test_plans:
   baseline-cip-nfs:
     rootfs: cip_nfs
     pattern: 'baseline/{category}-{method}-{protocol}-nfs-baseline-template.jinja2'
+    params:
+      priority: 85
     filters:
       - blocklist: *kselftest_defconfig_filter
 
@@ -141,10 +143,13 @@ test_plans:
     pattern: 'baseline/generic-fastboot-baseline-template.jinja2'
     params:
       job_timeout: '50'
+      priority: 90
 
   baseline-nfs:
     rootfs: debian_bullseye_nfs
     pattern: 'baseline/{category}-{method}-{protocol}-nfs-baseline-template.jinja2'
+    params:
+      priority: 85
     filters:
       - blocklist: *kselftest_defconfig_filter
 
@@ -152,6 +157,8 @@ test_plans:
     base_name: baseline
     rootfs: buildroot-baseline_ramdisk
     pattern: 'baseline/generic-qemu-baseline-template.jinja2'
+    params:
+      priority: 90
     filters:
       - blocklist: *kselftest_defconfig_filter
       - passlist: &qemu_labs_filter


### PR DESCRIPTION
When priorities were added for test jobs we raised the priority of the
baseline job on the basis that it helps ensure we get some basic
coverage for the boards and will in future allow us to avoid scheduling
other tests on boards that have boot issues. A similar argument applies
to all the other baseline tests so let's also raise their priorities to
match.

Put the NFS boot jobs at a slightly lower priority since they are
generally a secondary boot method for boards that also boot using
another method, they are still important since many of the other tests
rely on being booted via NFS.

Signed-off-by: Mark Brown <broonie@kernel.org>