### PR TITLE
qemu: add network to riscV qemu

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1556,7 +1556,7 @@ device_types:
       machine: 'virt'
       no_kvm: True
       memory: 1024
-      extra_options: ['-bios default']
+      extra_options: ['-bios default -device virtio-net,netdev=main -netdev user,id=main']
     filters:
       - passlist: {defconfig: ['defconfig']}
 


### PR DESCRIPTION
LAVA use old qemu network options which does not work on riscV qemu. So add network via extra-options with the new full explicit network options.