### PR TITLE
T35399 Create new user utility

### DIFF
--- a/kci_data
+++ b/kci_data
@@ -97,6 +97,22 @@ class cmd_submit_test(Command):
         return db.submit_test(data, args.verbose)
 
 
+class cmd_create_user(Command):
+    help = "Create new user"
+    args = [Args.db_config, Args.username, Args.password]
+    opt_args = [Args.is_admin, Args.db_token, Args.verbose]
+
+    def __call__(self, config_data, args):
+        config = config_data['db_configs'][args.db_config]
+        db = kernelci.db.get_db(config, args.db_token)
+        resp = db.create_user(
+            args.username, args.password, args.is_admin, args.verbose
+        )
+        if args.verbose:
+            print(resp)
+        return resp
+
+
 if __name__ == '__main__':
     opts = parse_opts("kci_data", globals())
     configs = kernelci.config.load(opts.yaml_config)

--- a/kernelci/cli.py
+++ b/kernelci/cli.py
@@ -170,6 +170,12 @@ class Args:
         "Path to the install directory, or _install_ inside kdir by default",
     }
 
+    is_admin = {
+        'name': '--is-admin',
+        'help': "Create an admin user",
+        'action': 'store_true',
+    }
+
     j = {
         'name': '-j',
         'help': "Number of parallel build processes",
@@ -236,6 +242,11 @@ class Args:
     output = {
         'name': '--output',
         'help': "Path the output directory",
+    }
+
+    password = {
+        'name': '--password',
+        'help': "Password of a new user",
     }
 
     plan = {
@@ -310,6 +321,11 @@ class Args:
         'name': '--user',
         'help': "Test lab user name",
         'section': SECTION_LAB,
+    }
+
+    username = {
+        'name': '--username',
+        'help': "Name of a new user",
     }
 
     variant = {

--- a/kernelci/db/kernelci_api.py
+++ b/kernelci/db/kernelci_api.py
@@ -51,9 +51,10 @@ class KernelCI_API(Database):
         resp.raise_for_status()
         return resp
 
-    def _post(self, path, data=None):
+    def _post(self, path, data=None, params=None):
         url = self._make_url(path)
-        resp = requests.post(url, headers=self._headers, data=data)
+        resp = requests.post(url, headers=self._headers, params=params,
+                             data=data)
         resp.raise_for_status()
         return resp
 
@@ -62,6 +63,18 @@ class KernelCI_API(Database):
         resp = requests.put(url, headers=self._headers, data=data)
         resp.raise_for_status()
         return resp
+
+    def create_user(self, username, password, is_admin, verbose=False):
+        """Create new user"""
+        path = '/'.join(['user', username])
+        params = {'is_admin': is_admin}
+        data = {'password': password}
+        try:
+            resp = self._post(path, data=json.dumps(data), params=params)
+        except requests.exceptions.HTTPError as ex:
+            self._print_http_error(ex, verbose)
+            raise(ex)
+        return resp.json()
 
     def subscribe(self, channel):
         resp = self._post(f'subscribe/{channel}')

--- a/kernelci/db/kernelci_api.py
+++ b/kernelci/db/kernelci_api.py
@@ -39,6 +39,12 @@ class KernelCI_API(Database):
     def _make_url(self, path):
         return urllib.parse.urljoin(self.config.url, path)
 
+    def _print_http_error(self, http_error, verbose=False):
+        print(http_error)
+        if verbose:
+            print("Error:",
+                  json.loads(http_error.response.content).get("detail", []))
+
     def _get(self, path, params=None):
         url = self._make_url(path)
         resp = requests.get(url, params=params, headers=self._headers)


### PR DESCRIPTION
Add command-line utility to `kci_data` to create new users.

Tested on local:
```
./kci_data create_user --username jeny --password jeny --db-config api --db-token eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJib2IiLCJzY29wZXMiOlsiYWRtaW4iXX0.t3bAE-pHSzZaSHp7FMlImqgYvL6f_0xDUD-nQwxEm3k --is-admin 1
{'_id': '62873c99c7fa5742896cc432', 'username': 'jeny', 'hashed_password': '$2b$12$rL9zT6Xtj1sgFpoZVNrNZu3WE.MBwDSNBXD/nondmY3ZORIc61IYu', 'active': True, 'is_admin': True}
```