### PR TITLE
test-configs: Add bcm2835-rpi-b-rev2

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -643,6 +643,13 @@ device_types:
     class: arm64-dtb
     boot_method: uboot
 
+  bcm2835-rpi-b-rev2:
+    mach: broadcom
+    class: arm-dtb
+    boot_method: uboot
+    filters:
+      - passlist: {defconfig: ['bcm2835_defconfig']}
+
   bcm2836-rpi-2-b:
     mach: broadcom
     class: arm-dtb
@@ -1908,6 +1915,11 @@ test_configs:
   - device_type: bcm2711-rpi-4-b
     test_plans:
       - baseline
+
+  - device_type: bcm2835-rpi-b-rev2
+    test_plans:
+      - baseline
+      - baseline-nfs
 
   - device_type: bcm2836-rpi-2-b
     test_plans:


### PR DESCRIPTION
One of the early Raspberry Pi systems.

Signed-off-by: Mark Brown <broonie@kernel.org>