### PR TITLE
Build kselftest only with v5.10 onwards

### DIFF
--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -1454,6 +1454,16 @@ class MakeSelftests(Step):
     def name(self):
         return 'kselftest'
 
+    def is_enabled(self):
+        """Check whether the kselftest fragment is enabled
+
+        Return True if the kselftest config fragment is enabled in the build
+        meta-data, or False otherwise.
+        """
+        return 'kselftest' in self._meta.get(
+            'bmeta', 'kernel', 'defconfig_extras'
+        )
+
     def run(self, jopt=None, verbose=False, opts=None):
         """Make the kernel selftests
 


### PR DESCRIPTION
Check the kernel version in `is_enable()` to only enable kselftest builds with v5.10 onwards.  Earlier versions don't have `gen_tar()` and don't have the scripts to only run a particular test collection.