### PR TITLE
config/lava: add boot_timeout template variable

### DIFF
--- a/config/lava/boot-fastboot/generic-fastboot-boot-template.jinja2
+++ b/config/lava/boot-fastboot/generic-fastboot-boot-template.jinja2
@@ -35,7 +35,7 @@ actions:
     prompts:
     - 'root@(.*):/#'
     timeout:
-      minutes: 5
+      minutes: {{ boot_timeout|default('5') }}
     method: lxc
 {%- endblock %}
 {%- block deploy_url %}
@@ -86,7 +86,7 @@ actions:
     prompts:
     - '/ #'
     timeout:
-      minutes: 15
+      minutes: {{ boot_timeout|default('15') }}
     method: fastboot
     transfer_overlay:
       download_command: udhcpc ; ip addr show ; wget

--- a/config/lava/boot-nfs/generic-barebox-tftp-nfs-template.jinja2
+++ b/config/lava/boot-nfs/generic-barebox-tftp-nfs-template.jinja2
@@ -6,7 +6,7 @@
 
 - boot:
     timeout:
-      minutes: 5
+      minutes: {{ boot_timeout|default('5') }}
     method: barebox
     commands: nfs
     prompts:

--- a/config/lava/boot-nfs/generic-depthcharge-tftp-nfs-template.jinja2
+++ b/config/lava/boot-nfs/generic-depthcharge-tftp-nfs-template.jinja2
@@ -14,7 +14,7 @@
 
 - boot:
     timeout:
-      minutes: 5
+      minutes: {{ boot_timeout|default('5') }}
     method: depthcharge
     commands: nfs
     prompts:

--- a/config/lava/boot-nfs/generic-grub-tftp-nfs-template.jinja2
+++ b/config/lava/boot-nfs/generic-grub-tftp-nfs-template.jinja2
@@ -12,7 +12,7 @@
 
 - boot:
     timeout:
-      minutes: 5
+      minutes: {{ boot_timeout|default('5') }}
     method: grub
     commands: nfs
     prompts:

--- a/config/lava/boot-nfs/generic-ipxe-tftp-nfs-template.jinja2
+++ b/config/lava/boot-nfs/generic-ipxe-tftp-nfs-template.jinja2
@@ -12,7 +12,7 @@
 
 - boot:
     timeout:
-      minutes: 5
+      minutes: {{ boot_timeout|default('5') }}
     method: ipxe
     commands: nfs
     prompts:

--- a/config/lava/boot-nfs/generic-uboot-tftp-nfs-template.jinja2
+++ b/config/lava/boot-nfs/generic-uboot-tftp-nfs-template.jinja2
@@ -12,7 +12,7 @@
 
 - boot:
     timeout:
-      minutes: 5
+      minutes: {{ boot_timeout|default('5') }}
     method: u-boot
     commands: nfs
     prompts:

--- a/config/lava/boot/generic-barebox-tftp-ramdisk-boot-template.jinja2
+++ b/config/lava/boot/generic-barebox-tftp-ramdisk-boot-template.jinja2
@@ -6,7 +6,7 @@
 
 - boot:
     timeout:
-      minutes: 5
+      minutes: {{ boot_timeout|default('5') }}
     method: barebox
     commands: ramdisk
     prompts:

--- a/config/lava/boot/generic-depthcharge-tftp-ramdisk-boot-template.jinja2
+++ b/config/lava/boot/generic-depthcharge-tftp-ramdisk-boot-template.jinja2
@@ -17,7 +17,7 @@
 
 - boot:
     timeout:
-      minutes: 5
+      minutes: {{ boot_timeout|default('5') }}
     method: depthcharge
     commands: ramdisk
     prompts:

--- a/config/lava/boot/generic-grub-tftp-ramdisk-boot-template.jinja2
+++ b/config/lava/boot/generic-grub-tftp-ramdisk-boot-template.jinja2
@@ -12,7 +12,7 @@
 
 - boot:
     timeout:
-      minutes: 5
+      minutes: {{ boot_timeout|default('5') }}
     method: grub
     commands: ramdisk
     prompts:

--- a/config/lava/boot/generic-ipxe-tftp-ramdisk-boot-template.jinja2
+++ b/config/lava/boot/generic-ipxe-tftp-ramdisk-boot-template.jinja2
@@ -12,7 +12,7 @@
 
 - boot:
     timeout:
-      minutes: 5
+      minutes: {{ boot_timeout|default('5') }}
     method: ipxe
     commands: ramdisk
     prompts:

--- a/config/lava/boot/generic-qemu-boot-template.jinja2
+++ b/config/lava/boot/generic-qemu-boot-template.jinja2
@@ -59,7 +59,7 @@ actions:
 
 - boot:
     timeout:
-      minutes: 5
+      minutes: {{ boot_timeout|default('5') }}
     method: qemu
     media: tmpfs
     docker:

--- a/config/lava/boot/generic-uboot-tftp-ramdisk-boot-template.jinja2
+++ b/config/lava/boot/generic-uboot-tftp-ramdisk-boot-template.jinja2
@@ -15,7 +15,7 @@
 
 - boot:
     timeout:
-      minutes: 5
+      minutes: {{ boot_timeout|default('5') }}
     method: u-boot
     commands: ramdisk
     prompts:


### PR DESCRIPTION
Add a boot_timeout template variable which can be used to override the
boot timeout.  This can typically be set in the device type parameters
for devices that take longer to boot.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>