### PR TITLE
test-configs: Add rk3399-roc-pc

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1616,6 +1616,11 @@ device_types:
       - blocklist: *device_config_filter
       - blocklist: {kernel: ['v3.', 'v4.4', 'v4.9']}
 
+  rk3399-roc-pc:
+    mach: rockchip
+    class: arm64-dtb
+    boot_method: uboot
+
   rk3399-rock-pi-4b:
     mach: rockchip
     class: arm64-dtb
@@ -2756,6 +2761,16 @@ test_configs:
   - device_type: rk3399-puma-haikou
     test_plans:
       - baseline
+
+  - device_type: rk3399-roc-pc
+    test_plans:
+      - baseline
+      - baseline-nfs
+      - igt-gpu-panfrost
+      - igt-kms-rockchip
+      - kselftest-alsa
+      - kselftest-cpufreq
+      - kselftest-rtc
 
   - device_type: rk3399-rock-pi-4b
     test_plans:


### PR DESCRIPTION
Add an initial set of tests for the Firefly rk3399-roc-pc system, with
baseline coverage plus targeted testsuites for hardware present in the
system.

Signed-off-by: Mark Brown <broonie@kernel.org>