### PR TITLE
choose the debian version depending on the plaform arch

### DIFF
--- a/config/core/image-distros.yaml
+++ b/config/core/image-distros.yaml
@@ -1,0 +1,65 @@
+distros:
+  buildroot-baseline_ramdisk:
+    distro_map:
+      buildroot-baseline_ramdisk: [{arch: default}]
+
+  debian-cros-ec_ramdisk:
+    distro_map:
+      debian_bullseye-cros-ec_ramdisk: [{arch: default}]
+      debian_sid-cros-ec_ramdisk:      [{arch: riscv},
+                                        {arch: riscv64}]
+  debian-gst-fluster_nfs:
+    distro_map:
+      debian_bullseye-gst-fluster_nfs: [{arch: default}]
+      debian_sid-gst-fluster_nfs:      [{arch: riscv},
+                                        {arch: riscv64}]
+  debian-igt_ramdisk:
+    distro_map:
+      debian_bullseye-igt_ramdisk: [{arch: default}]
+      debian_sid-igt_ramdisk:      [{arch: riscv},
+                                    {arch: riscv64}]
+  debian-kselftest_nfs:
+    distro_map:
+      debian_bullseye-kselftest_nfs: [{arch: default}]
+      debian_sid-kselftest_nfs:      [{arch: riscv},
+                                      {arch: riscv64}]
+  debian-libcamera_nfs:
+    distro_map:
+      debian_bullseye-libcamera_nfs: [{arch: default}]
+      debian_sid-libcamera_nfs:      [{arch: riscv},
+                                      {arch: riscv64}]
+  debian-ltp_nfs:
+    distro_map:
+      debian_bullseye-ltp_nfs: [{arch: default}]
+      debian_sid-ltp_nfs:      [{arch: riscv},
+                                {arch: riscv64}]
+  debian-ltp_ramdisk:
+    distro_map:
+      debian_bullseye-ltp_ramdisk: [{arch: default}]
+      debian_sid-ltp_ramdisk:      [{arch: riscv},
+                                    {arch: riscv64}]
+  debian-rt_ramdisk:
+    distro_map:
+      debian_bullseye-rt_ramdisk: [{arch: default}]
+      debian_sid-rt_ramdisk:      [{arch: riscv},
+                                   {arch: riscv64}]
+
+  debian-v4l2_ramdisk:
+    distro_map:
+      debian_bullseye-v4l2_ramdisk: [{arch: default}]
+      debian_sid-v4l2_ramdisk:      [{arch: riscv},
+                                     {arch: riscv64}]
+  debian_nfs:
+    distro_map:
+      debian_bullseye_nfs: [{arch: default}]
+      debian_sid_nfs:      [{arch: riscv},
+                            {arch: riscv64}]
+  debian_ramdisk:
+    distro_map:
+      debian_bullseye_ramdisk: [{arch: default}]
+      debian_sid_ramdisk:      [{arch: riscv},
+                                {arch: riscv64}]
+
+  cip_nfs:
+    distro_map:
+      cip_nfs: [{arch: default}]

--- a/config/core/rootfs-images.yaml
+++ b/config/core/rootfs-images.yaml
@@ -90,3 +90,27 @@ file_systems:
     ramdisk: bullseye/20221007.0/{arch}/rootfs.cpio.gz
     root_type: ramdisk
     type: debian
+  debian_sid-kselftest_nfs:
+    boot_protocol: tftp
+    nfs: sid-kselftest/20221007.0/{arch}/full.rootfs.tar.xz
+    params:
+      os_config: debian
+    prompt: '/ #'
+    ramdisk: sid-kselftest/20221007.0/{arch}/initrd.cpio.gz
+    root_type: nfs
+    type: debian
+  debian_sid_nfs:
+    boot_protocol: tftp
+    nfs: sid/20221007.0/{arch}/full.rootfs.tar.xz
+    params: {}
+    prompt: '/ #'
+    ramdisk: sid/20221007.0/{arch}/initrd.cpio.gz
+    root_type: nfs
+    type: debian
+  debian_sid_ramdisk:
+    boot_protocol: tftp
+    params: {}
+    prompt: '/ #'
+    ramdisk: sid/20221007.0/{arch}/rootfs.cpio.gz
+    root_type: ramdisk
+    type: debian

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -78,7 +78,7 @@ test_plans:
       priority: 90
 
   baseline-nfs:
-    rootfs: debian_bullseye_nfs
+    rootfs: debian_nfs
     pattern: 'baseline/{category}-{method}-{protocol}-nfs-baseline-template.jinja2'
     params:
       priority: 85
@@ -101,10 +101,10 @@ test_plans:
             - 'lab-collabora-staging'
 
   cros-ec:
-    rootfs: debian_bullseye-cros-ec_ramdisk
+    rootfs: debian-cros-ec_ramdisk
 
   igt: &igt
-    rootfs: debian_bullseye-igt_ramdisk
+    rootfs: debian-igt_ramdisk
     pattern: 'igt/{category}-{method}-{protocol}-{rootfs}-igt.jinja2'
 
   igt-gpu-amd:
@@ -209,7 +209,7 @@ test_plans:
       drm_driver: "tegra"
 
   kselftest: &kselftest
-    rootfs: debian_bullseye-kselftest_nfs
+    rootfs: debian-kselftest_nfs
     pattern: 'kselftest/{category}-{method}-{protocol}-{rootfs}-kselftest-template.jinja2'
     filters:
       - passlist: {defconfig: ['kselftest']}
@@ -370,13 +370,13 @@ test_plans:
       kselftest_collections: "vm"
 
   lc-compliance:
-    rootfs: debian_bullseye-libcamera_nfs
+    rootfs: debian-libcamera_nfs
     pattern: 'lc-compliance/{category}-{method}-{protocol}-{rootfs}-lc-compliance-template.jinja2'
     params:
       job_timeout: '45'
 
   ltp: &ltp
-    rootfs: debian_bullseye-ltp_nfs
+    rootfs: debian-ltp_nfs
     pattern: 'ltp/{category}-{method}-{protocol}-{rootfs}-ltp-template.jinja2'
     filters:
       - blocklist: *kselftest_defconfig_filter
@@ -444,7 +444,7 @@ test_plans:
   ltp-timers_qemu:
     <<: *ltp
     base_name: ltp-timers
-    rootfs: debian_bullseye-ltp_ramdisk
+    rootfs: debian-ltp_ramdisk
     pattern: 'ltp/{category}-{method}-{rootfs}-ltp-open-posix-template.jinja2'
     params:
       <<: *ltp-params
@@ -457,18 +457,18 @@ test_plans:
       - passlist: *qemu_labs_filter
 
   preempt-rt:
-    rootfs: debian_bullseye-rt_ramdisk
+    rootfs: debian-rt_ramdisk
     filters:
       - passlist: {defconfig: ['preempt_rt']}
 
   sleep:
-    rootfs: debian_bullseye_ramdisk
+    rootfs: debian_ramdisk
     params:
       sleep_params: mem freeze
 
   sleep_mem:
     base_name: sleep
-    rootfs: debian_bullseye_ramdisk
+    rootfs: debian_ramdisk
     pattern: 'sleep/{category}-{method}-{protocol}-{rootfs}-sleep-template.jinja2'
     params:
       sleep_params: mem
@@ -486,16 +486,16 @@ test_plans:
       - passlist: *qemu_labs_filter
 
   usb:
-    rootfs: debian_bullseye_ramdisk
+    rootfs: debian_ramdisk
 
   v4l2-compliance-uvc:
-    rootfs: debian_bullseye-v4l2_ramdisk
+    rootfs: debian-v4l2_ramdisk
     # FIXME - this is not very sustainable, improve template naming scheme
     pattern: 'v4l2-compliance/{category}-{method}-{protocol}-{rootfs}-v4l2-compliance-template.jinja2'
     params: {v4l2_driver: "uvcvideo"}
 
   v4l2-compliance-vivid:
-    rootfs: debian_bullseye-v4l2_ramdisk
+    rootfs: debian-v4l2_ramdisk
     pattern: 'v4l2-compliance/generic-qemu-v4l2-compliance-template.jinja2'
     params: {v4l2_driver: "vivid"}
     filters:
@@ -505,7 +505,7 @@ test_plans:
             - 'multi_v7_defconfig+virtualvideo'
 
   v4l2-decoder-conformance-av1:
-    rootfs: debian_bullseye-gst-fluster_nfs
+    rootfs: debian-gst-fluster_nfs
     pattern: 'v4l2-decoder-conformance/{category}-{method}-{protocol}-{rootfs}-v4l2-decoder-conformance-template.jinja2'
     params:
       job_timeout: '30'
@@ -514,7 +514,7 @@ test_plans:
       - passlist: {'tree': ['next', 'mainline', 'media']}
 
   v4l2-decoder-conformance-h264:
-    rootfs: debian_bullseye-gst-fluster_nfs
+    rootfs: debian-gst-fluster_nfs
     pattern: 'v4l2-decoder-conformance/{category}-{method}-{protocol}-{rootfs}-v4l2-decoder-conformance-template.jinja2'
     params:
       job_timeout: '30'
@@ -523,7 +523,7 @@ test_plans:
       - passlist: {'tree': ['next', 'mainline', 'media']}
 
   v4l2-decoder-conformance-h265:
-    rootfs: debian_bullseye-gst-fluster_nfs
+    rootfs: debian-gst-fluster_nfs
     pattern: 'v4l2-decoder-conformance/{category}-{method}-{protocol}-{rootfs}-v4l2-decoder-conformance-template.jinja2'
     params:
       job_timeout: '30'
@@ -532,7 +532,7 @@ test_plans:
       - passlist: {'tree': ['next', 'mainline', 'media']}
 
   v4l2-decoder-conformance-vp8:
-    rootfs: debian_bullseye-gst-fluster_nfs
+    rootfs: debian-gst-fluster_nfs
     pattern: 'v4l2-decoder-conformance/{category}-{method}-{protocol}-{rootfs}-v4l2-decoder-conformance-template.jinja2'
     params:
       job_timeout: '30'
@@ -541,7 +541,7 @@ test_plans:
       - passlist: {'tree': ['next', 'mainline', 'media']}
 
   v4l2-decoder-conformance-vp9:
-    rootfs: debian_bullseye-gst-fluster_nfs
+    rootfs: debian-gst-fluster_nfs
     pattern: 'v4l2-decoder-conformance/{category}-{method}-{protocol}-{rootfs}-v4l2-decoder-conformance-template.jinja2'
     params:
       job_timeout: '30'

--- a/kernelci/test.py
+++ b/kernelci/test.py
@@ -159,7 +159,9 @@ def get_params(meta, target, plan_config, storage, device_id):
         'kselftests_url': kselftests_url,
     }
 
-    rootfs = plan_config.rootfs
+    distro_rootfs = plan_config.rootfs
+    rootfs = distro_rootfs.get_distribution_rootfs(arch)
+
     if rootfs:
         initrd_url = rootfs.get_url('ramdisk', arch, variant, endian)
         initrd_compression = _get_compression(initrd_url)


### PR DESCRIPTION
In order to test kselftest and ltp on riscv platforms, we currently have to use debian-sid instead of debian-bullseye.
The reason for that is that bullseye does not support riscv platform and only sid does.
As a consequence, and in order to not duplicate the test plans in test-configs.yaml, the logic to be able to choose the debian version depending on the arch that is being tested has been added.

To do so:
- the mention to bullseye has been removed in rootfs in the test plans defintions
- a image-distros.yaml file has been added and it contains the information to get the rootfs name with the debian version from the name (without the debian version, now used in the test plan) and the architecture.
- a Distro object has been added to contain the information from the image-distros.yaml
- the TestPlan object now has a Distro object that can contain different RootFS objects depending on the architecture instead of a single RootFS object.
- When generating a test, the architecture is known and the correct RootFs object is chosen.

I am not really happy with this PR as:
- it duplicates information like the boot_protocol, the type etc
- the way `get_template_path(self, boot_method)` is modified at the moment is not great
- I feel like I may be missing something !

Maybe I can transfer some parameters from rootfs-images to the file I just created (for example: type and boot_protocol which would make the get_template_path function better)?
Maybe we should just duplicate the testplans for riscv/sid and not do all this?

Let me know what you think about this PR, what could be improved or if there is a completely different solution that would be much better...

Thanks