### PR TITLE
 build-configs.yaml: Add SERIAL_8250 to x86-chromebook fragment #1165

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -245,6 +245,7 @@ fragments:
   x86-chromebook:
     path: "kernel/configs/x86-chromebook.config"
     configs:
+      - 'CONFIG_SERIAL_8250=y'
       - 'CONFIG_SERIAL_8250_DW=y'
       - 'CONFIG_X86_AMD_PLATFORM_DEVICE=y'
       - 'CONFIG_MFD_INTEL_LPSS_PCI=y'


### PR DESCRIPTION
For initial testing of real hardware and qemu we need serial console support,
through which we can check if the OS has booted, if there is a login prompt,
and it is better to carry out initial diagnostics over the serial console,
since the network connection may not be available.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>