### PR TITLE
test-configs.yaml: set boot_timeout of 10min for qcom-qdf2400

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1338,6 +1338,8 @@ device_types:
     filters:
       - passlist: {defconfig: ['defconfig']}
       - blocklist: {kernel: ['v3.']}
+    params:
+      boot_timeout: '10'
 
   qemu_arm-versatilepb:
     base_name: qemu


### PR DESCRIPTION
Depends on #1217 

Set the boot_timeout parameter to 10 min for qcom-qdf2400 as it easily
takes more than 5 minutes to boot.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>