### PR TITLE
build-configs.yaml: add CONFIG_SPI_MT65XX to arm64-chromebook

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -145,6 +145,7 @@ fragments:
       - 'CONFIG_REGULATOR_DA9211=y'
       - 'CONFIG_ARM_MEDIATEK_CPUFREQ=y'
       - 'CONFIG_RTC_DRV_MT6397=y'
+      - 'CONFIG_SPI_MT65XX=y'
 
   crypto:
     path: "kernel/configs/crypto.config"


### PR DESCRIPTION
Add CONFIG_SPI_MT65XX=y to the arm64-chromebook config fragment to
enable the SPI controller driver on mt8173-elm-hana and
mt8183-kukui-jacuzzi-juniper-sku16. This is needed for the battery
to be detected correctly.

Signed-off-by: Laura Nao <laura.nao@collabora.com>