### PR TITLE
docs: Update docker image names

### DIFF
--- a/doc/kci_build.md
+++ b/doc/kci_build.md
@@ -120,7 +120,7 @@ with all the kernels on kernelci.org so they help with reproducing the same
 builds.  To use Docker with this example, first run these commands:
 
 ```
-$ docker run -it -v $PWD:/root/kernelci-core kernelci/build-gcc-10_x86 /bin/bash
+$ docker run -it -v $PWD:/root/kernelci-core kernelci/gcc-10:x86-kselftest-kernelci /bin/bash
 # cd /root/kernelci-core
 ```
 

--- a/doc/kci_rootfs.md
+++ b/doc/kci_rootfs.md
@@ -8,9 +8,9 @@ weight: 5
 
 ### How to build a rootfs image using kci_rootfs
 
-You will be using `kernelci/debos` docker image for this purpose.
+You will be using `kernelci/debos:kernelci` docker image for this purpose.
 
-1. Pull the docker image `docker pull kernelci/debos`
+1. Pull the docker image `docker pull kernelci/debos:kernelci`
 
 2. Clone the kernelci-core repo.
 
@@ -23,7 +23,7 @@ You will be using `kernelci/debos` docker image for this purpose.
    sudo docker run -itd \
      -v $(pwd)/kernelci-core:/kernelci-core \
      --device /dev/kvm -v /dev:/dev \
-     --privileged kernelci/debos
+     --privileged kernelci/debos:kernelci
    sudo docker exec -it <container_id> bash
    cd /kernelci-core/
    ```


### PR DESCRIPTION
As we have new docker image building system in place, and naming changed as well, update documentation for correct docker image names.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>