### PR TITLE
test-configs.yaml: add hp-x360-12b-ca0010nr-n4020-octopus device type

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -877,13 +877,13 @@ device_types:
     boot_method: depthcharge
     filters: *x86-chromebook-filters
 
-  hp-x360-12b-ca0500na-n4000-octopus: &octopus
+  hp-x360-12b-ca0010nr-n4020-octopus: &octopus
     mach: x86
     arch: x86_64
     boot_method: depthcharge
     filters: *x86-chromebook-filters
 
-  hp-x360-12b-n4000-octopus: *octopus
+  hp-x360-12b-ca0500na-n4000-octopus: *octopus
 
   hsdk:
     mach: arc
@@ -2157,7 +2157,7 @@ test_configs:
       - igt-gpu-i915
       - kselftest-lib
 
-  - device_type: hp-x360-12b-n4000-octopus
+  - device_type: hp-x360-12b-ca0010nr-n4020-octopus
     test_plans:
       - baseline
       - baseline-cip-nfs


### PR DESCRIPTION
Rename hp-x360-12b-n4000-octopus as hp-x360-12b-ca0010nr-n4020-octopus
which is the full generic name for this variant.

Fixes: d0c7caf202aa ("test-configs.yaml: add hp-x360-12b-ca0500na-n4000-octopus variant")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>