### PR TITLE
test-configs.yaml: Add V4L2 decoder conformance tests on rk3399-gru-kevin

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -226,6 +226,11 @@ fragments:
     path: "kernel/configs/tiny.config"
     defconfig: 'tinyconfig'
 
+  videodec:
+    path: "kernel/configs/videodec.config"
+    configs:
+      - 'CONFIG_VIDEO_ROCKCHIP_VDEC=m'
+
   virtualvideo:
     path: "kernel/configs/virtualvideo.config"
     configs:
@@ -395,7 +400,8 @@ build_configs_defaults:
             - 'defconfig+CONFIG_CPU_BIG_ENDIAN=y'
             - 'defconfig+CONFIG_RANDOMIZE_BASE=y'
             - 'defconfig+arm64-chromebook+kselftest'
-          fragments: [arm64-chromebook, crypto, ima]
+            - 'defconfig+arm64-chromebook+videodec'
+          fragments: [arm64-chromebook, crypto, ima, videodec]
 
         i386: &i386_arch
           base_defconfig: 'i386_defconfig'

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2886,6 +2886,14 @@ test_configs:
     filters:
       - blocklist: {kernel: ['v3.', 'v4.4', 'v4.9', 'v4.14']}
 
+  - device_type: rk3399-gru-kevin
+    test_plans:
+      - v4l2-decoder-conformance-h264
+      - v4l2-decoder-conformance-vp8
+      - v4l2-decoder-conformance-vp9
+    filters:
+      - passlist: {defconfig: ['videodec']}
+
   - device_type: rk3399-puma-haikou
     test_plans:
       - baseline

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -99,6 +99,12 @@ file_systems:
     type: debian
     ramdisk: 'bullseye-v4l2/20220718.0/{arch}/rootfs.cpio.gz'
 
+  debian_bullseye-gst-fluster_nfs:
+    type: debian
+    ramdisk: 'bullseye-gst-fluster/20220708.0/{arch}/initrd.cpio.gz'
+    nfs: 'bullseye-gst-fluster/20220708.0/{arch}/full.rootfs.tar.xz'
+    root_type: nfs
+
 
 
 default_filters:
@@ -581,6 +587,50 @@ test_plans:
             - 'defconfig+virtualvideo'
             - 'multi_v7_defconfig+virtualvideo'
 
+  v4l2-decoder-conformance-av1:
+    rootfs: debian_bullseye-gst-fluster_nfs
+    pattern: 'v4l2-decoder-conformance/{category}-{method}-{protocol}-{rootfs}-v4l2-decoder-conformance-template.jinja2'
+    params:
+      job_timeout: '30'
+      testsuite: 'AV1-TEST-VECTORS'
+    filters:
+      - passlist: {'tree': ['next', 'mainline', 'media']}
+
+  v4l2-decoder-conformance-h264:
+    rootfs: debian_bullseye-gst-fluster_nfs
+    pattern: 'v4l2-decoder-conformance/{category}-{method}-{protocol}-{rootfs}-v4l2-decoder-conformance-template.jinja2'
+    params:
+      job_timeout: '30'
+      testsuite: 'JVT-AVC_V1'
+    filters:
+      - passlist: {'tree': ['next', 'mainline', 'media']}
+
+  v4l2-decoder-conformance-h265:
+    rootfs: debian_bullseye-gst-fluster_nfs
+    pattern: 'v4l2-decoder-conformance/{category}-{method}-{protocol}-{rootfs}-v4l2-decoder-conformance-template.jinja2'
+    params:
+      job_timeout: '30'
+      testsuite: 'JCT-VC-HEVC-V1'
+    filters:
+      - passlist: {'tree': ['next', 'mainline', 'media']}
+
+  v4l2-decoder-conformance-vp8:
+    rootfs: debian_bullseye-gst-fluster_nfs
+    pattern: 'v4l2-decoder-conformance/{category}-{method}-{protocol}-{rootfs}-v4l2-decoder-conformance-template.jinja2'
+    params:
+      job_timeout: '30'
+      testsuite: 'VP8-TEST-VECTORS'
+    filters:
+      - passlist: {'tree': ['next', 'mainline', 'media']}
+
+  v4l2-decoder-conformance-vp9:
+    rootfs: debian_bullseye-gst-fluster_nfs
+    pattern: 'v4l2-decoder-conformance/{category}-{method}-{protocol}-{rootfs}-v4l2-decoder-conformance-template.jinja2'
+    params:
+      job_timeout: '30'
+      testsuite: 'VP9-TEST-VECTORS'
+    filters:
+      - passlist: {'tree': ['next', 'mainline', 'media']}
 
 device_types:
 

--- a/config/lava/v4l2-decoder-conformance/generic-depthcharge-tftp-nfs-v4l2-decoder-conformance-template.jinja2
+++ b/config/lava/v4l2-decoder-conformance/generic-depthcharge-tftp-nfs-v4l2-decoder-conformance-template.jinja2
@@ -1,0 +1,8 @@
+{% extends 'boot-nfs/generic-depthcharge-tftp-nfs-template.jinja2' %}
+
+{% block actions %}
+{{ super () }}
+
+{% include 'v4l2-decoder-conformance/v4l2-decoder-conformance.jinja2' %}
+
+{% endblock %}

--- a/config/lava/v4l2-decoder-conformance/generic-grub-tftp-nfs-v4l2-decoder-conformance-template.jinja2
+++ b/config/lava/v4l2-decoder-conformance/generic-grub-tftp-nfs-v4l2-decoder-conformance-template.jinja2
@@ -1,0 +1,8 @@
+{% extends 'boot-nfs/generic-grub-tftp-nfs-template.jinja2' %}
+
+{% block actions %}
+{{ super () }}
+
+{% include 'v4l2-decoder-conformance/v4l2-decoder-conformance.jinja2' %}
+
+{% endblock %}

--- a/config/lava/v4l2-decoder-conformance/generic-qemu-v4l2-decoder-conformance-template.jinja2
+++ b/config/lava/v4l2-decoder-conformance/generic-qemu-v4l2-decoder-conformance-template.jinja2
@@ -1,0 +1,11 @@
+{% extends 'boot/generic-qemu-boot-template.jinja2' %}
+{% block actions %}
+{{ super () }}
+
+{% include 'v4l2-decoder-conformance/v4l2-decoder-conformance.jinja2' %}
+
+{% endblock %}
+
+{%- block image_arg %}
+        image_arg: '-kernel {kernel} -append "console={{ console_dev }},115200 root=/dev/ram0 debug verbose {{ extra_kernel_args }}"'
+{%- endblock %}

--- a/config/lava/v4l2-decoder-conformance/generic-uboot-tftp-nfs-v4l2-decoder-conformance-template.jinja2
+++ b/config/lava/v4l2-decoder-conformance/generic-uboot-tftp-nfs-v4l2-decoder-conformance-template.jinja2
@@ -1,0 +1,8 @@
+{% extends 'boot-nfs/generic-uboot-tftp-nfs-template.jinja2' %}
+
+{% block actions %}
+{{ super () }}
+
+{% include 'v4l2-decoder-conformance/v4l2-decoder-conformance.jinja2' %}
+
+{% endblock %}

--- a/config/lava/v4l2-decoder-conformance/v4l2-decoder-conformance.jinja2
+++ b/config/lava/v4l2-decoder-conformance/v4l2-decoder-conformance.jinja2
@@ -1,0 +1,19 @@
+- test:
+    timeout:
+      minutes: {{ job_timeout }}
+    definitions:
+    - repository:
+        metadata:
+          format: Lava-Test Test Definition 1.0
+          name: {{ plan }}
+          description: "V4L2 decoder conformance test plan"
+          os:
+          - debian
+          scope:
+          - functional
+        run:
+          steps:
+          - python3 /usr/bin/fluster_parser.py -ts {{ testsuite }}
+      from: inline
+      name: {{ plan }}
+      path: inline/{{ plan }}.yaml


### PR DESCRIPTION
Add the V4L2 decoder conformance test plans for the AV1, H264, H265, VP8 and VP9 formats.
Run the tests only on next, mainline and media trees for now.
Enable the H264, VP8 and VP9 test plans on the `rk3399-gru-kevin` Chromebook.