### PR TITLE
config/scripts: set exit status to 0 even it test failed

### DIFF
--- a/config/scripts/base-python.jinja2
+++ b/config/scripts/base-python.jinja2
@@ -63,5 +63,5 @@ if __name__ == '__main__':
             node['status'] = "pass" if res else "fail"
             db.submit({'node': node})
 
-    sys.exit(0 if res is True else 1)
+    sys.exit(0)
 {% endblock %}


### PR DESCRIPTION
Set the exit status to 0 in base-python.jinja2 even if the test case
failed as the script ran successfully.

An exit status of 1 should only mean that the script failed to run,
for example if no test result could be sent to the API.  Some
follow-up changes might be required to handle error propagation
correctly if defaulting to Python exceptions is not enough.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>