### PR TITLE
test-configs.yaml: Enable KVM selftests on some arm64 boards

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2410,6 +2410,7 @@ test_configs:
       - kselftest-arm64
       - kselftest-cpufreq
       - kselftest-futex
+      - kselftest-kvm
       - kselftest-lib
       - kselftest-seccomp
       - ltp-crypto


### PR DESCRIPTION
For arm64 the KVM selftests really want to be run on a system with a single
CPU type, additional configuration is required for big.LITTLE systems. Get
some coverage by enabling on:

 - QDF2400 which is a unique CPU implementation and a server machine where
   KVM is one of the intended applications.
 - Le Potato which should be relatively abundant, especially once I have
   the couple I have queued for addition to my lab deployed, and covers
   Cortex-A53.

Signed-off-by: Mark Brown <broonie@kernel.org>