### PR TITLE
CHROMEOS test-configs-chromeos.yaml: update cros-flash rootfs URL

### DIFF
--- a/config/core/test-configs-chromeos.yaml
+++ b/config/core/test-configs-chromeos.yaml
@@ -77,7 +77,7 @@ device_types:
       - passlist: {defconfig: ['x86-chromebook']}
     params: &octopus-params
       cros_flash_nfs:
-        base_url: 'https://storage.staging.kernelci.org/images/rootfs/debian/bullseye-cros-flash/20220523.1/amd64/'
+        base_url: 'https://storage.kernelci.org/images/rootfs/debian/bullseye-cros-flash/20220527.0/amd64/'
         initrd: 'initrd.cpio.gz'
         initrd_compression: 'gz'
         rootfs: 'full.rootfs.tar.xz'


### PR DESCRIPTION
Update the URL of the bullseye-cros-flash rootfs with the production
build rather than the initial staging one.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>