### PR TITLE
test-configs.yaml: only run baseline-cip with cip tree

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -138,6 +138,7 @@ test_plans:
       priority: 85
     filters:
       - blocklist: *kselftest_defconfig_filter
+      - passlist: {'tree': ['cip']}
 
   baseline-fastboot:
     rootfs: buildroot-baseline_ramdisk


### PR DESCRIPTION
To reduce the load in the labs and keep the focus of upstream branches
on generic tests, only run baseline-cip-nfs with kernel builds from
the cip tree.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>