### PR TITLE
test-configs: Constrain defconfigs ltp-pty test is run on

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -537,6 +537,12 @@ test_plans:
       tst_cmdfiles: "pty"
       job_timeout: '25'
       priority: 0
+    filters:
+      - passlist:
+          defconfig:
+          - 'defconfig'
+          - 'multi_v5_defconfig'
+          - 'multi_v7_defconfig'
 
   ltp-sched:
     <<: *ltp


### PR DESCRIPTION
The PTY tests are quite slow to run, taking over 15 minutes on most systems,
but we schedule them for every defconfig variant we build which consumes a
lot of time on boards and leads to huge backlogs. Since this suite is not
expected to have much config dependency this is very wasteful add a
passlist which restricts it to just core defconfigs.

We probably want to look at doing this at a higher level, though for
quicker to run tests there's a tradeoff where we might catch issues and
some of the config variants like page size changes are likely to have an
impact on some test suites so let's do some focused restrictions for now.

Signed-off-by: Mark Brown <broonie@kernel.org>