### PR TITLE
config/docker: add i386 packages to clang.jinja2

### DIFF
--- a/config/docker-new/base/clang.jinja2
+++ b/config/docker-new/base/clang.jinja2
@@ -12,5 +12,11 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     binutils-riscv64-linux-gnu \
     binutils
 
+# 32-bit support for host tools and kselftest
+RUN apt-get update && apt-get install --no-install-recommends -y \
+   gcc-multilib \
+   libc6-i386 \
+   libc6-dev-i386
+
 RUN apt-get autoremove -y gcc
 {%- endblock %}


### PR DESCRIPTION
Add the 32-bit i386 packages to clang.jinja2 to build kselftest on
i386 and some 32-bit host tools.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>