### PR TITLE
CHROMEOS build-configs-chromeos.yaml: Remove modules compression on 5.10

### DIFF
--- a/config/core/build-configs-chromeos.yaml
+++ b/config/core/build-configs-chromeos.yaml
@@ -7,7 +7,7 @@ trees:
 chromeos_variants: &chromeos-variants
   chromeos-clang-14:
     build_environment: clang-14
-    architectures:
+    architectures: &variants_architectures
       arm:
         base_defconfig: 'cros://chromeos-5.10/armel/chromiumos-arm.flavour.config'
         extra_configs:
@@ -22,7 +22,7 @@ chromeos_variants: &chromeos-variants
           - 'cros://chromeos-5.10/arm64/chromiumos-qualcomm.flavour.config+arm64-chromebook'
           - 'cros://chromeos-5.10/arm64/chromiumos-rockchip64.flavour.config+arm64-chromebook'
         filters: *cros-filters
-      x86_64:
+      x86_64: &cros-arch_x86_64
         base_defconfig: 'cros://chromeos-5.10/x86_64/chromiumos-x86_64.flavour.config'
         fragments: [x86-chromebook]
         extra_configs:
@@ -35,16 +35,31 @@ chromeos_variants: &chromeos-variants
   clang-14:
     build_environment: clang-14
     architectures:
-      arm64: &arm64_defconfig
+      arm64:
         base_defconfig: 'defconfig'
         fragments: [arm64-chromebook]
         filters:
           - passlist: { defconfig: ['arm64-chromebook'] }
-      x86_64: &x86_64_defconfig
+      x86_64:
         base_defconfig: 'x86_64_defconfig'
         fragments: [x86-chromebook]
         filters:
           - passlist: { defconfig: ['x86-chromebook'] }
+
+chromeos_nocompress_variants: &chromeos-nocompress-variants
+  << : *chromeos-variants
+  chromeos-clang-14:
+    build_environment: clang-14
+    architectures:
+      << : *variants_architectures
+      x86_64:
+        << : *cros-arch_x86_64
+        extra_configs:
+          - 'cros://chromeos-5.10/x86_64/chromeos-amd-stoneyridge.flavour.config+x86-chromebook+CONFIG_MODULE_COMPRESS=n'
+          - 'cros://chromeos-5.10/x86_64/chromeos-intel-denverton.flavour.config+x86-chromebook+CONFIG_MODULE_COMPRESS=n'
+          - 'cros://chromeos-5.10/x86_64/chromeos-intel-pineview.flavour.config+x86-chromebook+CONFIG_MODULE_COMPRESS=n'
+          - 'cros://chromeos-5.10/x86_64/chromiumos-x86_64.flavour.config+x86-chromebook+CONFIG_MODULE_COMPRESS=n'
+
 
 build_configs:
 
@@ -56,7 +71,7 @@ build_configs:
   chromeos-stable_5.10:
     tree: stable
     branch: 'linux-5.10.y'
-    variants: *chromeos-variants
+    variants: *chromeos-nocompress-variants
 
   chromeos-stable_5.15:
     tree: stable
@@ -66,4 +81,4 @@ build_configs:
   kernelci_chromeos-stable:
     tree: kernelci
     branch: 'chromeos-stable'
-    variants: *chromeos-variants
+    variants: *chromeos-nocompress-variants


### PR DESCRIPTION
As investigated, 5.10 kernel doesnt have in-kernel modules decompression,
and because of ChromeOS specific use of LSM(LoadPin),
OS/kernel cannot load compressed modules.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>