### PR TITLE
CHROMEOS rootfs-configs-chromeos.yaml: add chromiumos-hatch

### DIFF
--- a/config/core/rootfs-configs-chromeos.yaml
+++ b/config/core/rootfs-configs-chromeos.yaml
@@ -20,6 +20,14 @@ rootfs_configs:
     arch_list:
       - amd64
 
+  chromiumos-hatch:
+    rootfs_type: chromiumos
+    board: hatch
+    branch: release-R100-14526.B
+    serial: ttyS0
+    arch_list:
+      - amd64
+
   chromiumos-octopus:
     rootfs_type: chromiumos
     board: octopus


### PR DESCRIPTION
Add a config entry for building Chromium OS R100 for hatch.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>