### PR TITLE
test-configs: Provide igt-kms coverage for lima driver

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -212,6 +212,18 @@ test_plans:
         gem_create
         i915_selftest
 
+  igt-gpu-lima:
+    <<: *igt
+    params:
+      drm_driver: "lima"
+      tests: >
+        core_auth
+        core_getclient
+        core_getstats
+        core_getversion
+        core_setmaster
+        core_setmaster_vs_auth
+
   igt-gpu-panfrost:
     <<: *igt
     params:
@@ -2821,6 +2833,7 @@ test_configs:
     test_plans:
       - baseline
       - baseline-nfs
+      - igt-gpu-lima
       - kselftest-arm64
       - kselftest-cpufreq
       - kselftest-filesystems


### PR DESCRIPTION
Enable igt-gpu for systems with the lima driver, enabled on pine64-plus
initially. There are no lima specific tests in upstream igt so it's just
the core tests.

Signed-off-by: Mark Brown <broonie@kernel.org>