### PR TITLE
CHROMEOS build_board.sh: Extract rootfs build information

### DIFF
--- a/config/rootfs/chromiumos/scripts/build_board.sh
+++ b/config/rootfs/chromiumos/scripts/build_board.sh
@@ -7,7 +7,6 @@ DATA_DIR=$(pwd)
 USERNAME=$(/usr/bin/id -run)
 SCRIPT=$(realpath "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
-MANIFESTDIR=$(dirname "$SCRIPTPATH")
 
 function cleanup()
 {
@@ -78,6 +77,8 @@ sudo chown -R "${USERNAME}" "${DATA_DIR}/${BOARD}"
 gzip -1 "${DATA_DIR}/${BOARD}/chromiumos_test_image.bin"
 sudo tar -cJf "${DATA_DIR}/${BOARD}/modules.tar.xz" -C ./chroot/build/${BOARD} lib/modules
 sudo cp "./chroot/build/${BOARD}/boot/vmlinuz" "${DATA_DIR}/${BOARD}/bzImage"
+sudo cp ./chroot/build/${BOARD}/boot/config* "${DATA_DIR}/${BOARD}/kernel.config"
+python3 "${SCRIPTPATH}/create_manifest.py" "${BOARD}" "${DATA_DIR}/${BOARD}"
 
 # Probably redundant, but better safe than sorry
 cleanup

--- a/config/rootfs/chromiumos/scripts/create_manifest.py
+++ b/config/rootfs/chromiumos/scripts/create_manifest.py
@@ -1,0 +1,38 @@
+#!/usr/env/bin python3
+
+import json
+import os
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+
+
+def main(args):
+    manifest_git_cmd = "git -C .repo/manifests log --oneline -1"
+    tree = ET.parse('.repo/manifest.xml')
+    root = tree.getroot()
+    xml_file = root[0].get('name')
+    manifest_fname = os.path.join(args[1], 'manifest.json')
+    date = subprocess.check_output("date -u", shell=True).decode().strip()
+    distro_version = os.readlink(f'src/build/images/{args[0]}/latest')
+    manifest_git = subprocess.check_output(manifest_git_cmd,
+                                           shell=True).decode().strip()
+
+    build_info = {
+        'date': date,
+        'distro': 'ChromiumOS',
+        'distro_version': distro_version,
+        'manifest_git': manifest_git,
+        'manifest_file': xml_file,
+    }
+
+    with open(manifest_fname, 'w') as manifest:
+        json.dump(build_info, manifest, indent=4)
+
+
+if __name__ == '__main__':
+    if len(sys.argv) == 3:
+        main(sys.argv[1:])
+    else:
+        print("Board name and destination directory required")
+        sys.exit(1)


### PR DESCRIPTION
For troubleshooting procedures we need extended information about ChromiumOS build. This patch adds manifest.json file on build, that contain such information, similar to debos approach.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>