### PR TITLE
test-configs: Additional tests for Tritium

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2890,7 +2890,24 @@ test_configs:
       - baseline
       - baseline-nfs
       - kselftest-alsa
+      - kselftest-arm64
+      - kselftest-capabilities
+      - kselftest-cgroup
+      - kselftest-clone3
+      - kselftest-cpufreq
+      - kselftest-exec
+      - kselftest-filesystems
+      - kselftest-futex
+      - kselftest-kcmp
+      - kselftest-kvm
+      - kselftest-lib
+      - kselftest-membarrier
+      - kselftest-mincore
+      - kselftest-openat2
+      - kselftest-seccomp
+      - kselftest-timers
       - ltp-crypto
+      - preempt-rt
 
   - device_type: sun50i-h5-nanopi-neo-plus2
     test_plans:


### PR DESCRIPTION
I have three Tritiums available in my lab which are mostly idle with the
current loading, add some more hardware agnostic tests to make use of
them.

Signed-off-by: Mark Brown <broonie@kernel.org>