### PR TITLE
config/docker: add wget to the k8s image

### DIFF
--- a/config/docker-new/k8s.jinja2
+++ b/config/docker-new/k8s.jinja2
@@ -11,4 +11,10 @@
   + fragments
 -%}
 
-{%- include 'base/debian.jinja2' %}
+{% extends 'base/debian.jinja2' %}
+
+{% block packages %}
+{{ super() }}
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    wget
+{%- endblock %}


### PR DESCRIPTION
Add the wget package to the k8s image as it's currently required to
download a JSON file with meta-data at the end of kernel builds using
Jenkins.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>