### PR TITLE
Add embedded firmware handling

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -282,6 +282,17 @@ fragments:
       - 'CONFIG_PINCTRL_AMD=y'
       - 'CONFIG_NVME_CORE=y'
       - 'CONFIG_BLK_DEV_NVME=y'
+      - 'CONFIG_EXTRA_FIRMWARE="
+      amdgpu/stoney_ce.bin
+      amdgpu/stoney_me.bin
+      amdgpu/stoney_mec.bin
+      amdgpu/stoney_pfp.bin
+      amdgpu/stoney_rlc.bin
+      amdgpu/stoney_sdma.bin
+      amdgpu/stoney_uvd.bin
+      amdgpu/stoney_vce.bin
+      rtl_nic/rtl8153b-2.fw
+      "'
 
   x86_kvm_guest:
     path: "kernel/configs/kvm_guest.config"

--- a/config/k8s/job-build.jinja2
+++ b/config/k8s/job-build.jinja2
@@ -99,6 +99,7 @@ set -x; \
   --describe-verbose=${GIT_DESCRIBE_VERBOSE}; \
 \
 ./kci_build make_config --defconfig=${DEFCONFIG} && \
+./kci_build fetch_firmware && \
 ./kci_build make_kernel && \
 ./kci_build make_modules && \
 ./kci_build make_dtbs && \

--- a/doc/kci_build.md
+++ b/doc/kci_build.md
@@ -124,11 +124,13 @@ $ docker run -it -v $PWD:/root/kernelci-core kernelci/build-gcc-10_x86 /bin/bash
 # cd /root/kernelci-core
 ```
 
-Then to generate the kernel configuration, build the main image and the
-modules:
+Then to generate the kernel configuration, optionally fetch firmware for embedding
+in kernel if CONFIG_EXTRA_FIRMWARE defined in configuration, build the main image 
+and the modules:
 
 ```
 ./kci_build make_config --defconfig=defconfig
+./kci_build fetch_firmware
 ./kci_build make_kernel
 ./kci_build make_modules
 ```

--- a/kci_build
+++ b/kci_build
@@ -371,6 +371,11 @@ class cmd_make_config(MakeCommand):
         }
 
 
+class cmd_fetch_firmware(MakeCommand):
+    help = "Fetch firmware"
+    step_cls = kernelci.build.FetchFirmware
+
+
 class cmd_make_kernel(MakeCommand):
     help = "Make a kernel image"
     step_cls = kernelci.build.MakeKernel


### PR DESCRIPTION
AMD Stoneyridge require early loaded firmware for GPU,
and it have to be loaded before rootfs is mounted, so
firmware have to be embedded inside kernel.
This PR enables such function during kernel build.
If option is present and non-empty, it will fetch linux-firmware repository,
and only then will start building kernel, so kernel can take from it all files it need to embed.

Fixes #1370 