### PR TITLE
Add Bullseye rootfs image for flashing Chrome OS on Chromebook devices

### DIFF
--- a/config/core/rootfs-configs-chromeos.yaml
+++ b/config/core/rootfs-configs-chromeos.yaml
@@ -1,0 +1,14 @@
+rootfs_configs:
+
+  bullseye-cros-flash:
+    rootfs_type: debos
+    debian_release: bullseye
+    arch_list:
+      - amd64
+    extra_packages:
+      - bzip2
+      - ca-certificates
+      - parted
+      - wget
+      - xz-utils
+    test_overlay: "overlays/cros-flash"

--- a/config/rootfs/debos/overlays/cros-flash/etc/resolv.conf
+++ b/config/rootfs/debos/overlays/cros-flash/etc/resolv.conf
@@ -1,0 +1,1 @@
+nameserver 8.8.8.8

--- a/config/rootfs/debos/overlays/cros-flash/opt/chromeos/flash
+++ b/config/rootfs/debos/overlays/cros-flash/opt/chromeos/flash
@@ -38,12 +38,13 @@ flash_chromeos()
     mount_special_fs "$IMAGE_MOUNTPOINT"
     mount --bind . "$mount_dir"/mnt/empty
     ls -l "$mount_dir"/mnt/empty/"$IMAGE_NAME"
-    ls -l "$mount_dir"/dev/mmc*
+    ls -l "$mount_dir"/dev/{mmc*,nvme*} || true
 
     echo "Starting to flash..."
     chroot "$mount_dir" \
          /usr/sbin/chromeos-install \
-        --dst /dev/mmcblk0 \
+        --debug \
+        --dst /dev/${FLASH_DEVICE} \
         --payload_image /mnt/empty/"$IMAGE_NAME" \
         --yes
     sync
@@ -62,7 +63,7 @@ enable_rw()
     echo "Making the rootfs writeable..."
     mkdir -p "$IMAGE_MOUNTPOINT"
     cd "$root_path"
-    mount /dev/mmcblk0p3 "$mount_dir" -o ro
+    mount /dev/${FLASH_DEVICE}p3 "$mount_dir" -o ro
     mount_special_fs "$IMAGE_MOUNTPOINT"
     cd "$mount_dir"
     chroot . \
@@ -73,7 +74,8 @@ enable_rw()
     umount_special_fs "$IMAGE_MOUNTPOINT"
     umount "$mount_dir"
     sync
-    partprobe /dev/mmcblk0
+    # Partprobe fails on NVMe chromebooks, ignore it
+    partprobe -s /dev/${FLASH_DEVICE} || true
 }
 
 fixup_root()
@@ -81,13 +83,13 @@ fixup_root()
     cd /root
     mkdir -p chromeos
     ls -ld chromeos
-    mount /dev/mmcblk0p3 chromeos
+    mount /dev/${FLASH_DEVICE}p3 chromeos
     ls -ld chromeos
     chown root: chromeos
     ls -ld chromeos
     umount chromeos
     ls -ld chromeos
-    mount /dev/mmcblk0p3 chromeos
+    mount /dev/${FLASH_DEVICE}p3 chromeos
     ls -ld chromeos
     umount chromeos
     ls -ld chromeos
@@ -97,6 +99,19 @@ fixup_root()
 commands="${*:-flash_chromeos enable_rw fixup_root}"
 IMAGE_NAME="${IMAGE_NAME:-octopus-chromiumos-test-image.bin}"
 IMAGE_MOUNTPOINT="${IMAGE_MOUNTPOINT:-/root/chromeos}"
+FLASH_DEVICE="${FLASH_DEVICE:-mmcblk0}"
+
+if [ "${FLASH_DEVICE}" == "detect" ]; then
+    echo "Detecting storage device"
+    if [ -e "/dev/mmcblk0" ]; then
+       FLASH_DEVICE="mmcblk0"
+    elif [ -e "/dev/mmcblk1" ]; then
+       FLASH_DEVICE="mmcblk1"
+    else
+       echo "MMC device not detected!"
+       exit 1
+    fi
+fi
 
 for cmd in $commands; do
     echo "Running [$cmd]"

--- a/config/rootfs/debos/overlays/cros-flash/opt/chromeos/flash
+++ b/config/rootfs/debos/overlays/cros-flash/opt/chromeos/flash
@@ -1,6 +1,28 @@
 #!/bin/bash
+#
+# Copyright (C) 2021, 2022 Collabora Limited
+# Author: Michal Galka <michal.galka@collabora.com>
+# Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+#
+# This module is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 set -xe
+
+IMAGE_NAME="${1:-chromiumos_test_image.bin}"
+BLOCK_DEVICE="${2:-mmcblk0}"
+IMAGE_MOUNTPOINT="${3:-/root/chromeos}"
 
 mount_special_fs()
 {
@@ -26,16 +48,20 @@ umount_special_fs()
 
 flash_chromeos()
 {
+    local block_device="$1"
+    local image_mountpoint="$2"
+    local image_name="$3"
     local dev
-    local mount_dir=$(basename "$IMAGE_MOUNTPOINT")
-    local root_path=$(dirname "$IMAGE_MOUNTPOINT")
+
+    local mount_dir=$(basename "$image_mountpoint")
+    local root_path=$(dirname "$image_mountpoint")
 
     echo "Setting up Chrome OS chroot..."
-    mkdir -p "$IMAGE_MOUNTPOINT"
+    mkdir -p "$image_mountpoint"
     cd "$root_path"
     dev=$(losetup -P -f --show "$IMAGE_NAME")
     mount "$dev"p3 "$mount_dir" -o ro
-    mount_special_fs "$IMAGE_MOUNTPOINT"
+    mount_special_fs "$image_mountpoint"
     mount --bind . "$mount_dir"/mnt/empty
     ls -l "$mount_dir"/mnt/empty/"$IMAGE_NAME"
     ls -l "$mount_dir"/dev/{mmc*,nvme*} || true
@@ -44,12 +70,12 @@ flash_chromeos()
     chroot "$mount_dir" \
          /usr/sbin/chromeos-install \
         --debug \
-        --dst /dev/${FLASH_DEVICE} \
+        --dst /dev/${block_device} \
         --payload_image /mnt/empty/"$IMAGE_NAME" \
         --yes
     sync
 
-    umount_special_fs "$IMAGE_MOUNTPOINT"
+    umount_special_fs "$image_mountpoint"
     umount "$mount_dir"/mnt/empty
     umount "$mount_dir"
     losetup -d "$dev"
@@ -57,65 +83,50 @@ flash_chromeos()
 
 enable_rw()
 {
-    local mount_dir=$(basename "$IMAGE_MOUNTPOINT")
-    local root_path=$(dirname "$IMAGE_MOUNTPOINT")
+    local block_device="$1"
+    local image_mountpoint="$2"
+
+    local mount_dir=$(basename "$image_mountpoint")
+    local root_path=$(dirname "$image_mountpoint")
 
     echo "Making the rootfs writeable..."
-    mkdir -p "$IMAGE_MOUNTPOINT"
+    mkdir -p "$image_mountpoint"
     cd "$root_path"
-    mount /dev/${FLASH_DEVICE}p3 "$mount_dir" -o ro
-    mount_special_fs "$IMAGE_MOUNTPOINT"
+    mount /dev/${block_device}p3 "$mount_dir" -o ro
+    mount_special_fs "$image_mountpoint"
     cd "$mount_dir"
     chroot . \
         /usr/share/vboot/bin/make_dev_ssd.sh \
         --remove_rootfs_verification \
         --force
     cd "$root_path"
-    umount_special_fs "$IMAGE_MOUNTPOINT"
+    umount_special_fs "$image_mountpoint"
     umount "$mount_dir"
     sync
     # Partprobe fails on NVMe chromebooks, ignore it
-    partprobe -s /dev/${FLASH_DEVICE} || true
+    partprobe -s /dev/${block_device} || true
 }
 
-fixup_root()
-{
-    cd /root
-    mkdir -p chromeos
-    ls -ld chromeos
-    mount /dev/${FLASH_DEVICE}p3 chromeos
-    ls -ld chromeos
-    chown root: chromeos
-    ls -ld chromeos
-    umount chromeos
-    ls -ld chromeos
-    mount /dev/${FLASH_DEVICE}p3 chromeos
-    ls -ld chromeos
-    umount chromeos
-    ls -ld chromeos
-    sync
-}
-
-commands="${*:-flash_chromeos enable_rw fixup_root}"
-IMAGE_NAME="${IMAGE_NAME:-octopus-chromiumos-test-image.bin}"
-IMAGE_MOUNTPOINT="${IMAGE_MOUNTPOINT:-/root/chromeos}"
-FLASH_DEVICE="${FLASH_DEVICE:-mmcblk0}"
-
-if [ "${FLASH_DEVICE}" == "detect" ]; then
-    echo "Detecting storage device"
-    if [ -e "/dev/mmcblk0" ]; then
-       FLASH_DEVICE="mmcblk0"
-    elif [ -e "/dev/mmcblk1" ]; then
-       FLASH_DEVICE="mmcblk1"
-    else
-       echo "MMC device not detected!"
-       exit 1
-    fi
+if [ -z "$IMAGE_NAME" ]; then
+    echo "Missing image name"
+    echo "Usage: flash IMAGE_NAME BLOCK_DEVICE image_mountpoint"
+    exit 1
 fi
 
-for cmd in $commands; do
-    echo "Running [$cmd]"
-    $cmd
-done
+if [ "${BLOCK_DEVICE}" == "detect" ]; then
+    echo "Detecting block device"
+    if [ -e "/dev/mmcblk0" ]; then
+       BLOCK_DEVICE="mmcblk0"
+    elif [ -e "/dev/mmcblk1" ]; then
+       BLOCK_DEVICE="mmcblk1"
+    else
+       echo "Block device not detected!"
+       exit 1
+    fi
+    echo "Block device: $BLOCK_DEVICE"
+fi
+
+flash_chromeos "$BLOCK_DEVICE" "$IMAGE_MOUNTPOINT" "$IMAGE_NAME"
+enable_rw "$BLOCK_DEVICE" "$IMAGE_MOUNTPOINT"
 
 exit 0

--- a/config/rootfs/debos/overlays/cros-flash/opt/chromeos/flash
+++ b/config/rootfs/debos/overlays/cros-flash/opt/chromeos/flash
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+set -xe
+
+mount_special_fs()
+{
+    local base="${1:-/root/chromeos}"
+
+    mount udev -t devtmpfs "$base"/dev
+    mount proc -t proc "$base"/proc
+    mount sysfs -t sysfs "$base"/sys
+    mount -t tmpfs tmpfs "$base"/tmp
+    mount
+}
+
+umount_special_fs()
+{
+    local base="${1:-/root/chromeos}"
+
+    umount "$base"/dev
+    umount "$base"/proc
+    umount "$base"/sys
+    umount "$base"/tmp
+    mount
+}
+
+flash_chromeos()
+{
+    local dev
+    local mount_dir=$(basename "$IMAGE_MOUNTPOINT")
+    local root_path=$(dirname "$IMAGE_MOUNTPOINT")
+
+    echo "Setting up Chrome OS chroot..."
+    mkdir -p "$IMAGE_MOUNTPOINT"
+    cd "$root_path"
+    dev=$(losetup -P -f --show "$IMAGE_NAME")
+    mount "$dev"p3 "$mount_dir" -o ro
+    mount_special_fs "$IMAGE_MOUNTPOINT"
+    mount --bind . "$mount_dir"/mnt/empty
+    ls -l "$mount_dir"/mnt/empty/"$IMAGE_NAME"
+    ls -l "$mount_dir"/dev/mmc*
+
+    echo "Starting to flash..."
+    chroot "$mount_dir" \
+         /usr/sbin/chromeos-install \
+        --dst /dev/mmcblk0 \
+        --payload_image /mnt/empty/"$IMAGE_NAME" \
+        --yes
+    sync
+
+    umount_special_fs "$IMAGE_MOUNTPOINT"
+    umount "$mount_dir"/mnt/empty
+    umount "$mount_dir"
+    losetup -d "$dev"
+}
+
+enable_rw()
+{
+    local mount_dir=$(basename "$IMAGE_MOUNTPOINT")
+    local root_path=$(dirname "$IMAGE_MOUNTPOINT")
+
+    echo "Making the rootfs writeable..."
+    mkdir -p "$IMAGE_MOUNTPOINT"
+    cd "$root_path"
+    mount /dev/mmcblk0p3 "$mount_dir" -o ro
+    mount_special_fs "$IMAGE_MOUNTPOINT"
+    cd "$mount_dir"
+    chroot . \
+        /usr/share/vboot/bin/make_dev_ssd.sh \
+        --remove_rootfs_verification \
+        --force
+    cd "$root_path"
+    umount_special_fs "$IMAGE_MOUNTPOINT"
+    umount "$mount_dir"
+    sync
+    partprobe /dev/mmcblk0
+}
+
+fixup_root()
+{
+    cd /root
+    mkdir -p chromeos
+    ls -ld chromeos
+    mount /dev/mmcblk0p3 chromeos
+    ls -ld chromeos
+    chown root: chromeos
+    ls -ld chromeos
+    umount chromeos
+    ls -ld chromeos
+    mount /dev/mmcblk0p3 chromeos
+    ls -ld chromeos
+    umount chromeos
+    ls -ld chromeos
+    sync
+}
+
+commands="${*:-flash_chromeos enable_rw fixup_root}"
+IMAGE_NAME="${IMAGE_NAME:-octopus-chromiumos-test-image.bin}"
+IMAGE_MOUNTPOINT="${IMAGE_MOUNTPOINT:-/root/chromeos}"
+
+for cmd in $commands; do
+    echo "Running [$cmd]"
+    $cmd
+done
+
+exit 0

--- a/config/rootfs/debos/overlays/cros-flash/opt/chromeos/install-modules
+++ b/config/rootfs/debos/overlays/cros-flash/opt/chromeos/install-modules
@@ -1,38 +1,67 @@
 #!/bin/bash
+#
+# Copyright (C) 2021, 2022 Collabora Limited
+# Author: Michal Galka <michal.galka@collabora.com>
+# Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+#
+# This module is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 set -xe
 
+MODULES_URL="$1"
+IMAGE_MOUNTPOINT="${2:-/root/chromeos}"
+
 install_modules()
 {
-    local mount_dir=$(basename "$IMAGE_MOUNTPOINT")
-    local root_path=$(dirname "$IMAGE_MOUNTPOINT")
-    local modules_tarball=$(basename "$MODULES_URL")
+    local modules_url="$1"
+    local image_mountpoint="$2"
 
-    echo "Downloading modules from $MODULES_URL..."
-    mkdir -p "$IMAGE_MOUNTPOINT"
+    local mount_dir=$(basename "$image_mountpoint")
+    local root_path=$(dirname "$image_mountpoint")
+    local modules_tarball=$(basename "$modules_url")
+
+    echo "Downloading modules from $modules_url..."
+    mkdir -p "$image_mountpoint"
     cd "$root_path"
-    wget "$MODULES_URL"
+    wget "$modules_url"
     mount /dev/mmcblk0p3 "$mount_dir"
 
     echo "Installing modules..."
     cd "$mount_dir"
     ls -l lib/modules
     rm -rf lib/modules
-    tar --no-same-owner --no-same-permissions --no-xattrs --no-selinux --no-acls -xf "$root_path/$modules_tarball"
-    chown root: -R lib
+    tar \
+        --no-same-owner \
+        --no-same-permissions \
+        --no-xattrs \
+        --no-selinux \
+        --no-acls \
+        -xf \
+        "$root_path/$modules_tarball"
     ls -l lib/modules
     cd "$root_path"
     umount "$mount_dir"
     sync
 }
 
-commands="${*:-install_modules}"
-IMAGE_MOUNTPOINT="${IMAGE_MOUNTPOINT:-/root/chromeos}"
-MODULES_URL="${MODULES_URL:-http://images.collabora.com/lava/chromeos/modules-4.14.243.tar.gz}"
+if [ -z "$MODULES_URL" ]; then
+    echo "Missing modules URL"
+    echo "Usage: install-modules MODULES_URL IMAGE_MOUNTPOINT"
+    exit 1
+fi
 
-for cmd in $commands; do
-    echo "Running [$cmd]"
-    $cmd
-done
+install_modules "$MODULES_URL" "$IMAGE_MOUNTPOINT"
 
 exit 0

--- a/config/rootfs/debos/overlays/cros-flash/opt/chromeos/install-modules
+++ b/config/rootfs/debos/overlays/cros-flash/opt/chromeos/install-modules
@@ -18,7 +18,7 @@ install_modules()
     cd "$mount_dir"
     ls -l lib/modules
     rm -rf lib/modules
-    tar xf "$root_path/$modules_tarball"
+    tar --no-same-owner --no-same-permissions --no-xattrs --no-selinux --no-acls -xf "$root_path/$modules_tarball"
     chown root: -R lib
     ls -l lib/modules
     cd "$root_path"

--- a/config/rootfs/debos/overlays/cros-flash/opt/chromeos/install-modules
+++ b/config/rootfs/debos/overlays/cros-flash/opt/chromeos/install-modules
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -xe
+
+install_modules()
+{
+    local mount_dir=$(basename "$IMAGE_MOUNTPOINT")
+    local root_path=$(dirname "$IMAGE_MOUNTPOINT")
+    local modules_tarball=$(basename "$MODULES_URL")
+
+    echo "Downloading modules from $MODULES_URL..."
+    mkdir -p "$IMAGE_MOUNTPOINT"
+    cd "$root_path"
+    wget "$MODULES_URL"
+    mount /dev/mmcblk0p3 "$mount_dir"
+
+    echo "Installing modules..."
+    cd "$mount_dir"
+    ls -l lib/modules
+    rm -rf lib/modules
+    tar xf "$root_path/$modules_tarball"
+    chown root: -R lib
+    ls -l lib/modules
+    cd "$root_path"
+    umount "$mount_dir"
+    sync
+}
+
+commands="${*:-install_modules}"
+IMAGE_MOUNTPOINT="${IMAGE_MOUNTPOINT:-/root/chromeos}"
+MODULES_URL="${MODULES_URL:-http://images.collabora.com/lava/chromeos/modules-4.14.243.tar.gz}"
+
+for cmd in $commands; do
+    echo "Running [$cmd]"
+    $cmd
+done
+
+exit 0


### PR DESCRIPTION
Add a rootfs configuration to flash Chrome OS images on Chromebook devices in LAVA.