### PR TITLE
CHROMEOS config/core/test-configs-chromeos.yaml: Change kernel in chromeos install-modules job to 5.10

### DIFF
--- a/config/core/test-configs-chromeos.yaml
+++ b/config/core/test-configs-chromeos.yaml
@@ -16,8 +16,8 @@ test_plans:
     params:
       job_timeout: '60'
       docker_image: 'kernelci/chromeos-flash'
-      flashing_kernel: https://storage.chromeos.kernelci.org/images/kernel/v5.10.112-x86-chromebook/kernel/bzImage
-      flashing_modules: https://storage.chromeos.kernelci.org/images/kernel/v5.10.112-x86-chromebook/modules.tar.xz
+      flashing_kernel: http://storage.chromeos.kernelci.org/images/kernel/v5.10.112-x86-chromebook/kernel/bzImage
+      flashing_modules: http://storage.chromeos.kernelci.org/images/kernel/v5.10.112-x86-chromebook/modules.tar.xz
       flashing_rootfs: http://storage.chromeos.kernelci.org/images/rootfs/chromeos/20220412.0/bullseye-chromeos-flash/amd64/full.rootfs.tar.xz
       flashing_ramdisk: http://storage.chromeos.kernelci.org/images/rootfs/chromeos/20220412.0/bullseye-chromeos-flash/amd64/initrd.cpio.gz
 
@@ -25,8 +25,8 @@ test_plans:
     pattern: 'chromeos/chromeos-install-modules-template.jinja2'
     params: &chromeos-install-modules-params
       job_timeout: '60'
-      flashing_kernel: http://storage.chromeos.kernelci.org/images/kernel/v5.17.2-x86_64+x86_chromebook/kernel/bzImage
-      flashing_modules: http://storage.chromeos.kernelci.org/images/kernel/v5.17.2-x86_64+x86_chromebook/modules.tar.xz
+      flashing_kernel: http://storage.chromeos.kernelci.org/images/kernel/v5.10.112-x86-chromebook/kernel/bzImage
+      flashing_modules: http://storage.chromeos.kernelci.org/images/kernel/v5.10.112-x86-chromebook/modules.tar.xz
       flashing_rootfs: http://storage.chromeos.kernelci.org/images/rootfs/chromeos/20220505.0/bullseye-chromeos-flash/amd64/full.rootfs.tar.xz
       flashing_ramdisk: http://storage.chromeos.kernelci.org/images/rootfs/chromeos/20220505.0/bullseye-chromeos-flash/amd64/initrd.cpio.gz
 


### PR DESCRIPTION
Replace kernel 5.17 with 5.10 to keep cheomeos-flash and
chromeos-install-modules jobs consistent

Signed-off-by: Michal Galka <michal.galka@collabora.com>