### PR TITLE
build-configs.yaml: Update mainline to build with clang-14

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -728,8 +728,8 @@ build_configs:
         build_environment: clang-11
         architectures: *arch_clang_configs
       # Latest stable release
-      clang-13:
-        build_environment: clang-13
+      clang-14:
+        build_environment: clang-14
         architectures: *arch_clang_configs
 
   media:


### PR DESCRIPTION
Since clang-14 has now been released update our mainline build to use that
rather than clang-13, ensuring that we're covering the latest release.

Signed-off-by: Mark Brown <broonie@kernel.org>