### PR TITLE
test-configs.yaml: add buildroot-staging rootfs definition

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -4,7 +4,7 @@
 
 file_system_types:
 
-  buildroot:
+  buildroot: &buildroot
     url: 'http://storage.kernelci.org/images/rootfs/buildroot'
 
     arch_map:
@@ -13,6 +13,10 @@ file_system_types:
       armel:   [{arch: arm}]
       x86:     [{arch: i386}, {arch: x86_64}]
       mipsel:  [{arch: mips}]
+
+  buildroot-staging:
+    <<: *buildroot
+    url: 'http://storage.staging.kernelci.org/images/rootfs/buildroot'
 
   cip:
     url: 'https://storage.kernelci.org/images/rootfs/cip/20211105'


### PR DESCRIPTION
Add a buildroot-staging rootfs definition for buildroot images built
on staging.  This is typically used with temporary patches to switch
test plans such as buildroot-baseline to using staging builds while
testing some changes.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>