### PR TITLE
kernelci_api: return only 'items' from 'get_nodes'

### DIFF
--- a/kernelci/db/kernelci_api.py
+++ b/kernelci/db/kernelci_api.py
@@ -91,7 +91,7 @@ class KernelCI_API(Database):
     def get_nodes(self, attributes: dict = None):
         """Get all nodes matching attributes"""
         resp = self._get('nodes', params=attributes)
-        return resp.json()
+        return resp.json()['items']
 
     def get_node_from_event(self, event):
         return self.get_node(event.data['id'])


### PR DESCRIPTION
Instead of returning entire paginated response
received from API, return only list of node
objects by fetching value of 'items' key.

Signed-off-by: Jeny Sadadia <jeny.sadadia@collabora.com>