### PR TITLE
test-configs.yaml: drop sleep and usb on odroid-xu3

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2501,8 +2501,6 @@ test_configs:
       - baseline-nfs
       - igt-kms-exynos
       - kselftest-alsa
-      - sleep
-      - usb
 
   - device_type: orion5x-rd88f5182-nas
     test_plans:


### PR DESCRIPTION
Stop running the sleep and usb test plans on odroid-xu3 as they take
too long to complete given there is only one device online for
kernelci.org at the moment.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>