### PR TITLE
CHROMEOS test-configs-chromeos.yaml: update cros-flash NFS rootfs URL

### DIFF
--- a/config/core/test-configs-chromeos.yaml
+++ b/config/core/test-configs-chromeos.yaml
@@ -111,7 +111,7 @@ device_types:
       - passlist: {defconfig: ['chromeos-intel-pineview']}
     params: &octopus-params
       cros_flash_nfs:
-        base_url: 'https://storage.kernelci.org/images/rootfs/debian/bullseye-cros-flash/20220527.0/amd64/'
+        base_url: 'https://storage.kernelci.org/images/rootfs/debian/bullseye-cros-flash/20220623.0/amd64/'
         initrd: 'initrd.cpio.gz'
         initrd_compression: 'gz'
         rootfs: 'full.rootfs.tar.xz'


### PR DESCRIPTION
Update the url of the bullseye-cros-flash NFS rootfs image with the
latest production build. There are some changes in install-modules
script which may break tests using older images.
This is slightly updated version of PR https://github.com/kernelci/kernelci-core/pull/1271

Signed-off-by: Michal Galka <michal.galka@collabora.com>
Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>