### PR TITLE
CHROMEOS tast_parser.py&Dockerfile: Run tast tests under cros-tast user

### DIFF
--- a/config/docker/cros-tast/Dockerfile
+++ b/config/docker/cros-tast/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && apt-get install -y \
     inetutils-ping \
     python3 \
     python-pkg-resources \
+    sudo \
     vim \
     xz-utils
 
@@ -23,6 +24,7 @@ RUN \
   useradd cros-tast -d /home/cros-tast && \
   chown cros-tast: -R /home/cros-tast && \
   adduser cros-tast sudo && \
+  echo 'PATH=/home/cros-tast/trunk/chromite/scripts:$PATH' >/home/cros-tast/.profile && \
   echo "cros-tast ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 USER cros-tast
 ENV HOME=/home/cros-tast

--- a/config/docker/cros-tast/tast_parser.py
+++ b/config/docker/cros-tast/tast_parser.py
@@ -21,6 +21,7 @@ import subprocess
 import sys
 import os
 import json
+import pwd
 
 RESULTS_DIR = "/tmp/results"
 TAST_PATH = "./tast"
@@ -37,10 +38,16 @@ def report_lava(testname, result):
 
 
 def run_tests(args):
+    uid = pwd.getpwnam("cros-tast").pw_uid
     if not os.path.isdir(RESULTS_DIR):
         os.makedirs(RESULTS_DIR, exist_ok=True)
+    os.chown(RESULTS_DIR, uid, 0)
     remote_ip = fetch_dut()
     tast_cmd = [
+        'sudo',
+        '-u',
+        'cros-tast',
+        '--login',
         TAST_PATH,
         'run',
         f'-resultsdir={RESULTS_DIR}',


### PR DESCRIPTION
After multiple tests we found that gsutil fail to run under root and cannot download resources for tast that are hosted on Google Storage. 
With this changes we can easily run tast under cros-tast username and  get gsutil working.
Tested by hand: https://lava.collabora.co.uk/scheduler/job/6744968