### PR TITLE
build-configs.yaml: Update -next to build with clang-15

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -782,9 +782,9 @@ build_configs:
               - 'allnoconfig'
               - 'allmodconfig'
 
-      # Latest clang release
-      clang-14:
-        build_environment: clang-14
+      # Current development clang release
+      clang-15:
+        build_environment: clang-15
         architectures:
           <<: *arch_clang_configs
           riscv:


### PR DESCRIPTION
Since clang-14 is now a real release update our -next builds to use
clang-15, ensuring that we have coverage of the current in development
kernel stuff with it's clang equivalent.

Signed-off-by: Mark Brown <broonie@kernel.org>