### PR TITLE
T35078 Get all nodes matching attributes from API

### DIFF
--- a/kernelci/db/kernelci_api.py
+++ b/kernelci/db/kernelci_api.py
@@ -39,9 +39,9 @@ class KernelCI_API(Database):
     def _make_url(self, path):
         return urllib.parse.urljoin(self.config.url, path)
 
-    def _get(self, path):
+    def _get(self, path, params=None):
         url = self._make_url(path)
-        resp = requests.get(url, headers=self._headers)
+        resp = requests.get(url, params=params, headers=self._headers)
         resp.raise_for_status()
         return resp
 
@@ -87,6 +87,11 @@ class KernelCI_API(Database):
     def get_node(self, node_id):
         resp = self._get('/'.join(['node', node_id]))
         return json.loads(resp.text)
+
+    def get_nodes(self, attributes: dict = None):
+        """Get all nodes matching attributes"""
+        resp = self._get('nodes', params=attributes)
+        return resp.json()
 
     def get_nodes_by_commit_hash(self, commit_hash):
         """

--- a/kernelci/db/kernelci_api.py
+++ b/kernelci/db/kernelci_api.py
@@ -93,14 +93,6 @@ class KernelCI_API(Database):
         resp = self._get('nodes', params=attributes)
         return resp.json()
 
-    def get_nodes_by_commit_hash(self, commit_hash):
-        """
-        Get list of node objects matching the commit SHA-1
-        provided to 'nodes' endpoint
-        """
-        resp = self._get('?'.join(['nodes', 'revision.commit='+commit_hash]))
-        return resp.json()
-
     def get_node_from_event(self, event):
         return self.get_node(event.data['id'])
 


### PR DESCRIPTION
Implement KernelCI_API.get_nodes
to get all the nodes from API.

Used this in https://github.com/kernelci/kernelci-pipeline/pull/71

Signed-off-by: Jeny Sadadia <jeny.sadadia@collabora.com>