### PR TITLE
CHROMEOS cros-boot.jinja2: Improve error message on invalid target

### DIFF
--- a/config/lava/chromeos/cros-boot.jinja2
+++ b/config/lava/chromeos/cros-boot.jinja2
@@ -13,6 +13,10 @@ tags: ['{{ device_id }}']
 {{ super () }}
 actions:
 
+{% if not cros_flash_kernel %}
+{{ kci_raise("CrOS parameter cros_flash_kernel missing. Invalid target?") }}
+{%- endif %}
+
 # Debian NFS to install kernel modules
 
 - deploy:


### PR DESCRIPTION
If we specify non-ChromeOS device name in kci_test, it might generate cryptic error. It is better to generate proper reason, why test generation failed.

Fixes #1326 

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>