### PR TITLE
lab-configs: Add a timeout for my lab

### DIFF
--- a/config/core/lab-configs.yaml
+++ b/config/core/lab-configs.yaml
@@ -19,6 +19,8 @@ labs:
     url: 'https://lava.sirena.org.uk/RPC2/'
     priority_min: 0
     priority_max: 40
+    queue_timeout:
+      days: 1
     filters:
       - passlist:
           plan:


### PR DESCRIPTION
Time out jobs after 24 hours - that's well after e-mail reports have
been sent out and in most cases it's likely the tree being tested will
have moved on by that time anyway.

Signed-off-by: Mark Brown <broonie@kernel.org>