### PR TITLE
Add cros-flash test plan with parameters for octopus

### DIFF
--- a/config/core/test-configs-chromeos.yaml
+++ b/config/core/test-configs-chromeos.yaml
@@ -1,0 +1,12 @@
+test_plans:
+
+  cros-flash:
+    pattern: 'chromeos/cros-flash.jinja2'
+    params:
+      job_timeout: '60'
+      docker_image: 'kernelci/chromeos-flash'
+      chromeos_image: 'chromiumos_test_image-R94-14150.19.0-octopus.bin'
+      flashing_kernel: https://people.collabora.com/~mgalka/stable/linux-5.10.y/v5.10.95/x86_64/x86_64_defconfig+x86-chromebook/gcc-10/kernel/bzImage
+      flashing_modules: https://people.collabora.com/~mgalka/stable/linux-5.10.y/v5.10.95/x86_64/x86_64_defconfig+x86-chromebook/gcc-10/modules.tar.xz
+      flashing_rootfs: http://storage.chromeos.kernelci.org/images/rootfs/chromeos/20220328.0/bullseye-chromeos-flash/amd64/full.rootfs.tar.xz
+      flashing_ramdisk: http://storage.kernelci.org/images/rootfs/debian/buster/20210503.0/amd64/initrd.cpio.gz

--- a/config/core/test-configs-chromeos.yaml
+++ b/config/core/test-configs-chromeos.yaml
@@ -6,7 +6,7 @@ test_plans:
       job_timeout: '60'
       docker_image: 'kernelci/chromeos-flash'
       chromeos_image: 'chromiumos_test_image-R94-14150.19.0-octopus.bin'
-      flashing_kernel: https://people.collabora.com/~mgalka/stable/linux-5.10.y/v5.10.95/x86_64/x86_64_defconfig+x86-chromebook/gcc-10/kernel/bzImage
-      flashing_modules: https://people.collabora.com/~mgalka/stable/linux-5.10.y/v5.10.95/x86_64/x86_64_defconfig+x86-chromebook/gcc-10/modules.tar.xz
-      flashing_rootfs: http://storage.chromeos.kernelci.org/images/rootfs/chromeos/20220328.0/bullseye-chromeos-flash/amd64/full.rootfs.tar.xz
-      flashing_ramdisk: http://storage.kernelci.org/images/rootfs/debian/buster/20210503.0/amd64/initrd.cpio.gz
+      flashing_kernel: https://storage.chromeos.kernelci.org/images/kernel/v5.10.112-x86-chromebook/kernel/bzImage
+      flashing_modules: https://storage.chromeos.kernelci.org/images/kernel/v5.10.112-x86-chromebook/modules.tar.xz
+      flashing_rootfs: http://storage.chromeos.kernelci.org/images/rootfs/chromeos/20220412.0/bullseye-chromeos-flash/amd64/full.rootfs.tar.xz
+      flashing_ramdisk: http://storage.chromeos.kernelci.org/images/rootfs/chromeos/20220412.0/bullseye-chromeos-flash/amd64/initrd.cpio.gz

--- a/config/core/test-configs-chromeos.yaml
+++ b/config/core/test-configs-chromeos.yaml
@@ -4,9 +4,3 @@ test_plans:
     pattern: 'chromeos/cros-flash.jinja2'
     params:
       job_timeout: '60'
-      docker_image: 'kernelci/chromeos-flash'
-      chromeos_image: 'chromiumos_test_image-R94-14150.19.0-octopus.bin'
-      flashing_kernel: https://storage.chromeos.kernelci.org/images/kernel/v5.10.112-x86-chromebook/kernel/bzImage
-      flashing_modules: https://storage.chromeos.kernelci.org/images/kernel/v5.10.112-x86-chromebook/modules.tar.xz
-      flashing_rootfs: http://storage.chromeos.kernelci.org/images/rootfs/chromeos/20220412.0/bullseye-chromeos-flash/amd64/full.rootfs.tar.xz
-      flashing_ramdisk: http://storage.chromeos.kernelci.org/images/rootfs/chromeos/20220412.0/bullseye-chromeos-flash/amd64/initrd.cpio.gz

--- a/config/core/test-configs-chromeos.yaml
+++ b/config/core/test-configs-chromeos.yaml
@@ -4,3 +4,32 @@ test_plans:
     pattern: 'chromeos/cros-flash.jinja2'
     params:
       job_timeout: '60'
+
+
+device_types:
+
+  hp-x360-12b-ca0010nr-n4020-octopus_chromeos: &octopus
+    base_name: hp-x360-12b-ca0010nr-n4020-octopus
+    mach: x86
+    arch: x86_64
+    boot_method: depthcharge
+    filters: &x86-chromebook-filters
+      - passlist: {defconfig: ['x86-chromebook']}
+    params: &octopus-params
+      cros_flash_initrd: 'https://storage.staging.kernelci.org/images/rootfs/debian/bullseye-cros-flash/20220523.1/amd64/initrd.cpio.gz'
+      cros_flash_nfs: 'https://storage.staging.kernelci.org/images/rootfs/debian/bullseye-cros-flash/20220523.1/amd64/full.rootfs.tar.xz'
+      cros_flash_image: 'https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-octopus/20220520.0/amd64/cros-flash.tar.gz'
+      cros_flash_kernel: 'http://storage.chromeos.kernelci.org/images/kernel/v5.10.112-x86-chromebook/kernel/bzImage'
+      cros_flash_modules: 'http://storage.chromeos.kernelci.org/images/kernel/v5.10.112-x86-chromebook/modules.tar.xz'
+      flashing_device: mmcblk0
+
+  hp-x360-12b-ca0500na-n4000-octopus_chromeos: *octopus
+
+
+test_configs:
+
+  - device_type: hp-x360-12b-ca0010nr-n4020-octopus_chromeos
+    test_plans: []
+
+  - device_type: hp-x360-12b-ca0500na-n4000-octopus_chromeos
+    test_plans: []

--- a/config/lava/chromeos/cros-flash.jinja2
+++ b/config/lava/chromeos/cros-flash.jinja2
@@ -1,4 +1,8 @@
 {% set priority = 'high' %}
+{% set kernel_url = cros_flash_kernel %}
+{% set modules_url = cros_flash_modules %}
+{% set initrd_url = cros_flash_initrd %}
+{% set nfsrootfs_url = cros_flash_image %}
 {% extends 'base/kernel-ci-base.jinja2' %}
 {% block main %}
 {{ super () }}

--- a/config/lava/chromeos/cros-flash.jinja2
+++ b/config/lava/chromeos/cros-flash.jinja2
@@ -14,25 +14,24 @@ tags: ['{{ device_id }}']
 actions:
 - deploy:
     kernel:
-      url: {{ flashing_kernel }}
+      url: {{ cros_flash_kernel }}
     modules:
-      url: {{ flashing_modules }}
+      url: {{ cros_flash_modules }}
       compression: xz
     nfsrootfs:
-      url: {{ flashing_rootfs }}
-      compression: xz
+      url: {{ cros_flash_image }}
+      compression: gz
     ramdisk:
-      url: {{ flashing_ramdisk }}
+      url: {{ cros_flash_initrd }}
       compression: gz
     os: oe
     timeout:
-      minutes: 60
+      minutes: 15
     to: tftp
-
 
 - boot:
     timeout:
-      minutes: 60
+      minutes: 5
     method: depthcharge
     commands: nfs
     prompts:
@@ -40,11 +39,7 @@ actions:
 
 - test:
     timeout:
-      minutes: 60
-    docker:
-      image: {{ docker_image }}
-      wait:
-        device: true
+      minutes: 30
     definitions:
     - repository:
         metadata:
@@ -52,13 +47,8 @@ actions:
           name: cros-flash
         run:
           steps:
-            - ping -c 1 172.17.0.1
-            - lava-test-case wget --shell "wget --no-check-certificate -O chromiumos_test_image.bin.gz {{ chromeos_image }}"
-            - lava-test-case unpack --shell "gzip -d chromiumos_test_image.bin.gz || mv chromiumos_test_image.bin.gz chromiumos_test_image.bin"
-            - lava-test-case scp --shell "scp -C -i /keys/id_rsa_chromeos_flash -o ConnectTimeout=3 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null chromiumos_test_image.bin root@$(lava-target-ip):/root"
-            - ssh -i /keys/id_rsa_chromeos_flash -o ConnectTimeout=3 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@$(lava-target-ip) "IMAGE_NAME=chromiumos_test_image.bin FLASH_DEVICE={{ flashing_device }} /bin/bash /opt/chromeos/flash"
+            - lava-test-case flash --shell "/opt/chromeos/flash chromiumos_test_image.bin {{ flashing_device }}"
       from: inline
       name: cros-flash
       path: inline/cros-flash.yaml
-
 {% endblock %}

--- a/config/lava/chromeos/cros-flash.jinja2
+++ b/config/lava/chromeos/cros-flash.jinja2
@@ -49,37 +49,14 @@ actions:
     - repository:
         metadata:
           format: Lava-Test Test Definition 1.0
-          name: docker-network
+          name: cros-flash
         run:
           steps:
             - ping -c 1 172.17.0.1
-            - lava-test-case wget --shell  "wget http://172.17.0.1/chromeos/{{ chromeos_image }}"
-            - lava-test-case scp --shell "scp -i /keys/id_rsa_chromeos_flash -o ConnectTimeout=3 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null {{ chromeos_image }} root@$(lava-target-ip):/root"
-      from: inline
-      name: docker-network
-      path: inline/docker-network.yaml
-
-- test:
-    timeout:
-      minutes: 60
-    definitions:
-    - repository:
-        metadata:
-          format: Lava-Test Test Definition 1.0
-          name: cros-flash
-          description: "Flash Chrome OS image"
-          os:
-            - debian
-          scope:
-            - functional
-          environment:
-            - lava-test-shell
-        run:
-          steps:
-            - lsblk
-            - ls -l /root
-            - IMAGE_NAME={{ chromeos_image }}  /bin/bash /opt/chromeos/flash
-      lava-signal: kmsg
+            - lava-test-case wget --shell "wget --no-check-certificate -O chromiumos_test_image.bin.gz {{ chromeos_image }}"
+            - lava-test-case unpack --shell "gzip -d chromiumos_test_image.bin.gz || mv chromiumos_test_image.bin.gz chromiumos_test_image.bin"
+            - lava-test-case scp --shell "scp -C -i /keys/id_rsa_chromeos_flash -o ConnectTimeout=3 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null chromiumos_test_image.bin root@$(lava-target-ip):/root"
+            - ssh -i /keys/id_rsa_chromeos_flash -o ConnectTimeout=3 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@$(lava-target-ip) "IMAGE_NAME=chromiumos_test_image.bin FLASH_DEVICE={{ flashing_device }} /bin/bash /opt/chromeos/flash"
       from: inline
       name: cros-flash
       path: inline/cros-flash.yaml

--- a/config/lava/chromeos/cros-flash.jinja2
+++ b/config/lava/chromeos/cros-flash.jinja2
@@ -1,0 +1,87 @@
+{% extends 'base/kernel-ci-base.jinja2' %}
+{% block main %}
+{{ super () }}
+context:
+  extra_kernel_args: console_msg_format=syslog cros_secure cros_debug
+{% if device_id %}
+tags: ['{{ device_id }}']
+{%- endif %}
+{%- endblock %}
+
+{% block actions %}
+{{ super () }}
+
+actions:
+- deploy:
+    kernel:
+      url: {{ flashing_kernel }}
+    modules:
+      url: {{ flashing_modules }}
+      compression: xz
+    nfsrootfs:
+      url: {{ flashing_rootfs }}
+      compression: xz
+    ramdisk:
+      url: {{ flashing_ramdisk }}
+      compression: gz
+    os: oe
+    timeout:
+      minutes: 60
+    to: tftp
+
+
+- boot:
+    timeout:
+      minutes: 60
+    method: depthcharge
+    commands: nfs
+    prompts:
+      - '/ #'
+
+- test:
+    timeout:
+      minutes: 60
+    docker:
+      image: {{ docker_image }}
+      wait:
+        device: true
+    definitions:
+    - repository:
+        metadata:
+          format: Lava-Test Test Definition 1.0
+          name: docker-network
+        run:
+          steps:
+            - ping -c 1 172.17.0.1
+            - lava-test-case wget --shell  "wget http://172.17.0.1/chromeos/{{ chromeos_image }}"
+            - lava-test-case scp --shell "scp -i /keys/id_rsa_chromeos_flash -o ConnectTimeout=3 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null {{ chromeos_image }} root@$(lava-target-ip):/root"
+      from: inline
+      name: docker-network
+      path: inline/docker-network.yaml
+
+- test:
+    timeout:
+      minutes: 60
+    definitions:
+    - repository:
+        metadata:
+          format: Lava-Test Test Definition 1.0
+          name: cros-flash
+          description: "Flash Chrome OS image"
+          os:
+            - debian
+          scope:
+            - functional
+          environment:
+            - lava-test-shell
+        run:
+          steps:
+            - lsblk
+            - ls -l /root
+            - IMAGE_NAME={{ chromeos_image }}  /bin/bash /opt/chromeos/flash
+      lava-signal: kmsg
+      from: inline
+      name: cros-flash
+      path: inline/cros-flash.yaml
+
+{% endblock %}

--- a/config/lava/chromeos/cros-flash.jinja2
+++ b/config/lava/chromeos/cros-flash.jinja2
@@ -1,3 +1,4 @@
+{% set priority = 'high' %}
 {% extends 'base/kernel-ci-base.jinja2' %}
 {% block main %}
 {{ super () }}

--- a/config/lava/chromeos/cros-flash.jinja2
+++ b/config/lava/chromeos/cros-flash.jinja2
@@ -10,6 +10,8 @@ context:
   extra_kernel_args: console_msg_format=syslog cros_secure cros_debug
 {% if device_id %}
 tags: ['{{ device_id }}']
+{%- else %}
+{{ kci_raise("No device id provided") }}
 {%- endif %}
 {%- endblock %}
 

--- a/kci_test
+++ b/kci_test
@@ -197,7 +197,8 @@ class cmd_generate(Command):
                 Args.build_output, Args.install_path,
                 Args.lab_json, Args.user, Args.lab_token, Args.db_config,
                 Args.callback_id, Args.callback_dataset,
-                Args.callback_type, Args.callback_url, Args.mach]
+                Args.callback_type, Args.callback_url, Args.mach,
+                Args.device_id]
 
     def __call__(self, configs, args):
         if args.callback_id and not args.callback_url:
@@ -254,7 +255,8 @@ class cmd_generate(Command):
             os.makedirs(args.output)
         for device_config, plan_config in jobs_list:
             params = kernelci.test.get_params(
-                meta, device_config, plan_config, args.storage)
+                meta, device_config, plan_config, args.storage,
+                args.device_id)
             job = lab_api.generate(params, device_config, plan_config,
                                    callback_opts)
             if job is None:

--- a/kernelci/cli.py
+++ b/kernelci/cli.py
@@ -148,6 +148,11 @@ class Args:
         'help': "Verbose version of git describe",
     }
 
+    device_id = {
+        'name': '--device-id',
+        'help': "Limit test job to run on a specific device",
+    }
+
     dtbs_json = {
         'name': '--dtbs-json',
         'help': "Path to the dtbs.json file",

--- a/kernelci/lab/__init__.py
+++ b/kernelci/lab/__init__.py
@@ -20,6 +20,12 @@ import json
 import os
 
 
+def add_kci_raise(env):
+    def template_exception(msg):
+        raise Exception(msg)
+    env.globals['kci_raise'] = template_exception
+
+
 class LabAPI:
     """Remote API to a test lab"""
 

--- a/kernelci/lab/lava/__init__.py
+++ b/kernelci/lab/lava/__init__.py
@@ -21,7 +21,7 @@
 
 from jinja2 import Environment, FileSystemLoader
 import os
-from kernelci.lab import LabAPI
+from kernelci.lab import add_kci_raise, LabAPI
 
 
 class LavaAPI(LabAPI):
@@ -60,6 +60,7 @@ class LavaAPI(LabAPI):
             self._add_callback_params(params, callback_opts)
         jinja2_env = Environment(loader=FileSystemLoader(templates_path),
                                  extensions=["jinja2.ext.do"])
+        add_kci_raise(jinja2_env)
         template = jinja2_env.get_template(short_template_file)
         data = template.render(params)
         return data

--- a/kernelci/test.py
+++ b/kernelci/test.py
@@ -73,13 +73,14 @@ def match_configs(configs, meta, lab):
     return match
 
 
-def get_params(meta, target, plan_config, storage):
+def get_params(meta, target, plan_config, storage, device_id):
     """Get a dictionary with all the test parameters to run a test job
 
     *meta* is a MetaStep object
     *target* is the name of the target platform to run the test
     *plan_config* is a TestPlan object for the test plan to run
     *storage* is the URL of the storage server
+    *device_id* is the id of the device to run the test
     """
 
     def _get_compression(url):
@@ -174,5 +175,7 @@ def get_params(meta, target, plan_config, storage):
 
     params.update(plan_config.params)
     params.update(target.params)
+    if device_id:
+        params['device_id'] = device_id
 
     return params


### PR DESCRIPTION
Add a `cros-flash` test plan to flash Chrome OS images on Chromebooks, starting with `octopus`.