### PR TITLE
debos: bullseye-ltp: fix build

### DIFF
--- a/config/rootfs/debos/scripts/bullseye-ltp.sh
+++ b/config/rootfs/debos/scripts/bullseye-ltp.sh
@@ -64,7 +64,7 @@ make all
 find . -executable -type f -exec strip {} \;
 make install
 
-cd testcases/open_posix_testsuite/ && make generate-makefiles prefix=/opt/ltp
+cd testcases/open_posix_testsuite/ && ./configure
 make all
 make install prefix=/opt/ltp
 

--- a/config/rootfs/debos/scripts/bullseye-ltp.sh
+++ b/config/rootfs/debos/scripts/bullseye-ltp.sh
@@ -58,14 +58,16 @@ index 1bbdddfd5..de84b9e6f 100755
 \t\techo \".run-test files not found under \$1, have been the tests compiled?\"
 " | patch -p1
 
+NBCPU=$(grep ^processor /proc/cpuinfo | wc -l)
+
 make autotools
 ./configure
-make all
+make all -j$NBCPU
 find . -executable -type f -exec strip {} \;
 make install
 
 cd testcases/open_posix_testsuite/ && ./configure
-make all
+make all -j$NBCPU
 make install prefix=/opt/ltp
 
 ########################################################################


### PR DESCRIPTION
This PR fix the LTP rootfs build which fail currently due to open_posix_testsuite.