### PR TITLE
T35800 Allow multivalued PubSub filter

### DIFF
--- a/kernelci/db/kernelci_api.py
+++ b/kernelci/db/kernelci_api.py
@@ -121,8 +121,15 @@ class KernelCI_API(Database):
                 for sub_key, sub_value in value.items():
                     if sub_key not in event.get(key):
                         continue
-                    if sub_value != event.get(key).get(sub_key):
+                    if isinstance(sub_value, tuple):
+                        if not any(sub_sub_value == event.get(key).get(sub_key)
+                                   for sub_sub_value in sub_value):
+                            return False
+                    elif sub_value != event.get(key).get(sub_key):
                         return False
+            elif isinstance(value, tuple):
+                if not any(sub_value == event[key] for sub_value in value):
+                    return False
             elif value != event[key]:
                 return False
 


### PR DESCRIPTION
Fixes https://github.com/kernelci/kernelci-api/issues/130

Support multivalued PubSub filer by providing tuple values.
A PubSub event will be received even if any one value of the multivalued filter matches the event data.

Now we can provide filters like below:
{"op":("updated","created")}
{"revision":{"commit": ("a", "b")}, "status": ("pass","fail"), "op": "created"}