### PR TITLE
CHROMEOS config/lava/chromeos: Add rootwait to kernel options

### DIFF
--- a/config/lava/chromeos/chromeos-boot-chromebook-template.jinja2
+++ b/config/lava/chromeos/chromeos-boot-chromebook-template.jinja2
@@ -2,7 +2,7 @@
 {% block main %}
 {{ super () }}
 context:
-  extra_kernel_args: console_msg_format=syslog cros_secure cros_debug root=/dev/{{ flashing_device }}p3
+  extra_kernel_args: console_msg_format=syslog cros_secure cros_debug root=/dev/{{ flashing_device }}p3 rootwait
 {%- if device_id %}
 tags: ['{{ device_id }}']
 {%- endif %}

--- a/config/lava/chromeos/chromeos-tast-template.jinja2
+++ b/config/lava/chromeos/chromeos-tast-template.jinja2
@@ -1,6 +1,6 @@
 {% extends 'base/kernel-ci-base.jinja2' %}
 {% block main %}
-{% do context.update({"extra_kernel_args": "console_msg_format=syslog earlycon cros_debug cros_secure root=/dev/mmcblk0p3" }) %}
+{% do context.update({"extra_kernel_args": "console_msg_format=syslog earlycon cros_debug cros_secure root=/dev/mmcblk0p3 rootwait" }) %}
 {{ super() }}
 {%- if device_id %}
 tags: ['{{ device_id }}']


### PR DESCRIPTION
Devices that are detected asynchronously such as USB or MMC,
require rootwait option, so kernel wait root, instead of panic.
Without this option LAVA depthcharge boot become unreliable.
Also this option used by ChromeOS itself.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>