### PR TITLE
add Kontron KSwitch D10 boards

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1116,6 +1116,18 @@ device_types:
     dtb: 'freescale/fsl-ls1028a-kontron-kbox-a-230-ls.dtb'
     boot_method: uboot
 
+  kontron-kswitch-d10-mmt-6g-2gs:
+    mach: at91
+    class: arm-dtb
+    dtb: 'lan966x-kontron-kswitch-d10-mmt-6g-2gs.dtb'
+    boot_method: uboot
+
+  kontron-kswitch-d10-mmt-8g:
+    mach: at91
+    class: arm-dtb
+    dtb: 'lan966x-kontron-kswitch-d10-mmt-8g.dtb'
+    boot_method: uboot
+
   kontron-pitx-imx8m:
     mach: freescale
     class: arm64-dtb
@@ -2362,6 +2374,16 @@ test_configs:
       - baseline-nfs
 
   - device_type: kontron-kbox-a-230-ls
+    test_plans:
+      - baseline
+      - baseline-nfs
+
+  - device_type: kontron-kswitch-d10-mmt-6g-2gs
+    test_plans:
+      - baseline
+      - baseline-nfs
+
+  - device_type: kontron-kswitch-d10-mmt-8g
     test_plans:
       - baseline
       - baseline-nfs


### PR DESCRIPTION
The Kontron KSwitch is supported since next-20220531.
The device type has already been upstreamed to lava: https://git.lavasoftware.org/lava/lava/-/merge_requests/1760
There is once instance of this board (kontron-kswitch-d10-mmt-6g-2gs) in the Kontron KernelCI. It is expected that the second variant (kontron-kswitch-d10-mmt-8g) of the board will be added soon.