### PR TITLE
test-configs: Enable lima tests for tritium

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2889,6 +2889,7 @@ test_configs:
     test_plans:
       - baseline
       - baseline-nfs
+      - igt-gpu-lima
       - kselftest-alsa
       - ltp-crypto
 


### PR DESCRIPTION
The Tritium has a Mali supported by the Lima driver, now both the
Tritium and the Lima tests are merged let's enable Lima on this board
too.

Signed-off-by: Mark Brown <broonie@kernel.org>