### PR TITLE
rootfs-configs.yaml: drop sparc64 buildroot builds

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -11,7 +11,6 @@ rootfs_configs:
       - armel
       - mipsel
       - riscv
-      - sparc64
       - x86
     frags:
       - baseline


### PR DESCRIPTION
The sparc64 buildroot builds aren't working, which is blocking buildroot updates for all the other architectures.  As there's no test definition in test-configs.yaml using sparc64, drop the buildroot sparc64 builds for now until they're fixed properly and there's a use-case for it.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>