### PR TITLE
test-configs: Drop slow tests for pine64plus

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2881,8 +2881,6 @@ test_configs:
       - ltp-ima
       - ltp-ipc
       # ltp-mm - runs system out of memory
-      - ltp-pty
-      - ltp-timers
       - smc
 
   - device_type: sun50i-h5-libretech-all-h3-cc


### PR DESCRIPTION
None of the labs have multiple pin64plus boards and we currently don't
have effective prioritisation of tests so the long running tests like
the LTP pty and timers tests are contributing greatly to a massive
backlog of tests on these boards. Drop those tests for now.

Signed-off-by: Mark Brown <broonie@kernel.org>