### PR TITLE
scripts/lava-v2-callback.py: Fix YAML loading

### DIFF
--- a/scripts/lava-v2-callback.py
+++ b/scripts/lava-v2-callback.py
@@ -58,7 +58,7 @@ TEST_CASE_STATUS_MAP = {
 
 def is_infra_error(cb):
     lava_yaml = cb['results']['lava']
-    lava = yaml.load(lava_yaml)
+    lava = yaml.load(lava_yaml, Loader=yaml.CLoader)
     stages = {s['name']: s for s in lava}
     job_meta = stages['job']['metadata']
     return job_meta.get('error_type') == "Infrastructure"


### PR DESCRIPTION
PyYAML requires explicitly provided loader class when parsing YAML content from file
(https://github.com/yaml/pyyaml/commit/c2743653bc89e42679ba097b4f9888db47c61d63)

This commit fixes places which were left with the old yaml.load() method call and eventually caused script to crash.

Signed-off-by: Michal Galka <michal.galka@collabora.com>