### PR TITLE
CHROMEOS test-configs.yaml: use octopus Chromium OS R100 image

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -885,7 +885,7 @@ device_types:
     boot_method: depthcharge
     filters: *x86-chromebook-filters
     params:
-      chromeos_image: 'https://storage.chromeos.kernelci.org/images/rootfs/chromeos/crostest007/chromiumos-octopus/amd64/chromiumos_test_image.bin.gz'
+      chromeos_image: 'https://storage.chromeos.kernelci.org/images/rootfs/chromeos/20220427.0/chromiumos-octopus/amd64/chromiumos_test_image.bin.gz'
       flashing_device: mmcblk0
       reference_kernel:
         image: 'https://storage.chromeos.kernelci.org/images/kernel/chromeos-octopus-4.14.243/vmlinuz-4.14.243'


### PR DESCRIPTION
Update the URL of the Chromium OS image for octopus to R100.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>