### PR TITLE
T35078: Get all child nodes from parent

### DIFF
--- a/kernelci/db/kernelci_api.py
+++ b/kernelci/db/kernelci_api.py
@@ -108,6 +108,14 @@ class KernelCI_API(Database):
         resp = self._get('?'.join(['regressions', 'name=' + regression_name]))
         return json.loads(resp.text)
 
+    def get_child_nodes_from_parent(self, node_id):
+        """Get child nodes from parent"""
+        params = {
+            "parent": node_id
+        }
+        resp = self._get('nodes', params=params)
+        return resp.json()
+
     def pubsub_event_filter(self, sub_id, event):
         """Filter Pub/Sub events
 

--- a/kernelci/db/kernelci_api.py
+++ b/kernelci/db/kernelci_api.py
@@ -39,9 +39,9 @@ class KernelCI_API(Database):
     def _make_url(self, path):
         return urllib.parse.urljoin(self.config.url, path)
 
-    def _get(self, path):
+    def _get(self, path, params=None):
         url = self._make_url(path)
-        resp = requests.get(url, headers=self._headers)
+        resp = requests.get(url, params=params, headers=self._headers)
         resp.raise_for_status()
         return resp
 


### PR DESCRIPTION
Send GET request to /trigger_completed_event endpoint of API.