### PR TITLE
config/docker: Update clang-15 Dockerfile

### DIFF
--- a/config/docker/clang-15/Dockerfile
+++ b/config/docker/clang-15/Dockerfile
@@ -2,7 +2,7 @@ ARG PREFIX=kernelci/
 FROM ${PREFIX}clang-base
 
 RUN wget -q -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-RUN echo 'deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye main' \
+RUN echo 'deb http://apt.llvm.org/bullseye/ llvm-toolchain-15 main' \
    >> /etc/apt/sources.list.d/clang.list
 
 RUN apt-get update && apt-get install --no-install-recommends -y \


### PR DESCRIPTION
Clang 15 got moved to llvm-toolchain-15 so the clang-15 Dockerfile needs
to be updated accordingly.

Signed-off-by: Michal Galka <michal.galka@collabora.com>