### PR TITLE
test-configs: Add more tests to BeagleBone Black

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2107,8 +2107,22 @@ test_configs:
       - baseline-cip-nfs
       - baseline-nfs
       - kselftest-alsa
+      - kselftest-capabilities
+      - kselftest-cgroup
+      - kselftest-clone3
+      - kselftest-exec
+      - kselftest-filesystems
+      - kselftest-futex
+      - kselftest-kcmp
+      - kselftest-lib
+      - kselftest-membarrier
+      - kselftest-mincore
+      - kselftest-openat2
+      - kselftest-seccomp
+      - kselftest-timers
       - ltp-crypto
       - ltp-ipc
+      - preempt-rt
 
   - device_type: cubietruck
     test_plans:


### PR DESCRIPTION
At least my lab has multiple BeagleBone Blacks with plenty of spare
capacity at current loads so add a few more tests to increase coverage.

Signed-off-by: Mark Brown <broonie@kernel.org>