### PR TITLE
Lower priorities for longer running tests

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -474,6 +474,7 @@ test_plans:
       <<: *ltp-params
       tst_cmdfiles: "pty"
       job_timeout: '25'
+      priority: 0
 
   ltp-timers:
     <<: *ltp
@@ -482,6 +483,7 @@ test_plans:
       <<: *ltp-params
       grp_test: "TMR"
       job_timeout: '30'
+      priority: 0
 
   ltp-timers_qemu:
     <<: *ltp
@@ -492,6 +494,7 @@ test_plans:
       <<: *ltp-params
       grp_test: "TMR"
       job_timeout: '30'
+      priority: 0
     filters:
       - combination: *arch_defconfig_filter
       - blocklist: *kselftest_defconfig_filter

--- a/kernelci/lab/lava/__init__.py
+++ b/kernelci/lab/lava/__init__.py
@@ -43,7 +43,7 @@ class LavaAPI(LabAPI):
             if priority > 100:
                 priority = 100
         else:
-            priority = 0
+            priority = 20
 
         prio_range = self.config._priority_max - self.config._priority_min
         priority = int(((priority * prio_range) / 100) +


### PR DESCRIPTION
This branch aims to mitigate the impact of longer running tests on labs which are overloaded by configuring lower priorities for jobs which are expected to have longer runtimes, trying to help us get a wider range of coverage more promptly with the bandwidth on the boards we have.

This won't fix anything if the lab is just completely overwhelmed but for cases where there are peaks in load it should help us get a wider set of results through more promptly as we catch up and if the lab has a queue timeout it should be these slower jobs that get timed out.