### PR TITLE
config/k8s: run builds as root user

### DIFF
--- a/config/k8s/job-build.jinja2
+++ b/config/k8s/job-build.jinja2
@@ -49,9 +49,14 @@ spec:
         - mountPath: "/scratch"
           name: scratch-volume
 
+        # Run as root so the build artifacts have root uid:gid set on them
+        securityContext:
+          runAsUser: 0
+          runAsGroup: 0
+
         command: ["/bin/bash", "-x", "-c"]
         args: ["\
-echo nproc=$(nproc); df; free; \
+echo nproc=$(nproc); df; free; whoami; \
 export KDIR=/tmp/kci/linux && export CCACHE_DISABLE=true && \
 cd /scratch/kernelci-core &&  \
 \


### PR DESCRIPTION
Run the builds as root user with the new Docker images that set the
default user to kernelci (1000).  The previous images used root by
default, and the build artifacts were all owned by root as a result.
It's important to keep that as kernel files are expected to be owned
by root.

A follow-up improvement could be to run the build with the regular
user and then have a step in another container to change the ownership
of the artifacts to root before uploading them.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>