### PR TITLE
config/docker: Configure bridge helper ACLs

### DIFF
--- a/config/docker/qemu/Dockerfile
+++ b/config/docker/qemu/Dockerfile
@@ -15,3 +15,5 @@ RUN apt-get update && \
 	qemu-system-x86 \
 	qemu-utils && \
 	apt-get clean
+
+RUN mkdir -p /etc/qemu && echo allow all > /etc/qemu/bridge.conf


### PR DESCRIPTION
The collabora lab connects the qemu test device to a host bridge to
allow for predictable IP address per dut (so external test can acces
them). For this to work when running qemu in docker the bridge helper
acl needs to be configured.

This simply configures it to allow access to all host bridges.

Signed-off-by: Sjoerd Simons <sjoerd@collabora.com>