### PR TITLE
CHROMEOS config/lava/cros*: Update home path in tast tests

### DIFF
--- a/config/lava/chromeos/cros-tast.jinja2
+++ b/config/lava/chromeos/cros-tast.jinja2
@@ -10,7 +10,7 @@
       wait:
         device: true
     results:
-      location: /home/cros-tast/lava
+      location: /home/cros/lava
     definitions:
     - repository:
         metadata:
@@ -18,7 +18,7 @@
           name: cros-tast
         run:
           steps:
-            - cd /home/cros-tast
+            - cd /home/cros
             - >-
               lava-test-case tast-tarball --shell
               curl -s {{ cros_image.base_url }}{{ cros_image.tast_tarball }}
@@ -30,7 +30,7 @@
               ./ssh_retry.sh
               -o StrictHostKeyChecking=no
               -o UserKnownHostsFile=/dev/null
-              -i /home/cros-tast/.ssh/id_rsa
+              -i /home/cros/.ssh/id_rsa
               root@$(lava-target-ip)
               cat /etc/os-release
             - >-

--- a/config/lava/chromeos/tast.jinja2
+++ b/config/lava/chromeos/tast.jinja2
@@ -6,7 +6,7 @@
         wait:
           device: true
       results:
-          location: /home/cros-tast/lava
+          location: /home/cros/lava
       definitions:
       - repository:
           metadata:
@@ -14,8 +14,8 @@
             name: tast-tests
           run:
             steps:
-              - 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /home/cros-tast/.ssh/id_rsa root@$(lava-target-ip) cat /etc/os-release'
-              - 'cd /home/cros-tast'
+              - 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /home/cros/.ssh/id_rsa root@$(lava-target-ip) cat /etc/os-release'
+              - 'cd /home/cros'
               - 'curl -s {{ tast_tarball }} | tar xzf -'
               - 'cp remote_test_runner /usr/bin/remote_test_runner'
               - 'while ! ping -c 1 -w 1 $(lava-target-ip); do sleep 1; done'


### PR DESCRIPTION
As in new Docker images we are using unified username for CrOS, we need to update some of LAVA templates that are using old username 'cros-tast' to new - 'cros'.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>