### PR TITLE
config/docker: add coccinelle and cvehound templates

### DIFF
--- a/config/docker-new/coccinelle.jinja2
+++ b/config/docker-new/coccinelle.jinja2
@@ -1,0 +1,12 @@
+{# SPDX-License-Identifier: LGPL-2.1-or-later
+ #
+ # Copyright (C) 2022 Collabora Limited
+ # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+-#}
+
+{% extends 'base/debian.jinja2' %}
+
+{% block packages %}
+
+{% include 'fragment/coccinelle.jinja2' %}
+{%- endblock %}

--- a/config/docker-new/cvehound.jinja2
+++ b/config/docker-new/cvehound.jinja2
@@ -1,0 +1,20 @@
+{# SPDX-License-Identifier: LGPL-2.1-or-later
+ #
+ # Copyright (C) 2022 Collabora Limited
+ # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+-#}
+
+{% extends 'base/debian.jinja2' %}
+
+{% block packages %}
+
+{% include 'fragment/coccinelle.jinja2' %}
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    git \
+    python3-pip \
+    python3-setuptools \
+    python3-wheel
+
+RUN pip3 install --system git+https://github.com/evdenis/cvehound.git@master
+{%- endblock %}

--- a/config/docker-new/fragment/coccinelle.jinja2
+++ b/config/docker-new/fragment/coccinelle.jinja2
@@ -1,0 +1,1 @@
+RUN apt-get update && apt-get install --no-install-recommends -y coccinelle


### PR DESCRIPTION
Add a fragment/coccinelle.jinja2 template that can be reused by images
that need coccinelle to be installed.  Also add a coccinelle.jinja2
template to build an image with just coccinelle, and cvehound to build
an image with cvehound which includes the coccinelle fragment.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>