### PR TITLE
CHROMEOS config/docker: Migrate CrOS to kci_docker

### DIFF
--- a/config/docker/cros-baseline.jinja2
+++ b/config/docker/cros-baseline.jinja2
@@ -1,0 +1,28 @@
+{# SPDX-License-Identifier: LGPL-2.1-or-later
+ #
+ # Copyright (C) 2021, 2022 Collabora Limited
+ # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+-#}
+
+{% extends 'base/debian.jinja2' %}
+
+{% block packages %}
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    curl \
+    git \
+    inetutils-ping \
+    sudo \
+    ssh \
+    wget
+
+{% include 'fragment/cros-lava.jinja2' %}
+
+{{ super() }}
+
+ADD https://raw.githubusercontent.com/kernelci/kernelci-core/chromeos.kernelci.org/config/rootfs/debos/overlays/baseline/opt/kernelci/dmesg.sh /home/cros/dmesg.sh
+
+# Needed by LAVA to install the overlay
+USER root
+RUN chmod +x /home/cros/dmesg.sh
+{%- endblock %}

--- a/config/docker/cros-qemu-modules.jinja2
+++ b/config/docker/cros-qemu-modules.jinja2
@@ -1,0 +1,25 @@
+{# SPDX-License-Identifier: LGPL-2.1-or-later
+ #
+ # Copyright (C) 2021, 2022 Collabora Limited
+ # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+-#}
+
+{% extends 'base/debian.jinja2' %}
+
+{% block packages %}
+
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+          libguestfs-tools \
+          linux-image-generic \
+          qemu-utils
+
+ENV LIBGUESTFS_BACKEND=direct \
+    HOME=/root
+
+ADD https://raw.githubusercontent.com/kernelci/kernelci-core/chromeos.kernelci.org/config/docker/data/add_modules.sh /add_modules.sh
+
+# Needed by LAVA to install the overlay
+USER root
+RUN chmod +x /add_modules.sh
+{%- endblock %}

--- a/config/docker/cros-sdk.jinja2
+++ b/config/docker/cros-sdk.jinja2
@@ -1,0 +1,27 @@
+{# SPDX-License-Identifier: LGPL-2.1-or-later
+ #
+ # Copyright (C) 2021, 2022 Collabora Limited
+ # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+-#}
+
+{% extends 'base/debian.jinja2' %}
+
+{% block packages %}
+{{ super() }}
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        curl \
+        git \
+        netbase \
+        sudo \
+        ssh \
+        wget
+
+RUN useradd -u 996 -ms /bin/sh cros
+RUN adduser cros sudo && echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+RUN mkdir -p /home/cros/chromiumos
+RUN chown -R cros /home/cros/chromiumos
+
+{%- endblock %}

--- a/config/docker/cros-tast.jinja2
+++ b/config/docker/cros-tast.jinja2
@@ -1,0 +1,31 @@
+{# SPDX-License-Identifier: LGPL-2.1-or-later
+ #
+ # Copyright (C) 2021, 2022 Collabora Limited
+ # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+-#}
+
+{% extends 'base/debian.jinja2' %}
+
+{% block packages %}
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    curl \
+    git \
+    inetutils-ping \
+    python3 \
+    python-pkg-resources \
+    sudo \
+    ssh \
+    wget
+
+{% include 'fragment/cros-lava.jinja2' %}
+
+{{ super() }}
+
+ADD https://raw.githubusercontent.com/kernelci/kernelci-core/chromeos.kernelci.org/config/docker/data/tast_parser.py /home/cros/tast_parser.py
+ADD https://raw.githubusercontent.com/kernelci/kernelci-core/chromeos.kernelci.org/config/docker/data/ssh_retry.sh /home/cros/ssh_retry.sh
+
+# Needed by LAVA to install the overlay
+USER root
+RUN chmod +x /home/cros/tast_parser.py /home/cros/ssh_retry.sh
+{%- endblock %}

--- a/config/docker/fragment/cros-lava.jinja2
+++ b/config/docker/fragment/cros-lava.jinja2
@@ -1,0 +1,22 @@
+RUN \
+  mkdir -p /home/cros && \
+  useradd cros -d /home/cros && \
+  chown cros: -R /home/cros && \
+  adduser cros sudo && \
+  echo "cros ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+USER cros
+ENV HOME=/home/cros
+WORKDIR $HOME
+
+# All this just to extract rsa key to access DUT
+# Adding private key "as is" might trigger github audit alert
+RUN mkdir -p $HOME/trunk
+RUN git clone \
+    https://chromium.googlesource.com/chromiumos/chromite \
+    $HOME/trunk/chromite
+ENV PATH=$PATH:$HOME/trunk/chromite/scripts
+
+# This SSH key is only used with Chrome OS test images.
+RUN mkdir "$HOME/.ssh"
+RUN cp "$HOME/trunk/chromite/ssh_keys/testing_rsa" "$HOME/.ssh/id_rsa"
+RUN chmod 0600 "$HOME/.ssh/id_rsa"


### PR DESCRIPTION
Migrate remaining ChromeOS related images to new template based kci_docker.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>