### PR TITLE
CHROMIUMOS test-configs-chromeos.yaml: Remove blocklist for cros

### DIFF
--- a/config/core/test-configs-chromeos.yaml
+++ b/config/core/test-configs-chromeos.yaml
@@ -9,7 +9,6 @@ test_plans:
     <<: *cros-boot
     filters: &cros-filters-fixed
       - blocklist: { defconfig: ['kselftest'] }
-      - blocklist: { defconfig: ['cros'] }
     params:
       fixed_kernel: true
 
@@ -25,7 +24,6 @@ test_plans:
     base_name: cros-boot-fixed
     filters: &cros-qemu-filters-fixed
       - blocklist: { defconfig: ['kselftest'] }
-      - blocklist: { defconfig: ['cros'] }
       - passlist: { lab: ['lab-collabora-staging', 'lab-collabora'] }
     params:
       fixed_kernel: true


### PR DESCRIPTION
As we need cros://chromeos-5.10/x86_64/chromiumos-x86_64.flavour.config
for proper qemu support, we should remove "cros" from blocklist.
Device already have proper filter.
It will solve issue with missing tests for -fixed tests.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>