### PR TITLE
debos: enable systemd-timesync

### DIFF
--- a/config/rootfs/debos/rootfs.yaml
+++ b/config/rootfs/debos/rootfs.yaml
@@ -36,6 +36,7 @@ actions:
       - usbutils
       - initramfs-tools
       - patch
+      - systemd-timesyncd
 
   - action: run
     description: Build testsuite

--- a/config/rootfs/debos/scripts/crush.sh
+++ b/config/rootfs/debos/scripts/crush.sh
@@ -105,9 +105,6 @@ systemd_dns_nw_ntp_tools() {
 
    # Systemd network configuration
    find usr etc -name '*networkd*' -prune -exec rm -r {} \;
-
-   # systemd ntp client (connman is in use)
-   find usr etc -name '*timesyncd*' -prune -exec rm -r {} \;
 }
 
 ncurses()  {


### PR DESCRIPTION
DUT need to have a correct time and cannot rely on having a RTC for that.
This is needed for lot of tests which need to have a correct time. Moslty all x509/TLS based actions, like doing apt (over https).

Signed-off-by: Corentin Labbe <clabbe@baylibre.com>