### PR TITLE
test-configs: Add more tests for Udoo boards

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2312,6 +2312,11 @@ test_configs:
       - baseline-nfs
       - igt-gpu-etnaviv
       - kselftest-alsa
+      - kselftest-capabilities
+      - kselftest-cgroup
+      - kselftest-exec
+      - kselftest-futex
+      - kselftest-kcmp
       - ltp-crypto
 
   - device_type: imx6q-nitrogen6x
@@ -2345,6 +2350,11 @@ test_configs:
       - baseline-nfs
       - igt-gpu-etnaviv
       - kselftest-alsa
+      - kselftest-capabilities
+      - kselftest-cgroup
+      - kselftest-exec
+      - kselftest-futex
+      - kselftest-kcmp
       - ltp-crypto
 
   - device_type: imx6q-var-dt6customboard


### PR DESCRIPTION
The Udoo boards in my lab are currently fairly lightly loaded, add more
generic tests to improve coverage.

Signed-off-by: Mark Brown <broonie@kernel.org>