### PR TITLE
docker: Add build deps for perf

### DIFF
--- a/config/docker/clang-base/Dockerfile
+++ b/config/docker/clang-base/Dockerfile
@@ -58,4 +58,49 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
    libpopt-dev:armhf \
    pkg-config
 
+# perf x86
+RUN apt-get update && apt-get install --no-install-recommends -y \
+   libbabeltrace-dev \
+   libcap-dev \
+   libdw-dev \
+   libnuma-dev \
+   libopencsd-dev \
+   libperl-dev \
+   libpython3-dev \
+   libslang2-dev \
+   libssl-dev \
+   libunwind-dev \
+   libzstd-dev \
+   systemtap-sdt-dev
+
+# perf arm
+RUN apt-get update && apt-get install --no-install-recommends -y \
+   libbabeltrace-dev:armhf \
+   libcap-dev:armhf \
+   libdw-dev:armhf \
+   libnuma-dev:armhf \
+   libopencsd-dev:armhf \
+   libperl-dev:armhf \
+   libpython3-dev:armhf \
+   libslang2-dev:armhf \
+   libssl-dev:armhf \
+   libunwind-dev:armhf \
+   libzstd-dev:armhf \
+   systemtap-sdt-dev:armhf
+
+# perf arm64
+RUN apt-get update && apt-get install --no-install-recommends -y \
+   libbabeltrace-dev:arm64 \
+   libcap-dev:arm64 \
+   libdw-dev:arm64 \
+   libnuma-dev:arm64 \
+   libopencsd-dev:arm64 \
+   libperl-dev:arm64 \
+   libpython3-dev:arm64 \
+   libslang2-dev:arm64 \
+   libssl-dev:arm64 \
+   libunwind-dev:arm64 \
+   libzstd-dev:arm64 \
+   systemtap-sdt-dev:arm64
+
 RUN apt-get autoremove -y gcc

--- a/config/docker/gcc-10_arm/Dockerfile
+++ b/config/docker/gcc-10_arm/Dockerfile
@@ -29,3 +29,18 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
    libasound2-dev:armhf \
    libasound2-dev \
    pkg-config
+
+# perf
+RUN apt-get update && apt-get install --no-install-recommends -y \
+   libbabeltrace-dev:armhf \
+   libcap-dev:armhf \
+   libdw-dev:armhf \
+   libnuma-dev:armhf \
+   libopencsd-dev:armhf \
+   libperl-dev:armhf \
+   libpython3-dev:armhf \
+   libslang2-dev:armhf \
+   libssl-dev:armhf \
+   libunwind-dev:armhf \
+   libzstd-dev:armhf \
+   systemtap-sdt-dev:armhf

--- a/config/docker/gcc-10_arm64/Dockerfile
+++ b/config/docker/gcc-10_arm64/Dockerfile
@@ -40,3 +40,18 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
    libasound2-dev:arm64 \
    libasound2-dev \
    pkg-config
+
+# perf
+RUN apt-get update && apt-get install --no-install-recommends -y \
+   libbabeltrace-dev:arm64 \
+   libcap-dev:arm64 \
+   libdw-dev:arm64 \
+   libnuma-dev:arm64 \
+   libopencsd-dev:arm64 \
+   libperl-dev:arm64 \
+   libpython3-dev:arm64 \
+   libslang2-dev:arm64 \
+   libssl-dev:arm64 \
+   libunwind-dev:arm64 \
+   libzstd-dev:arm64 \
+   systemtap-sdt-dev:arm64

--- a/config/docker/gcc-10_armv5/Dockerfile
+++ b/config/docker/gcc-10_armv5/Dockerfile
@@ -29,3 +29,18 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
    libasound2-dev:armel \
    libasound2-dev \
    pkg-config
+
+# perf
+RUN apt-get update && apt-get install --no-install-recommends -y \
+   libbabeltrace-dev:armel \
+   libcap-dev:armel \
+   libdw-dev:armel \
+   libnuma-dev:armel \
+   libopencsd-dev:armel \
+   libperl-dev:armel \
+   libpython3-dev:armel \
+   libslang2-dev:armel \
+   libssl-dev:armel \
+   libunwind-dev:armel \
+   libzstd-dev:armel \
+   systemtap-sdt-dev:armel

--- a/config/docker/gcc-10_x86/Dockerfile
+++ b/config/docker/gcc-10_x86/Dockerfile
@@ -28,5 +28,20 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
    libc6-i386 \
    libc6-dev-i386
 
+# perf
+RUN apt-get update && apt-get install --no-install-recommends -y \
+   libbabeltrace-dev \
+   libcap-dev \
+   libdw-dev \
+   libnuma-dev \
+   libopencsd-dev \
+   libperl-dev \
+   libpython3-dev \
+   libslang2-dev \
+   libssl-dev \
+   libunwind-dev \
+   libzstd-dev \
+   systemtap-sdt-dev
+
 ADD gcc-header-fix.patch /
 RUN cd / && patch -p1 </gcc-header-fix.patch


### PR DESCRIPTION
The perf tool is included in the kernel source and has some entertainingly
extensive build dependency options. In preparation for building perf and
it's testsuite add these to our images, more work will be needed to enable
both builds but this will be a bit easier if the dependencies are in the
docker images.

There are some duplicate dependencies with kselftest, I've left these in
place as apt will cope with the duplicate adds without trouble and there
is a documenting effect from including them twice.

Signed-off-by: Mark Brown <broonie@kernel.org>