### PR TITLE
test-configs.yaml: update rootfs URLs to 20220624.0

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -41,7 +41,7 @@ file_systems:
 
   buildroot-baseline_ramdisk:
     type: buildroot
-    ramdisk: 'buildroot-baseline/20220617.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'buildroot-baseline/20220624.0/{arch}/rootfs.cpio.gz'
 
   cip_nfs:
     type: cip
@@ -51,34 +51,34 @@ file_systems:
 
   debian_bullseye_ramdisk:
     type: debian
-    ramdisk: 'bullseye/20220617.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'bullseye/20220624.0/{arch}/rootfs.cpio.gz'
 
   debian_bullseye_nfs:
     type: debian
-    ramdisk: 'bullseye/20220617.0/{arch}/initrd.cpio.gz'
-    nfs: 'bullseye/20220617.0/{arch}/full.rootfs.tar.xz'
+    ramdisk: 'bullseye/20220624.0/{arch}/initrd.cpio.gz'
+    nfs: 'bullseye/20220624.0/{arch}/full.rootfs.tar.xz'
     root_type: nfs
 
   debian_bullseye-cros-ec_ramdisk:
     type: debian
-    ramdisk: 'bullseye-cros-ec/20220617.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'bullseye-cros-ec/20220624.0/{arch}/rootfs.cpio.gz'
 
   debian_bullseye-igt_ramdisk:
     type: debian
-    ramdisk: 'bullseye-igt/20220617.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'bullseye-igt/20220624.0/{arch}/rootfs.cpio.gz'
 
   debian_bullseye-kselftest_nfs:
     type: debian
-    ramdisk: 'bullseye-kselftest/20220617.0/{arch}/initrd.cpio.gz'
-    nfs: 'bullseye-kselftest/20220617.0/{arch}/full.rootfs.tar.xz'
+    ramdisk: 'bullseye-kselftest/20220624.0/{arch}/initrd.cpio.gz'
+    nfs: 'bullseye-kselftest/20220624.0/{arch}/full.rootfs.tar.xz'
     root_type: nfs
     params:
       os_config: 'debian'
 
   debian_bullseye-libcamera_nfs:
     type: debian
-    ramdisk: 'bullseye-libcamera/20220617.0/{arch}/initrd.cpio.gz'
-    nfs: 'bullseye-libcamera/20220617.0/{arch}/full.rootfs.tar.xz'
+    ramdisk: 'bullseye-libcamera/20220624.0/{arch}/initrd.cpio.gz'
+    nfs: 'bullseye-libcamera/20220624.0/{arch}/full.rootfs.tar.xz'
     root_type: nfs
 
   debian_bullseye-ltp_nfs:
@@ -93,11 +93,11 @@ file_systems:
 
   debian_bullseye-rt_ramdisk:
     type: debian
-    ramdisk: 'bullseye-rt/20220617.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'bullseye-rt/20220624.0/{arch}/rootfs.cpio.gz'
 
   debian_bullseye-v4l2_ramdisk:
     type: debian
-    ramdisk: 'bullseye-v4l2/20220617.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'bullseye-v4l2/20220624.0/{arch}/rootfs.cpio.gz'
 
 
 


### PR DESCRIPTION
Update all rootfs URLs to 20220624.0 except bullseye-ltp which failed
to build again.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>