### PR TITLE
Fix the build of some kselftest testsuites for riscv64

### DIFF
--- a/config/docker/fragment/kselftest.jinja2
+++ b/config/docker/fragment/kselftest.jinja2
@@ -1,10 +1,16 @@
 # kselftest
 {%- if sub_arch %}
-{%- set pkgarch = ':' + sub_arch %}
-RUN dpkg --add-architecture {{ sub_arch }}
+    {%- if sub_arch == 'riscv64' %}
+        {%- set libc6_pkgarch = '-' + sub_arch + '-cross' %}
+        {%- set pkgarch = '' %}
+    {% else %}
+        {%- set libc6_pkgarch = ':' + sub_arch %}
+        {%- set pkgarch = libc6_pkgarch %}
+        RUN dpkg --add-architecture {{ sub_arch }}
+    {%- endif %}
 {%- endif %}
 RUN apt-get update && apt-get install --no-install-recommends -y \
-   libc6-dev{{ pkgarch }} \
+   libc6-dev{{ libc6_pkgarch }} \
    libcap-dev{{ pkgarch }} \
    libcap-ng-dev{{ pkgarch }} \
    libelf-dev{{ pkgarch }} \

--- a/config/docker/gcc-10-riscv64.jinja2
+++ b/config/docker/gcc-10-riscv64.jinja2
@@ -1,3 +1,4 @@
+{%- set sub_arch = 'riscv64' %}
 {% extends 'base/host-tools.jinja2' %}
 
 {% block packages %}


### PR DESCRIPTION
This PR fixes the build of some kselftest testsuites for riscv64 platforms by using the cross compiled libc6 package.
Also install clang in order to build kselftest testsuites that require it.
Note that some kselftest testsuites are still failing to build due to the fact that several libs that are needed are not available yet for riscv64.