### PR TITLE
CHROMEOS test-configs-chromeos.yaml: Add pineview filter for Octopus

### DIFF
--- a/config/core/test-configs-chromeos.yaml
+++ b/config/core/test-configs-chromeos.yaml
@@ -91,8 +91,8 @@ device_types:
     mach: x86
     arch: x86_64
     boot_method: depthcharge
-    filters: &x86-chromebook-filters
-      - passlist: {defconfig: ['x86-chromebook']}
+    filters:
+      - passlist: {defconfig: ['chromeos-intel-pineview']}
     params: &octopus-params
       cros_flash_nfs:
         base_url: 'https://storage.kernelci.org/images/rootfs/debian/bullseye-cros-flash/20220527.0/amd64/'


### PR DESCRIPTION
According to ChromiumOS SDK even Octopus board is chipset-glk,
kernel fragment should be used chromeos-intel-pineview.
Add filter, because kernel builds with wrong configs might give
false negative test results.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>