### PR TITLE
test-configs.yaml: update rootfs URLs to 20220610

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -38,7 +38,7 @@ file_systems:
 
   buildroot-baseline_ramdisk:
     type: buildroot
-    ramdisk: 'buildroot-baseline/20220603.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'buildroot-baseline/20220610.1/{arch}/rootfs.cpio.gz'
 
   cip_nfs:
     type: cip
@@ -48,53 +48,53 @@ file_systems:
 
   debian_bullseye_ramdisk:
     type: debian
-    ramdisk: 'bullseye/20220603.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'bullseye/20220610.0/{arch}/rootfs.cpio.gz'
 
   debian_bullseye_nfs:
     type: debian
-    ramdisk: 'bullseye/20220603.0/{arch}/initrd.cpio.gz'
-    nfs: 'bullseye/20220603.0/{arch}/full.rootfs.tar.xz'
+    ramdisk: 'bullseye/20220610.0/{arch}/initrd.cpio.gz'
+    nfs: 'bullseye/20220610.0/{arch}/full.rootfs.tar.xz'
     root_type: nfs
 
   debian_bullseye-cros-ec_ramdisk:
     type: debian
-    ramdisk: 'bullseye-cros-ec/20220603.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'bullseye-cros-ec/20220610.0/{arch}/rootfs.cpio.gz'
 
   debian_bullseye-igt_ramdisk:
     type: debian
-    ramdisk: 'bullseye-igt/20220603.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'bullseye-igt/20220610.0/{arch}/rootfs.cpio.gz'
 
   debian_bullseye-kselftest_nfs:
     type: debian
-    ramdisk: 'bullseye-kselftest/20220603.0/{arch}/initrd.cpio.gz'
-    nfs: 'bullseye-kselftest/20220603.0/{arch}/full.rootfs.tar.xz'
+    ramdisk: 'bullseye-kselftest/20220610.0/{arch}/initrd.cpio.gz'
+    nfs: 'bullseye-kselftest/20220610.0/{arch}/full.rootfs.tar.xz'
     root_type: nfs
     params:
       os_config: 'debian'
 
   debian_bullseye-libcamera_nfs:
     type: debian
-    ramdisk: 'bullseye-libcamera/20220603.0/{arch}/initrd.cpio.gz'
-    nfs: 'bullseye-libcamera/20220603.0/{arch}/full.rootfs.tar.xz'
+    ramdisk: 'bullseye-libcamera/20220610.0/{arch}/initrd.cpio.gz'
+    nfs: 'bullseye-libcamera/20220610.0/{arch}/full.rootfs.tar.xz'
     root_type: nfs
 
   debian_bullseye-ltp_nfs:
     type: debian
-    ramdisk: 'bullseye-ltp/20220603.0/{arch}/initrd.cpio.gz'
-    nfs: 'bullseye-ltp/20220603.0/{arch}/full.rootfs.tar.xz'
+    ramdisk: 'bullseye-ltp/20220610.0/{arch}/initrd.cpio.gz'
+    nfs: 'bullseye-ltp/20220610.0/{arch}/full.rootfs.tar.xz'
     root_type: nfs
 
   debian_bullseye-ltp_ramdisk:
     type: debian
-    ramdisk: 'bullseye-ltp/20220603.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'bullseye-ltp/20220610.0/{arch}/rootfs.cpio.gz'
 
   debian_bullseye-rt_ramdisk:
     type: debian
-    ramdisk: 'bullseye-rt/20220603.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'bullseye-rt/20220610.0/{arch}/rootfs.cpio.gz'
 
   debian_bullseye-v4l2_ramdisk:
     type: debian
-    ramdisk: 'bullseye-v4l2/20220603.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'bullseye-v4l2/20220610.2/{arch}/rootfs.cpio.gz'
 
 
 


### PR DESCRIPTION
Upate all the rootfs URLs to 20220610.* builds from today.  The
buildroot-baseline ones were rebuilt with latest bootrr changes.  The
bullseye-v4l2 ones were rebuilt with latest changes in the
v4l2-parser.sh script.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>