### PR TITLE
CHROMEOS cros-tast.jinja2: Fix failing Google Storage downloads required by tast

### DIFF
--- a/config/docker/cros-tast.jinja2
+++ b/config/docker/cros-tast.jinja2
@@ -19,6 +19,9 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     wget
 
 {% include 'fragment/cros-lava.jinja2' %}
+# Update gsutil to latest version, so it doesnt download it in LAVA
+# docker each time
+RUN gsutil update -n
 
 {{ super() }}
 
@@ -28,4 +31,7 @@ ADD https://raw.githubusercontent.com/kernelci/kernelci-core/chromeos.kernelci.o
 # Needed by LAVA to install the overlay
 USER root
 RUN chmod +x /home/cros/tast_parser.py /home/cros/ssh_retry.sh
+
+# Create symlink to /usr/local/bin for tast gs:// downloads
+RUN ln -s /home/cros/trunk/chromite/scripts/gsutil /usr/local/bin/
 {%- endblock %}


### PR DESCRIPTION
Due chromite commit 6d9d46f930d2c4b771d15e78ae725558d1f0b6e9 we cannot expect gsutil to be working as before, and we need to download/update it first.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>