### PR TITLE
config/runtime: add /dev/shm to kubernetes.jinja2

### DIFF
--- a/config/runtime/base/kubernetes.jinja2
+++ b/config/runtime/base/kubernetes.jinja2
@@ -16,6 +16,9 @@ spec:
       - name: scratch-volume
         emptyDir: { medium: "Memory" }
 
+      - name: dev-shm
+        emptyDir: { medium: "Memory" }
+
       tolerations:
       - key: "kubernetes.azure.com/scalesetpriority"
         operator: "Equal"
@@ -40,6 +43,10 @@ spec:
         volumeMounts:
         - mountPath: "/scratch"
           name: scratch-volume
+
+        volumeMounts:
+        - mountPath: "/dev/shm"
+          name: dev-shm
 
         env:
         - name: API_TOKEN


### PR DESCRIPTION
Add a tmpfs volume mounted in /dev/shm as this is required for running
KUnit tests in particular.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>