### PR TITLE
config/scripts: align base templates with kubernetes

### DIFF
--- a/config/kubernetes/base-k8s.jinja2
+++ b/config/kubernetes/base-k8s.jinja2
@@ -1,3 +1,6 @@
+{# -*- mode: YAML -*- -#}
+{# SPDX-License-Identifier: LGPL-2.1-or-later -#}
+
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/config/scripts/base-python.jinja2
+++ b/config/scripts/base-python.jinja2
@@ -3,7 +3,8 @@
 
 {%- extends 'base.jinja2' %}
 
-{% block script_init -%}
+{% block commands %}
+{%- block python_imports -%}
 import os
 import sys
 import tarfile
@@ -12,15 +13,19 @@ import yaml
 
 import kernelci.db
 import kernelci.config
-
-DB_CONFIG_YAML = """
-{{ db_config_yaml }}"""
-NODE_ID = "{{ node_id }}"
-TARBALL_URL = "{{ tarball_url }}"
-WORKSPACE = "{{ workspace }}"
 {% endblock %}
 
-{% block script_exit -%}
+{%- block python_globals %}
+DB_CONFIG_YAML = """
+{{ db_config_yaml }}"""
+NODE_ID = '{{ node_id }}'
+TARBALL_URL = '{{ tarball_url }}'
+WORKSPACE = '/tmp/kci'
+{% endblock %}
+
+{%- block python_body %}{% endblock %}
+
+{% block python_main -%}
 def _get_db():
     if not DB_CONFIG_YAML:
         return None
@@ -65,3 +70,4 @@ if __name__ == '__main__':
 
     sys.exit(0)
 {% endblock %}
+{%- endblock %}

--- a/config/scripts/base.jinja2
+++ b/config/scripts/base.jinja2
@@ -3,12 +3,5 @@
 
 #!{{ shebang|default("/bin/sh") }}
 
-{% block script_init -%}
-set -e
-{% endblock -%}
-
-{%- block commands %}{% endblock %}
-
-{% block script_exit -%}
-exit 0
-{%- endblock %}
+{%- block commands %}
+{% endblock %}


### PR DESCRIPTION
Align the base templates in config/scripts with the ones in
config/kubernetes so that test plans templates such as check-describe
(in kernelci-pipeline) can include either base-python.jinja2 or
base-k8s-python.jinja2 depending on the runtime environment.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>