### PR TITLE
CHROMEOS Update version of QEMU ChromiumOS build to R100

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -243,7 +243,7 @@ rootfs_configs:
   chromiumos-amd64-generic:
     rootfs_type: chromiumos
     board: amd64-generic
-    branch: release-R99-14469.B
+    branch: release-R100-14526.B
     arch_list:
       - amd64
 


### PR DESCRIPTION
Bump up ChromiumOS release to be in sync with Chromebook builds versions.
Also R100 required as ./build_packages -> build_packages rename
introduced in it.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>