### PR TITLE
CHROMEOS build-configs-chromeos.yaml: Add 5.15 LTS stable tree

### DIFF
--- a/config/core/build-configs-chromeos.yaml
+++ b/config/core/build-configs-chromeos.yaml
@@ -52,9 +52,14 @@ build_configs:
     branch: 'master'
     variants: *chromeos-variants
 
-  chromeos-stable:
+  chromeos-stable_5.10:
     tree: stable
     branch: 'linux-5.10.y'
+    variants: *chromeos-variants
+
+  chromeos-stable_5.15:
+    tree: stable
+    branch: 'linux-5.15.y'
     variants: *chromeos-variants
 
   kernelci_chromeos-stable:


### PR DESCRIPTION
Add a chromeos-stable_5.15 build configuration based on v5.15 LTS.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>