### PR TITLE
lab-configs.yaml: Update Collabora LAVA URL

### DIFF
--- a/config/core/lab-configs.yaml
+++ b/config/core/lab-configs.yaml
@@ -88,7 +88,7 @@ labs:
   lab-collabora:
     lab_type: lava.lava_rest
     config_path: 'lava'
-    url: 'https://lava.collabora.co.uk/'
+    url: 'https://lava.collabora.dev/'
     priority: '45'
     queue_timeout:
       days: 2


### PR DESCRIPTION
As Collabora notified at 15/07/2022 they will change hostname
of LAVA from lava.collabora.co.uk to lava.collabora.dev.
This commit update relevant config.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>