### PR TITLE
Add Chrome OS Docker images

### DIFF
--- a/config/docker/cros-qemu-modules/Dockerfile
+++ b/config/docker/cros-qemu-modules/Dockerfile
@@ -1,0 +1,15 @@
+FROM debian:bullseye-slim
+MAINTAINER "KernelCI TSC" <kernelci-tsc@groups.io>
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+          libguestfs-tools \
+          linux-image-generic \
+          qemu-utils
+
+ENV LIBGUESTFS_BACKEND=direct \
+    HOME=/root
+
+ADD add_modules.sh /add_modules.sh

--- a/config/docker/cros-qemu-modules/add_modules.sh
+++ b/config/docker/cros-qemu-modules/add_modules.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# In case you experience any problems with guestfish,
+# you can enable extended debug:
+#export LIBGUESTFS_DEBUG=1 LIBGUESTFS_TRACE=1
+guestfish <<_EOF_
+add chromiumos_test_image.bin
+run
+mount /dev/sda3 /
+tar-in modules.tar /
+umount-all
+_EOF_

--- a/config/docker/cros-sdk/Dockerfile
+++ b/config/docker/cros-sdk/Dockerfile
@@ -1,0 +1,37 @@
+# syntax=docker/dockerfile:1
+FROM debian:bullseye-slim
+MAINTAINER "KernelCI TSC" <kernelci-tsc@groups.io>
+
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends \
+        sudo \
+        ca-certificates \
+        netbase \
+	git \
+	build-essential \
+	python3 \
+	curl \
+	wget \
+	ssh \
+    && apt-get clean \
+    && apt-get autoremove \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN useradd -u 996 -ms /bin/sh user && adduser user sudo && echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+RUN mkdir -p /home/user/chromiumos && chown -R user /home/user/chromiumos
+
+# Extra packages needed by kernelCI
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    python3.9 \
+    python3-requests \
+    python3-yaml
+
+USER user
+ENV HOME=/home/user
+WORKDIR $HOME/chromiumos
+
+RUN git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
+ENV PATH="/home/user/chromiumos/depot_tools:${PATH}"
+
+WORKDIR /kernelci-core

--- a/config/docker/cros-tast/Dockerfile
+++ b/config/docker/cros-tast/Dockerfile
@@ -1,0 +1,46 @@
+FROM debian:bullseye-slim
+MAINTAINER "KernelCI TSC" <kernelci-tsc@groups.io>
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    apt-transport-https \
+    bzip2 \
+    ca-certificates strace \
+    ssh
+
+RUN apt-get update && apt-get install -y \
+    curl \
+    git \
+    inetutils-ping \
+    python3 \
+    python-pkg-resources \
+    vim \
+    xz-utils
+
+RUN \
+  mkdir -p /home/cros-tast && \
+  useradd cros-tast -d /home/cros-tast && \
+  chown cros-tast: -R /home/cros-tast && \
+  adduser cros-tast sudo && \
+  echo "cros-tast ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+USER cros-tast
+ENV HOME=/home/cros-tast
+WORKDIR $HOME
+
+RUN mkdir -p $HOME/trunk
+RUN git clone \
+    https://chromium.googlesource.com/chromiumos/chromite \
+    $HOME/trunk/chromite
+ENV PATH=$PATH:$HOME/trunk/chromite/scripts
+RUN yes | gsutil update
+
+# This SSH key is only used with Chrome OS test images.
+RUN mkdir "$HOME/.ssh"
+RUN cp "$HOME/trunk/chromite/ssh_keys/testing_rsa" "$HOME/.ssh/id_rsa"
+RUN chmod 0600 "$HOME/.ssh/id_rsa"
+
+ADD tast_parser.py /home/cros-tast/tast_parser.py
+
+# Needed by LAVA to install the overlay
+USER root

--- a/config/docker/cros-tast/tast_parser.py
+++ b/config/docker/cros-tast/tast_parser.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2022 Collabora Limited
+# Author: Denys Fedoryshchenko <denys.f@collabora.com>
+#
+# This script is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+import subprocess
+import sys
+import os
+import json
+
+RESULTS_DIR = "/tmp/results"
+TAST_PATH = "./tast"
+
+
+def fetch_dut():
+    output = subprocess.check_output("lava-target-ip", shell=True).strip()
+    return output
+
+
+def report_lava(testname, result):
+    opts = ['lava-test-case', testname, '--result', result]
+    subprocess.run(opts)
+
+
+def run_tests(args):
+    if not os.path.isdir(RESULTS_DIR):
+        os.makedirs(RESULTS_DIR, exist_ok=True)
+    remote_ip = fetch_dut()
+    tast_cmd = [
+        TAST_PATH,
+        'run',
+        f'-resultsdir={RESULTS_DIR}',
+        '-sysinfo=false',
+        '-build=false',
+        remote_ip
+    ]
+    tast_cmd.extend(args)
+    subprocess.run(tast_cmd, check=True)
+
+
+def parse_results():
+    json_file = os.path.join(RESULTS_DIR, 'results.json')
+    with open(json_file, 'r') as fh:
+        jdata = json.load(fh)
+        for element in jdata:
+            if len(element["skipReason"]) > 0:
+                report_lava(element["name"], "skip")
+                continue
+            if element["errors"] is not None:
+                report_lava(element["name"], "fail")
+                continue
+            report_lava(element["name"], "pass")
+
+
+if __name__ == '__main__':
+    if len(sys.argv) == 1:
+        print("No tests provided")
+        sys.exit(1)
+    run_tests(sys.argv[1:])
+    parse_results()


### PR DESCRIPTION
Add some Dockerfiles for creating images used to build Chrome OS user-space and run Chrome OS tests in LAVA.

Changes compared to the `chromeos` branch:
* `tast-parser.py` renamed to `tast_parser.py` and `pycodestyle` issues fixed
* images renamed with `cros-` prefix and less ambiguous names
* `build-and-push.sh` changes are not included in this PR, it can be done as a follow-up