### PR TITLE
Support for using kernelci-core tools within other CI pipelines

### DIFF
--- a/config/lava/base/kernel-ci-base-tftp-deploy.jinja2
+++ b/config/lava/base/kernel-ci-base-tftp-deploy.jinja2
@@ -22,6 +22,12 @@ actions:
     to: tftp
     kernel:
       url: {{ kernel_url }}
+{%- if storage_headers %}
+      headers:
+{%- for header, value in storage_headers.items() %}
+        {{ header }}: {{ value }}
+{%- endfor %}
+{%- endif %}
 {%- block kernel_image_type %}
       type: {{ kernel_image.lower() }}
 {%- endblock %}
@@ -42,6 +48,12 @@ actions:
 {%- if modules_url %}
     modules:
       url: {{ modules_url }}
+{%- if storage_headers %}
+      headers:
+{%- for header, value in storage_headers.items() %}
+        {{ header }}: {{ value }}
+{%- endfor %}
+{%- endif %}
       {%- if modules_compression %}
       compression: {{ modules_compression }}
       {%- endif %}
@@ -49,6 +61,12 @@ actions:
 {%- if dtb_url %}
     dtb:
       url: {{ dtb_url }}
+{%- if storage_headers %}
+      headers:
+{%- for header, value in storage_headers.items() %}
+        {{ header }}: {{ value }}
+{%- endfor %}
+{%- endif %}
 {%- endif %}
     os: {{ os_config|default("oe") }}
 {% endblock %}

--- a/config/lava/boot/generic-qemu-boot-template.jinja2
+++ b/config/lava/boot/generic-qemu-boot-template.jinja2
@@ -48,6 +48,12 @@ actions:
         image_arg: '-kernel {kernel} -append "console={{ console_dev }},115200 root=/dev/ram0 debug verbose {{ extra_kernel_args }}"'
 {%- endblock %}
         url: {{ kernel_url }}
+{%- if storage_headers %}
+        headers:
+{%- for header, value in storage_headers.items() %}
+          {{ header }}: {{ value }}
+{%- endfor %}
+{%- endif %}
       ramdisk:
         image_arg: '-initrd {ramdisk}'
         url: {{ initrd_url }}
@@ -55,6 +61,12 @@ actions:
       dtb:
         image_arg: '-dtb {dtb}'
         url: {{ dtb_url }}
+{%- if storage_headers %}
+        headers:
+{%- for header, value in storage_headers.items() %}
+          {{ header }}: {{ value }}
+{%- endfor %}
+{%- endif %}
 {% endif %}
 
 - boot:

--- a/kci_test
+++ b/kci_test
@@ -275,7 +275,7 @@ class cmd_generate(Command):
                 Args.lab_json, Args.user, Args.lab_token, Args.db_config,
                 Args.callback_id, Args.callback_dataset,
                 Args.callback_type, Args.callback_url, Args.mach,
-                Args.device_id]
+                Args.device_id, Args.storage_header]
 
     def __call__(self, configs, args):
         if args.callback_id and not args.callback_url:
@@ -333,7 +333,7 @@ class cmd_generate(Command):
         for device_config, plan_config in jobs_list:
             params = kernelci.test.get_params(
                 meta, device_config, plan_config, args.storage,
-                args.device_id)
+                args.device_id, args.storage_header)
             job = lab_api.generate(params, device_config, plan_config,
                                    callback_opts)
             if job is None:

--- a/kci_test
+++ b/kci_test
@@ -275,7 +275,7 @@ class cmd_generate(Command):
                 Args.lab_json, Args.user, Args.lab_token, Args.db_config,
                 Args.callback_id, Args.callback_dataset,
                 Args.callback_type, Args.callback_url, Args.mach,
-                Args.device_id, Args.storage_header]
+                Args.device_id, Args.omit_publish_path, Args.storage_header]
 
     def __call__(self, configs, args):
         if args.callback_id and not args.callback_url:
@@ -333,7 +333,7 @@ class cmd_generate(Command):
         for device_config, plan_config in jobs_list:
             params = kernelci.test.get_params(
                 meta, device_config, plan_config, args.storage,
-                args.device_id, args.storage_header)
+                args.device_id, args.omit_publish_path, args.storage_header)
             job = lab_api.generate(params, device_config, plan_config,
                                    callback_opts)
             if job is None:

--- a/kernelci/cli/base.py
+++ b/kernelci/cli/base.py
@@ -212,6 +212,12 @@ class Args:
         'help': "Path to log file",
     }
 
+    omit_publish_path = {
+        'name': '--omit-publish-path',
+        'help': "Do not extend the given storage URL with the publish path",
+        'action': 'store_true',
+    }
+
     mach = {
         'name': '--mach',
         'help': "Mach name (aka SoC family)",

--- a/kernelci/cli/base.py
+++ b/kernelci/cli/base.py
@@ -287,6 +287,12 @@ class Args:
         'section': SECTION_STORAGE,
     }
 
+    storage_header = {
+        'name': '--storage-header',
+        'help': "A KEY=VALUE pair to provide when accessing storage",
+        'action': 'append'
+    }
+
     target = {
         'name': '--target',
         'help': "Name of a target platform",

--- a/kernelci/test.py
+++ b/kernelci/test.py
@@ -88,7 +88,7 @@ def urljoin_with_query(lhs, rhs):
 
 
 def get_params(meta, target, plan_config, storage, device_id,
-               storage_header=None):
+               omit_publish_path=False, storage_header=None):
     """Get a dictionary with all the test parameters to run a test job
 
     *meta* is a MetaStep object
@@ -116,18 +116,20 @@ def get_params(meta, target, plan_config, storage, device_id,
     url_px = publish_path
     # Truncate to <200 characters, LAVA limit
     job_name = '-'.join([job_px, target.name, plan_config.name])[:199]
-    base_url = urljoin_with_query(storage, '/'.join([url_px, '']))
+    if not omit_publish_path:
+        storage = urljoin_with_query(storage, '/'.join([url_px, '']))
+
+    base_url = storage
     kernel_img = meta.get_single_artifact('kernel', 'image', 'path')
-    kernel_url = urljoin_with_query(storage, '/'.join([url_px, kernel_img]))
+    kernel_url = urljoin_with_query(storage, kernel_img)
 
     if dtb_full and dtb_full.endswith('.dtb'):
-        dtb_url = urljoin_with_query(
-            storage, '/'.join([url_px, dtb_full]))
+        dtb_url = urljoin_with_query(storage, dtb_full)
     else:
         dtb_url = None
     modules = meta.get_single_artifact('modules', attr='path')
     modules_url = (
-        urljoin_with_query(storage, '/'.join([url_px, modules]))
+        urljoin_with_query(storage, modules)
         if modules else None
     )
     modules_compression = _get_compression(modules_url)
@@ -137,7 +139,7 @@ def get_params(meta, target, plan_config, storage, device_id,
     describe = rev['describe']
     kselftests = meta.get_single_artifact('kselftest', attr='path')
     kselftests_url = (
-        urljoin_with_query(storage, '/'.join([url_px, kselftests]))
+        urljoin_with_query(storage, kselftests)
         if kselftests else None
     )
 

--- a/kernelci/test.py
+++ b/kernelci/test.py
@@ -73,7 +73,8 @@ def match_configs(configs, meta, lab):
     return match
 
 
-def get_params(meta, target, plan_config, storage, device_id):
+def get_params(meta, target, plan_config, storage, device_id,
+               storage_header=None):
     """Get a dictionary with all the test parameters to run a test job
 
     *meta* is a MetaStep object
@@ -158,6 +159,14 @@ def get_params(meta, target, plan_config, storage, device_id):
         'build_environment': meta.get('bmeta', 'environment', 'name'),
         'kselftests_url': kselftests_url,
     }
+
+    if storage_header:
+        if "storage_headers" not in params:
+            params["storage_headers"] = {}
+
+        for header in storage_header:
+            k, v = header.split('=', 1)
+            params["storage_headers"][k] = v
 
     rootfs = plan_config.rootfs
     if rootfs:


### PR DESCRIPTION
This provides 4 changes that assist in building CI pipelines around kernelci tools:

- Add a flag to kernelci to be able to insert authorisation headers into the requests made from LAVA jobs. It's used like: `--storage-auth=TOKEN=example-token-value`
- Change uses of urljoin to preserve any query parameters present in the storage URL. This means that the additional parts of the path are added in the middle (before the query parameters). For example, if our storage URL was `https://storage.example.com/?token=example-token` then this allows our kernel URL to end up being `https://storage.example.com/next/5.10/blah/arm64/defconfig/gcc-10/Image?token=example-token`.
- Honor `--install-path` within `kci_build`. This means that you can pick where the install directory is made, rather than having it always be `_install_` within the kernel build. This makes it easier to control the URLs that are generated, e.g. in gitlab, where you can't remove leading parts of the path from the artifact paths.
- Permit the publish path to be omitted from the generate storage URLs. Using `--omit-publish-path`, the LAVA jobs will be generated containing URLs like `https://storage.example.com/kernel/Image` rather than `https://storage.example.com/next/5.10/blah/arm64/defconfig/gcc-10/kernel/Image`

I can split this PR if that would be more convenient, I wasn't sure which was preferable.