### PR TITLE
CHROMEOS config/core/build-configs-chromeos.yaml: Rework extra_configs

### DIFF
--- a/config/core/build-configs-chromeos.yaml
+++ b/config/core/build-configs-chromeos.yaml
@@ -1,37 +1,11 @@
 trees:
-
   kernelci:
     url: "https://github.com/kernelci/linux.git"
 
+# Common blocks
+###############
 
-chromeos_variants: &chromeos-variants
-  chromeos-clang-14:
-    build_environment: clang-14
-    architectures: &variants_architectures
-      arm:
-        base_defconfig: 'cros://chromeos-5.10/armel/chromiumos-arm.flavour.config'
-        extra_configs:
-          - 'cros://chromeos-5.10/armel/chromiumos-rockchip.flavour.config'
-        filters: &cros-filters
-          - regex: { defconfig: 'cros' }
-      arm64:
-        base_defconfig: 'cros://chromeos-5.10/arm64/chromiumos-arm64.flavour.config'
-        fragments: [arm64-chromebook]
-        extra_configs:
-          - 'cros://chromeos-5.10/arm64/chromiumos-mediatek.flavour.config+arm64-chromebook'
-          - 'cros://chromeos-5.10/arm64/chromiumos-qualcomm.flavour.config+arm64-chromebook'
-          - 'cros://chromeos-5.10/arm64/chromiumos-rockchip64.flavour.config+arm64-chromebook'
-        filters: *cros-filters
-      x86_64: &cros-arch_x86_64
-        base_defconfig: 'cros://chromeos-5.10/x86_64/chromiumos-x86_64.flavour.config'
-        fragments: [x86-chromebook]
-        extra_configs:
-          - 'cros://chromeos-5.10/x86_64/chromeos-amd-stoneyridge.flavour.config+x86-chromebook'
-          - 'cros://chromeos-5.10/x86_64/chromeos-intel-denverton.flavour.config+x86-chromebook'
-          - 'cros://chromeos-5.10/x86_64/chromeos-intel-pineview.flavour.config+x86-chromebook'
-          - 'cros://chromeos-5.10/x86_64/chromiumos-x86_64.flavour.config+x86-chromebook'
-        filters: *cros-filters
-
+clang-14-variant: &clang-14-variant
   clang-14:
     build_environment: clang-14
     architectures:
@@ -46,14 +20,58 @@ chromeos_variants: &chromeos-variants
         filters:
           - passlist: { defconfig: ['x86-chromebook'] }
 
-chromeos_nocompress_variants: &chromeos-nocompress-variants
-  << : *chromeos-variants
+cros-filters: &cros-filters
+  - regex: { defconfig: 'cros' }
+
+arm-chromebook: &arm-chromebook
+  filters: *cros-filters
+
+arm64-chromebook: &arm64-chromebook
+  fragments: [arm64-chromebook]
+  filters: *cros-filters
+
+x86_64-chromebook: &x86_64-chromebook
+  fragments: [x86-chromebook]
+  filters: *cros-filters
+
+# Build variants
+################
+
+chromeos-variants-5_10: &chromeos-variants-5_10
+  chromeos-clang-14:
+    build_environment: clang-14
+    architectures: &variants_architectures-5_10
+      arm:
+        << : *arm-chromebook
+        base_defconfig: 'cros://chromeos-5.10/armel/chromiumos-arm.flavour.config'
+        extra_configs:
+          - 'cros://chromeos-5.10/armel/chromiumos-rockchip.flavour.config'
+      arm64:
+        << : *arm64-chromebook
+        base_defconfig: 'cros://chromeos-5.10/arm64/chromiumos-arm64.flavour.config'
+        extra_configs:
+          - 'cros://chromeos-5.10/arm64/chromiumos-mediatek.flavour.config+arm64-chromebook'
+          - 'cros://chromeos-5.10/arm64/chromiumos-qualcomm.flavour.config+arm64-chromebook'
+          - 'cros://chromeos-5.10/arm64/chromiumos-rockchip64.flavour.config+arm64-chromebook'
+      x86_64: &cros-arch_x86_64-5_10
+        << : *x86_64-chromebook
+        base_defconfig: 'cros://chromeos-5.10/x86_64/chromiumos-x86_64.flavour.config'
+        extra_configs:
+          - 'cros://chromeos-5.10/x86_64/chromeos-amd-stoneyridge.flavour.config+x86-chromebook'
+          - 'cros://chromeos-5.10/x86_64/chromeos-intel-denverton.flavour.config+x86-chromebook'
+          - 'cros://chromeos-5.10/x86_64/chromeos-intel-pineview.flavour.config+x86-chromebook'
+          - 'cros://chromeos-5.10/x86_64/chromiumos-x86_64.flavour.config+x86-chromebook'
+  << : *clang-14-variant
+
+
+chromeos-variants-5_10-nocompress: &chromeos-variants-5_10-nocompress
+  << : *chromeos-variants-5_10
   chromeos-clang-14:
     build_environment: clang-14
     architectures:
-      << : *variants_architectures
+      << : *variants_architectures-5_10
       x86_64:
-        << : *cros-arch_x86_64
+        << : *cros-arch_x86_64-5_10
         extra_configs:
           - 'cros://chromeos-5.10/x86_64/chromeos-amd-stoneyridge.flavour.config+x86-chromebook+CONFIG_MODULE_COMPRESS=n'
           - 'cros://chromeos-5.10/x86_64/chromeos-intel-denverton.flavour.config+x86-chromebook+CONFIG_MODULE_COMPRESS=n'
@@ -61,24 +79,68 @@ chromeos_nocompress_variants: &chromeos-nocompress-variants
           - 'cros://chromeos-5.10/x86_64/chromiumos-x86_64.flavour.config+x86-chromebook+CONFIG_MODULE_COMPRESS=n'
 
 
+chromeos-variants_5_15: &chromeos-variants-5_15
+  chromeos-clang-14:
+    build_environment: clang-14
+    architectures: &variants_architectures-5_15
+      arm:
+        << : *arm-chromebook
+        base_defconfig: 'cros://chromeos-5.15/armel/chromiumos-arm.flavour.config'
+        extra_configs:
+          - 'cros://chromeos-5.15/armel/chromiumos-rockchip.flavour.config'
+      arm64:
+        << : *arm64-chromebook
+        base_defconfig: 'cros://chromeos-5.10/arm64/chromiumos-arm64.flavour.config'
+        extra_configs:
+          - 'cros://chromeos-5.15/arm64/chromiumos-mediatek.flavour.config+arm64-chromebook'
+          - 'cros://chromeos-5.15/arm64/chromiumos-qualcomm.flavour.config+arm64-chromebook'
+          - 'cros://chromeos-5.15/arm64/chromiumos-rockchip64.flavour.config+arm64-chromebook'
+      x86_64: &cros-arch_x86_64-5_15
+        << : *x86_64-chromebook
+        base_defconfig: 'cros://chromeos-5.15/x86_64/chromiumos-x86_64.flavour.config'
+        extra_configs:
+          - 'cros://chromeos-5.15/x86_64/chromeos-amd-stoneyridge.flavour.config+x86-chromebook'
+          - 'cros://chromeos-5.15/x86_64/chromeos-intel-denverton.flavour.config+x86-chromebook'
+          - 'cros://chromeos-5.15/x86_64/chromeos-intel-pineview.flavour.config+x86-chromebook'
+          - 'cros://chromeos-5.15/x86_64/chromiumos-x86_64.flavour.config+x86-chromebook'
+  << : *clang-14-variant
+
+
+chromeos-variants-5_15-nocompress: &chromeos-variants-5_15-nocompress
+  << : *chromeos-variants-5_15
+  chromeos-clang-14:
+    build_environment: clang-14
+    architectures:
+      << : *variants_architectures-5_15
+      x86_64:
+        << : *cros-arch_x86_64-5_15
+        extra_configs:
+          - 'cros://chromeos-5.15/x86_64/chromeos-amd-stoneyridge.flavour.config+x86-chromebook+CONFIG_MODULE_COMPRESS=n'
+          - 'cros://chromeos-5.15/x86_64/chromeos-intel-denverton.flavour.config+x86-chromebook+CONFIG_MODULE_COMPRESS=n'
+          - 'cros://chromeos-5.15/x86_64/chromeos-intel-pineview.flavour.config+x86-chromebook+CONFIG_MODULE_COMPRESS=n'
+          - 'cros://chromeos-5.15/x86_64/chromiumos-x86_64.flavour.config+x86-chromebook+CONFIG_MODULE_COMPRESS=n'
+
+# Build configs
+###############
+
 build_configs:
 
   chromeos-next:
     tree: next
     branch: 'master'
-    variants: *chromeos-variants
+    variants: *chromeos-variants-5_10
 
   chromeos-stable_5.10:
     tree: stable
     branch: 'linux-5.10.y'
-    variants: *chromeos-nocompress-variants
+    variants: *chromeos-variants-5_10-nocompress
 
   chromeos-stable_5.15:
     tree: stable
     branch: 'linux-5.15.y'
-    variants: *chromeos-variants
+    variants: *chromeos-variants-5_15
 
   kernelci_chromeos-stable:
     tree: kernelci
     branch: 'chromeos-stable'
-    variants: *chromeos-nocompress-variants
+    variants: *chromeos-variants-5_10-nocompress


### PR DESCRIPTION
The current ChromeOS tests for kernel v5.15 use a v5.15 kernel built with ChromeOS kernel config fragments from v5.10. I ran the same tests on a v5.15 kernel with v5.15 config fragments and it fared a bit better, it could at least reach a login prompt (https://lava.collabora.dev/scheduler/job/7012884).

This commit reworks the variants definitions for ChromeOS builds. I have only tested this manually, though. `kci_build` seems to ignore the variants definitions and the processing of ChromeOS-specific config fragments is still done in a separate step from the rest of fragments defined in `build-configs.yaml`, so proper testing within the test pipeline would be necessary.

============================================================

Split the build variants between the different kernel versions (5.10 and
5.15 for now). For each version define two variants: one with module
compression support and another without it.

Signed-off-by: Ricardo Cañuelo <ricardo.canuelo@collabora.com>