### PR TITLE
CHROMEOS config/lava/chromeos: use tast_tarball from device config

### DIFF
--- a/config/core/test-configs-chromeos.yaml
+++ b/config/core/test-configs-chromeos.yaml
@@ -42,7 +42,6 @@ test_plans:
       job_timeout: '60'
       prompt_command: 'sof-audio-pci'
       docker_image: 'kernelci/chromeos-tast'
-      cros_tast_tarball: 'http://172.17.0.1/chromeos/autotest_server_package_octopus_R92_13981.0.0.tar.bz2'
 
   chromeos-tast-fixed:
     <<: *chromeos-tast

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -886,6 +886,7 @@ device_types:
     filters: *x86-chromebook-filters
     params:
       chromeos_image: 'https://storage.chromeos.kernelci.org/images/rootfs/chromeos/20220427.0/chromiumos-octopus/amd64/chromiumos_test_image.bin.gz'
+      tast_tarball: 'https://storage.chromeos.kernelci.org/images/rootfs/chromeos/20220427.0/chromiumos-octopus/amd64/tast.tgz'
       flashing_device: mmcblk0
       reference_kernel:
         image: 'https://storage.chromeos.kernelci.org/images/kernel/chromeos-octopus-4.14.243/vmlinuz-4.14.243'

--- a/config/lava/chromeos/tast.jinja2
+++ b/config/lava/chromeos/tast.jinja2
@@ -15,13 +15,8 @@
           run:
             steps:
               - 'cd /home/cros-tast'
-{%- if cros_tast_tarball %}
-              - 'curl -s {{cros_tast_tarball}} | tar xjf -'
-{% endif %}
-{%- if rootfs_url %}
-              - 'curl -s {{rootfs_url}}tast.tgz | tar xzf -'
+              - 'curl -s {{ tast_tarball }} | tar xzf -'
               - 'cp remote_test_runner /usr/bin/remote_test_runner'
-{% endif %}
               - 'while ! ping -c 1 -w 1 $(lava-target-ip); do sleep 1; done'
               - 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /home/cros-tast/.ssh/id_rsa root@$(lava-target-ip) whoami'
               - './tast-parser.py example.ARCFixture example.ManyParams.arc_state example.Param.dog example.Pass example.Fail'


### PR DESCRIPTION
Add a tast_tarball template variable in tast.jinja2 and use the value
provided from the device config parameters.  Update the octopus
parameters accordingly to provide the tast_tarball URL for R100.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>