### PR TITLE
test-configs: Add etnaviv GPU test stanza

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -199,6 +199,18 @@ test_plans:
     filters:
       - passlist: {defconfig: ['amdgpu']}
 
+  igt-gpu-etnaviv:
+    <<: *igt
+    params:
+      drm_driver: "etnaviv"
+      tests: >
+        core_auth
+        core_getclient
+        core_getstats
+        core_getversion
+        core_setmaster
+        core_setmaster_vs_auth
+
   igt-gpu-i915:
     <<: *igt
     params:
@@ -2247,6 +2259,7 @@ test_configs:
     test_plans:
       - baseline
       - baseline-nfs
+      - igt-gpu-etnaviv
       - kselftest-alsa
       - ltp-crypto
 
@@ -2279,6 +2292,7 @@ test_configs:
     test_plans:
       - baseline
       - baseline-nfs
+      - igt-gpu-etnaviv
       - kselftest-alsa
       - ltp-crypto
 


### PR DESCRIPTION
Add some IGT testing for the Vivante GPUs used in many SoCs, including some
i.MX generations. There aren't any etnaviv specific tests in upstream igt
yet.

I'll add these to the Udoo devices once support for those is merged, they
could also run this on other i.MX6 devices.

Signed-off-by: Mark Brown <broonie@kernel.org>