### PR TITLE
CHROMEOS config/core: Add fragments for ChromeOS qemu

### DIFF
--- a/config/core/build-configs-chromeos.yaml
+++ b/config/core/build-configs-chromeos.yaml
@@ -29,6 +29,7 @@ chromeos_variants: &chromeos-variants
           - 'cros://chromeos-5.10/x86_64/chromeos-amd-stoneyridge.flavour.config+x86-chromebook'
           - 'cros://chromeos-5.10/x86_64/chromeos-intel-denverton.flavour.config+x86-chromebook'
           - 'cros://chromeos-5.10/x86_64/chromeos-intel-pineview.flavour.config+x86-chromebook'
+          - 'cros://chromeos-5.10/x86_64/chromiumos-x86_64.flavour.config+x86-chromebook'
         filters: *cros-filters
 
   clang-14:

--- a/config/core/test-configs-chromeos.yaml
+++ b/config/core/test-configs-chromeos.yaml
@@ -149,7 +149,7 @@ device_types:
         - '-device ich9-intel-hda,id=sound0,bus=pcie.0,addr=0x1b'
         - '-machine pc-q35-5.2,accel=kvm,usb=off,vmport=off,dump-guest-core=off'
     filters:
-      - passlist: {}
+      - passlist: {defconfig: ['chromiumos-x86_64']}
 
 
 test_configs:


### PR DESCRIPTION
QEMU require it's own specific configuration, with virtio
and few other drivers.
This patch add new fragment for builds and limit QEMU to
test only with build that is compatible with it.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>