### PR TITLE
CHROMEOS build-configs.yaml: Enable kernel serial console

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -243,6 +243,7 @@ fragments:
     path: "kernel/configs/x86-chromebook.config"
     configs:
       - 'CONFIG_SERIAL_8250=y'
+      - 'CONFIG_SERIAL_8250_CONSOLE=y'
       - 'CONFIG_SERIAL_8250_DW=y'
       - 'CONFIG_X86_AMD_PLATFORM_DEVICE=y'
       - 'CONFIG_MFD_INTEL_LPSS_PCI=y'


### PR DESCRIPTION
By default, with chromeos fragments CONFIG_SERIAL_8250_CONSOLE is disabled,
while it is important to have this option enabled to monitor kernel messages
in LAVA.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>