### PR TITLE
build-configs-cip.yaml: Disable arm64 builds for 4.4-cip

### DIFF
--- a/config/core/build-configs-cip.yaml
+++ b/config/core/build-configs-cip.yaml
@@ -30,6 +30,9 @@ cip_variants: &cip_variants
       arm64:
         fragments: [arm64-chromebook]
         extra_configs: ['allnoconfig']
+        filters:
+          - blocklist:
+              kernel: ['v4.4']
       i386:
         base_defconfig: 'i386_defconfig'
         extra_configs: ['allnoconfig']


### PR DESCRIPTION
arm64 was out of scope for the 4.4 series. Disabling it save some
resources and silences arm64 related testing issues.

Signed-off-by: Florian Bezdeka <florian.bezdeka@siemens.com>