### PR TITLE
CHROMEOS docker/cros-tast: Add dmesg baseline tests

### DIFF
--- a/config/core/test-configs-chromeos.yaml
+++ b/config/core/test-configs-chromeos.yaml
@@ -1,32 +1,61 @@
 test_plans:
 
-  cros-boot: &cros-boot
-    pattern: 'chromeos/cros-boot.jinja2'
+  cros-baseline: &cros-baseline
+    pattern: 'chromeos/cros-baseline.jinja2'
     filters: &cros-filters
       - blocklist: { defconfig: ['kselftest'] }
+    params:
+      docker_image: 'kernelci/cros-baseline'
 
-  cros-boot-fixed:
-    <<: *cros-boot
+  cros-baseline-fixed:
+    <<: *cros-baseline
     filters: &cros-filters-fixed
       - blocklist: { defconfig: ['kselftest'] }
       - blocklist: { defconfig: ['cros'] }
+    params:
+      docker_image: 'kernelci/cros-baseline'
+      fixed_kernel: true
+
+  cros-baseline_qemu: &cros-baseline_qemu
+    base_name: cros-baseline
+    pattern: 'chromeos/cros-baseline.jinja2'
+    filters: &cros-qemu-filters
+      - blocklist: { defconfig: ['kselftest'] }
+      - passlist: { lab: ['lab-collabora-staging', 'lab-collabora'] }
+    params: &cros-baseline-qemu-params
+      base_template: 'chromeos/cros-boot-qemu.jinja2'
+      docker_image: 'kernelci/cros-baseline'
+
+  cros-baseline_qemu-fixed:
+    <<: *cros-baseline_qemu
+    base_name: cros-baseline-fixed
+    filters: &cros-qemu-filters-fixed
+      - blocklist: { defconfig: ['kselftest'] }
+      - blocklist: { defconfig: ['cros'] }
+      - passlist: { lab: ['lab-collabora-staging', 'lab-collabora'] }
+    params:
+      <<: *cros-baseline-qemu-params
+      fixed_kernel: true
+
+  cros-boot: &cros-boot
+    pattern: 'chromeos/cros-boot.jinja2'
+    filters: *cros-filters
+
+  cros-boot-fixed:
+    <<: *cros-boot
+    filters: *cros-filters-fixed
     params:
       fixed_kernel: true
 
   cros-boot_qemu: &cros-boot_qemu
     base_name: cros-boot
     pattern: 'chromeos/cros-boot-qemu.jinja2'
-    filters: &cros-qemu-filters
-      - blocklist: { defconfig: ['kselftest'] }
-      - passlist: { lab: ['lab-collabora-staging', 'lab-collabora'] }
+    filters: *cros-qemu-filters
 
   cros-boot_qemu-fixed:
     <<: *cros-boot_qemu
     base_name: cros-boot-fixed
-    filters: &cros-qemu-filters-fixed
-      - blocklist: { defconfig: ['kselftest'] }
-      - blocklist: { defconfig: ['cros'] }
-      - passlist: { lab: ['lab-collabora-staging', 'lab-collabora'] }
+    filters: *cros-qemu-filters-fixed
     params:
       fixed_kernel: true
 
@@ -156,6 +185,8 @@ test_configs:
 
   - device_type: hp-x360-12b-ca0010nr-n4020-octopus_chromeos
     test_plans:
+      - cros-baseline
+      - cros-baseline-fixed
       - cros-boot
       - cros-boot-fixed
       - cros-tast
@@ -163,6 +194,8 @@ test_configs:
 
   - device_type: hp-x360-12b-ca0500na-n4000-octopus_chromeos
     test_plans:
+      - cros-baseline
+      - cros-baseline-fixed
       - cros-boot
       - cros-boot-fixed
       - cros-tast
@@ -170,6 +203,8 @@ test_configs:
 
   - device_type: qemu_x86_64-uefi-chromeos
     test_plans:
+      - cros-baseline_qemu
+      - cros-baseline_qemu-fixed
       - cros-boot_qemu
       - cros-boot_qemu-fixed
       - cros-tast_qemu

--- a/config/docker/cros-baseline/Dockerfile
+++ b/config/docker/cros-baseline/Dockerfile
@@ -1,0 +1,41 @@
+FROM debian:bullseye-slim
+MAINTAINER "KernelCI TSC" <kernelci-tsc@groups.io>
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    apt-transport-https \
+    ca-certificates 
+
+RUN apt-get update && apt-get install -y \
+    git \
+    inetutils-ping \
+    ssh
+
+RUN \
+  mkdir -p /home/cros && \
+  useradd cros -d /home/cros && \
+  chown cros: -R /home/cros && \
+  adduser cros sudo && \
+  echo "cros ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+USER cros
+ENV HOME=/home/cros
+WORKDIR $HOME
+
+# All this just to extract rsa key to access DUT
+# Adding private key "as is" might trigger github audit alert
+RUN mkdir -p $HOME/trunk
+RUN git clone \
+    https://chromium.googlesource.com/chromiumos/chromite \
+    $HOME/trunk/chromite
+ENV PATH=$PATH:$HOME/trunk/chromite/scripts
+
+# This SSH key is only used with Chrome OS test images.
+RUN mkdir "$HOME/.ssh"
+RUN cp "$HOME/trunk/chromite/ssh_keys/testing_rsa" "$HOME/.ssh/id_rsa"
+RUN chmod 0600 "$HOME/.ssh/id_rsa"
+
+ADD https://raw.githubusercontent.com/kernelci/kernelci-core/chromeos.kernelci.org/config/rootfs/debos/overlays/baseline/opt/kernelci/dmesg.sh /home/cros/dmesg.sh
+
+# Needed by LAVA to install the overlay
+USER root

--- a/config/lava/chromeos/cros-baseline.jinja2
+++ b/config/lava/chromeos/cros-baseline.jinja2
@@ -1,0 +1,30 @@
+{% extends base_template|default('chromeos/cros-boot.jinja2') %}
+{% block actions %}
+{{ super() }}
+- test:
+    namespace: chromeos
+    timeout:
+      minutes: 5
+    docker:
+      image: {{ docker_image }}
+      wait:
+        device: true
+    results:
+      location: /home/cros/lava
+    definitions:
+    - repository:
+        metadata:
+          format: Lava-Test Test Definition 1.0
+          name: cros-baseline
+        run:
+          steps:
+            - cd /home/cros
+            - while ! ping -c 1 -w 1 $(lava-target-ip); do sleep 1; done
+            - >-
+              KERNELCI_LAVA=y
+              cmdwrapper="ssh -i /home/cros/.ssh/id_rsa -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@$(lava-target-ip)"
+              /bin/sh dmesg.sh
+      from: inline
+      name: cros-baseline
+      path: inline/cros-baseline.yaml
+{% endblock %}


### PR DESCRIPTION
To improve tests information, it is useful to add test similar to other kernelci
baseline tests that show kernel messages with warn/error/crit levels,
mark test as fail if they are present, and highlight number of such messages.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>