### PR TITLE
docs: use gcc-10 instead of gcc-8 in examples

### DIFF
--- a/doc/kci_build.md
+++ b/doc/kci_build.md
@@ -42,7 +42,7 @@ verbose: true
 [kci_build]
 kdir: linux
 output: linux/build-x86
-build_env: gcc-8
+build_env: gcc-10
 arch: x86_64
 install: true
 ```
@@ -120,7 +120,7 @@ with all the kernels on kernelci.org so they help with reproducing the same
 builds.  To use Docker with this example, first run these commands:
 
 ```
-$ docker run -it -v $PWD:/root/kernelci-core kernelci/build-gcc-8_x86 /bin/bash
+$ docker run -it -v $PWD:/root/kernelci-core kernelci/build-gcc-10_x86 /bin/bash
 # cd /root/kernelci-core
 ```
 

--- a/doc/kci_data.md
+++ b/doc/kci_data.md
@@ -71,7 +71,7 @@ file with the results, for example:
     "git_commit": "d012a7190fc1fd72ed48911e77ca97ba4521bccd",
     "kernel" : "v5.9-rc2",
 
-    "build_environment": "gcc-8",
+    "build_environment": "gcc-10",
     "arch": "arm64",
     "defconfig": "defconfig",
     "defconfig_full": "defconfig",

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -59,7 +59,7 @@ for command line arguments.  For example:
 
 mirror: linux-mirror.git
 kdir: linux
-build_env: gcc-8
+build_env: gcc-10
 j: 3
 ```
 
@@ -143,7 +143,7 @@ callback_url: http://localhost:5001
 [kci_build]
 
 kdir: linux
-build_env: gcc-8
+build_env: gcc-10
 ```
 
 you can then run these commands:


### PR DESCRIPTION
Use gcc-10 which is the default toolchain now instead of gcc-8 in the
documentation examples so they should actually work with the current
YAML config.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>