### PR TITLE
rootfs/bullseye-libcamera: install cmake in build script

### DIFF
--- a/config/rootfs/debos/scripts/bullseye-libcamera.sh
+++ b/config/rootfs/debos/scripts/bullseye-libcamera.sh
@@ -10,6 +10,7 @@ set -e
 BUILD_DEPS="\
       g++ \
       ninja-build \
+      cmake \
       python3-yaml \
       python3-ply \
       python3-jinja2 \
@@ -18,7 +19,6 @@ BUILD_DEPS="\
       openssl \
       pkg-config \
       libevent-dev \
-
       python3-pip \
       git \
       ca-certificates \


### PR DESCRIPTION
Install cmake in the bullseye-libcameara.sh build script to fix a
build failure:

  2022/05/27 11:32:39 bullseye-libcamera.sh | HEAD is now at 2c891fc Changes for v0.2.5 release
  2022/05/27 11:32:39 bullseye-libcamera.sh |
  2022/05/27 11:32:39 bullseye-libcamera.sh | Executing subproject [1mlibyaml[0m method [1mcmake[0m
  2022/05/27 11:32:39 bullseye-libcamera.sh |
  2022/05/27 11:32:39 bullseye-libcamera.sh | libyaml| Did not find CMake 'cmake'
  2022/05/27 11:32:39 bullseye-libcamera.sh | libyaml| Found CMake: [1;31mNO[0m
  2022/05/27 11:32:39 bullseye-libcamera.sh |
  2022/05/27 11:32:39 bullseye-libcamera.sh | src/libcamera/meson.build:98:4: [1;31mERROR:[0m Unable to find CMake

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>