### PR TITLE
test-configs: Increase timeout for LTP pty tests

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -383,6 +383,7 @@ test_plans:
     params:
       <<: *ltp-params
       tst_cmdfiles: "pty"
+      job_timeout: '25'
 
   ltp-timers:
     <<: *ltp


### PR DESCRIPTION
The LTP pty tests have been timing out in production, with only one
board managing to complete the tests recently. The default timeout is 15
minutes but running with a larger timeout showed that the test job took
17 minutes to complete on Pine64 Plus. Raise the timeout to 25 minutes,
covering that with some additional headroom for slower systems.

Signed-off-by: Mark Brown <broonie@kernel.org>