### PR TITLE
test-configs.yaml: Enable hardware coverage for BeagleBone Black

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1934,6 +1934,8 @@ test_configs:
       - baseline
       - baseline-cip-nfs
       - baseline-nfs
+      - kselftest-alsa
+      - ltp-crypto
       - ltp-ipc
 
   - device_type: cubietruck


### PR DESCRIPTION
The BeagleBone Black has both a sound card and a crypto engine so
enable both the ALSA kselftests and the LTP crypto tests to cover
both of these.  Since these tests run fairly quickly the load on
labs should be reasonably light.

Signed-off-by: Mark Brown <broonie@kernel.org>