### PR TITLE
Update minnowboard config filters

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2473,7 +2473,7 @@ test_configs:
     test_plans:
       - baseline
       - baseline-nfs
-      # kselftest-alsa - Board capacity in a lab
+      - kselftest-alsa
 
   - device_type: minnowboard-turbot-E3826
     test_plans:

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1250,6 +1250,8 @@ device_types:
     mach: x86
     arch: x86_64
     boot_method: grub
+    filters:
+      - blocklist: {lab: ['lab-collabora']}
 
   mt8173-elm-hana:
     mach: mediatek


### PR DESCRIPTION
Disable tests in lab-collabora on `minnowboard-turbot-E3826` and enable `kselftest-alsa` on `minnowboard-max-E3825` as it should have enough capacity in `lab-collabora-staging` to run it.