### PR TITLE
build-configs.yaml: remove lee_android_3.18 build config

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -61,9 +61,6 @@ trees:
   kselftest:
     url: 'https://git.kernel.org/pub/scm/linux/kernel/git/shuah/linux-kselftest.git'
 
-  lee:
-    url: "https://git.kernel.org/pub/scm/linux/kernel/git/lee/linux.git"
-
   linusw:
     url: "https://git.kernel.org/pub/scm/linux/kernel/git/linusw/linux-gpio.git/"
 
@@ -705,11 +702,6 @@ build_configs:
   kselftest_next:
     <<: *kselftest-tree
     branch: 'next'
-
-  lee_android_3.18:
-    tree: lee
-    branch: 'android-3.18-preview'
-    variants: *medium_variants
 
   linusw_devel:
     tree: linusw


### PR DESCRIPTION
Remove lee_android_3.18 as requested in https://github.com/kernelci/kernelci-core/issues/235#issuecomment-1122124032

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>