### PR TITLE
T37615 kernelci_api: add 'Database.count_nodes()' method

### DIFF
--- a/kernelci/db/kernelci_api.py
+++ b/kernelci/db/kernelci_api.py
@@ -84,6 +84,11 @@ class KernelCI_API(Database):
                 continue
             return event
 
+    def count_nodes(self, attributes: dict = None):
+        """Get the count of all nodes matching attributes"""
+        resp = self._get('count', params=attributes)
+        return resp.json()
+
     def get_node(self, node_id):
         resp = self._get('/'.join(['node', node_id]))
         return json.loads(resp.text)


### PR DESCRIPTION
Depends on https://github.com/kernelci/kernelci-api/pull/179

Implement database method to get the count of all nodes matching attributes from API.

Signed-off-by: Jeny Sadadia <jeny.sadadia@collabora.com>