### PR TITLE
kernelci.lab.shell: drop get_process

### DIFF
--- a/kernelci/lab/shell.py
+++ b/kernelci/lab/shell.py
@@ -35,9 +35,8 @@ class Shell(LabAPI):
         os.chmod(output_file, 0o775)
         return output_file
 
-    def submit(self, job_path, get_process=False):
-        process = subprocess.Popen(job_path)
-        return process if get_process else process.pid
+    def submit(self, job_path):
+        return subprocess.Popen(job_path)
 
 
 def get_api(lab, **kwargs):


### PR DESCRIPTION
Drop the get_process argument in .submit() as it's specific to the
shell runtime environment and the default behaviour should be to
return the process object.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>

Fixes: #880