### PR TITLE
CHROMEOS lava/__init__.py: Remove dtb from job name

### DIFF
--- a/kernelci/lab/lava/__init__.py
+++ b/kernelci/lab/lava/__init__.py
@@ -113,7 +113,6 @@ class LavaAPI(LabAPI):
                 params['arch'],
                 self._shorten_cros_defconfig(defconfig_full),
                 params['build_environment'],
-                params.get('dtb_full') or 'no-dtb',
                 self._shorten_cros_device_type(params['device_type']),
                 params['plan'],
             )).replace('/', '-')


### PR DESCRIPTION
As we found there is one more place where dtb might be added
to generated job name, removing it, to shorten job name length.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>