### PR TITLE
T34238 kernelci Docker image

### DIFF
--- a/config/docker/build-and-push.sh
+++ b/config/docker/build-and-push.sh
@@ -58,6 +58,7 @@ coccinelle \
 cvehound \
 debos \
 dt-validation \
+kernelci \
 k8s \
 qemu \
 "
@@ -72,11 +73,18 @@ echo "targets: $targets"
 
 docker_build_and_tag() {
     local target="$1"
+    local extra_args="$2"
     local tag=${tag_px}"$target"
 
     echo "Building [$tag]"
 
-    docker build --build-arg PREFIX="$tag_px" ${quiet} ${cache_args} $1 -t $tag
+    docker build \
+           --build-arg PREFIX="$tag_px" \
+           ${quiet} \
+           ${cache_args} \
+           ${extra_args} \
+           ${target} \
+           -t ${tag}
 
     if [ "x${push}" == "xtrue" ]
     then
@@ -92,6 +100,10 @@ for target in $targets; do
         do
             docker_build_and_tag "$cc"
         done
+    elif [ "$target" = "kernelci" ]; then
+        core_rev=$(git show --pretty=format:%H -s origin/main)
+        echo "kernelci-core revision: ${core_rev}"
+        docker_build_and_tag kernelci "--build-arg core_rev=${core_rev}"
     else
         docker_build_and_tag "$target"
     fi

--- a/config/docker/kernelci/Dockerfile
+++ b/config/docker/kernelci/Dockerfile
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2021, 2022 Collabora Limited
+# Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+
+FROM python:3.10
+MAINTAINER "KernelCI TSC" <kernelci-tsc@groups.io>
+
+# Upgrade pip3 - never mind the warning about running this as root
+RUN pip3 install --upgrade pip
+
+ARG core_rev=main
+RUN git clone \
+    --depth=1 \
+    https://github.com/kernelci/kernelci-core.git \
+    /tmp/kernelci-core
+WORKDIR /tmp/kernelci-core
+RUN git fetch origin $core_rev
+RUN git checkout FETCH_HEAD
+RUN pip3 install -r requirements-dev.txt
+RUN python3 setup.py install
+RUN cp -R config /etc/kernelci/
+WORKDIR /root
+RUN rm -rf /tmp/kernelci-core
+
+RUN useradd kernelci -u 1000 -d /home/kernelci -s /bin/bash
+RUN mkdir -p /home/kernelci
+RUN chown kernelci: /home/kernelci
+USER kernelci
+ENV PATH=$PATH:/home/kernelci/.local/bin
+WORKDIR /home/kernelci

--- a/setup.py
+++ b/setup.py
@@ -46,11 +46,6 @@ setuptools.setup(
         "kernelci.lab.lava",
         "kernelci.data",
     ],
-    data_files=(
-        [('doc', glob('doc/*.md'))]
-        + _list_files('config/lava', '*.jinja2')
-        + _list_files('config/scripts', '*.jinja2')
-    ),
     scripts=[
         'kci_build',
         'kci_test',


### PR DESCRIPTION
Add a `kernelci/kernelci` Docker image with the `kernelci` Python package installed with its dependencies as well as the config files copied to `/etc/kernelci`.