### PR TITLE
lab-configs.yaml: drop lab-mhart

### DIFF
--- a/config/core/lab-configs.yaml
+++ b/config/core/lab-configs.yaml
@@ -142,16 +142,6 @@ labs:
             - stable-rc
             - stable
 
-  lab-mhart:
-    lab_type: lava.lava_xmlrpc
-    config_path: 'lava'
-    url: 'http://lava.streamtester.net/RPC2/'
-    filters:
-      - blocklist: {tree: ['android', 'drm-tip', 'linaro-android']}
-      - passlist:
-          plan:
-            - baseline
-
   lab-nxp:
     lab_type: lava.lava_rest
     config_path: 'lava'


### PR DESCRIPTION
Drop lab-mhart from the list of configs as it has been offline for
about two years now.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>