### PR TITLE
kernelci_api: Use 'items' key to get regression nodes

### DIFF
--- a/kernelci/db/kernelci_api.py
+++ b/kernelci/db/kernelci_api.py
@@ -107,7 +107,7 @@ class KernelCI_API(Database):
             "parent": node_id
         }
         resp = self._get('nodes', params=params)
-        return resp.json()
+        return resp.json()['items']
 
     def pubsub_event_filter(self, sub_id, event):
         """Filter Pub/Sub events


### PR DESCRIPTION
Need to retrieve 'items' key to get list of regression nodes from the`/nodes` endpoint response in `Database.get_regressions_by_node_id` method. This change is due to implementation of pagination in API.

Signed-off-by: Jeny Sadadia <jeny.sadadia@collabora.com>