### PR TITLE
CHROMEOS rootfs-configs-chromeos.yaml: Add fixed PARTUUID and lid state ignore

### DIFF
--- a/config/core/rootfs-configs-chromeos.yaml
+++ b/config/core/rootfs-configs-chromeos.yaml
@@ -8,6 +8,7 @@ rootfs_configs:
     extra_packages:
       - bzip2
       - ca-certificates
+      - gdisk
       - parted
       - wget
       - xz-utils

--- a/config/rootfs/debos/overlays/cros-flash/opt/chromeos/flash
+++ b/config/rootfs/debos/overlays/cros-flash/opt/chromeos/flash
@@ -105,6 +105,10 @@ enable_rw()
     sync
     # Partprobe fails on NVMe chromebooks, ignore it
     partprobe -s /dev/${block_device} || true
+    # Set fixed PARTUUID value
+    blkid
+    sgdisk --partition-guid=3:566F7961-6765-7220-746F-20756E697665 /dev/${block_device}
+    blkid
 }
 
 if [ -z "$IMAGE_NAME" ]; then

--- a/config/rootfs/debos/overlays/cros-flash/opt/chromeos/flash
+++ b/config/rootfs/debos/overlays/cros-flash/opt/chromeos/flash
@@ -109,6 +109,13 @@ enable_rw()
     blkid
     sgdisk --partition-guid=3:566F7961-6765-7220-746F-20756E697665 /dev/${block_device}
     blkid
+    # Ignore lid state, do not sleep if lid closed
+    mount -o rw /dev/${block_device}p3 "$mount_dir"
+    cd "$mount_dir"
+    echo 0 > usr/share/power_manager/use_lid
+    cd "$root_path"
+    umount "$mount_dir"
+    sync
 }
 
 if [ -z "$IMAGE_NAME" ]; then


### PR DESCRIPTION
For ChromiumOS PARTUUID change we need sgdisk tool capable to
change this parameter. Changing this parameter helps with
ChromiumOS devices where block device number is not predictable.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>