### PR TITLE
lab-configs: Block Android trees in my lab

### DIFF
--- a/config/core/lab-configs.yaml
+++ b/config/core/lab-configs.yaml
@@ -22,6 +22,7 @@ labs:
     priority_min: 0
     priority_max: 40
     filters:
+      - blocklist: {tree: [android]}
       - passlist:
           plan:
             - baseline


### PR DESCRIPTION
I'd be happy with boot tests only for Android, but with our present test
generation the number of Android trees and frequency of updates means we
are generating so many test jobs that they DoS all the other trees and
we can't control test jobs per tree per lab.

Signed-off-by: Mark Brown <broonie@kernel.org>