### PR TITLE
host-tools.jinja2: Add packages for gki_defconfig build

### DIFF
--- a/config/docker-new/base/host-tools.jinja2
+++ b/config/docker-new/base/host-tools.jinja2
@@ -55,6 +55,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     bsdmainutils \
     ccache \
     cpio \
+    dwarves \
     flex \
     g++ \
     gcc \
@@ -62,8 +63,11 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     kmod \
     libssl-dev \
     libelf-dev \
+    lz4 \
     lzop \
     make \
+    python \
+    python3 \
     rsync \
     tar \
     u-boot-tools \


### PR DESCRIPTION
As in https://github.com/kernelci/kernelci-core/pull/1158 we need
to add several packages to be able run pahole and other tools,
which is required to complete gki_defconfig build.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>