### PR TITLE
CHROMEOS rootfs/chromiumos: fix hard-coded user in build_board.sh

### DIFF
--- a/config/rootfs/chromiumos/scripts/build_board.sh
+++ b/config/rootfs/chromiumos/scripts/build_board.sh
@@ -19,7 +19,7 @@ trap cleanup EXIT
 
 echo "Preparing environment, branch ${BRANCH}"
 sudo mkdir chromiumos-sdk
-sudo chown user chromiumos-sdk
+sudo chown ${USERNAME} chromiumos-sdk
 cd chromiumos-sdk
 git config --global user.email "bot@kernelci.org"
 git config --global user.name "KernelCI Bot"


### PR DESCRIPTION
Use the ${USERNAME} variable in build_board.sh rather than the
hard-coded "user" name.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>