### PR TITLE
test-configs.yaml: Remove baseline-fastboot from device not supporting fastboot

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2439,7 +2439,6 @@ test_configs:
   - device_type: meson-g12a-sei510
     test_plans:
       - baseline
-      - baseline-fastboot
 
   - device_type: meson-g12a-u200
     test_plans:
@@ -2527,7 +2526,6 @@ test_configs:
   - device_type: meson-sm1-sei610
     test_plans:
       - baseline
-      - baseline-fastboot
 
   - device_type: meson8b-odroidc1
     test_plans:


### PR DESCRIPTION
According to staging jenkins logs baseline-fastboot scheduled to meson-sm1-sei610
device, but device doesnt have fastboot tag and this cause error during job submit.
For example: https://bot.staging.kernelci.org/job/test-runner/34511/console
ERROR /data/workspace/bot.staging.kernelci.org/test-runner/workspace/test-runner/jobs/lab-baylibre/kernelci-staging-mainline-staging-mainline-20220707.0-arm64-defconfig-clang-11-meson-g12a-sei510.dtb-meson-g12a-sei510-baseline-fastboot.yaml: <Fault 400: "Device unavailable: No devices of type meson-g12a-sei510 are available which have all of the tags 'fastboot'.">

Also i cannot find any successfull baseline-fastboot test on staging or production.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>