### PR TITLE
build-configs: clang-15+: use LLVM linker on riscv

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -375,14 +375,19 @@ build_environments:
   clang-15:
     cc: clang
     cc_version: 15
-    arch_params:
-      <<: *clang_12_arch_params
+    arch_params: &clang_15_arch_params
+      <<: *clang_11_arch_params
+      riscv:
+        <<: *riscv_params
+        name:
+        opts:
+          LLVM_IAS: '1'
 
   clang-16:
     cc: clang
     cc_version: 16
     arch_params:
-      <<: *clang_12_arch_params
+      <<: *clang_15_arch_params
 
 # Default config with full build coverage
 build_configs_defaults:


### PR DESCRIPTION
Recent mainline & linux-next kernels do not build when using the GNU linker on riscv, so drop the LD=riscv64-linux-gnu-ld option to make build buildling with clang-15+

Signed-off-by: Kevin Hilman <khilman@baylibre.com>