### PR TITLE
test-configs.yaml: drop ltp-mm from rock2-square

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2676,7 +2676,6 @@ test_configs:
     test_plans:
       - baseline
       - baseline-nfs
-      - ltp-mm
       - sleep
       - usb
 


### PR DESCRIPTION
Drop the ltp-mm test plan from rk3288-rock2-square as there is only
one board online in kernelci.org at the moment and it can't cope with
the test load.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>