### PR TITLE
CHROMEOS test-configs-chromeos.yaml: drop device_id from octopus

### DIFF
--- a/config/core/test-configs-chromeos.yaml
+++ b/config/core/test-configs-chromeos.yaml
@@ -114,14 +114,10 @@ device_types:
         image: 'https://storage.chromeos.kernelci.org/images/kernel/chromeos-octopus-4.14.243/vmlinuz-4.14.243'
         modules: 'https://storage.chromeos.kernelci.org/images/kernel/chromeos-octopus-4.14.243/modules-4.14.243.tar.gz'
       block_device: mmcblk0
-      device_id: cbg-4
 
   hp-x360-12b-ca0500na-n4000-octopus_chromeos:
     <<: *octopus
     base_name: hp-x360-12b-ca0500na-n4000-octopus
-    params:
-      <<: *octopus-params
-      device_id: cbg-0
 
   qemu_x86_64-uefi-chromeos:
     base_name: qemu


### PR DESCRIPTION
Drop the device_id parameters in the octopus device types as all
devices should be flashed with the same R100 image in production now.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>