### PR TITLE
config/runtime: add missing requests import

### DIFF
--- a/config/runtime/base/python.jinja2
+++ b/config/runtime/base/python.jinja2
@@ -7,6 +7,7 @@
 {% block commands %}
 {%- block python_imports -%}
 import os
+import requests
 import sys
 import tarfile
 import urllib.parse

--- a/config/runtime/base/python.jinja2
+++ b/config/runtime/base/python.jinja2
@@ -5,7 +5,7 @@
 {%- extends base_template %}
 
 {% block commands %}
-{%- block python_imports -%}
+{% block python_imports %}
 import os
 import requests
 import sys


### PR DESCRIPTION
Add missing Python import for the requests package in the
base/python.jinja2 template.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>