### PR TITLE
test-configs.yaml: stop running v5.10 onwards on hip07-d05

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -863,6 +863,12 @@ device_types:
     mach: hisilicon
     class: arm64-dtb
     boot_method: grub
+    filters:
+      - passlist:
+          # A regression was introduced between v5.4 and v5.10 so only run
+          # kernels earlier than v5.10 for now.
+          # https://github.com/kernelci/kernelci-project/issues/113
+          kernel: ['v4.', 'v5.4']
 
   hp-11A-G6-EE-grunt:
     mach: x86


### PR DESCRIPTION
There is a known regression on the hip07-d05 platform between v5.4 and
v5.10 so stop running kernels more recent than v5.4 until it's fixed
as all jobs with v5.10 onwards just time out.

Link: https://github.com/kernelci/kernelci-project/issues/113
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>