### PR TITLE
test-configs.yaml: Enable KVM selftests on qdf2400

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -336,7 +336,7 @@ test_plans:
   kselftest-kvm:
     <<: *kselftest
     params:
-      job_timeout: '10'
+      job_timeout: '15'
       kselftest_collections: "kvm"
     filters: *kselftest_no_fragment
 
@@ -2534,6 +2534,7 @@ test_configs:
       - baseline
       - kselftest-filesystems
       - kselftest-futex
+      - kselftest-kvm
       - kselftest-lib
       - kselftest-lkdtm
       - kselftest-seccomp


### PR DESCRIPTION
For arm64 the KVM selftests really want to be run on a system with a single
CPU type, additional configuration is required for big.LITTLE systems. The
QDF2400 is interesting for this since it is a unique CPU implementation and
a server machine where KVM is one of the intended applications so let's
enable KVM there. Unfortunately the platform is also very slow to boot
which in conjunction with the ~6 minute runtime for the tests means that
we are on the edge of the current 10 minute job timeout, raise that a bit
to give some headroom.

Signed-off-by: Mark Brown <broonie@kernel.org>