### PR TITLE
T33737 update kselftest make commands

### DIFF
--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -1490,8 +1490,16 @@ class MakeSelftests(Step):
         opts = {
             'FORMAT': '.xz',
         }
-        res = self._make('gen_tar', jopt, verbose, opts,
-                         'tools/testing/selftests')
+        if self._check_min_kver(5, 20):
+            # Once v5.20 has been released and a new LTS has been declared then
+            # we can always run this command and bump the v5.10 version test
+            # for kselftest altogether.
+            res = self._make('kselftest-gen_tar', jopt, verbose, opts)
+        else:
+            res = self._make('headers', jopt, verbose)
+            if res:
+                res = self._make('gen_tar', jopt, verbose, opts,
+                                 'tools/testing/selftests')
         return self._add_run_step(res, jopt)
 
     def _get_kselftests(self, kselftest_tarball):


### PR DESCRIPTION
Call `make headers` first for kernels earlier than v5.20 and just call `make kselftest-gen_tar` for `v5.20` onwards. This relies on the changes described in https://github.com/kernelci/kernelci-project/issues/92 to have been merged in mainline (which should happen during the v5.20 merge window).

We may drop the 2-step make approach once the next LTS has been declared and stop building kselftest for earlier kernels (say, `v6.0` or something).