### PR TITLE
generic-uboot-tftp-ramdisk-preempt-rt-template.jinja2: Add missing template

### DIFF
--- a/config/lava/preempt-rt/generic-uboot-tftp-ramdisk-preempt-rt-template.jinja2
+++ b/config/lava/preempt-rt/generic-uboot-tftp-ramdisk-preempt-rt-template.jinja2
@@ -1,0 +1,7 @@
+{% extends 'boot/generic-uboot-tftp-ramdisk-boot-template.jinja2' %}
+{% block actions %}
+{{ super () }}
+
+{% include 'preempt-rt/preempt-rt.jinja2' %}
+
+{% endblock %}


### PR DESCRIPTION
As reported in issue https://github.com/kernelci/kernelci-core/issues/1307
We have error that this template is missing and many preempt-rt tests are
not being executed.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>