### PR TITLE
CHROMEOS ssh_retry.sh: Add ssh retry mechanism

### DIFF
--- a/config/docker/cros-tast/Dockerfile
+++ b/config/docker/cros-tast/Dockerfile
@@ -43,6 +43,7 @@ RUN cp "$HOME/trunk/chromite/ssh_keys/testing_rsa" "$HOME/.ssh/id_rsa"
 RUN chmod 0600 "$HOME/.ssh/id_rsa"
 
 ADD tast_parser.py /home/cros-tast/tast_parser.py
+ADD ssh_retry.sh /home/cros-tast/ssh_retry.sh
 
 # Needed by LAVA to install the overlay
 USER root

--- a/config/docker/cros-tast/ssh_retry.sh
+++ b/config/docker/cros-tast/ssh_retry.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+let tries=10
+
+if [ -z "$*" ] ; then
+    echo "Need to specify ssh options"
+    exit 1
+fi
+
+while [[ $tries -ne 0 ]] ; do
+    ssh $*
+    retcode=$?
+    if [[ $retcode -eq 0 ]] ; then
+        break
+    else
+        echo "Failed, retrying..."
+        sleep 1
+    fi
+    let tries--
+done
+
+if [[ $retcode -ne 0 ]] ; then
+    echo "Connection to $* failed, giving up"
+    exit 1
+fi

--- a/config/lava/chromeos/cros-tast.jinja2
+++ b/config/lava/chromeos/cros-tast.jinja2
@@ -27,7 +27,7 @@
             - while ! ping -c 1 -w 1 $(lava-target-ip); do sleep 1; done
             - >-
               lava-test-case os-release --shell
-              ssh
+              ./ssh_retry.sh
               -o StrictHostKeyChecking=no
               -o UserKnownHostsFile=/dev/null
               -i /home/cros-tast/.ssh/id_rsa


### PR DESCRIPTION
As discovered during lava tests, network stack of ChromeOS might
be pingable, but ssh daemon is not up yet (Connection refused).
As ssh don't have internal retry mechanism for such situation,
we add simple helper script for that.
This script will retry 10 times with delay, until it is able to connect
to DUT over ssh.

Example of failure
```
+ ping -c 1 -w 1 192.168.201.13
PING 192.168.201.13 (192.168.201.13): 56 data bytes
64 bytes from 192.168.201.13: icmp_seq=0 ttl=63 time=0.529 ms
--- 192.168.201.13 ping statistics ---
1 packets transmitted, 1 packets received, 0% packet loss
round-trip min/avg/max/stddev = 0.529/0.529/0.529/0.000 ms
+ lava-target-ip
+ lava-test-case os-release --shell ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /home/cros-tast/.ssh/id_rsa root@192.168.201.13 cat /etc/os-release
ssh: connect to host 192.168.201.13 port 22: Connection refused
```

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>