### PR TITLE
test-configs: Don't run slow LTP tests on Juno

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2359,8 +2359,6 @@ test_configs:
       - ltp-fcntl-locktests
       - ltp-ipc
       # ltp-mm - runs system out of memory
-      - ltp-pty
-      - ltp-timers
       - smc
 
   - device_type: kirkwood-db-88f6282


### PR DESCRIPTION
We only have one Juno available and it's never going to be able to keep
up with all the LTP tests we're currently scheduling, don't try to
schedule any.

Signed-off-by: Mark Brown <broonie@kernel.org>