### PR TITLE
CHROMEOS config/lava/chromeos: rename cros-baseline and cros-tast tests

### DIFF
--- a/config/lava/chromeos/cros-baseline.jinja2
+++ b/config/lava/chromeos/cros-baseline.jinja2
@@ -25,6 +25,6 @@
               cmdwrapper="ssh -i /home/cros/.ssh/id_rsa -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@$(lava-target-ip)"
               /bin/sh dmesg.sh
       from: inline
-      name: cros-baseline
+      name: dmesg
       path: inline/cros-baseline.yaml
 {% endblock %}

--- a/config/lava/chromeos/cros-tast.jinja2
+++ b/config/lava/chromeos/cros-tast.jinja2
@@ -41,6 +41,6 @@
               video.ChromeStackDecoding.*
               ui.WindowCyclePerf
       from: inline
-      name: cros-tast
+      name: tast
       path: inline/cros-tast.yaml
 {% endblock %}


### PR DESCRIPTION
Correct wrong test names. "dmesg" test in cros-baseline.jinja2 was named
"cros-baseline", which is incorrect. Renamed it to "dmesg".
"cros-tast" test renamed to "tast".