### PR TITLE
CHROMEOS cros-tast.jinja2: Add more tast tests (tabswitch + videodecode)

### DIFF
--- a/config/lava/chromeos/cros-tast.jinja2
+++ b/config/lava/chromeos/cros-tast.jinja2
@@ -4,7 +4,7 @@
 - test:
     namespace: chromeos
     timeout:
-      minutes: 5
+      minutes: 30
     docker:
       image: {{ docker_image }}
       wait:
@@ -38,6 +38,8 @@
               example.ARCFixture
               example.ManyParams.arc_state example.Param.dog
               example.Pass example.Fail
+              video.ChromeStackDecoding.*
+              ui.WindowCyclePerf
       from: inline
       name: cros-tast
       path: inline/cros-tast.yaml


### PR DESCRIPTION
It's time to expand the number of tast tests and include more interesting ones.
One of the tests switches different tabs in chrome, the second tests video decoding.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>