### PR TITLE
config/k8s: Add labels to the build jobs and their pods

### DIFF
--- a/config/k8s/job-build.jinja2
+++ b/config/k8s/job-build.jinja2
@@ -2,6 +2,12 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ job_name }}
+  labels:
+    kernelci/build: "{{ "FIXME" | env_override('BUILD_ID') }}"
+    kernelci/arch: "{{ "FIXME" | env_override('ARCH') }}"
+    kernelci/buildenv: "{{ "FIXME" | env_override('BUILD_ENVIRONMENT') }}"
+    kernelci/commit: "{{ "FIXME" | env_override('COMMIT_ID') }}"
+    kernelci/buildconfig: "{{ "FIXME" | env_override('BUILD_CONFIG') }}"
 spec:
   completions: 1
   template:


### PR DESCRIPTION
Annotate the build jobs and the pods they create with Kubernetes labels
for job parameters, allowing use of these labels to be used when doing
queries via the Kubernetes interfaces. For example we can list all jobs
scheduled for build 12345 with:

	kubectl get jobs -l kernelci/build=12345

which can help with debugging, and is generally idiomatic for
Kubernetes.

Signed-off-by: Mark Brown <broonie@kernel.org>