### PR TITLE
CHROMEOS rework device type parameters to avoid duplicated URLs

### DIFF
--- a/config/core/test-configs-chromeos.yaml
+++ b/config/core/test-configs-chromeos.yaml
@@ -72,16 +72,26 @@ device_types:
       - passlist: {defconfig: ['x86-chromebook']}
       - blocklist: {defconfig: ['allmodconfig', 'allnoconfig']}
     params: &octopus-params
-      cros_flash_initrd: 'https://storage.staging.kernelci.org/images/rootfs/debian/bullseye-cros-flash/20220523.1/amd64/initrd.cpio.gz'
-      cros_flash_nfs: 'https://storage.staging.kernelci.org/images/rootfs/debian/bullseye-cros-flash/20220523.1/amd64/full.rootfs.tar.xz'
-      cros_flash_image: 'https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-octopus/20220520.0/amd64/cros-flash.tar.gz'
-      cros_flash_kernel: 'http://storage.chromeos.kernelci.org/images/kernel/v5.10.112-x86-chromebook/kernel/bzImage'
-      cros_flash_modules: 'http://storage.chromeos.kernelci.org/images/kernel/v5.10.112-x86-chromebook/modules.tar.xz'
-      tast_tarball: 'https://storage.chromeos.kernelci.org/images/rootfs/chromeos/20220427.0/chromiumos-octopus/amd64/tast.tgz'
-      block_device: mmcblk0
+      cros_flash_nfs:
+        base_url: 'https://storage.staging.kernelci.org/images/rootfs/debian/bullseye-cros-flash/20220523.1/amd64/'
+        initrd: 'initrd.cpio.gz'
+        initrd_compression: 'gz'
+        rootfs: 'full.rootfs.tar.xz'
+        rootfs_compression: 'xz'
+      cros_flash_kernel:
+        base_url: 'http://storage.chromeos.kernelci.org/images/kernel/v5.10.112-x86-chromebook/'
+        image: 'kernel/bzImage'
+        modules: 'modules.tar.xz'
+        modules_compression: 'xz'
+      cros_image:
+        base_url: 'https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-octopus/20220520.0/amd64/'
+        flash_tarball: 'cros-flash.tar.gz'
+        flash_tarball_compression: 'gz'
+        tast_tarball: 'tast.tgz'
       reference_kernel:
         image: 'https://storage.chromeos.kernelci.org/images/kernel/chromeos-octopus-4.14.243/vmlinuz-4.14.243'
         modules: 'https://storage.chromeos.kernelci.org/images/kernel/chromeos-octopus-4.14.243/modules-4.14.243.tar.gz'
+      block_device: mmcblk0
       device_id: cbg-4
 
   hp-x360-12b-ca0500na-n4000-octopus_chromeos:
@@ -98,8 +108,10 @@ device_types:
     boot_method: qemu
     params:
       bios_url: 'http://storage.kernelci.org/images/uefi/edk2-stable202005/x86_64/OVMF.fd'
-      rootfs_url: 'https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-amd64-generic/20220523.0/amd64/chromiumos_test_image.bin.gz'
-      tast_tarball: 'https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-amd64-generic/20220523.0/amd64/tast.tgz'
+      cros_image:
+        base_url: 'https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-amd64-generic/20220523.0/amd64/'
+        image: 'chromiumos_test_image.bin.gz'
+        tast_tarball: 'tast.tgz'
       reference_kernel:
         image: 'https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-amd64-generic/20220523.0/amd64/bzImage'
         modules: 'https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-amd64-generic/20220523.0/amd64/modules.tar.xz'

--- a/config/lava/chromeos/cros-boot-qemu.jinja2
+++ b/config/lava/chromeos/cros-boot-qemu.jinja2
@@ -18,7 +18,7 @@ actions:
     to: downloads
     images:
       rootfs:
-        url: {{ rootfs_url }}
+        url: {{ cros_image.base_url }}{{ cros_image.image }}
         compression: gz
       kernel:
 {% if fixed_kernel is not defined %}

--- a/config/lava/chromeos/cros-boot.jinja2
+++ b/config/lava/chromeos/cros-boot.jinja2
@@ -21,16 +21,16 @@ actions:
       minutes: 5
     to: tftp
     kernel:
-      url: {{ cros_flash_kernel }}
+      url: {{ cros_flash_kernel.base_url }}{{ cros_flash_kernel.image }}
     modules:
-      url: {{ cros_flash_modules }}
-      compression: xz
+      url: {{ cros_flash_kernel.base_url }}{{ cros_flash_kernel.modules }}
+      compression: {{ cros_flash_kernel.modules_compression }}
     nfsrootfs:
-      url: {{ cros_flash_nfs }}
-      compression: xz
+      url: {{ cros_flash_nfs.base_url }}{{ cros_flash_nfs.rootfs }}
+      compression: {{ cros_flash_nfs.rootfs_compression }}
     ramdisk:
-      url: {{ cros_flash_initrd }}
-      compression: gz
+      url: {{ cros_flash_nfs.base_url }}{{ cros_flash_nfs.initrd }}
+      compression: {{ cros_flash_nfs.initrd_compression }}
     os: oe
 
 - boot:

--- a/config/lava/chromeos/cros-flash.jinja2
+++ b/config/lava/chromeos/cros-flash.jinja2
@@ -15,16 +15,16 @@ tags: ['{{ device_id }}']
 actions:
 - deploy:
     kernel:
-      url: {{ cros_flash_kernel }}
+      url: {{ cros_flash_kernel.base_url }}{{ cros_flash_kernel.image }}
     modules:
-      url: {{ cros_flash_modules }}
-      compression: xz
+      url: {{ cros_flash_kernel.base_url }}{{ cros_flash_kernel.modules }}
+      compression: {{ cros_flash_kernel.modules_compression }}
     nfsrootfs:
-      url: {{ cros_flash_image }}
-      compression: gz
+      url: {{ cros_image.base_url }}{{ cros_image.flash_tarball }}
+      compression: {{ cros_image.flash_tarball_compression }}
     ramdisk:
-      url: {{ cros_flash_initrd }}
-      compression: gz
+      url: {{ cros_flash_nfs.base_url }}{{ cros_flash_nfs.initrd }}
+      compression: {{ cros_flash_nfs.initrd_compression }}
     os: oe
     timeout:
       minutes: 15

--- a/config/lava/chromeos/cros-tast.jinja2
+++ b/config/lava/chromeos/cros-tast.jinja2
@@ -21,7 +21,8 @@
             - cd /home/cros-tast
             - >-
               lava-test-case tast-tarball --shell
-              curl -s {{ tast_tarball }} \| tar xzvf -
+              curl -s {{ cros_image.base_url }}{{ cros_image.tast_tarball }}
+              \| tar xzvf -
               && cp remote_test_runner /usr/bin/remote_test_runner
             - while ! ping -c 1 -w 1 $(lava-target-ip); do sleep 1; done
             - >-


### PR DESCRIPTION
Depends on #1215 

Rework the parameters in the device type definitions to avoid
repeating URLs everywhere.  Use a base_url attribute and the name of
the path where to find resources instead.  Update the
cros-{flash,boot,tast}.jinja2 templates accordingly.