### PR TITLE
CHROMEOS build-configs-chromeos.yaml: switch to clang-14

### DIFF
--- a/config/core/build-configs-chromeos.yaml
+++ b/config/core/build-configs-chromeos.yaml
@@ -1,6 +1,6 @@
 chromeos_variants: &chromeos-variants
-  chromeos-clang-13:
-    build_environment: clang-13
+  chromeos-clang-14:
+    build_environment: clang-14
     architectures:
       arm:
         base_defconfig: 'cros://chromeos-5.10/armel/chromiumos-arm.flavour.config'
@@ -25,8 +25,8 @@ chromeos_variants: &chromeos-variants
           - 'cros://chromeos-5.10/x86_64/chromeos-intel-pineview.flavour.config+x86-chromebook'
         filters: *cros-filters
 
-  clang-13:
-    build_environment: clang-13
+  clang-14:
+    build_environment: clang-14
     architectures:
       arm64: &arm64_defconfig
         base_defconfig: 'defconfig'


### PR DESCRIPTION
Switch all Chrome OS build configs from clang-13 to clang-14.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>