### PR TITLE
CHROMEOS add tags for octopus devices

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -891,8 +891,13 @@ device_types:
       reference_kernel:
         image: 'https://storage.chromeos.kernelci.org/images/kernel/chromeos-octopus-4.14.243/vmlinuz-4.14.243'
         modules: 'https://storage.chromeos.kernelci.org/images/kernel/chromeos-octopus-4.14.243/modules-4.14.243.tar.gz'
+      device_id: cbg-4
 
-  hp-x360-12b-ca0500na-n4000-octopus: *octopus
+  hp-x360-12b-ca0500na-n4000-octopus:
+    <<: *octopus
+    params:
+      <<: *octopus-params
+      device_id: cbg-0
 
   hsdk:
     mach: arc


### PR DESCRIPTION
Add `device_id` template parameter and define it for octopus devices so Chrome OS jobs run on only particular devices.

Depends on #1195 