### PR TITLE
test-configs.yaml: Add mt8192-asurada-spherion-r0

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1324,6 +1324,12 @@ device_types:
     boot_method: depthcharge
     filters: *arm64-chromebook-filters
 
+  mt8192-asurada-spherion-r0:
+    mach: mediatek
+    class: arm64-dtb
+    boot_method: depthcharge
+    filters: *arm64-chromebook-filters
+
   mustang:
     mach: apm
     class: arm64-dtb
@@ -2602,6 +2608,11 @@ test_configs:
       - baseline-nfs
       - kselftest-lkdtm
       - kselftest-seccomp
+
+  - device_type: mt8192-asurada-spherion-r0
+    test_plans:
+      - baseline
+      - baseline-nfs
 
   - device_type: mustang
     test_plans:


### PR DESCRIPTION
Add an entry for the mt8192-asurada-spherion-r0 device and enable the
baseline tests for it.

Signed-off-by: Nícolas F. R. A. Prado <nfraprado@collabora.com>

At this moment the devicetree for this machine is only available on linux-next.

baseline test LAVA run: https://lava.collabora.dev/scheduler/job/6896370
baseline-nfs test LAVA run: https://lava.collabora.dev/scheduler/job/6900379
