### PR TITLE
CHROMEOS rootfs-configs-chromeos.yaml: Add missing serial to qemu build

### DIFF
--- a/config/core/rootfs-configs-chromeos.yaml
+++ b/config/core/rootfs-configs-chromeos.yaml
@@ -17,6 +17,7 @@ rootfs_configs:
     rootfs_type: chromiumos
     board: amd64-generic
     branch: release-R100-14526.B
+    serial: ttyS0
     arch_list:
       - amd64
 


### PR DESCRIPTION
Serial is required for qemu too, as it is necessary to enable serial
console.
rootfs built without serial support will not pass LAVA tests, example:
https://lava.collabora.dev/scheduler/job/7046848

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>