### PR TITLE
CHROMEOS rootfs-configs-chromeos.yaml: Update release to R106

### DIFF
--- a/config/core/rootfs-configs-chromeos.yaml
+++ b/config/core/rootfs-configs-chromeos.yaml
@@ -17,7 +17,7 @@ rootfs_configs:
   chromiumos-amd64-generic:
     rootfs_type: chromiumos
     board: amd64-generic
-    branch: release-R102-14695.B
+    branch: release-R106-15054.B
     serial: ttyS0
     arch_list:
       - amd64
@@ -25,7 +25,7 @@ rootfs_configs:
   chromiumos-coral:
     rootfs_type: chromiumos
     board: coral
-    branch: release-R100-14526.B
+    branch: release-R106-15054.B
     serial: ttyS2
     arch_list:
       - amd64
@@ -33,7 +33,7 @@ rootfs_configs:
   chromiumos-grunt:
     rootfs_type: chromiumos
     board: grunt
-    branch: release-R102-14695.B
+    branch: release-R106-15054.B
     serial: ttyS0
     arch_list:
       - amd64
@@ -41,7 +41,7 @@ rootfs_configs:
   chromiumos-hatch:
     rootfs_type: chromiumos
     board: hatch
-    branch: release-R102-14695.B
+    branch: release-R106-15054.B
     serial: ttyS0
     arch_list:
       - amd64
@@ -49,7 +49,7 @@ rootfs_configs:
   chromiumos-octopus:
     rootfs_type: chromiumos
     board: octopus
-    branch: release-R102-14695.B
+    branch: release-R106-15054.B
     serial: ttyS1
     arch_list:
       - amd64


### PR DESCRIPTION
Update ChromiumOS rootfs release to R106, as we got it tested, to be able to build newest stable version.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>