### PR TITLE
Add hatch and grunt config for Chromium OS

### DIFF
--- a/config/core/rootfs-configs-chromeos.yaml
+++ b/config/core/rootfs-configs-chromeos.yaml
@@ -20,6 +20,14 @@ rootfs_configs:
     arch_list:
       - amd64
 
+  chromiumos-grunt:
+    rootfs_type: chromiumos
+    board: grunt
+    branch: release-R100-14526.B
+    serial: ttyS0
+    arch_list:
+      - amd64
+
   chromiumos-hatch:
     rootfs_type: chromiumos
     board: hatch

--- a/config/core/rootfs-configs-chromeos.yaml
+++ b/config/core/rootfs-configs-chromeos.yaml
@@ -20,6 +20,14 @@ rootfs_configs:
     arch_list:
       - amd64
 
+  chromiumos-hatch:
+    rootfs_type: chromiumos
+    board: hatch
+    branch: release-R100-14526.B
+    serial: ttyS0
+    arch_list:
+      - amd64
+
   chromiumos-octopus:
     rootfs_type: chromiumos
     board: octopus


### PR DESCRIPTION
Add config entries for Chromium OS R100 rootfs images for the hatch and grunt Chromebooks.