### PR TITLE
test.py: Remove dtb from job name and truncate below 200 chars

### DIFF
--- a/kernelci/test.py
+++ b/kernelci/test.py
@@ -99,8 +99,8 @@ def get_params(meta, target, plan_config, storage, device_id):
     publish_path = kernel['publish_path']
     job_px = publish_path.replace('/', '-')
     url_px = publish_path
-    job_name = '-'.join([job_px, dtb or 'no-dtb',
-                         target.name, plan_config.name])
+    # Truncate to <200 characters, LAVA limit
+    job_name = '-'.join([job_px, target.name, plan_config.name])[:199]
     base_url = urllib.parse.urljoin(storage, '/'.join([url_px, '']))
     kernel_img = meta.get_single_artifact('kernel', 'image', 'path')
     kernel_url = urllib.parse.urljoin(storage, '/'.join([url_px, kernel_img]))


### PR DESCRIPTION
LAVA doesn't accept job names with more than 200 characters, drop dtb
from job name to reduce size and truncate job name below 200 characters

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>