### PR TITLE
config/docker: remove unnecessary comprehension in kci_docker

### DIFF
--- a/config/docker-new/kci_docker
+++ b/config/docker-new/kci_docker
@@ -81,11 +81,9 @@ def main(args):
         _dump_dockerfile(dockerfile)
 
     print(f"Building {name}")
-    buildargs = {
-        name: value for (name, value) in (
-            barg.split('=') for barg in args.build_arg
-        )
-    } if args.build_arg else {}
+    buildargs = dict(
+        barg.split('=') for barg in args.build_arg
+    ) if args.build_arg else {}
     _, build_log = _build_image(dockerfile, name, buildargs)
     if args.verbose:
         _dump_log(build_log)


### PR DESCRIPTION
Drop unnecessary dictionary comprehension in kci_docker as reported by
pylint since the dict() constructor can iterate over a list of pairs.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>