### PR TITLE
CHROMEOS build_board.sh: disable selinux use flags

### DIFF
--- a/config/rootfs/chromiumos/scripts/build_board.sh
+++ b/config/rootfs/chromiumos/scripts/build_board.sh
@@ -65,6 +65,10 @@ sed -i s,'media-libs/apl-hotword-support','# media-libs/apl-hotword-support', sr
 sed -i s,'USE="${USE} cros_ec"','# USE="${USE} cros_ec"', src/overlays/baseboard-coral/profiles/base/make.defaults
 fi
 
+# Disable SELinux in upstart and other packages to allow booting newer kernels on
+# CrOS images which don't define all selinux policies
+sed -i 's/selinux/-selinux/g' src/third_party/chromiumos-overlay/profiles/features/selinux/package.use
+
 # Temporary workaround as chrome-icu build fails at 10/08/2022 due corrupt git cache
 cros_sdk sync_chrome --tag=102.0.5005.171 --reset --gclient=/mnt/host/depot_tools/gclient /var/cache/chromeos-cache/distfiles/chrome-src --skip_cache
 


### PR DESCRIPTION
The CrOS userpace does not support the latest kernels
used by KernelCI in the sense that they miss selinux
policies for newer watches which fail as described in
https://github.com/kernelci/kernelci-core/issues/1372

We can't just disable selinux at boot via the kernel
cmdline selinux=0 because that will cause packages like
the upstart init system to fail, so we need to actually
disable them during image builds.

Signed-off-by: Adrian Ratiu <adrian.ratiu@collabora.com>