### PR TITLE
CHROMEOS build_board.sh&Dockerfile: Do not cache depot_tools

### DIFF
--- a/config/docker/cros-sdk/Dockerfile
+++ b/config/docker/cros-sdk/Dockerfile
@@ -32,9 +32,5 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 
 USER cros
 ENV HOME=/home/cros
-WORKDIR $HOME/chromiumos
-
-RUN git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
-ENV PATH="/home/cros/chromiumos/depot_tools:${PATH}"
 
 WORKDIR /kernelci-core

--- a/config/rootfs/chromiumos/scripts/build_board.sh
+++ b/config/rootfs/chromiumos/scripts/build_board.sh
@@ -17,6 +17,12 @@ function cleanup()
 
 trap cleanup EXIT
 
+echo "Preparing depot tools"
+cd "/home/${USERNAME}/chromiumos"
+git clone --depth=1 https://chromium.googlesource.com/chromium/tools/depot_tools.git
+export PATH="/home/${USERNAME}/chromiumos/depot_tools:${PATH}"
+cd ${DATA_DIR}
+
 echo "Preparing environment, branch ${BRANCH}"
 sudo mkdir chromiumos-sdk
 sudo chown ${USERNAME} chromiumos-sdk


### PR DESCRIPTION
We faced issue with building R100 release recently, as seems
ChromiumOS tree even have R100 branch, it is not frozen,
and keep being updated. At some moment it got updated and
require newer depot_tools than those cached in Dockerfile,
which lead to rootfs build failures.
This also make recipe fully following official developer guide:
https://chromium.googlesource.com/chromiumos/docs/+/main/developer_guide.md

But as proper solution, we will develop snapshot feature
that will provide us working and reproducible builds
for ChromiumOS.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>