### PR TITLE
CHROMEOS test-configs-chromeos.yaml: Replace all cros-boot by baseline

### DIFF
--- a/config/core/test-configs-chromeos.yaml
+++ b/config/core/test-configs-chromeos.yaml
@@ -226,8 +226,8 @@ test_configs:
 
   - device_type: asus-C436FA-Flip-hatch_chromeos
     test_plans:
-      - cros-boot
-      - cros-boot-fixed
+      - cros-baseline
+      - cros-baseline-fixed
       - cros-tast
       - cros-tast-fixed
 
@@ -235,8 +235,6 @@ test_configs:
     test_plans:
       - cros-baseline
       - cros-baseline-fixed
-      - cros-boot
-      - cros-boot-fixed
       - cros-tast
       - cros-tast-fixed
 
@@ -244,8 +242,6 @@ test_configs:
     test_plans:
       - cros-baseline
       - cros-baseline-fixed
-      - cros-boot
-      - cros-boot-fixed
       - cros-tast
       - cros-tast-fixed
 
@@ -253,7 +249,5 @@ test_configs:
     test_plans:
       - cros-baseline_qemu
       - cros-baseline_qemu-fixed
-      - cros-boot_qemu
-      - cros-boot_qemu-fixed
       - cros-tast_qemu
       - cros-tast_qemu-fixed


### PR DESCRIPTION
As discussed, cros-boot replaced by more comprehensive baseline test.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>