### PR TITLE
CHROMEOS dmesg.sh: Add support for ssh wrapper for network test

### DIFF
--- a/config/rootfs/debos/overlays/baseline/opt/kernelci/dmesg.sh
+++ b/config/rootfs/debos/overlays/baseline/opt/kernelci/dmesg.sh
@@ -9,7 +9,7 @@ else
 fi
 
 for level in crit alert emerg; do
-    dmesg --level=$level --notime -x -k > dmesg.$level
+    ${cmdwrapper} dmesg --level=$level --notime -x -k > dmesg.$level
     test -s dmesg.$level && res=fail || res=pass
     count=$(cat dmesg.$level | wc -l)
     cat dmesg.$level


### PR DESCRIPTION
As ChromeOS architecture is different from existing OS,
installing LAVA helpers on rootfs might be difficult and unreliable.
We can test DUT over ssh with very simple modification,
as suggested by Guillaume Tucker.

Test can be run as following:
KERNELCI_LAVA=y cmdwrapper="ssh -i /home/cros/.ssh/id_rsa
-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
root@$(lava-target-ip)" /bin/sh dmesg.sh

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>