### PR TITLE
docker: add dwarves package for pahole tool

### DIFF
--- a/config/docker/clang-base/Dockerfile
+++ b/config/docker/clang-base/Dockerfile
@@ -9,7 +9,11 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     binutils-aarch64-linux-gnu \
     binutils-arm-linux-gnueabihf \
     binutils-riscv64-linux-gnu \
-    binutils
+    binutils \
+    dwarves \
+    lz4 \
+    python3 \
+    python
 
 # kselftest x86
 RUN apt-get update && apt-get install --no-install-recommends -y \

--- a/config/docker/gcc-10_arm/Dockerfile
+++ b/config/docker/gcc-10_arm/Dockerfile
@@ -2,6 +2,7 @@ ARG PREFIX=kernelci/
 FROM ${PREFIX}build-base
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
+    dwarves \
     gcc-10-arm-linux-gnueabihf \
     gcc-10-plugin-dev-arm-linux-gnueabihf
 

--- a/config/docker/gcc-10_arm64/Dockerfile
+++ b/config/docker/gcc-10_arm64/Dockerfile
@@ -2,6 +2,7 @@ ARG PREFIX=kernelci/
 FROM ${PREFIX}build-base
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
+    dwarves \
     gcc-10-aarch64-linux-gnu \
     gcc-10-plugin-dev-aarch64-linux-gnu \
     gcc-10-arm-linux-gnueabihf \

--- a/config/docker/gcc-10_x86/Dockerfile
+++ b/config/docker/gcc-10_x86/Dockerfile
@@ -2,6 +2,7 @@ ARG PREFIX=kernelci/
 FROM ${PREFIX}build-base
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
+    dwarves \
     gcc-10 \
     gcc-10-plugin-dev
 


### PR DESCRIPTION
As reported in maillist https://groups.io/g/kernelci/message/1489 recent builds are failing,
because pahole tool is missing.
This patch add required support and tested locally.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>