### PR TITLE
test-configs.yaml: update rootfs URLs to 20220812.0

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -51,53 +51,53 @@ file_systems:
 
   debian_bullseye_ramdisk:
     type: debian
-    ramdisk: 'bullseye/20220805.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'bullseye/20220812.0/{arch}/rootfs.cpio.gz'
 
   debian_bullseye_nfs:
     type: debian
-    ramdisk: 'bullseye/20220805.0/{arch}/initrd.cpio.gz'
-    nfs: 'bullseye/20220805.0/{arch}/full.rootfs.tar.xz'
+    ramdisk: 'bullseye/20220812.0/{arch}/initrd.cpio.gz'
+    nfs: 'bullseye/20220812.0/{arch}/full.rootfs.tar.xz'
     root_type: nfs
 
   debian_bullseye-cros-ec_ramdisk:
     type: debian
-    ramdisk: 'bullseye-cros-ec/20220805.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'bullseye-cros-ec/20220812.0/{arch}/rootfs.cpio.gz'
 
   debian_bullseye-igt_ramdisk:
     type: debian
-    ramdisk: 'bullseye-igt/20220805.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'bullseye-igt/20220812.0/{arch}/rootfs.cpio.gz'
 
   debian_bullseye-kselftest_nfs:
     type: debian
-    ramdisk: 'bullseye-kselftest/20220805.0/{arch}/initrd.cpio.gz'
-    nfs: 'bullseye-kselftest/20220805.0/{arch}/full.rootfs.tar.xz'
+    ramdisk: 'bullseye-kselftest/20220812.0/{arch}/initrd.cpio.gz'
+    nfs: 'bullseye-kselftest/20220812.0/{arch}/full.rootfs.tar.xz'
     root_type: nfs
     params:
       os_config: 'debian'
 
   debian_bullseye-libcamera_nfs:
     type: debian
-    ramdisk: 'bullseye-libcamera/20220805.0/{arch}/initrd.cpio.gz'
-    nfs: 'bullseye-libcamera/20220805.0/{arch}/full.rootfs.tar.xz'
+    ramdisk: 'bullseye-libcamera/20220812.0/{arch}/initrd.cpio.gz'
+    nfs: 'bullseye-libcamera/20220812.0/{arch}/full.rootfs.tar.xz'
     root_type: nfs
 
   debian_bullseye-ltp_nfs:
     type: debian
-    ramdisk: 'bullseye-ltp/20220805.0/{arch}/initrd.cpio.gz'
-    nfs: 'bullseye-ltp/20220805.0/{arch}/full.rootfs.tar.xz'
+    ramdisk: 'bullseye-ltp/20220812.0/{arch}/initrd.cpio.gz'
+    nfs: 'bullseye-ltp/20220812.0/{arch}/full.rootfs.tar.xz'
     root_type: nfs
 
   debian_bullseye-ltp_ramdisk:
     type: debian
-    ramdisk: 'bullseye-ltp/20220805.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'bullseye-ltp/20220812.0/{arch}/rootfs.cpio.gz'
 
   debian_bullseye-rt_ramdisk:
     type: debian
-    ramdisk: 'bullseye-rt/20220805.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'bullseye-rt/20220812.0/{arch}/rootfs.cpio.gz'
 
   debian_bullseye-v4l2_ramdisk:
     type: debian
-    ramdisk: 'bullseye-v4l2/20220805.0/{arch}/rootfs.cpio.gz'
+    ramdisk: 'bullseye-v4l2/20220812.0/{arch}/rootfs.cpio.gz'
 
 
 


### PR DESCRIPTION
Update rootfs URLs to 20220812.0 except buildroot-baseline which failed
to build.

Signed-off-by: kernelci.org bot <bot@kernelci.org>