### PR TITLE
test-configs: hifive-unleashed: fix blocklist

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -896,7 +896,7 @@ device_types:
     # no console in tinyconfig
       - blocklist:
           defconfig: ['tinyconfig']
-          kernel: ['v4.', 'v5.1', 'v5.2']
+          kernel: ['v4.']
 
   hip07-d05:
     mach: hisilicon


### PR DESCRIPTION
Having "v5.1" in the kernel blockist actually blocks v5.1*, which
explains why this board has not been booting on v5.10+ either. :(

Since we have not been build/boot testing v5.1 for a long time, just
removing this is an OK fix, but this is just a workaround for deeper
problem when kernel minor versions have two digits.  For example, the
v5.2 block would have also  blocked v5.20, but fortunately (for us),
the kernels past v5.19 are v6.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>