### PR TITLE
CHROMEOS config/lava/chromeos: cat os-release in tast.jinja2

### DIFF
--- a/config/lava/chromeos/tast.jinja2
+++ b/config/lava/chromeos/tast.jinja2
@@ -14,6 +14,7 @@
             name: tast-tests
           run:
             steps:
+              - 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /home/cros-tast/.ssh/id_rsa root@$(lava-target-ip) cat /etc/os-release'
               - 'cd /home/cros-tast'
 {%- if cros_tast_tarball %}
               - 'curl -s {{cros_tast_tarball}} | tar xjf -'
@@ -23,7 +24,6 @@
               - 'cp remote_test_runner /usr/bin/remote_test_runner'
 {% endif %}
               - 'while ! ping -c 1 -w 1 $(lava-target-ip); do sleep 1; done'
-              - 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /home/cros-tast/.ssh/id_rsa root@$(lava-target-ip) whoami'
               - './tast-parser.py example.ARCFixture example.ManyParams.arc_state example.Param.dog example.Pass example.Fail'
         from: inline
         name: docker-tast-tests


### PR DESCRIPTION
Replace the "whoami" command with "cat /etc/os-release" in the
tast.jinja2 template.  This shows information about the Chrome OS
image version currently being used.  For example, with the current
R100 octopus image:

NAME=Chromium OS
ID=chromiumos
HOME_URL=https://www.chromium.org/chromium-os
BUG_REPORT_URL=https://crbug.com/new
VERSION=100
VERSION_ID=100
BUILD_ID=14526.105.2022_04_27_1612

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>