### PR TITLE
config/rootfs: fix ramdisk creation

### DIFF
--- a/config/rootfs/debos/scripts/create_initrd_ramdisk.sh
+++ b/config/rootfs/debos/scripts/create_initrd_ramdisk.sh
@@ -21,4 +21,8 @@ index 4ec926c..ca06c0b 100644
 EOF
 
 KVER=min
+
+# update-initramfs uses kernel config to decide how to compress ramdisk
+echo "CONFIG_RD_GZIP=y" > /boot/config-$KVER
+
 update-initramfs -c -k $KVER


### PR DESCRIPTION
In newer versions of debian, the update-initramfs script checks the
kernel config (via /boot/config-<kernel version>) in order to
determine how to compress the initial ramdisk.  Without a valid kernel
config entry, update-initramfs will refuse to generate an initramfs.

KernelCI tooling is expecting gzip compressed ramdisk for the "min"
ramdisk, so convince update-initramfs to use gzip by creating dummy
kernel config for the "min" kernel before running update-initramfs.

Tested with a riscv64-sid rootfs, and it generates a working ramdisk
that can then pivot_root to a full debian rootfs.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>