### PR TITLE
Load YAML config from /etc/kernelci/core by default

### DIFF
--- a/config/k8s/gen.py
+++ b/config/k8s/gen.py
@@ -59,7 +59,7 @@ params = {
     'cpu_request': cpu_request,
     'mem_request': "{}Gi".format(mem_request)
 }
-env = Environment(loader=FileSystemLoader(['config/k8s']),
+env = Environment(loader=FileSystemLoader(['config/k8s', '/etc/kernelci/k8s']),
                   extensions=["jinja2.ext.do"])
 env.filters['env_override'] = env_override
 template = env.get_template("job-build.jinja2")

--- a/kernelci/cli.py
+++ b/kernelci/cli.py
@@ -561,7 +561,7 @@ def make_options(args, prog):
     return opts
 
 
-def parse_opts(prog, glob, default_config_path="config/core"):
+def parse_opts(prog, glob, yaml_config_path=None):
     """Return an Options object with command line arguments and settings
 
     This will create a parser and automatically add the sub-commands from the
@@ -570,12 +570,17 @@ def parse_opts(prog, glob, default_config_path="config/core"):
 
     *prog* is the command line program name
 
-    *default_config_path* is the name of the default YAML configuration
-                          directory to use with the command line utility
+    *yaml_config_path* is the name of a particular YAML configuration directory
+                       to use with the command line utility
 
     *glob* is the dictionary with all the global attributes where to look for
            commands starting with `cmd_`
     """
-    parser = make_parser(prog, default_config_path)
+    if yaml_config_path is None:
+        for config_path in ['config/core', '/etc/kernelci/core']:
+            if os.path.isdir(config_path):
+                yaml_config_path = config_path
+                break
+    parser = make_parser(prog, yaml_config_path)
     args = parse_args_with_parser(parser, glob)
     return make_options(args, prog)

--- a/kernelci/config/__init__.py
+++ b/kernelci/config/__init__.py
@@ -104,5 +104,7 @@ def load(config_path):
 
     *config_path* is the path to the YAML config directory
     """
+    if config_path is None:
+        return {}
     data = load_yaml(config_path)
     return from_data(data)

--- a/kernelci/lab/__init__.py
+++ b/kernelci/lab/__init__.py
@@ -82,7 +82,7 @@ class LabAPI:
         return self.config.match(filter_data)
 
     def generate(self, params, device_config, plan_config,
-                 callback_opts=None, templates_path=None, lab_config=None):
+                 callback_opts=None, templates_paths=None, lab_config=None):
         """Generate a test job definition.
 
         *params* is a dictionary with the test parameters which can be used
@@ -96,11 +96,14 @@ class LabAPI:
 
         *callback_opts* is a dictionary with extra options used for callbacks
 
-        *templates_path* is an optional argument to specify the path where the
-            template files should be found, when not in the standard location
+        *templates_paths* is an optional argument to specify the path(s) where
+            the template files should be found, when not in the standard
+            location.  This could be either a string or a list of strings to
+            provide several paths.
 
         *lab_config* is a configuration object for the API
             where the tests should be run
+
         """
         raise NotImplementedError("Lab.generate() is required")
 

--- a/kernelci/lab/kubernetes.py
+++ b/kernelci/lab/kubernetes.py
@@ -24,11 +24,14 @@ from kernelci.lab import LabAPI
 
 
 class Kubernetes(LabAPI):
+    DEFAULT_TEMPLATE_PATHS = ['config/runtime', '/etc/kernelci/runtime']
     RANDOM_CHARACTERS = string.ascii_lowercase + string.digits
 
     def generate(self, params, device_config, plan_config,
-                 callback_opts=None, templates_path='config/runtime'):
-        jinja2_env = Environment(loader=FileSystemLoader(templates_path))
+                 callback_opts=None, templates_paths=None):
+        if templates_paths is None:
+            templates_paths = self.DEFAULT_TEMPLATE_PATHS
+        jinja2_env = Environment(loader=FileSystemLoader(templates_paths))
         template_path = plan_config.get_template_path(None)
         template = jinja2_env.get_template(template_path)
         job_name = '-'.join([

--- a/kernelci/lab/shell.py
+++ b/kernelci/lab/shell.py
@@ -22,10 +22,13 @@ from kernelci.lab import LabAPI
 
 
 class Shell(LabAPI):
+    DEFAULT_TEMPLATE_PATHS = ['config/runtime', '/etc/kernelci/runtime']
 
     def generate(self, params, device_config, plan_config,
-                 callback_opts=None, templates_path='config/runtime'):
-        jinja2_env = Environment(loader=FileSystemLoader(templates_path))
+                 callback_opts=None, templates_paths=None):
+        if templates_paths is None:
+            templates_paths = self.DEFAULT_TEMPLATE_PATHS
+        jinja2_env = Environment(loader=FileSystemLoader(templates_paths))
         template_path = plan_config.get_template_path(None)
         template = jinja2_env.get_template(template_path)
         return template.render(params)


### PR DESCRIPTION
When no YAML configuration path is provided, load either from a local `config/core` directory or from the system-wide `/etc/kernelci/core` if they exist.