### PR TITLE
CHROMEOS lava/__init__.py: Fix regex failure if no fragment set

### DIFF
--- a/kernelci/lab/lava/__init__.py
+++ b/kernelci/lab/lava/__init__.py
@@ -24,7 +24,7 @@ import os
 import re
 from kernelci.lab import LabAPI
 
-CROS_CONFIG_RE = re.compile(r'cros://chromeos-([0-9.]+)/([a-z0-9_]+)/([a-z0-9-._]+).flavour.config(\+[a-z0-9-+]+)?')  # noqa
+CROS_CONFIG_RE = re.compile(r'cros://chromeos-([0-9.]+)/([a-z0-9_]+)/([a-z0-9-._]+).flavour.config(\+*[a-z0-9-+]*)?')  # noqa
 
 CROS_FLAVOURS = {
     'chromeos-amd-stoneyridge': 'ston',


### PR DESCRIPTION
In case if flavour only set, without fragment, regex will fail.
This patch allows empty/non-existing fragment in defconfig_full.

Tested with:
cros://chromeos-5.10/x86_64/chromiumos-x86_64.flavour.config
converted to:
kernelci-chromeos-stable-chromeos-stable-20220606.0-x86_64-x86_64-x86-5.10--clang-14-no-dtb-minnowboard-turbot-E3826-baseline.yaml

cros://chromeos-5.10/armel/chromiumos-arm.flavour.config
converted to:
kernelci-chromeos-stable-chromeos-stable-20220606.0-arm-armel-arm-5.10--clang-14-dtbs-rk3288-rock2-square.dtb-rk3288-rock2-square-baseline-nfs.yaml

Also tested with arbitrary config:
cros://chromeos-5.10/x86_64/chromeos-intel-pineview.flavour.config+x86-chromebook
converted to:
kernelci-chromeos-stable-chromeos-stable-20220606.0-x86_64-x86_64-pine-5.10-x86-chromebook-clang-14-no-dtb-asus-cx9400-volteer-baseline.yaml

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>