### PR TITLE
rootfs/bullseye-cros-flash: Add block device parameter to install_modules

### DIFF
--- a/config/rootfs/debos/overlays/cros-flash/opt/chromeos/install-modules
+++ b/config/rootfs/debos/overlays/cros-flash/opt/chromeos/install-modules
@@ -21,12 +21,14 @@
 set -xe
 
 MODULES_URL="$1"
-IMAGE_MOUNTPOINT="${2:-/root/chromeos}"
+BLOCK_DEVICE="${2:-mmcblk0}"
+IMAGE_MOUNTPOINT="${3:-/root/chromeos}"
 
 install_modules()
 {
     local modules_url="$1"
-    local image_mountpoint="$2"
+    local block_device="$2"
+    local image_mountpoint="$3"
 
     local mount_dir=$(basename "$image_mountpoint")
     local root_path=$(dirname "$image_mountpoint")
@@ -36,7 +38,7 @@ install_modules()
     mkdir -p "$image_mountpoint"
     cd "$root_path"
     wget "$modules_url"
-    mount /dev/mmcblk0p3 "$mount_dir"
+    mount /dev/${block_device}p3 "$mount_dir"
 
     echo "Installing modules..."
     cd "$mount_dir"
@@ -58,10 +60,10 @@ install_modules()
 
 if [ -z "$MODULES_URL" ]; then
     echo "Missing modules URL"
-    echo "Usage: install-modules MODULES_URL IMAGE_MOUNTPOINT"
+    echo "Usage: install-modules MODULES_URL BLOCK_DEVICE IMAGE_MOUNTPOINT"
     exit 1
 fi
 
-install_modules "$MODULES_URL" "$IMAGE_MOUNTPOINT"
+install_modules "$MODULES_URL" "$BLOCK_DEVICE" "$IMAGE_MOUNTPOINT"
 
 exit 0


### PR DESCRIPTION
Add parameter to specify which device should be used for installing
kernel modules.

Signed-off-by: Michal Galka <michal.galka@collabora.com>