### PR TITLE
CHROMEOS LAVA flash improvements

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -173,7 +173,6 @@ test_plans:
     params:
       job_timeout: '60'
       docker_image: 'kernelci/chromeos-flash'
-      chromeos_image: 'chromiumos_test_image-R94-14150.19.0-octopus.bin'
       flashing_kernel: http://storage.chromeos.kernelci.org/images/kernel/v5.17.2-x86_64+x86_chromebook/kernel/bzImage
       flashing_modules: http://storage.chromeos.kernelci.org/images/kernel/v5.17.2-x86_64+x86_chromebook/modules.tar.xz
       flashing_rootfs: http://storage.chromeos.kernelci.org/images/rootfs/chromeos/20220412.0/bullseye-chromeos-flash/amd64/full.rootfs.tar.xz
@@ -653,6 +652,9 @@ device_types:
     arch: x86_64
     boot_method: depthcharge
     filters: *x86-chromebook-filters
+    params:
+      chromeos_image: 'https://storage.chromeos.kernelci.org/images/rootfs/chromeos/crostest007/chromiumos-hatch/amd64/chromiumos_test_image.bin.gz'
+      flashing_device: nvme0n1
 
   asus-C523NA-A20057-coral:
     mach: x86
@@ -823,6 +825,9 @@ device_types:
     arch: x86_64
     boot_method: depthcharge
     filters: *x86-chromebook-filters
+    params:
+      chromeos_image: 'https://storage.chromeos.kernelci.org/images/rootfs/chromeos/crostest007/chromiumos-grunt/amd64/chromiumos_test_image.bin.gz'
+      flashing_device: detect
 
   # Alphabetical order exception: 14 is an int but 12b is a string
   hp-x360-14-G1-sona:
@@ -836,6 +841,9 @@ device_types:
     arch: x86_64
     boot_method: depthcharge
     filters: *x86-chromebook-filters
+    params:
+      chromeos_image: 'https://storage.chromeos.kernelci.org/images/rootfs/chromeos/crostest007/chromiumos-octopus/amd64/chromiumos_test_image.bin.gz'
+      flashing_device: mmcblk0
 
   hp-x360-12b-n4000-octopus: *octopus
 

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -173,8 +173,8 @@ test_plans:
     params:
       job_timeout: '60'
       docker_image: 'kernelci/chromeos-flash'
-      flashing_kernel: http://storage.chromeos.kernelci.org/images/kernel/v5.17.2-x86_64+x86_chromebook/kernel/bzImage
-      flashing_modules: http://storage.chromeos.kernelci.org/images/kernel/v5.17.2-x86_64+x86_chromebook/modules.tar.xz
+      flashing_kernel: https://storage.chromeos.kernelci.org/images/kernel/v5.10.112-x86-chromebook/kernel/bzImage
+      flashing_modules: https://storage.chromeos.kernelci.org/images/kernel/v5.10.112-x86-chromebook/modules.tar.xz
       flashing_rootfs: http://storage.chromeos.kernelci.org/images/rootfs/chromeos/20220412.0/bullseye-chromeos-flash/amd64/full.rootfs.tar.xz
       flashing_ramdisk: http://storage.chromeos.kernelci.org/images/rootfs/chromeos/20220412.0/bullseye-chromeos-flash/amd64/initrd.cpio.gz
 

--- a/config/lava/chromeos/chromeos-flash-template.jinja2
+++ b/config/lava/chromeos/chromeos-flash-template.jinja2
@@ -46,39 +46,16 @@ actions:
     - repository:
         metadata:
           format: Lava-Test Test Definition 1.0
-          name: docker-network
+          name: docker-network-flashing
         run:
           steps:
             - ping -c 1 172.17.0.1
-            - lava-test-case wget --shell  "wget http://172.17.0.1/chromeos/{{ chromeos_image }}"
-            - lava-test-case scp --shell "scp -i /keys/id_rsa_chromeos_flash -o ConnectTimeout=3 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null {{ chromeos_image }} root@$(lava-target-ip):/root"
+            - lava-test-case wget --shell "wget --no-check-certificate -O chromiumos_test_image.bin.gz {{ chromeos_image }}"
+            - lava-test-case unpack --shell "gzip -d chromiumos_test_image.bin.gz || mv chromiumos_test_image.bin.gz chromiumos_test_image.bin"
+            - lava-test-case scp --shell "scp -C -i /keys/id_rsa_chromeos_flash -o ConnectTimeout=3 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null chromiumos_test_image.bin root@$(lava-target-ip):/root"
+            - ssh -i /keys/id_rsa_chromeos_flash -o ConnectTimeout=3 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@$(lava-target-ip) "IMAGE_NAME=chromiumos_test_image.bin FLASH_DEVICE={{ flashing_device }} /bin/bash /opt/chromeos/flash"
       from: inline
-      name: docker-network
+      name: docker-network-flashing
       path: inline/docker-network.yaml
-
-- test:
-    timeout:
-      minutes: 60
-    definitions:
-    - repository:
-        metadata:
-          format: Lava-Test Test Definition 1.0
-          name: chromeos-flash
-          description: "Flash Chrome OS image"
-          os:
-            - debian
-          scope:
-            - functional
-          environment:
-            - lava-test-shell
-        run:
-          steps:
-            - lsblk
-            - ls -l /root
-            - IMAGE_NAME={{ chromeos_image }}  /bin/bash /opt/chromeos/flash
-      lava-signal: kmsg
-      from: inline
-      name: chromeos-flash
-      path: inline/chromeos-flash.yaml
 
 {% endblock %}


### PR DESCRIPTION
Based on real testing, to improve reliability of flashing following changes are done:
1)Accept ChromiumOS as full URL, as it might be placed on various resources, not only internally
2)Assume image is compressed (significant space gains)
3)Use compressed scp (few minutes win over 100Mbps-forced port)
4)Flash over ssh, as serial console very unreliable
5)Specify root device for each device type flashing job
6)Include examples for known device types that was flashed successfully

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>