### PR TITLE
CHROMEOS Add test definition to install modules from the fixed reference kernel

### DIFF
--- a/config/core/test-configs-chromeos.yaml
+++ b/config/core/test-configs-chromeos.yaml
@@ -21,15 +21,20 @@ test_plans:
       flashing_rootfs: http://storage.chromeos.kernelci.org/images/rootfs/chromeos/20220412.0/bullseye-chromeos-flash/amd64/full.rootfs.tar.xz
       flashing_ramdisk: http://storage.chromeos.kernelci.org/images/rootfs/chromeos/20220412.0/bullseye-chromeos-flash/amd64/initrd.cpio.gz
 
-  chromeos-install-modules:
+  chromeos-install-modules: &chromeos-install-modules
     pattern: 'chromeos/chromeos-install-modules-template.jinja2'
-    params:
+    params: &chromeos-install-modules-params
       job_timeout: '60'
-      modules_url: http://storage.chromeos.kernelci.org/images/kernel/chromeos-octopus-4.14.243/modules-4.14.243.tar.gz
       flashing_kernel: http://storage.chromeos.kernelci.org/images/kernel/v5.17.2-x86_64+x86_chromebook/kernel/bzImage
       flashing_modules: http://storage.chromeos.kernelci.org/images/kernel/v5.17.2-x86_64+x86_chromebook/modules.tar.xz
       flashing_rootfs: http://storage.chromeos.kernelci.org/images/rootfs/chromeos/20220505.0/bullseye-chromeos-flash/amd64/full.rootfs.tar.xz
       flashing_ramdisk: http://storage.chromeos.kernelci.org/images/rootfs/chromeos/20220505.0/bullseye-chromeos-flash/amd64/initrd.cpio.gz
+
+  chromeos-install-modules-fixed:
+    <<: *chromeos-install-modules
+    params:
+      <<: *chromeos-install-modules-params
+      fixed_kernel: true
 
   chromeos-tast: &chromeos-tast
     pattern: 'chromeos/chromeos-tast-template.jinja2'

--- a/config/lava/chromeos/chromeos-install-modules-template.jinja2
+++ b/config/lava/chromeos/chromeos-install-modules-template.jinja2
@@ -57,7 +57,12 @@ actions:
           steps:
             - lsblk
             - ls -l /root
+{%- if fixed_kernel is not defined %}
             - MODULES_URL="{{ modules_url }}"  /bin/bash /opt/chromeos/install-modules
+{%- else %}
+            # Fixed reference kernel
+            - MODULES_URL="{{ reference_kernel.modules }}"  /bin/bash /opt/chromeos/install-modules
+{%- endif %}
       lava-signal: kmsg
       from: inline
       name: chromeos-install-modules


### PR DESCRIPTION
Add a test plan variant `chromeos-install-modules-fixed` to install modules from the fixed reference kernel as this is needed to run the `-boot-fixed` and `-tast-fixed` test plans.