### PR TITLE
kci_test update_rootfs_urls

### DIFF
--- a/config/core/rootfs-images.yaml
+++ b/config/core/rootfs-images.yaml
@@ -1,0 +1,92 @@
+# Automatically generated (initial)
+file_systems:
+  buildroot-baseline_ramdisk:
+    boot_protocol: tftp
+    params: {}
+    prompt: '/ #'
+    ramdisk: buildroot-baseline/20220805.0/{arch}/rootfs.cpio.gz
+    root_type: ramdisk
+    type: buildroot
+  debian_bullseye-cros-ec_ramdisk:
+    boot_protocol: tftp
+    params: {}
+    prompt: '/ #'
+    ramdisk: bullseye-cros-ec/20220826.0/{arch}/rootfs.cpio.gz
+    root_type: ramdisk
+    type: debian
+  debian_bullseye-gst-fluster_nfs:
+    boot_protocol: tftp
+    nfs: bullseye-gst-fluster/20220913.0/{arch}/full.rootfs.tar.xz
+    params: {}
+    prompt: '/ #'
+    ramdisk: bullseye-gst-fluster/20220913.0/{arch}/initrd.cpio.gz
+    root_type: nfs
+    type: debian
+  debian_bullseye-igt_ramdisk:
+    boot_protocol: tftp
+    params: {}
+    prompt: '/ #'
+    ramdisk: bullseye-igt/20220826.0/{arch}/rootfs.cpio.gz
+    root_type: ramdisk
+    type: debian
+  debian_bullseye-kselftest_nfs:
+    boot_protocol: tftp
+    nfs: bullseye-kselftest/20220826.0/{arch}/full.rootfs.tar.xz
+    params:
+      os_config: debian
+    prompt: '/ #'
+    ramdisk: bullseye-kselftest/20220826.0/{arch}/initrd.cpio.gz
+    root_type: nfs
+    type: debian
+  debian_bullseye-libcamera_nfs:
+    boot_protocol: tftp
+    nfs: bullseye-libcamera/20220826.0/{arch}/full.rootfs.tar.xz
+    params: {}
+    prompt: '/ #'
+    ramdisk: bullseye-libcamera/20220826.0/{arch}/initrd.cpio.gz
+    root_type: nfs
+    type: debian
+  debian_bullseye-ltp_nfs:
+    boot_protocol: tftp
+    nfs: bullseye-ltp/20220826.0/{arch}/full.rootfs.tar.xz
+    params: {}
+    prompt: '/ #'
+    ramdisk: bullseye-ltp/20220826.0/{arch}/initrd.cpio.gz
+    root_type: nfs
+    type: debian
+  debian_bullseye-ltp_ramdisk:
+    boot_protocol: tftp
+    params: {}
+    prompt: '/ #'
+    ramdisk: bullseye-ltp/20220826.0/{arch}/rootfs.cpio.gz
+    root_type: ramdisk
+    type: debian
+  debian_bullseye-rt_ramdisk:
+    boot_protocol: tftp
+    params: {}
+    prompt: '/ #'
+    ramdisk: bullseye-rt/20220826.0/{arch}/rootfs.cpio.gz
+    root_type: ramdisk
+    type: debian
+  debian_bullseye-v4l2_ramdisk:
+    boot_protocol: tftp
+    params: {}
+    prompt: '/ #'
+    ramdisk: bullseye-v4l2/20220826.0/{arch}/rootfs.cpio.gz
+    root_type: ramdisk
+    type: debian
+  debian_bullseye_nfs:
+    boot_protocol: tftp
+    nfs: bullseye/20220826.0/{arch}/full.rootfs.tar.xz
+    params: {}
+    prompt: '/ #'
+    ramdisk: bullseye/20220826.0/{arch}/initrd.cpio.gz
+    root_type: nfs
+    type: debian
+  debian_bullseye_ramdisk:
+    boot_protocol: tftp
+    params: {}
+    prompt: '/ #'
+    ramdisk: bullseye/20220826.0/{arch}/rootfs.cpio.gz
+    root_type: ramdisk
+    type: debian

--- a/config/core/rootfs-images.yaml
+++ b/config/core/rootfs-images.yaml
@@ -1,17 +1,17 @@
-# Automatically generated (initial)
+# Automatically generated (20220912.0)
 file_systems:
   buildroot-baseline_ramdisk:
     boot_protocol: tftp
     params: {}
     prompt: '/ #'
-    ramdisk: buildroot-baseline/20220805.0/{arch}/rootfs.cpio.gz
+    ramdisk: buildroot-baseline/20220912.0/{arch}/rootfs.cpio.gz
     root_type: ramdisk
     type: buildroot
   debian_bullseye-cros-ec_ramdisk:
     boot_protocol: tftp
     params: {}
     prompt: '/ #'
-    ramdisk: bullseye-cros-ec/20220826.0/{arch}/rootfs.cpio.gz
+    ramdisk: bullseye-cros-ec/20220912.0/{arch}/rootfs.cpio.gz
     root_type: ramdisk
     type: debian
   debian_bullseye-gst-fluster_nfs:
@@ -31,19 +31,19 @@ file_systems:
     type: debian
   debian_bullseye-kselftest_nfs:
     boot_protocol: tftp
-    nfs: bullseye-kselftest/20220826.0/{arch}/full.rootfs.tar.xz
+    nfs: bullseye-kselftest/20220912.0/{arch}/full.rootfs.tar.xz
     params:
       os_config: debian
     prompt: '/ #'
-    ramdisk: bullseye-kselftest/20220826.0/{arch}/initrd.cpio.gz
+    ramdisk: bullseye-kselftest/20220912.0/{arch}/initrd.cpio.gz
     root_type: nfs
     type: debian
   debian_bullseye-libcamera_nfs:
     boot_protocol: tftp
-    nfs: bullseye-libcamera/20220826.0/{arch}/full.rootfs.tar.xz
+    nfs: bullseye-libcamera/20220912.0/{arch}/full.rootfs.tar.xz
     params: {}
     prompt: '/ #'
-    ramdisk: bullseye-libcamera/20220826.0/{arch}/initrd.cpio.gz
+    ramdisk: bullseye-libcamera/20220912.0/{arch}/initrd.cpio.gz
     root_type: nfs
     type: debian
   debian_bullseye-ltp_nfs:
@@ -65,28 +65,28 @@ file_systems:
     boot_protocol: tftp
     params: {}
     prompt: '/ #'
-    ramdisk: bullseye-rt/20220826.0/{arch}/rootfs.cpio.gz
+    ramdisk: bullseye-rt/20220912.0/{arch}/rootfs.cpio.gz
     root_type: ramdisk
     type: debian
   debian_bullseye-v4l2_ramdisk:
     boot_protocol: tftp
     params: {}
     prompt: '/ #'
-    ramdisk: bullseye-v4l2/20220826.0/{arch}/rootfs.cpio.gz
+    ramdisk: bullseye-v4l2/20220912.0/{arch}/rootfs.cpio.gz
     root_type: ramdisk
     type: debian
   debian_bullseye_nfs:
     boot_protocol: tftp
-    nfs: bullseye/20220826.0/{arch}/full.rootfs.tar.xz
+    nfs: bullseye/20220912.0/{arch}/full.rootfs.tar.xz
     params: {}
     prompt: '/ #'
-    ramdisk: bullseye/20220826.0/{arch}/initrd.cpio.gz
+    ramdisk: bullseye/20220912.0/{arch}/initrd.cpio.gz
     root_type: nfs
     type: debian
   debian_bullseye_ramdisk:
     boot_protocol: tftp
     params: {}
     prompt: '/ #'
-    ramdisk: bullseye/20220826.0/{arch}/rootfs.cpio.gz
+    ramdisk: bullseye/20220912.0/{arch}/rootfs.cpio.gz
     root_type: ramdisk
     type: debian

--- a/config/core/test-configs-cip.yaml
+++ b/config/core/test-configs-cip.yaml
@@ -1,0 +1,58 @@
+file_system_types:
+
+  cip:
+    url: 'https://storage.kernelci.org/images/rootfs/cip/20211105'
+    arch_map:
+      amd64: [{arch: x86_64}]
+
+
+file_systems:
+
+  cip_nfs:
+    type: cip
+    ramdisk: 'qemu-{arch}/cip-core-image-kernelci-cip-core-buster-qemu-{arch}-initrd.img.gz'
+    nfs: 'qemu-{arch}/cip-core-image-kernelci-cip-core-buster-qemu-{arch}.tar.gz'
+    root_type: nfs
+
+
+test_plans:
+
+  baseline-cip-nfs:
+    rootfs: cip_nfs
+    pattern: 'baseline/{category}-{method}-{protocol}-nfs-baseline-template.jinja2'
+    params:
+      priority: 85
+    filters:
+      - blocklist: {'defconfig': ['kselftest']}
+      - passlist: {'tree': ['cip']}
+
+
+test_configs:
+
+  - device_type: beaglebone-black
+    test_plans:
+      - baseline-cip-nfs
+
+  - device_type: hp-11A-G6-EE-grunt
+    test_plans:
+      - baseline-cip-nfs
+
+  - device_type: hp-x360-12b-ca0010nr-n4020-octopus
+    test_plans:
+      - baseline-cip-nfs
+
+  - device_type: mt8173-elm-hana
+    test_plans:
+      - baseline-cip-nfs
+
+  - device_type: r8a774a1-hihope-rzg2m-ex
+    test_plans:
+      - baseline-cip-nfs
+
+  - device_type: r8a774b1-hihope-rzg2n-ex
+    test_plans:
+      - baseline-cip-nfs
+
+  - device_type: r8a774c0-ek874
+    test_plans:
+      - baseline-cip-nfs

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -18,11 +18,6 @@ file_system_types:
     <<: *buildroot
     url: 'http://storage.staging.kernelci.org/images/rootfs/buildroot'
 
-  cip:
-    url: 'https://storage.kernelci.org/images/rootfs/cip/20211105'
-    arch_map:
-      amd64: [{arch: x86_64}]
-
   debian: &debian
     url: 'http://storage.kernelci.org/images/rootfs/debian'
     arch_map:
@@ -42,12 +37,6 @@ file_systems:
   buildroot-baseline_ramdisk:
     type: buildroot
     ramdisk: 'buildroot-baseline/20220805.0/{arch}/rootfs.cpio.gz'
-
-  cip_nfs:
-    type: cip
-    ramdisk: 'qemu-{arch}/cip-core-image-kernelci-cip-core-buster-qemu-{arch}-initrd.img.gz'
-    nfs: 'qemu-{arch}/cip-core-image-kernelci-cip-core-buster-qemu-{arch}.tar.gz'
-    root_type: nfs
 
   debian_bullseye_ramdisk:
     type: debian
@@ -143,15 +132,6 @@ test_plans:
       priority: 90
     filters:
       - blocklist: *kselftest_defconfig_filter
-
-  baseline-cip-nfs:
-    rootfs: cip_nfs
-    pattern: 'baseline/{category}-{method}-{protocol}-nfs-baseline-template.jinja2'
-    params:
-      priority: 85
-    filters:
-      - blocklist: *kselftest_defconfig_filter
-      - passlist: {'tree': ['cip']}
 
   baseline-fastboot:
     rootfs: buildroot-baseline_ramdisk
@@ -2198,7 +2178,6 @@ test_configs:
   - device_type: beaglebone-black
     test_plans:
       - baseline
-      - baseline-cip-nfs
       - baseline-nfs
       - kselftest-alsa
       - kselftest-capabilities
@@ -2301,7 +2280,6 @@ test_configs:
   - device_type: hp-11A-G6-EE-grunt
     test_plans:
       - baseline
-      - baseline-cip-nfs
       - baseline-nfs
       - cros-ec
       - igt-gpu-amd
@@ -2344,7 +2322,6 @@ test_configs:
   - device_type: hp-x360-12b-ca0010nr-n4020-octopus
     test_plans:
       - baseline
-      - baseline-cip-nfs
       - baseline-nfs
       - cros-ec
       - igt-gpu-i915
@@ -2678,7 +2655,6 @@ test_configs:
   - device_type: mt8173-elm-hana
     test_plans:
       - baseline
-      - baseline-cip-nfs
       - baseline-nfs
       - cros-ec
       - kselftest-arm64
@@ -2848,7 +2824,6 @@ test_configs:
   - device_type: r8a774a1-hihope-rzg2m-ex
     test_plans:
       - baseline
-      - baseline-cip-nfs
       - baseline-nfs
       - kselftest-filesystems
       - kselftest-futex
@@ -2868,12 +2843,10 @@ test_configs:
   - device_type: r8a774b1-hihope-rzg2n-ex
     test_plans:
       - baseline
-      - baseline-cip-nfs
 
   - device_type: r8a774c0-ek874
     test_plans:
       - baseline
-      - baseline-cip-nfs
 
   - device_type: r8a7791-porter
     test_plans:

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -32,69 +32,6 @@ file_system_types:
     <<: *debian
     url: 'http://storage.staging.kernelci.org/images/rootfs/debian'
 
-file_systems:
-
-  buildroot-baseline_ramdisk:
-    type: buildroot
-    ramdisk: 'buildroot-baseline/20220805.0/{arch}/rootfs.cpio.gz'
-
-  debian_bullseye_ramdisk:
-    type: debian
-    ramdisk: 'bullseye/20220826.0/{arch}/rootfs.cpio.gz'
-
-  debian_bullseye_nfs:
-    type: debian
-    ramdisk: 'bullseye/20220826.0/{arch}/initrd.cpio.gz'
-    nfs: 'bullseye/20220826.0/{arch}/full.rootfs.tar.xz'
-    root_type: nfs
-
-  debian_bullseye-cros-ec_ramdisk:
-    type: debian
-    ramdisk: 'bullseye-cros-ec/20220826.0/{arch}/rootfs.cpio.gz'
-
-  debian_bullseye-igt_ramdisk:
-    type: debian
-    ramdisk: 'bullseye-igt/20220826.0/{arch}/rootfs.cpio.gz'
-
-  debian_bullseye-kselftest_nfs:
-    type: debian
-    ramdisk: 'bullseye-kselftest/20220826.0/{arch}/initrd.cpio.gz'
-    nfs: 'bullseye-kselftest/20220826.0/{arch}/full.rootfs.tar.xz'
-    root_type: nfs
-    params:
-      os_config: 'debian'
-
-  debian_bullseye-libcamera_nfs:
-    type: debian
-    ramdisk: 'bullseye-libcamera/20220826.0/{arch}/initrd.cpio.gz'
-    nfs: 'bullseye-libcamera/20220826.0/{arch}/full.rootfs.tar.xz'
-    root_type: nfs
-
-  debian_bullseye-ltp_nfs:
-    type: debian
-    ramdisk: 'bullseye-ltp/20220826.0/{arch}/initrd.cpio.gz'
-    nfs: 'bullseye-ltp/20220826.0/{arch}/full.rootfs.tar.xz'
-    root_type: nfs
-
-  debian_bullseye-ltp_ramdisk:
-    type: debian
-    ramdisk: 'bullseye-ltp/20220826.0/{arch}/rootfs.cpio.gz'
-
-  debian_bullseye-rt_ramdisk:
-    type: debian
-    ramdisk: 'bullseye-rt/20220826.0/{arch}/rootfs.cpio.gz'
-
-  debian_bullseye-v4l2_ramdisk:
-    type: debian
-    ramdisk: 'bullseye-v4l2/20220826.0/{arch}/rootfs.cpio.gz'
-
-  debian_bullseye-gst-fluster_nfs:
-    type: debian
-    ramdisk: 'bullseye-gst-fluster/20220913.0/{arch}/initrd.cpio.gz'
-    nfs: 'bullseye-gst-fluster/20220913.0//{arch}/full.rootfs.tar.xz'
-    root_type: nfs
-
-
 
 default_filters:
 

--- a/kci_test
+++ b/kci_test
@@ -21,8 +21,10 @@ import argparse
 import glob
 import json
 import os
+import re
 import requests
 import sys
+import yaml
 
 from kernelci.cli import Args, Command, parse_opts
 import kernelci
@@ -31,6 +33,8 @@ import kernelci.config.test
 import kernelci.build
 import kernelci.lab
 import kernelci.test
+
+RELEASE_RE = re.compile(r'(.*)([0-9.]{10})(.*)')
 
 
 # -----------------------------------------------------------------------------
@@ -73,40 +77,112 @@ class cmd_validate(Command):
         return True
 
 
+def _iterate_fs_configs(file_systems_config):
+    for fs, config in file_systems_config.items():
+        fs_parts = fs.split('_')
+        if fs_parts[0] == 'debian':
+            name = fs_parts[1]
+            root_type = fs_parts[2]
+        elif fs_parts[0].startswith('buildroot'):
+            name = fs_parts[0]
+            root_type = fs_parts[1]
+        else:
+            continue
+        yield fs, config, name, root_type
+
+
+def _check_rootfs_urls(fs_config, rootfs_config, root_type, verbose):
+    url_formats = [
+        url_fmt for url_fmt in (
+            fs_config.get_url_format(fmt_type)
+            for fmt_type in set({root_type}).union({'nfs', 'ramdisk'})
+        ) if url_fmt
+    ]
+    for arch in rootfs_config.arch_list:
+        for url_format in url_formats:
+            url = url_format.format(arch=arch)
+            resp = requests.head(url)
+            if verbose:
+                print(f"  {resp.status_code} {url}")
+            resp.raise_for_status()
+
+
+def _get_fs_config_dicts(config, release):
+    old_config_dict = config.to_dict()
+    new_config_dict = old_config_dict.copy()
+    for image in ['ramdisk', 'nfs']:
+        path = old_config_dict.get(image)
+        if path:
+            p_start, p_rel, p_end = RELEASE_RE.match(path).groups()
+            new_config_dict[image] = ''.join([p_start, release, p_end])
+    return old_config_dict, new_config_dict
+
+
+def _check_new_config_urls(new_config, rootfs, root_type, verbose):
+    try:
+        _check_rootfs_urls(new_config, rootfs, root_type, verbose)
+        if verbose:
+            print("  OK")
+        return True
+    except Exception as e:
+        if verbose:
+            print(f"  FAIL: {e}")
+        return False
+
+
 class cmd_validate_rootfs_urls(Command):
     help = "Check that all the rootfs URLs are valid"
     opt_args = [Args.verbose]
 
     def __call__(self, config_data, args, **kwargs):
-        file_systems_config = config_data['file_systems']
         rootfs_configs = config_data['rootfs_configs']
-        for fs, fs_config in file_systems_config.items():
-            fs_parts = fs.split('_')
-            if fs_parts[0] == 'debian':
-                fs_name = fs_parts[1]
-                root_type = fs_parts[2]
-            elif fs_parts[0].startswith('buildroot'):
-                fs_name = fs_parts[0]
-                root_type = fs_parts[1]
-            else:
-                continue
-            rootfs_config = rootfs_configs.get(fs_name)
-            url_formats = list(
-                url_fmt for url_fmt in (
-                    fs_config.get_url_format(fmt_type)
-                    for fmt_type in set({root_type}).union({'nfs', 'ramdisk'})
-                ) if url_fmt
-            )
+        fs_configs = config_data['file_systems']
+        for fs, config, name, root_type in _iterate_fs_configs(fs_configs):
             if args.verbose:
                 print(fs)
-            for arch in rootfs_config.arch_list:
-                for url_format in url_formats:
-                    url = url_format.format(arch=arch)
-                    resp = requests.head(url)
-                    if args.verbose:
-                        print(f"  {resp.status_code} {url}")
-                    resp.raise_for_status()
+            rootfs_config = rootfs_configs.get(name)
+            _check_rootfs_urls(config, rootfs_config, root_type, args.verbose)
         return True
+
+
+class cmd_update_rootfs_urls(Command):
+    help = "Update the rootfs URLs for those that are valid"
+    args = [
+        {
+            'name': '--release',
+            'help': 'Release name used in the path e.g. 20220913.0',
+        },
+        {
+            'name': '--output',
+            'help': 'Ouput YAML file name to store the new configuration',
+        },
+    ]
+    opt_args = [Args.verbose]
+
+    def __call__(self, config_data, args):
+        fs_types = config_data['file_system_types']
+        fs_configs = config_data['file_systems']
+        rootfs_configs = config_data['rootfs_configs']
+        new_configs = {}
+        for fs, config, name, root_type in _iterate_fs_configs(fs_configs):
+            if args.verbose:
+                print(fs)
+            rootfs_config = rootfs_configs.get(name)
+            old_dict, new_dict = _get_fs_config_dicts(config, args.release)
+            new_config = kernelci.config.test.RootFS.from_yaml(
+                fs_types, new_dict
+            )
+            new_configs[fs] = (
+                new_dict if _check_new_config_urls(
+                    new_config, rootfs_config, root_type, args.verbose)
+                else old_dict
+            )
+        if args.verbose:
+            print(f"Writing output to {args.output}")
+        with open(args.output, 'w') as output_file:
+            output_file.write(f"# Automatically generated ({args.release})\n")
+            data = {'file_systems': new_configs}
+            yaml.dump(data, output_file, default_flow_style=False)
 
 
 class cmd_list_jobs(Command):

--- a/kernelci/config/base.py
+++ b/kernelci/config/base.py
@@ -53,7 +53,9 @@ class YAMLObject:
         non-serialisable objects such as Filters.
         """
         return {
-            attr: getattr(self, attr) for attr in self._get_attrs()
+            attr: value for attr, value in (
+                (attr, getattr(self, attr)) for attr in self._get_attrs()
+            ) if value is not None
         }
 
     def to_yaml(self):

--- a/kernelci/config/test.py
+++ b/kernelci/config/test.py
@@ -543,6 +543,7 @@ def from_yaml(data, filters):
     ]
 
     return {
+        'file_system_types': fs_types,
         'file_systems': file_systems,
         'test_plans': test_plans,
         'device_types': device_types,

--- a/kernelci/config/test.py
+++ b/kernelci/config/test.py
@@ -276,7 +276,8 @@ class RootFS(YAMLObject):
     """Root file system model."""
 
     def __init__(self, url_formats, fs_type, boot_protocol='tftp',
-                 root_type=None, prompt="/ #", params=None):
+                 root_type=None, prompt="/ #", params=None,
+                 ramdisk=None, nfs=None):
         """A root file system is any user-space that can be used in test jobs.
 
         *url_formats* are a dictionary with a format string for each type of
@@ -306,6 +307,8 @@ class RootFS(YAMLObject):
         self._prompt = prompt
         self._params = params or dict()
         self._arch_dict = {}
+        self._ramdisk = ramdisk
+        self._nfs = nfs
 
     @classmethod
     def from_yaml(cls, file_system_types, rootfs):
@@ -314,6 +317,9 @@ class RootFS(YAMLObject):
         fs_type = file_system_types[rootfs['type']]
         base_url = fs_type.url
         kw['fs_type'] = fs_type
+        for fs, url in ((fs, rootfs.get(fs)) for fs in ['ramdisk', 'nfs']):
+            if url:
+                kw[fs] = url
         kw['url_formats'] = {
             fs: '/'.join([base_url, url]) for fs, url in (
                 (fs, rootfs.get(fs)) for fs in ['ramdisk', 'nfs'])
@@ -328,6 +334,14 @@ class RootFS(YAMLObject):
     @property
     def boot_protocol(self):
         return self._boot_protocol
+
+    @property
+    def ramdisk(self):
+        return self._ramdisk
+
+    @property
+    def nfs(self):
+        return self._nfs
 
     @property
     def root_type(self):
@@ -345,8 +359,10 @@ class RootFS(YAMLObject):
         attrs = super()._get_attrs()
         attrs.update({
             'boot_protocol',
+            'nfs',
             'params',
             'prompt',
+            'ramdisk',
             'root_type',
             'type',
         })

--- a/kernelci/config/test.py
+++ b/kernelci/config/test.py
@@ -211,8 +211,10 @@ class DeviceTypeFactory(YAMLObject):
 class RootFSType(YAMLObject):
     """Root file system type model."""
 
-    def __init__(self, url, arch_dict=None):
+    def __init__(self, name, url, arch_dict=None):
         """A root file system type covers common file system features.
+
+        *name* is the file system type name e.g. 'debian' or 'buildroot'
 
         *url* is the base URL for file system binaries.  Each file system
               variant will have some URLs based on this one with various
@@ -225,12 +227,16 @@ class RootFSType(YAMLObject):
                     dictionaries with kernel architecture names and other
                     properties such as the endinanness.
         """
+        self._name = name
         self._url = url
         self._arch_dict = arch_dict or dict()
 
     @classmethod
-    def from_yaml(cls, fs_type):
-        kw = cls._kw_from_yaml(fs_type, ['url'])
+    def from_yaml(cls, name, fs_type):
+        kw = {
+            'name': name,
+        }
+        kw.update(cls._kw_from_yaml(fs_type, ['url']))
         arch_map = fs_type.get('arch_map')
         if arch_map:
             arch_dict = {}
@@ -240,6 +246,10 @@ class RootFSType(YAMLObject):
                     arch_dict[key] = arch_name
             kw['arch_dict'] = arch_dict
         return cls(**kw)
+
+    @property
+    def name(self):
+        return self._name
 
     @property
     def url(self):
@@ -322,6 +332,10 @@ class RootFS(YAMLObject):
     @property
     def root_type(self):
         return self._root_type
+
+    @property
+    def type(self):
+        return self._fs_type.name
 
     @property
     def params(self):
@@ -516,7 +530,7 @@ class TestConfig(YAMLObject):
 
 def from_yaml(data, filters):
     fs_types = {
-        name: RootFSType.from_yaml(fs_type)
+        name: RootFSType.from_yaml(name, fs_type)
         for name, fs_type in data.get('file_system_types', {}).items()
     }
 


### PR DESCRIPTION
Add a command to automatically generate the YAML configuration with the rootfs images URLs when they exist and leave them to their previous URLs when getting HTTP 404.  For example:
```
kci_test update_rootfs_url --release=20220913.0 --output=config/core/rootfs-image.yaml
```