### PR TITLE
config/docker: split lines in debos.jinja2

### DIFF
--- a/config/docker/debos.jinja2
+++ b/config/docker/debos.jinja2
@@ -20,8 +20,8 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     libostree-dev
 
 # Build debos
-RUN go get github.com/go-debos/debos/cmd/debos && \
-    go install github.com/go-debos/debos/cmd/debos
+RUN go get github.com/go-debos/debos/cmd/debos
+RUN go install github.com/go-debos/debos/cmd/debos
 
 # Dependencies to run debos
 RUN apt-get update && apt-get install --no-install-recommends -y \


### PR DESCRIPTION
Split the "go get" and "go install" commands into two lines as it's not useful to have them on the same line and now we can better tell when something fails what is causing it.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>