### PR TITLE
config/docker: fix kci_docker with no build args

### DIFF
--- a/config/docker-new/kci_docker
+++ b/config/docker-new/kci_docker
@@ -85,7 +85,7 @@ def main(args):
         name: value for (name, value) in (
             barg.split('=') for barg in args.build_arg
         )
-    }
+    } if args.build_arg else {}
     _, build_log = _build_image(dockerfile, name, buildargs)
     if args.verbose:
         _dump_log(build_log)


### PR DESCRIPTION
Fix the case where there is no build argument as the args.build_arg
variable is then None.

Fixes: df6106e71add ("config/docker: add --build-arg option to kci_docker")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>