### PR TITLE
CHROMEOS Enable Chrome OS tests to run on octopus Chromebook

### DIFF
--- a/config/core/test-configs-chromeos.yaml
+++ b/config/core/test-configs-chromeos.yaml
@@ -86,11 +86,17 @@ test_configs:
 
   - device_type: hp-x360-12b-ca0500na-n4000-octopus
     test_plans:
+      - chromeos-boot
+      - chromeos-boot-fixed
       - chromeos-tast
+      - chromeos-tast-fixed
 
   - device_type: hp-x360-12b-n4000-octopus
     test_plans:
+      - chromeos-boot
+      - chromeos-boot-fixed
       - chromeos-tast
+      - chromeos-tast-fixed
 
   - device_type: qemu_x86_64-uefi-chromeos
     test_plans:

--- a/config/core/test-configs-chromeos.yaml
+++ b/config/core/test-configs-chromeos.yaml
@@ -1,8 +1,15 @@
 test_plans:
 
-  chromeos-boot:
+  chromeos-boot: &chromeos-boot
     pattern: 'chromeos/chromeos-boot-chromebook-template.jinja2'
-    prompt_command: 'NETDEV_UP'
+    params: &chromeos-boot-params
+      prompt_command: 'sof-audio-pci'
+
+  chromeos-boot-fixed:
+    <<: *chromeos-boot
+    params:
+      <<: *chromeos-boot-params
+      fixed_kernel: true
 
   chromeos-flash:
     pattern: 'chromeos/chromeos-flash-template.jinja2'
@@ -14,13 +21,19 @@ test_plans:
       flashing_rootfs: http://storage.chromeos.kernelci.org/images/rootfs/chromeos/20220412.0/bullseye-chromeos-flash/amd64/full.rootfs.tar.xz
       flashing_ramdisk: http://storage.chromeos.kernelci.org/images/rootfs/chromeos/20220412.0/bullseye-chromeos-flash/amd64/initrd.cpio.gz
 
-  chromeos-tast:
+  chromeos-tast: &chromeos-tast
     pattern: 'chromeos/chromeos-tast-template.jinja2'
-    params:
+    params: &chromeos-tast-params
       job_timeout: '60'
       prompt_command: 'sof-audio-pci'
       docker_image: 'kernelci/chromeos-tast'
       cros_tast_tarball: 'http://172.17.0.1/chromeos/autotest_server_package_octopus_R92_13981.0.0.tar.bz2'
+
+  chromeos-tast-fixed:
+    <<: *chromeos-tast
+    params:
+      <<: *chromeos-tast-params
+      fixed_kernel: true
 
   chromeos-tast-qemu: &chromeos-tast-qemu
     pattern: 'chromeos/chromeos-tast-qemu.jinja2'

--- a/config/core/test-configs-chromeos.yaml
+++ b/config/core/test-configs-chromeos.yaml
@@ -71,6 +71,10 @@ device_types:
 
 test_configs:
 
+  - device_type: hp-x360-12b-ca0500na-n4000-octopus
+    test_plans:
+      - chromeos-tast
+
   - device_type: hp-x360-12b-n4000-octopus
     test_plans:
       - chromeos-tast

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -887,6 +887,9 @@ device_types:
     params:
       chromeos_image: 'https://storage.chromeos.kernelci.org/images/rootfs/chromeos/crostest007/chromiumos-octopus/amd64/chromiumos_test_image.bin.gz'
       flashing_device: mmcblk0
+      reference_kernel:
+        image: 'https://storage.chromeos.kernelci.org/images/kernel/chromeos-octopus-4.14.243/vmlinuz-4.14.243'
+        modules: 'https://storage.chromeos.kernelci.org/images/kernel/chromeos-octopus-4.14.243/modules-4.14.243.tar.gz'
 
   hp-x360-12b-n4000-octopus: *octopus
 

--- a/config/lava/chromeos/chromeos-boot-chromebook-template.jinja2
+++ b/config/lava/chromeos/chromeos-boot-chromebook-template.jinja2
@@ -15,7 +15,12 @@ actions:
         minutes: 60
       to: tftp
       kernel:
+{%- if fixed_kernel is not defined %}
         url: {{ kernel_url }}
+{%- else %}
+        # Fixed reference kernel
+        url: {{ reference_kernel.image }}
+{%- endif %}
       os: oe
 
 - boot:

--- a/config/lava/chromeos/chromeos-boot-chromebook-template.jinja2
+++ b/config/lava/chromeos/chromeos-boot-chromebook-template.jinja2
@@ -2,7 +2,7 @@
 {% block main %}
 {{ super () }}
 context:
-  extra_kernel_args: console_msg_format=syslog cros_secure cros_debug boot=/dev/{{ flashing_device }}p3
+  extra_kernel_args: console_msg_format=syslog cros_secure cros_debug root=/dev/{{ flashing_device }}p3
 {% endblock %}
 
 {% block actions %}

--- a/config/lava/chromeos/chromeos-tast-template.jinja2
+++ b/config/lava/chromeos/chromeos-tast-template.jinja2
@@ -10,7 +10,12 @@ actions:
         minutes: {{ job_timeout }}
       to: tftp
       kernel:
+{%- if fixed_kernel is not defined %}
         url: {{ kernel_url }}
+{%- else %}
+        # Fixed reference kernel
+        url: {{ reference_kernel.image }}
+{%- endif %}
       os: oe
 
 - boot:


### PR DESCRIPTION
Enable `chromeos-boot`, `chromeos-boot-fixed`, `chromeos-tast` and `chromeos-tast-fixed` to run on both `octopus` variants.