### PR TITLE
riscv/clang build updates

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -380,8 +380,6 @@ build_environments:
       riscv:
         <<: *riscv_params
         name:
-        opts:
-          LLVM_IAS: '1'
 
   clang-16:
     cc: clang

--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -498,7 +498,13 @@ arch_clang_configs: &arch_clang_configs
     extra_configs:
       - 'allmodconfig'
       - 'allnoconfig'
-
+  riscv:
+    extra_configs: &riscv_clang_configs
+      - 'allnoconfig'
+      - 'defconfig+CONFIG_EFI=n'
+    filters:
+      - passlist:
+          defconfig: *riscv_clang_configs
 
 # Minimum architecture defconfigs
 arch_defconfigs: &arch_defconfigs
@@ -835,13 +841,6 @@ build_configs:
         build_environment: clang-16
         architectures:
           <<: *arch_clang_configs
-          riscv:
-            extra_configs: &riscv_clang_configs
-              - 'allnoconfig'
-              - 'defconfig+CONFIG_EFI=n'
-            filters:
-              - passlist:
-                  defconfig: *riscv_clang_configs
 
   next_pending-fixes:
     tree: next

--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -499,10 +499,6 @@ arch_clang_configs: &arch_clang_configs
   riscv:
     extra_configs: &riscv_clang_configs
       - 'allnoconfig'
-      - 'defconfig+CONFIG_EFI=n'
-    filters:
-      - passlist:
-          defconfig: *riscv_clang_configs
 
 # Minimum architecture defconfigs
 arch_defconfigs: &arch_defconfigs

--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -375,14 +375,19 @@ build_environments:
   clang-15:
     cc: clang
     cc_version: 15
-    arch_params:
-      <<: *clang_12_arch_params
+    arch_params: &clang_15_arch_params
+      <<: *clang_11_arch_params
+      riscv:
+        <<: *riscv_params
+        name:
+        opts:
+          LLVM_IAS: '1'
 
   clang-16:
     cc: clang
     cc_version: 16
     arch_params:
-      <<: *clang_12_arch_params
+      <<: *clang_15_arch_params
 
 # Default config with full build coverage
 build_configs_defaults:


### PR DESCRIPTION
Update riscv/clang builds to work with recent clang for mainline & linux-next, removing some workarounds put in place for older kernels/toolchains and also enabling builds for all upstream riscv defconfigs.