### PR TITLE
CHROMEOS build-configs-chromeos.yaml: add chromeos-stable

### DIFF
--- a/config/core/build-configs-chromeos.yaml
+++ b/config/core/build-configs-chromeos.yaml
@@ -45,3 +45,8 @@ build_configs:
     tree: next
     branch: 'master'
     variants: *chromeos-variants
+
+  chromeos-stable:
+    tree: stable
+    branch: 'linux-5.10.y'
+    variants: *chromeos-variants


### PR DESCRIPTION
Add a chromeos-stable build configuration based on v5.10 LTS.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>