### PR TITLE
CHROMEOS build-configs-chromeos.yaml: add kernelci_chromeos-stable

### DIFF
--- a/config/core/build-configs-chromeos.yaml
+++ b/config/core/build-configs-chromeos.yaml
@@ -1,3 +1,9 @@
+trees:
+
+  kernelci:
+    url: "https://github.com/kernelci/linux.git"
+
+
 chromeos_variants: &chromeos-variants
   chromeos-clang-14:
     build_environment: clang-14
@@ -49,4 +55,9 @@ build_configs:
   chromeos-stable:
     tree: stable
     branch: 'linux-5.10.y'
+    variants: *chromeos-variants
+
+  kernelci_chromeos-stable:
+    tree: kernelci
+    branch: 'chromeos-stable'
     variants: *chromeos-variants


### PR DESCRIPTION
Add kernelci_chromeos-stable build config with test branch in kernelci
tree based on stable (5.10 LTS).

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>