### PR TITLE
docker: Install yamllint for dt-validation

### DIFF
--- a/config/docker/dt-validation/Dockerfile
+++ b/config/docker/dt-validation/Dockerfile
@@ -21,4 +21,5 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     flex \
     libyaml-dev \
     pkg-config \
+    yamllint \
     python3-yaml


### PR DESCRIPTION
Newer versions of the kernel are able to make optional use of yamllint in
DT validation so install it in the dt-validation container.

Signed-off-by: Mark Brown <broonie@kernel.org>