### PR TITLE
test-configs: Add Udoo i.MX boards

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -938,6 +938,11 @@ device_types:
             - 'multi_v5_defconfig'
             - 'allmodconfig'
 
+  imx6dl-udoo:
+    mach: imx
+    class: arm-dtb
+    boot_method: uboot
+
   imx6q-nitrogen6x:
     mach: imx
     class: arm-dtb
@@ -963,6 +968,11 @@ device_types:
           kernel: ['v3.18']
 
   imx6q-sabresd:
+    mach: imx
+    class: arm-dtb
+    boot_method: uboot
+
+  imx6q-udoo:
     mach: imx
     class: arm-dtb
     boot_method: uboot
@@ -2187,6 +2197,13 @@ test_configs:
       - baseline-nfs
       - sleep
 
+  - device_type: imx6dl-udoo
+    test_plans:
+      - baseline
+      - baseline-nfs
+      - kselftest-alsa
+      - ltp-crypto
+
   - device_type: imx6q-nitrogen6x
     test_plans:
       - baseline
@@ -2211,6 +2228,13 @@ test_configs:
   - device_type: imx6q-sabresd
     test_plans:
       - baseline
+
+  - device_type: imx6q-udoo
+    test_plans:
+      - baseline
+      - baseline-nfs
+      - kselftest-alsa
+      - ltp-crypto
 
   - device_type: imx6q-var-dt6customboard
     test_plans:


### PR DESCRIPTION
These two boards are unusual in that as well as having the
primary Arm system which KernelCI interacts with they also have
an Arduino on the same board. There are two different models with
i.MX6DL and i.MX6Q SoCs:

   https://www.udoo.org/udoo-quad-dual/

Just add some very basic test coverage for now.

Signed-off-by: Mark Brown <broonie@kernel.org>