### PR TITLE
config/docker: use godebos/debos as base image for debos

### DIFF
--- a/config/docker/base/debos.jinja2
+++ b/config/docker/base/debos.jinja2
@@ -1,0 +1,45 @@
+{# SPDX-License-Identifier: LGPL-2.1-or-later
+ #
+ # Copyright (C) 2022 Collabora Limited
+ # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+-#}
+
+FROM godebos/debos
+MAINTAINER "KernelCI TSC" <kernelci-tsc@groups.io>
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Docker for jenkins really needs procps otherwise the jenkins side fails
+RUN apt-get update && apt-get install --no-install-recommends -y procps
+
+# SSL / HTTPS support
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    apt-transport-https \
+    ca-certificates
+
+# Dependencies to run debos
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    binfmt-support \
+    busybox \
+    debian-ports-archive-keyring \
+    debootstrap \
+    dosfstools \
+    e2fsprogs \
+    linux-image-amd64 \
+    parted \
+    pkg-config \
+    qemu-system-x86 \
+    qemu-user-static \
+    systemd-container \
+    xz-utils
+
+# Jenkins hacks
+RUN useradd -u 996 -ms /bin/sh jenkins
+
+{%- block fragments %}
+{%- for fragment in fragments %}
+{% with is_debian = true, sub_arch = sub_arch %}
+{% include fragment %}
+{%- endwith %}
+{%- endfor %}
+{%- endblock %}

--- a/config/docker/debos.jinja2
+++ b/config/docker/debos.jinja2
@@ -4,41 +4,6 @@
  # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
 -#}
 
-{% extends 'base/debian.jinja2' %}
+{%- include 'base/debos.jinja2' %}
 
-{% block packages %}
-ENV HOME=/tmp
-ENV GOPATH=/usr/local/go
-ENV PATH=$PATH:/usr/local/go/bin
-
-# Dependencies to build debos
-RUN apt-get update && apt-get install --no-install-recommends -y \
-    gcc \
-    git \
-    golang-go \
-    libc6-dev \
-    libostree-dev
-
-# Build debos
-RUN go get github.com/go-debos/debos/cmd/debos
-RUN go install github.com/go-debos/debos/cmd/debos
-
-# Dependencies to run debos
-RUN apt-get update && apt-get install --no-install-recommends -y \
-    binfmt-support \
-    busybox \
-    debian-ports-archive-keyring \
-    debootstrap \
-    dosfstools \
-    e2fsprogs \
-    linux-image-amd64 \
-    parted \
-    pkg-config \
-    qemu-system-x86 \
-    qemu-user-static \
-    systemd-container \
-    xz-utils
-
-# Jenkins hacks
-RUN useradd -u 996 -ms /bin/sh jenkins
-{%- endblock %}
+ENTRYPOINT []


### PR DESCRIPTION
Move debos.jinja2 to base/debos.jinja2 and use godebos/debos as the base image since we can now just add fragments on top of it.

Fixes #1440 