### PR TITLE
CHROMEOS cros-boot.jinja2: set a static part-uuid for grunt

### DIFF
--- a/config/core/test-configs-chromeos.yaml
+++ b/config/core/test-configs-chromeos.yaml
@@ -238,7 +238,7 @@ device_types:
       reference_kernel:
         image: 'https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-grunt/20220811.0/amd64/bzImage'
         modules: 'https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-grunt/20220811.0/amd64/modules.tar.xz'
-      block_device: mmcblk1
+      block_device: detect
 
   hp-x360-12b-ca0010nr-n4020-octopus_chromeos: &octopus
     base_name: hp-x360-12b-ca0010nr-n4020-octopus

--- a/config/lava/chromeos/cros-boot.jinja2
+++ b/config/lava/chromeos/cros-boot.jinja2
@@ -94,7 +94,11 @@ actions:
       minutes: 5
     method: depthcharge
     commands: emmc
+{%- if block_device == 'detect' %}
+    extra_kernel_args: cros_secure cros_debug root=PARTUUID=566f7961-6765-7220-746f-20756e697665 rootwait ro
+{%- else %}
     extra_kernel_args: cros_secure cros_debug root=/dev/{{ block_device }}p3 rootwait ro
+{%- endif %}
     prompts:
       - 'localhost(.*)~(.*)#'
     auto_login:


### PR DESCRIPTION
Grunt is having a variation on block_device when
booted, so the idea of this fix is to set a static
part-uuid independent of the block_device used.

Signed-off-by: Alexandra Pereira <alexandra.pereira@collabora.com>
Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>