### PR TITLE
CHROMEOS cros-tast.jinja2: Add new file required by R106 tast

### DIFF
--- a/config/lava/chromeos/cros-tast.jinja2
+++ b/config/lava/chromeos/cros-tast.jinja2
@@ -24,6 +24,8 @@
               curl -s {{ cros_image.base_url }}{{ cros_image.tast_tarball }}
               \| tar xzvf -
               && cp remote_test_runner /usr/bin/remote_test_runner
+              && mkdir -p /usr/libexec/tast/bundles/remote/
+              && cp cros /usr/libexec/tast/bundles/remote/
             - while ! ping -c 1 -w 1 $(lava-target-ip); do sleep 1; done
             - >-
               lava-test-case os-release --shell


### PR DESCRIPTION
As tast tests keep evolving, local docker require new file that seems working as kind of RPC server. Without this file tast tests can be listed, but cannot be executed.
This patch need to be enabled only after all Chromebooks are flashed to R106.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>