### PR TITLE
config/docker: update clang-15.jinja2 template

### DIFF
--- a/config/docker-new/clang-14.jinja2
+++ b/config/docker-new/clang-14.jinja2
@@ -1,6 +1,6 @@
 {% extends 'base/clang.jinja2' %}
 
-{%- block packages -%}
+{% block packages %}
 {{ super() }}
 RUN wget -q -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 RUN echo 'deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-14 main' \

--- a/config/docker-new/clang-15.jinja2
+++ b/config/docker-new/clang-15.jinja2
@@ -3,7 +3,7 @@
 {% block packages %}
 {{ super() }}
 RUN wget -q -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-RUN echo 'deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye main' \
+RUN echo 'deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-15 main' \
    >> /etc/apt/sources.list.d/clang.list
 
 RUN apt-get update && apt-get install --no-install-recommends -y \


### PR DESCRIPTION
The LLVM 15.0 release is now approaching and version 16 has become the
new one in the default repository.  Update the clang-15 repository
name accordingly.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>