### PR TITLE
kernelci.build: fix _check_min_kver() logic

### DIFF
--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -756,7 +756,7 @@ class Step:
         m = self.KVER_RE.match(kver)
         if m and len(m.groups()) == 2:
             k_major, k_minor = (int(g) for g in m.groups())
-            return k_major >= major and k_minor >= minor
+            return (k_major, k_minor) >= (major, minor)
         return False
 
     def _add_run_step(self, status, jopt=None, action=''):


### PR DESCRIPTION
Fix the logic in Step._check_min_kver() which failed to treat the
minor version as a minor version number, causing the check to return
False if the minor version was lower even though the major version was
higher.

Fixes: 4930f88a76db ("kernelci.build: add Step._check_min_kver()")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>