### PR TITLE
config/runtime: replace 'done' state with 'complete'

### DIFF
--- a/config/runtime/base/python.jinja2
+++ b/config/runtime/base/python.jinja2
@@ -63,7 +63,7 @@ class BaseJob:
         node = db.get_node(node_id)
         node.update({
             'result': result,
-            'status': 'complete',
+            'state': 'done',
         })
         db.submit({'node': node})
         return node


### PR DESCRIPTION
The Node state names have changed and "complete" has now been replaced
with "done".  Update the base python.jinja2 template accordingly.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>