### PR TITLE
kernelci/config: add email configuration to kernelci-core

### DIFF
--- a/kernelci/config/__init__.py
+++ b/kernelci/config/__init__.py
@@ -23,6 +23,7 @@ import kernelci
 import kernelci.config
 import kernelci.config.build
 import kernelci.config.db
+import kernelci.config.email
 import kernelci.config.lab
 import kernelci.config.rootfs
 import kernelci.config.test
@@ -90,6 +91,7 @@ def from_data(data):
     filters = kernelci.config.base.default_filters_from_yaml(data)
     config.update(kernelci.config.build.from_yaml(data, filters))
     config.update(kernelci.config.db.from_yaml(data, filters))
+    config.update(kernelci.config.email.from_yaml(data))
     config.update(kernelci.config.lab.from_yaml(data, filters))
     config.update(kernelci.config.rootfs.from_yaml(data, filters))
     config.update(kernelci.config.test.from_yaml(data, filters))

--- a/kernelci/config/email.py
+++ b/kernelci/config/email.py
@@ -1,0 +1,49 @@
+# Copyright (C) 2022 Collabora Limited
+# Author: Alexandra Pereira <alexandra.pereira@collabora.com>
+#
+# This module is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+import yaml
+
+from kernelci.config.base import YAMLObject
+
+
+class Email(YAMLObject):
+    def __init__(self, email_env, email_send_to):
+        self._email_env = email_env
+        self._email_send_to = email_send_to
+
+    @classmethod
+    def from_yaml(cls, email_env, kw):
+        return cls(email_env, **kw)
+
+    @property
+    def email_env(self):
+        return self._email_env
+
+    @property
+    def email_send_to(self):
+        return self._email_send_to
+
+
+def from_yaml(data):
+    emails = {
+        name: Email.from_yaml(name, email_config)
+        for name, email_config in data.get('email_configs', {}).items()
+    }
+
+    return {
+        'email_configs': emails,
+    }


### PR DESCRIPTION
Include a class in KernelCI core to load a basic set of email configurations.

Signed-off-by: Alexandra Pereira <alexandra.pereira@collabora.com>