### PR TITLE
kernelci.test: use describe_verbose for kernel filters

### DIFF
--- a/kernelci/test.py
+++ b/kernelci/test.py
@@ -43,7 +43,7 @@ def match_configs(configs, meta, lab):
     filters = {
         'arch': arch,
         'defconfig': defconfig,
-        'kernel': rev['describe'],
+        'kernel': rev['describe_verbose'],
         'build_environment': env['name'],
         'tree': rev['tree'],
         'branch': rev['branch'],


### PR DESCRIPTION
Use the describe_verbose meta-data attribute when applying filters
based on the kernel revision.  This attribute is formatted to always
rely on standard kernel release tags e.g. v5.4.123 rather than any
other tree-specific tags set by maintainers or linux-next etc.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>