### PR TITLE
docker/build-base: Add patched(+zlib) kmod install

### DIFF
--- a/config/docker/build-base/Dockerfile
+++ b/config/docker/build-base/Dockerfile
@@ -3,6 +3,38 @@ MAINTAINER "KernelCI TSC" <kernelci-tsc@groups.io>
 
 ARG DEBIAN_FRONTEND=noninteractive
 
+# Prepare environment for building packages
+RUN set -ex \
+    && sed -i -- 's/# deb-src/deb-src/g' /etc/apt/sources.list \
+    && echo "deb-src http://deb.debian.org/debian bullseye main non-free contrib" >>/etc/apt/sources.list \
+    && echo "deb-src http://deb.debian.org/debian-security/ bullseye-security main contrib non-free" >>/etc/apt/sources.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+               build-essential \
+               cdbs \
+               devscripts \
+               equivs \
+               fakeroot \
+               wget \
+    && apt-get clean \
+    && rm -rf /tmp/* /var/tmp/*
+
+ADD kmod_kci.patch /root/debs/kmod_kci.patch
+
+# Prepare kmod sources, patch, install dependencies, build
+RUN cd /root/debs && \
+    apt-get source kmod && \
+    cd kmod-28 && \
+    patch -p1 <../kmod_kci.patch && \
+    mk-build-deps -ir -t "apt-get -o Debug::pkgProblemResolver=yes -y --no-install-recommends" && \
+    debuild -b -uc -us
+
+FROM debian:bullseye
+
+# Fetch debs from previous stage
+COPY --from=0 /root/debs/*.deb /root/
+RUN dpkg -i /root/*.deb && rm /root/*.deb
+
 # Docker for jenkins really needs procps otherwise the jenkins side fails
 RUN apt-get update && apt-get install --no-install-recommends -y procps
 

--- a/config/docker/build-base/kmod_kci.patch
+++ b/config/docker/build-base/kmod_kci.patch
@@ -1,0 +1,36 @@
+diff -Naur kmod-28/debian/changelog kmod-28-kernelci/debian/changelog
+--- kmod-28/debian/changelog	2021-01-08 02:37:04.000000000 +0100
++++ kmod-28-kernelci/debian/changelog	2022-07-22 10:46:26.626030970 +0200
+@@ -1,3 +1,9 @@
++kmod (28-999) unstable; urgency=medium
++
++  * Add gz compression support
++
++ -- Denys Fedoryshchenko <denys.f@collabora.com>  Fri, 22 Jul 2022 11:37:04 +0300
++
+ kmod (28-1) unstable; urgency=medium
+ 
+   * New upstream release.
+diff -Naur kmod-28/debian/control kmod-28-kernelci/debian/control
+--- kmod-28/debian/control	2021-01-08 01:23:24.000000000 +0100
++++ kmod-28-kernelci/debian/control	2022-07-22 08:58:37.682360273 +0200
+@@ -3,7 +3,7 @@
+ Priority: important
+ Maintainer: Marco d'Itri <md@linux.it>
+ Build-Depends: debhelper-compat (= 12), liblzma-dev, libssl-dev, xsltproc,
+-  autoconf, automake, libtool, gtk-doc-tools
++  autoconf, automake, libtool, gtk-doc-tools, zlib1g-dev
+ Standards-Version: 4.5.1.0
+ Rules-Requires-Root: no
+ Vcs-Git: https://salsa.debian.org/md/kmod.git
+diff -Naur kmod-28/debian/rules kmod-28-kernelci/debian/rules
+--- kmod-28/debian/rules	2021-01-08 01:46:40.000000000 +0100
++++ kmod-28-kernelci/debian/rules	2022-07-22 08:58:19.122220998 +0200
+@@ -21,6 +21,7 @@
+   --enable-gtk-doc \
+   --with-openssl \
+   --with-xz \
++  --with-zlib \
+   --enable-debug
+ CONFFLAGS_udeb = $(CONFFLAGS) \
+   $(subst -O2,-Os -fomit-frame-pointer,$(shell DEB_BUILD_MAINT_OPTIONS="hardening=-all" \


### PR DESCRIPTION
Some tests (allmodconfig, ChromeOS) require
support for gzip/zlib compression of kernel modules,
for this we will patch and rebuild the kmod package
during the build-base Docker image rebuild.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>