### PR TITLE
CHROMEOS Add --device-ids argument

### DIFF
--- a/config/lava/chromeos/chromeos-boot-chromebook-template.jinja2
+++ b/config/lava/chromeos/chromeos-boot-chromebook-template.jinja2
@@ -3,6 +3,9 @@
 {{ super () }}
 context:
   extra_kernel_args: console_msg_format=syslog cros_secure cros_debug root=/dev/{{ flashing_device }}p3
+{%- if device_id %}
+tags: ['{{ device_id }}']
+{%- endif %}
 {% endblock %}
 
 {% block actions %}

--- a/config/lava/chromeos/chromeos-flash-template.jinja2
+++ b/config/lava/chromeos/chromeos-flash-template.jinja2
@@ -3,6 +3,9 @@
 {{ super () }}
 context:
   extra_kernel_args: console_msg_format=syslog cros_secure cros_debug
+{%- if device_id %}
+tags: ['{{ device_id }}']
+{%- endif %}
 {% endblock %}
 
 {% block actions %}

--- a/config/lava/chromeos/chromeos-install-modules-template.jinja2
+++ b/config/lava/chromeos/chromeos-install-modules-template.jinja2
@@ -3,6 +3,9 @@
 {{ super () }}
 context:
   extra_kernel_args: console_msg_format=syslog cros_secure cros_debug
+{%- if device_id %}
+tags: ['{{ device_id }}']
+{%- endif %}
 {% endblock %}
 
 {% block actions %}

--- a/config/lava/chromeos/chromeos-tast-qemu.jinja2
+++ b/config/lava/chromeos/chromeos-tast-qemu.jinja2
@@ -1,6 +1,9 @@
 {% extends 'base/kernel-ci-base.jinja2' %}
 {% block main %}
 {{ super () }}
+{%- if device_id %}
+tags: ['{{ device_id }}']
+{%- endif %}
 {% endblock %}
 
 {% block actions %}

--- a/config/lava/chromeos/chromeos-tast-template.jinja2
+++ b/config/lava/chromeos/chromeos-tast-template.jinja2
@@ -2,6 +2,9 @@
 {% block main %}
 {% do context.update({"extra_kernel_args": "console_msg_format=syslog earlycon cros_debug cros_secure root=/dev/mmcblk0p3" }) %}
 {{ super() }}
+{%- if device_id %}
+tags: ['{{ device_id }}']
+{%- endif %}
 {% endblock %}
 {% block actions %}
 actions:

--- a/kci_test
+++ b/kci_test
@@ -197,7 +197,8 @@ class cmd_generate(Command):
                 Args.build_output, Args.install_path,
                 Args.lab_json, Args.user, Args.lab_token, Args.db_config,
                 Args.callback_id, Args.callback_dataset,
-                Args.callback_type, Args.callback_url, Args.mach]
+                Args.callback_type, Args.callback_url, Args.mach,
+                Args.device_id]
 
     def __call__(self, configs, args):
         if args.callback_id and not args.callback_url:
@@ -254,7 +255,8 @@ class cmd_generate(Command):
             os.makedirs(args.output)
         for device_config, plan_config in jobs_list:
             params = kernelci.test.get_params(
-                meta, device_config, plan_config, args.storage)
+                meta, device_config, plan_config, args.storage,
+                args.device_ids)
             job = lab_api.generate(params, device_config, plan_config,
                                    callback_opts)
             if job is None:

--- a/kci_test
+++ b/kci_test
@@ -256,7 +256,7 @@ class cmd_generate(Command):
         for device_config, plan_config in jobs_list:
             params = kernelci.test.get_params(
                 meta, device_config, plan_config, args.storage,
-                args.device_ids)
+                args.device_id)
             job = lab_api.generate(params, device_config, plan_config,
                                    callback_opts)
             if job is None:

--- a/kernelci/cli.py
+++ b/kernelci/cli.py
@@ -151,8 +151,6 @@ class Args:
     device_id = {
         'name': '--device-id',
         'help': "Limit test job to run on a specific device",
-        'action': 'append',
-        'dest': 'device_ids'
     }
 
     dtbs_json = {

--- a/kernelci/cli.py
+++ b/kernelci/cli.py
@@ -148,6 +148,13 @@ class Args:
         'help': "Verbose version of git describe",
     }
 
+    device_id = {
+        'name': '--device-id',
+        'help': "Limit test job to run on a specific device",
+        'action': 'append',
+        'dest': 'device_ids'
+    }
+
     dtbs_json = {
         'name': '--dtbs-json',
         'help': "Path to the dtbs.json file",

--- a/kernelci/test.py
+++ b/kernelci/test.py
@@ -73,13 +73,14 @@ def match_configs(configs, meta, lab):
     return match
 
 
-def get_params(meta, target, plan_config, storage):
+def get_params(meta, target, plan_config, storage, device_ids):
     """Get a dictionary with all the test parameters to run a test job
 
     *meta* is a MetaStep object
     *target* is the name of the target platform to run the test
     *plan_config* is a TestPlan object for the test plan to run
     *storage* is the URL of the storage server
+    *device_ids* iterable of device ids to run the test
     """
 
     def _get_compression(url):
@@ -174,5 +175,6 @@ def get_params(meta, target, plan_config, storage):
 
     params.update(plan_config.params)
     params.update(target.params)
+    params.update({'device_ids': device_ids})
 
     return params

--- a/kernelci/test.py
+++ b/kernelci/test.py
@@ -73,14 +73,14 @@ def match_configs(configs, meta, lab):
     return match
 
 
-def get_params(meta, target, plan_config, storage, device_ids):
+def get_params(meta, target, plan_config, storage, device_id):
     """Get a dictionary with all the test parameters to run a test job
 
     *meta* is a MetaStep object
     *target* is the name of the target platform to run the test
     *plan_config* is a TestPlan object for the test plan to run
     *storage* is the URL of the storage server
-    *device_ids* iterable of device ids to run the test
+    *device_id* is the id of the device to run the test
     """
 
     def _get_compression(url):
@@ -175,6 +175,7 @@ def get_params(meta, target, plan_config, storage, device_ids):
 
     params.update(plan_config.params)
     params.update(target.params)
-    params.update({'device_ids': device_ids})
+    if device_id:
+        params['device_id'] = device_id
 
     return params


### PR DESCRIPTION
Add --device-id option to kci_test commandline tool to add explicitly devices 
on which the test plan should be executed. 
The option produces device_ids argument being a list of device 
identifiers.
The --device-id commandline option can be repeated multiple times
providing single device id per occurrence.


Add support to specify device ids list to the Chrome OS related job templates based on device_ids list provided.

