### PR TITLE
config: add rust build configurations

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -109,6 +109,9 @@ trees:
   rt-stable:
     url: "https://git.kernel.org/pub/scm/linux/kernel/git/rt/linux-stable-rt.git"
 
+  rust-for-linux:
+    url: "https://github.com/Rust-for-Linux/linux.git"
+
   samsung:
     url: "https://git.kernel.org/pub/scm/linux/kernel/git/kgene/linux-samsung.git"
 
@@ -227,6 +230,42 @@ fragments:
       - 'CONFIG_EXPERT=y'
       - 'CONFIG_PREEMPT_RT=y'
       - 'CONFIG_PREEMPT_RT_FULL=y' # <= v4.19
+
+  rust:
+    path: "kernel/configs/rust.config"
+    configs:
+      - 'CONFIG_RUST=y'
+
+  rust-for-linux-samples:
+    path: "kernel/configs/rust-for-linux-samples.config"
+    configs:
+      - 'CONFIG_SAMPLES=y'
+      - 'CONFIG_SAMPLES_RUST=y'
+      - 'CONFIG_SAMPLE_RUST_MINIMAL=m'
+      - 'CONFIG_SAMPLE_RUST_HOSTPROGS=m'
+      - 'CONFIG_SAMPLE_RUST_PRINT=m'
+      - 'CONFIG_SAMPLE_RUST_MODULE_PARAMETERS=m'
+      - 'CONFIG_SAMPLE_RUST_SYNC=m'
+      - 'CONFIG_SAMPLE_RUST_CHRDEV=m'
+      - 'CONFIG_SAMPLE_RUST_MISCDEV=m'
+      - 'CONFIG_SAMPLE_RUST_STACK_PROBING=m'
+      - 'CONFIG_SAMPLE_RUST_SEMAPHORE=m'
+      - 'CONFIG_SAMPLE_RUST_SEMAPHORE_C=m'
+      - 'CONFIG_SAMPLE_RUST_RANDOM=m'
+      - 'CONFIG_SAMPLE_RUST_PLATFORM=m'
+      - 'CONFIG_SAMPLE_RUST_FS=m'
+      - 'CONFIG_SAMPLE_RUST_NETFILTER=m'
+      - 'CONFIG_SAMPLE_RUST_ECHO_SERVER=m'
+      - 'CONFIG_SAMPLE_RUST_HOSTPROGS=m'
+      - 'CONFIG_SAMPLE_RUST_SELFTESTS=m'
+
+  rust-samples:
+    path: "kernel/configs/rust-samples.config"
+    configs:
+      - 'CONFIG_SAMPLES=y'
+      - 'CONFIG_SAMPLES_RUST=y'
+      - 'CONFIG_SAMPLE_RUST_HOSTPROGS=y'
+      - 'CONFIG_SAMPLE_RUST_MINIMAL=m'
 
   tinyconfig:
     path: "kernel/configs/tiny.config"
@@ -395,6 +434,14 @@ build_environments:
     cc_version: 16
     arch_params:
       <<: *clang_15_arch_params
+
+  rustc-1.62:
+    cc: clang
+    cc_version: 15
+    arch_params:
+      x86_64:
+        <<: *x86_64_params
+        name:
 
 # Default config with full build coverage
 build_configs_defaults:
@@ -959,6 +1006,26 @@ build_configs:
     tree: rt-stable
     branch: 'v5.15-rt'
     variants: *preempt_rt_variants
+
+  rust:
+    tree: mainline
+    branch: 'master'
+    variants:
+      rustc-1.62:
+        build_environment: rustc-1.62
+        fragments: [rust, rust-samples, kselftest]
+        architectures:
+          x86_64: *x86_64_arch
+
+  rust-for-linux:
+    tree: rust-for-linux
+    branch: 'rust'
+    variants:
+      rustc-1.62:
+        build_environment: rustc-1.62
+        fragments: [rust, rust-for-linux-samples, kselftest]
+        architectures:
+          x86_64: *x86_64_arch
 
   samsung:
     tree: samsung

--- a/config/docker/rustc-1.62.jinja2
+++ b/config/docker/rustc-1.62.jinja2
@@ -1,0 +1,39 @@
+{% extends 'clang-15.jinja2' %}
+
+{% block packages %}
+{{ super() }}
+
+ARG RUST_VER=1.62.0
+ARG BINDGEN_VER=0.56.0
+
+ARG RUST_TRIPLE=rust-${RUST_VER}-x86_64-unknown-linux-gnu
+
+ENV CARGO_HOME=/home/kernelci/.cargo
+ENV PATH=/usr/${RUST_TRIPLE}/bin:${CARGO_HOME}/bin:${PATH}
+
+ARG SHA256SUM=4172d3cb316498025410bdf33a4d0f756f5e77fbaee1fb042ccdef78239be1db
+
+# fetch, verify the toolchain
+RUN wget https://static.rust-lang.org/dist/${RUST_TRIPLE}.tar.gz && \
+    echo "${SHA256SUM} ${RUST_TRIPLE}.tar.gz" | sha256sum --check --quiet
+
+# install & cleanup tmp files
+RUN tar -xf ${RUST_TRIPLE}.tar.gz  -C /tmp/ && \
+    /tmp/${RUST_TRIPLE}/install.sh --prefix=/usr/${RUST_TRIPLE} \
+        --components=rustc,cargo,rust-std-x86_64-unknown-linux-gnu && \
+    rm -rf /tmp/${RUST_TRIPLE} && \
+    rm /${RUST_TRIPLE}*
+
+# This image is based on clang-*jinja2 which only has clang installed but rustc
+# defaults to linker "cc" which calls the non-existing GNU stack (gcc, libgcc).
+# So we point cargo/rustc to use the LLVM stack via the clang linker entrypoint.
+RUN mkdir -p ${CARGO_HOME} && \
+    printf '[build]\nrustflags = ["-C", "linker=clang"]' > ${CARGO_HOME}/config.toml
+
+RUN git clone --recurse-submodules --branch $RUST_VER \
+        https://github.com/rust-lang/rust \
+        $(rustc --print sysroot)/lib/rustlib/src/rust
+
+RUN cargo install --locked --version ${BINDGEN_VER} bindgen
+
+{%- endblock %}


### PR DESCRIPTION
    config: add rust build configurations
    
    Starting with the upcoming v6.1, mainline Linux has merged the
    initial Rust infrastructure so this adds some configs for build
    testing it together with some sample modules.
    
    The kernel requires a specific version of rustc, so we add the
    rustc-1.62 build environment which derives from clang-15, since
    a C compiler is still required to build the kernel and the
    supported kernel version is 15 (we might bump this later).
    
    Obviously GCC can be used as well but for now testing all the
    toolchain combinations does not add significant value. In the
    future more toolchain combinations can be used as needed.
    
    The official "offline" toolchain installation method is used as
    documented at [1] with sha256sum and because some distros like
    Debian stable might not provide up to date toolchain and crates
    to keep up with the mainline kernel.
    
    Only the x86_64 architecture is supported by the kernel for now.
    
    We also add the Rust-for-Linux kernel maintainer trees which
    contain additional modules and bindings.
    
    Signed-off-by: Adrian Ratiu <adrian.ratiu@collabora.com>