### PR TITLE
rootfs-configs.yaml: Add bullseye-audio

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -52,6 +52,21 @@ rootfs_configs:
     script: "scripts/install-bootrr.sh"
     test_overlay: "overlays/baseline"
 
+  bullseye-audio:
+    rootfs_type: debos
+    debian_release: bullseye
+    arch_list:
+      - amd64
+      - arm64
+      - armhf
+    extra_packages:
+      - alsa-utils
+    extra_packages_remove:
+      - bash
+      - e2fslibs
+      - e2fsprogs
+    script: "scripts/bullseye-audio.sh"
+
   bullseye-cros-ec:
     rootfs_type: debos
     debian_release: bullseye

--- a/config/rootfs/debos/scripts/bullseye-audio.sh
+++ b/config/rootfs/debos/scripts/bullseye-audio.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Important: This script is run under QEMU
+
+set -e
+
+BUILD_DEPS="\
+      automake \
+      make \
+      libtool \
+      git \
+      openssl \
+      ca-certificates \
+      curl \
+"
+
+apt-get install --no-install-recommends -y  ${BUILD_DEPS}
+
+BUILDFILE=/test_suites.json
+echo '{  "tests_suites": [' >> $BUILDFILE
+
+# Build libasound2
+########################################################################
+
+LIBASOUND_PREFIX_DIR=/usr/local/
+LIBASOUND_URL=https://github.com/alsa-project/alsa-lib.git
+mkdir -p /var/tests/libasound2 && cd /var/tests/libasound2
+
+git clone --depth=1 $LIBASOUND_URL .
+
+echo '    {"name": "libasound2", "git_url": "'$LIBASOUND_URL'", "git_commit": ' \"`git rev-parse HEAD`\" '}' >> $BUILDFILE
+
+./gitcompile --prefix=$LIBASOUND_PREFIX_DIR
+make install
+
+# Make the libasound we built take precendence over the one from the distro
+echo $LIBASOUND_PREFIX_DIR/lib > /etc/ld.so.conf.d/1-libasound.conf
+
+echo '  ]}' >> $BUILDFILE
+
+# Download alsa-ucm-conf
+########################################################################
+
+UCM_CONF_DIR=$LIBASOUND_PREFIX_DIR/share/alsa
+mkdir -p /var/tests/ucm-conf && cd /var/tests/ucm-conf
+mkdir -p $UCM_CONF_DIR
+curl -L -o alsa-ucm-conf.tar.gz https://github.com/alsa-project/alsa-ucm-conf/archive/refs/heads/master.tar.gz
+tar xvzf alsa-ucm-conf.tar.gz -C $UCM_CONF_DIR --strip-components=1 --wildcards "*/ucm" "*/ucm2"
+
+########################################################################
+# Cleanup: remove files and packages we don't want in the images       #
+########################################################################
+rm -rf /var/tests
+
+apt-get remove --purge -y ${BUILD_DEPS}
+apt-get autoremove --purge -y
+apt-get clean
+
+# re-add some stuff that is removed by accident
+apt-get install -y initramfs-tools


### PR DESCRIPTION
Add a rootfs that can provide us the tools to validate a working audio setup. As a first step, the alsactl utility provided by the alsa-utils package can be used for this purpose.

A lot of current devices rely on UCM configuration files to have working audio. Ideally we would just add alsa-ucm-conf to the list of packages and call it a day. Unfortunately that package is very old and missing the files for a lot of devices that were enabled since. Additionally, the libasound package provides a library that is too old to parse most of the newer UCM files. For these reasons, also add a script that builds the latest libasound and downloads the latest UCM configuration files.

Signed-off-by: Nícolas F. R. A. Prado <nfraprado@collabora.com>

LAVA run running the rootfs on mt8173-elm-hana: https://lava.collabora.dev/scheduler/job/7797317