### PR TITLE
CHROMEOS lava/__init__.py: Fix regex failure on some configurations

### DIFF
--- a/kernelci/lab/lava/__init__.py
+++ b/kernelci/lab/lava/__init__.py
@@ -24,7 +24,7 @@ import os
 import re
 from kernelci.lab import LabAPI
 
-CROS_CONFIG_RE = re.compile(r'cros://chromeos-([0-9.]+)/([a-z0-9_]+)/([a-z-.]+).flavour.config(\+[a-z0-9-+]+)?')  # noqa
+CROS_CONFIG_RE = re.compile(r'cros://chromeos-([0-9.]+)/([a-z0-9_]+)/([a-z0-9-._]+).flavour.config(\+[a-z0-9-+]+)?')  # noqa
 
 CROS_FLAVOURS = {
     'chromeos-amd-stoneyridge': 'ston',


### PR DESCRIPTION
Current regex fails on x86_64, for example defconfig_full:
chromeos-5.10/x86_64/chromiumos-x86_64.flavour.config+x86-chromebook

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>