### PR TITLE
CHROMEOS install-modules: Ignore uid/gid and attributes in tar

### DIFF
--- a/config/rootfs/debos/overlays/chromeos-flash/opt/chromeos/install-modules
+++ b/config/rootfs/debos/overlays/chromeos-flash/opt/chromeos/install-modules
@@ -18,7 +18,7 @@ install_modules()
     cd "$mount_dir"
     ls -l lib/modules
     rm -rf lib/modules
-    tar xf "$root_path/$modules_tarball"
+    tar --no-same-owner --no-same-permissions --no-xattrs --no-selinux --no-acls -xf "$root_path/$modules_tarball"
     chown root: -R lib
     ls -l lib/modules
     cd "$root_path"


### PR DESCRIPTION

In some circumstances during archive unpacking tar might modify /root
ownership and break ChromeOS rootfs booting.
Add flags to handle unpacking more safely.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>