### PR TITLE
GitHub: assign to KernelCI project automatically

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -1,0 +1,29 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Project
+
+on:
+  issues:
+    types: [opened, labeled]
+  pull_request_target:
+    types: [opened, labeled]
+  issue_comment:
+    types: [created]
+
+env:
+  MY_GITHUB_TOKEN: ${{ secrets.MY_GITHUB_TOKEN }}
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  assign_one_project:
+    runs-on: ubuntu-latest
+    name: Assign to KernelCI Project
+    steps:
+
+    - name: Assign issues and PRs to KernelCI project
+      uses: srggrs/assign-one-project-github-action@1.3.1
+      if: github.event.action == 'opened'
+      with:
+        project: 'https://github.com/orgs/kernelci/projects/1'


### PR DESCRIPTION
Add a GitHub action to automatically assign PRs and issues to the
KernelCI project.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>