### PR TITLE
config/docker: add gcc-10-sparc template for kci_docker

### DIFF
--- a/config/docker-new/gcc-10-sparc.jinja2
+++ b/config/docker-new/gcc-10-sparc.jinja2
@@ -1,0 +1,31 @@
+{%- set sub_arch = 'sparc64' %}
+{%- extends 'base/host-tools.jinja2' %}
+
+{% block packages %}
+{{ super() }}
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    gcc-10-sparc64-linux-gnu
+
+RUN update-alternatives \
+    --install /usr/bin/sparc64-linux-gnu-gcc \
+              sparc64-linux-gnu-gcc \
+              /usr/bin/sparc64-linux-gnu-gcc-10 500 \
+    --slave /usr/bin/sparc64-linux-gnu-gcc-ar \
+            sparc64-linux-gnu-ar \
+            /usr/bin/sparc64-linux-gnu-gcc-ar-10 \
+    --slave /usr/bin/sparc64-linux-gnu-gcc-nm \
+            sparc64-linux-gnu-nm \
+            /usr/bin/sparc64-linux-gnu-gcc-nm-10 \
+    --slave /usr/bin/sparc64-linux-gnu-gcc-ranlib \
+            sparc64-linux-gnu-ranlib \
+            /usr/bin/sparc64-linux-gnu-gcc-ranlib-10 \
+    --slave /usr/bin/sparc64-linux-gnu-gcc-gcov \
+            sparc64-linux-gnu-gcov \
+            /usr/bin/sparc64-linux-gnu-gcov-10 \
+    --slave /usr/bin/sparc64-linux-gnu-gcc-gcov-dump \
+            sparc64-linux-gnu-gcov-dump \
+            /usr/bin/sparc64-linux-gnu-gcov-dump-10 \
+    --slave /usr/bin/sparc64-linux-gnu-gcc-gcov-tool \
+            sparc64-linux-gnu-gcov-tool \
+            /usr/bin/sparc64-linux-gnu-gcov-tool-10
+{%- endblock %}


### PR DESCRIPTION
Add a template for the sparc architecture with gcc-10 to be used with
the new kci_docker tool.  This can build both sparc32_defconfig and
sparc64_defconfig kernels.
