### PR TITLE
lab-configs: Add yet more tests for my lab

### DIFF
--- a/config/core/lab-configs.yaml
+++ b/config/core/lab-configs.yaml
@@ -25,14 +25,6 @@ labs:
       days: 1
     filters:
       - blocklist: {tree: [android]}
-      - passlist:
-          plan:
-            - baseline
-            - kselftest
-            - ltp
-            - preempt-rt
-            - sleep
-            - smc
 
   lab-cip:
     lab_type: lava.lava_xmlrpc


### PR DESCRIPTION
Since we have to manually list all the testsuites we're willing to run
in each lab add patterns for all the currently defined ones to my lab.

Signed-off-by: Mark Brown <broonie@kernel.org>