### PR TITLE
config/docker-new: update URLs for patch files

### DIFF
--- a/config/docker-new/base/host-tools.jinja2
+++ b/config/docker-new/base/host-tools.jinja2
@@ -26,8 +26,8 @@ WORKDIR /root/debs
 
 # Get patch to enable compression
 RUN wget -q https://raw.githubusercontent.com/kernelci/kernelci-core/\
-f8a03576724cdb78c94e75bf150b6e493d725cdb/\
-config/docker/build-base/kmod_kci.patch
+8642bf83db5a26ddc22ec738586b435499d01137/\
+config/docker-new/data/kmod_kci.patch
 
 # Prepare kmod sources, patch, install dependencies, build
 RUN apt-get source kmod

--- a/config/docker-new/gcc-10-x86.jinja2
+++ b/config/docker-new/gcc-10-x86.jinja2
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y curl patch
 RUN \
     cd / && \
     curl -s https://raw.githubusercontent.com/kernelci/kernelci-core/\
-1c801889144969f8c0e6f736baaf8276e44bd882/\
-config/docker/gcc-10_x86/gcc-header-fix.patch \
+fa6ae5ed63e9f2b22d0996af4d9fa60cb3def79f/\
+config/docker-new/data/gcc-header-fix.patch \
     | patch -p1
 {%- endblock %}


### PR DESCRIPTION
Update the URLs of the patch files used for the kmod and gcc-10 x86 images to download them from the config/docker-new/data directory on the main branch now that they have been merged.