### PR TITLE
CHROMEOS config/lava: Add 2-step job to install modules and boot Chromebook

### DIFF
--- a/config/core/test-configs-chromeos.yaml
+++ b/config/core/test-configs-chromeos.yaml
@@ -30,6 +30,19 @@ test_plans:
       flashing_rootfs: http://storage.chromeos.kernelci.org/images/rootfs/chromeos/20220505.0/bullseye-chromeos-flash/amd64/full.rootfs.tar.xz
       flashing_ramdisk: http://storage.chromeos.kernelci.org/images/rootfs/chromeos/20220505.0/bullseye-chromeos-flash/amd64/initrd.cpio.gz
 
+  chromeos-install-modules-and-boot:
+    pattern: 'chromeos/chromeos-install-modules-and-boot-template.jinja2'
+    params:
+      <<: *chromeos-install-modules-params
+      <<: *chromeos-boot-params
+
+  chromeos-install-modules-and-boot-fixed:
+    pattern: 'chromeos/chromeos-install-modules-and-boot-template.jinja2'
+    params:
+      <<: *chromeos-install-modules-params
+      <<: *chromeos-boot-params
+      fixed_kernel: true
+
   chromeos-install-modules-fixed:
     <<: *chromeos-install-modules
     params:

--- a/config/lava/chromeos/chromeos-install-modules-and-boot-template.jinja2
+++ b/config/lava/chromeos/chromeos-install-modules-and-boot-template.jinja2
@@ -1,0 +1,97 @@
+{% extends 'base/kernel-ci-base.jinja2' %}
+{% block main %}
+{{ super () }}
+{% do context.update({"extra_kernel_args": "console_msg_format=syslog earlycon cros_debug cros_secure rootwait" }) %}
+{%- if device_id %}
+tags: ['{{ device_id }}']
+{%- endif %}
+{% endblock %}
+
+{% block actions %}
+{{ super () }}
+
+actions:
+- deploy:
+    namespace: install_modules
+    kernel:
+      url: {{ flashing_kernel }}
+    modules:
+      url: {{ flashing_modules }}
+      compression: xz
+    nfsrootfs:
+      url: {{ flashing_rootfs }}
+      compression: xz
+    ramdisk:
+      url: {{ flashing_ramdisk }}
+      compression: gz
+    os: oe
+    timeout:
+      minutes: 60
+    to: tftp
+
+
+- boot:
+    namespace: install_modules
+    timeout:
+      minutes: 60
+    method: depthcharge
+    commands: nfs
+    prompts:
+      - '/ #'
+
+- test:
+    namespace: install_modules
+    timeout:
+      minutes: 60
+    definitions:
+    - repository:
+        metadata:
+          format: Lava-Test Test Definition 1.0
+          name: chromeos-install-modules
+          description: "Install Chrome OS kernel modules"
+          os:
+            - debian
+          scope:
+            - functional
+          environment:
+            - lava-test-shell
+        run:
+          steps:
+            - lsblk
+            - ls -l /root
+{%- if fixed_kernel is not defined %}
+            - MODULES_URL="{{ modules_url }}"  /bin/bash /opt/chromeos/install-modules
+{%- else %}
+            # Fixed reference kernel
+            - MODULES_URL="{{ reference_kernel.modules }}"  /bin/bash /opt/chromeos/install-modules
+{%- endif %}
+      lava-signal: kmsg
+      from: inline
+      name: chromeos-install-modules
+      path: inline/chromeos-install-modules.yaml
+
+- deploy:
+      namespace: boot_chromeos
+      timeout:
+        minutes: 60
+      to: tftp
+      kernel:
+{%- if fixed_kernel is not defined %}
+        url: {{ kernel_url }}
+{%- else %}
+        # Fixed reference kernel
+        url: {{ reference_kernel.image }}
+{%- endif %}
+      os: oe
+
+- boot:
+    namespace: boot_chromeos
+    timeout:
+        minutes: 30
+    method: depthcharge
+    commands: emmc
+    extra_kernel_args: root=/dev/{{ flashing_device }}p3 rootwait ro
+    prompts:
+        - {{ prompt_command }}
+
+{% endblock %}


### PR DESCRIPTION
Add job template and configuration for arbitrary and the fixed kernel
for installing modules and booting CrOS in a single 2-stage LAVA job.