### PR TITLE
CHROMEOS build-configs.yaml: Add NFS support to cros builds

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -275,6 +275,11 @@ fragments:
       - 'CONFIG_PINCTRL_AMD=y'
       - 'CONFIG_NVME_CORE=y'
       - 'CONFIG_BLK_DEV_NVME=y'
+      - 'CONFIG_NFS_V2=y'
+      - 'CONFIG_NFS_V3=y'
+      - 'CONFIG_NFS_V3_ACL=y'
+      - 'CONFIG_NFS_V4=y'
+      - 'CONFIG_ROOT_NFS=y'
 
   x86_kvm_guest:
     path: "kernel/configs/kvm_guest.config"


### PR DESCRIPTION
This is experimental commit to verify options required
for cros:// builds to pass NFS-based tests.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>