### PR TITLE
config/docker: add clang-16.jinja2 template

### DIFF
--- a/config/docker-new/clang-16.jinja2
+++ b/config/docker-new/clang-16.jinja2
@@ -1,0 +1,13 @@
+{% extends 'base/clang.jinja2' %}
+
+{% block packages %}
+{{ super() }}
+RUN wget -q -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+RUN echo 'deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye main' \
+   >> /etc/apt/sources.list.d/clang.list
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    clang-16 lld-16 llvm-16
+
+ENV PATH=/usr/lib/llvm-16/bin:${PATH}
+{%- endblock %}


### PR DESCRIPTION
Add a clang-16.jinja2 template to build clang-16 images with the
current latest LLVM version (not released yet).

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>