### PR TITLE
CHROMEOS build_board.sh: Build octopus with ttyS1 serial console

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -246,6 +246,7 @@ rootfs_configs:
     rootfs_type: chromiumos
     board: amd64-generic
     branch: release-R100-14526.B
+    serial: ttyS0
     arch_list:
       - amd64
 
@@ -253,6 +254,7 @@ rootfs_configs:
     rootfs_type: chromiumos
     board: grunt
     branch: release-R100-14526.B
+    serial: ttyS0
     arch_list:
       - amd64
 
@@ -260,6 +262,7 @@ rootfs_configs:
     rootfs_type: chromiumos
     board: hatch
     branch: release-R100-14526.B
+    serial: ttyS0
     arch_list:
       - amd64
 
@@ -267,5 +270,6 @@ rootfs_configs:
     rootfs_type: chromiumos
     board: octopus
     branch: release-R100-14526.B
+    serial: ttyS1
     arch_list:
       - amd64

--- a/config/rootfs/chromiumos/scripts/build_board.sh
+++ b/config/rootfs/chromiumos/scripts/build_board.sh
@@ -2,6 +2,7 @@
 set -e
 BOARD=$1
 BRANCH=$2
+SERIAL=$3
 DATA_DIR=$(pwd)
 USERNAME=$(/usr/bin/id -run)
 
@@ -16,7 +17,7 @@ function cleanup()
 
 trap cleanup EXIT
 
-echo Preparing environment, branch ${BRANCH}
+echo "Preparing environment, branch ${BRANCH}"
 sudo mkdir chromiumos-sdk
 sudo chown user chromiumos-sdk
 cd chromiumos-sdk
@@ -28,29 +29,29 @@ repo sync -j$(nproc)
 echo Building SDK
 cros_sdk --create
 
-echo Board ${BOARD} setup
+echo "Board ${BOARD} setup"
 # Compiling ChromiumOS image
 # Future possible option --profile=x, for example kernel-5_15, profiles are at /mnt/host/source/src/overlays/overlay-${BOARD}/profiles/
 cros_sdk setup_board --board=${BOARD}
 
 # Without workarounds hatch and octopus build failing
 if [ "${BOARD}" == "hatch" ]; then
-echo Patching hatch specific issue
+echo "Patching hatch specific issue"
 sed -i 's/EC_BOARDS=()/EC_BOARDS=(hatch)/' src/third_party/chromiumos-overlay/eclass/cros-ec-board.eclass
 fi
 if [ "${BOARD}" == "octopus" ]; then
-echo Patching octopus specific issue
+echo "Patching octopus specific issue"
 sed -i s,'use fuzzer || die',"#use fuzzer || die", src/third_party/chromiumos-overlay/eclass/cros-ec-board.eclass
 fi
 
 # Add serial support
-echo Add serial support
+echo "Add serial ${SERIAL} support"
 cros_sdk USE=pcserial build_packages --board=${BOARD}
-cros_sdk USE="tty_console_ttyS0" emerge-"${BOARD}" chromeos-base/tty
-echo Building image
-cros_sdk ./build_image --enable_serial ttyS0 --board="${BOARD}" --boot_args "earlyprintk=serial,keep console=tty0" --noenable_rootfs_verification test
+cros_sdk USE="tty_console_${SERIAL}" emerge-"${BOARD}" chromeos-base/tty
+echo "Building image (${SERIAL})"
+cros_sdk ./build_image --enable_serial ${SERIAL} --board="${BOARD}" --boot_args "earlyprintk=serial,keep console=tty0" --noenable_rootfs_verification test
 
-echo Moving artifacts
+echo "Moving artifacts"
 # Create artifacts dir and copy generated image and tast files
 sudo mkdir -p "${DATA_DIR}/${BOARD}"
 sudo cp "src/build/images/${BOARD}/latest/chromiumos_test_image.bin" "${DATA_DIR}/${BOARD}"

--- a/kernelci/config/rootfs.py
+++ b/kernelci/config/rootfs.py
@@ -183,11 +183,12 @@ class RootFS_Buildroot(RootFS):
 
 class RootFS_ChromiumOS(RootFS):
     def __init__(self, name, rootfs_type, arch_list=None, board=None,
-                 branch=None):
+                 branch=None, serial=None):
         super().__init__(name, rootfs_type)
         self._arch_list = arch_list or list()
         self._board = board
         self._branch = branch
+        self._serial = serial
 
     @classmethod
     def from_yaml(cls, config, name):
@@ -195,7 +196,7 @@ class RootFS_ChromiumOS(RootFS):
             'name': name,
         }
         kw.update(cls._kw_from_yaml(config, [
-            'rootfs_type', 'arch_list', 'board', 'branch'
+            'rootfs_type', 'arch_list', 'board', 'branch', 'serial'
         ]))
         return cls(**kw)
 
@@ -206,6 +207,10 @@ class RootFS_ChromiumOS(RootFS):
     @property
     def board(self):
         return self._board
+
+    @property
+    def serial(self):
+        return self._serial
 
     @property
     def branch(self):
@@ -354,3 +359,4 @@ def _dump_config_chromiumos(config_name, config):
     print('\tarch_list: {}'.format(config.arch_list))
     print('\board: {}'.format(config.board))
     print('\branch: {}'.format(config.branch))
+    print('\tserial: {}'.format(config.serial))

--- a/kernelci/rootfs.py
+++ b/kernelci/rootfs.py
@@ -151,7 +151,7 @@ class ChromiumosBuilder(RootfsBuilder):
             os.makedirs(temp_dir, exist_ok=True)
 
         cmd = f'cd {temp_dir} && {build_script} \
-              {config.board} {config.branch}'
+              {config.board} {config.branch} {config.serial}'
         ret = shell_cmd(cmd, True)
         if not ret:
             return False


### PR DESCRIPTION
As investigated, octopus are different from QEMU by using second serial,
so slight adjustments for build script required.
It is done such way that it will be easier to add similar Chromebooks in
future.
Patch tested by manual build and verified on LAVA for console functionality.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>