### PR TITLE
T35922 Implement APIs to request /regressions endpoint

### DIFF
--- a/kernelci/db/kernelci_api.py
+++ b/kernelci/db/kernelci_api.py
@@ -103,6 +103,11 @@ class KernelCI_API(Database):
         resp = self._get('/'.join(['get_root_node', node_id]))
         return json.loads(resp.text)
 
+    def get_regressions(self, regression_name):
+        """ Get a list of regressions matching regression name"""
+        resp = self._get('?'.join(['regressions', 'name=' + regression_name]))
+        return json.loads(resp.text)
+
     def pubsub_event_filter(self, sub_id, event):
         """Filter Pub/Sub events
 


### PR DESCRIPTION
Implement `KernelCI_API.get_regressions` to request `/regression` endpoint of API with regression name.