### PR TITLE
HACK use 20220608.1/buildroot-baseline from staging

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -37,8 +37,8 @@ file_system_types:
 file_systems:
 
   buildroot-baseline_ramdisk:
-    type: buildroot
-    ramdisk: 'buildroot-baseline/20220603.0/{arch}/rootfs.cpio.gz'
+    type: buildroot-staging
+    ramdisk: 'buildroot-baseline/20220608.1/{arch}/rootfs.cpio.gz'
 
   cip_nfs:
     type: cip


### PR DESCRIPTION
This should include bootrr changes from https://github.com/kernelci/bootrr/pull/16 with tests for Kontron KSwitch D10 boards