### PR TITLE
CHROMEOS kernel-ci-base.jinja2: Make initrd_url as optional value

### DIFF
--- a/config/lava/base/kernel-ci-base.jinja2
+++ b/config/lava/base/kernel-ci-base.jinja2
@@ -24,8 +24,12 @@ metadata:
   job.kernel_url: {{ kernel_url }}
   job.kernel_image: {{ kernel_image }}
   job.modules_url: {{ modules_url }}
+{%- if initrd_url %}
   job.initrd_url: {{ initrd_url }}
+{%- endif %}
+{%- if nfsrootfs_url %}
   job.nfsrootfs_url: {{ nfsrootfs_url }}
+{%- endif %}
   job.dtb_url: {{ dtb_url }}
   job.file_server_resource: {{ file_server_resource }}
   job.build_environment: {{ build_environment }}


### PR DESCRIPTION
In some tests, like ChromeOS, initrd might be not present.
Do not add it in metadata if it is not present to avoid LAVA errors like this:

Problem with submitted job data: expected str for dictionary value @ data['metadata']['job.initrd_url']

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>