### PR TITLE
Enable audio test on mt8173-elm-hana

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -145,6 +145,8 @@ fragments:
       - 'CONFIG_REGULATOR_DA9211=y'
       - 'CONFIG_ARM_MEDIATEK_CPUFREQ=y'
       - 'CONFIG_RTC_DRV_MT6397=y'
+      - 'CONFIG_SND_SOC_MT8173=m'
+      - 'CONFIG_SND_SOC_MT8173_RT5650=m'
       # This is required for sc7180-trogdor-lazor-limozeen and it hasn't been
       # merged upstream yet.
       - 'CONFIG_INTERCONNECT_QCOM_SC7180=y'

--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -52,6 +52,21 @@ rootfs_configs:
     script: "scripts/install-bootrr.sh"
     test_overlay: "overlays/baseline"
 
+  bullseye-audio:
+    rootfs_type: debos
+    debian_release: bullseye
+    arch_list:
+      - amd64
+      - arm64
+      - armhf
+    extra_packages:
+      - alsa-utils
+    extra_packages_remove:
+      - bash
+      - e2fslibs
+      - e2fsprogs
+    script: "scripts/bullseye-audio.sh"
+
   bullseye-cros-ec:
     rootfs_type: debos
     debian_release: bullseye

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2595,6 +2595,7 @@ test_configs:
 
   - device_type: mt8173-elm-hana
     test_plans:
+      - audio
       - baseline
       - baseline-nfs
       - cros-ec

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -63,6 +63,10 @@ default_filters:
 
 test_plans:
 
+  audio:
+    rootfs: debian_bullseye-audio_nfs
+    pattern: 'audio/{category}-{method}-{protocol}-{rootfs}-audio-template.jinja2'
+
   baseline:
     rootfs: buildroot-baseline_ramdisk
     params:

--- a/config/lava/audio/audio.jinja2
+++ b/config/lava/audio/audio.jinja2
@@ -1,0 +1,19 @@
+- test:
+    timeout:
+      minutes: {{ job_timeout }}
+    definitions:
+    - repository:
+        metadata:
+          format: Lava-Test Test Definition 1.0
+          name: {{ plan }}
+          description: "Audio test plan"
+          os:
+          - debian
+          scope:
+          - functional
+        run:
+          steps:
+          - lava-test-case audio-init --shell alsactl init
+      from: inline
+      name: {{ plan }}
+      path: inline/{{ plan }}.yaml

--- a/config/lava/audio/generic-depthcharge-tftp-nfs-audio-template.jinja2
+++ b/config/lava/audio/generic-depthcharge-tftp-nfs-audio-template.jinja2
@@ -1,0 +1,8 @@
+{% extends 'boot-nfs/generic-depthcharge-tftp-nfs-template.jinja2' %}
+
+{% block actions %}
+{{ super () }}
+
+{% include 'audio/audio.jinja2' %}
+
+{% endblock %}

--- a/config/lava/audio/generic-grub-tftp-nfs-audio-template.jinja2
+++ b/config/lava/audio/generic-grub-tftp-nfs-audio-template.jinja2
@@ -1,0 +1,8 @@
+{% extends 'boot-nfs/generic-grub-tftp-nfs-template.jinja2' %}
+
+{% block actions %}
+{{ super () }}
+
+{% include 'audio/audio.jinja2' %}
+
+{% endblock %}

--- a/config/lava/audio/generic-uboot-tftp-nfs-audio-template.jinja2
+++ b/config/lava/audio/generic-uboot-tftp-nfs-audio-template.jinja2
@@ -1,0 +1,8 @@
+{% extends 'boot-nfs/generic-uboot-tftp-nfs-template.jinja2' %}
+
+{% block actions %}
+{{ super () }}
+
+{% include 'audio/audio.jinja2' %}
+
+{% endblock %}

--- a/config/rootfs/debos/scripts/bullseye-audio.sh
+++ b/config/rootfs/debos/scripts/bullseye-audio.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Important: This script is run under QEMU
+
+set -e
+
+BUILD_DEPS="\
+      automake \
+      make \
+      libtool \
+      git \
+      openssl \
+      ca-certificates \
+      curl \
+"
+
+apt-get install --no-install-recommends -y  ${BUILD_DEPS}
+
+BUILDFILE=/test_suites.json
+echo '{  "tests_suites": [' >> $BUILDFILE
+
+# Build libasound2
+########################################################################
+
+LIBASOUND_PREFIX_DIR=/usr/local/
+LIBASOUND_URL=https://github.com/alsa-project/alsa-lib.git
+mkdir -p /var/tests/libasound2 && cd /var/tests/libasound2
+
+git clone --depth=1 $LIBASOUND_URL .
+
+echo '    {"name": "libasound2", "git_url": "'$LIBASOUND_URL'", "git_commit": ' \"`git rev-parse HEAD`\" '}' >> $BUILDFILE
+
+./gitcompile --prefix=$LIBASOUND_PREFIX_DIR
+make install
+
+# Make the libasound we built take precendence over the one from the distro
+echo $LIBASOUND_PREFIX_DIR/lib > /etc/ld.so.conf.d/1-libasound.conf
+
+echo '  ]}' >> $BUILDFILE
+
+# Download alsa-ucm-conf
+########################################################################
+
+UCM_CONF_DIR=$LIBASOUND_PREFIX_DIR/share/alsa
+mkdir -p /var/tests/ucm-conf && cd /var/tests/ucm-conf
+mkdir -p $UCM_CONF_DIR
+curl -L -o alsa-ucm-conf.tar.gz https://github.com/alsa-project/alsa-ucm-conf/archive/refs/heads/master.tar.gz
+tar xvzf alsa-ucm-conf.tar.gz -C $UCM_CONF_DIR --strip-components=1 --wildcards "*/ucm" "*/ucm2"
+
+########################################################################
+# Cleanup: remove files and packages we don't want in the images       #
+########################################################################
+rm -rf /var/tests
+
+apt-get remove --purge -y ${BUILD_DEPS}
+apt-get autoremove --purge -y
+apt-get clean
+
+# re-add some stuff that is removed by accident
+apt-get install -y initramfs-tools


### PR DESCRIPTION
Based on #1483.

Enable the audio test added on #1483 to run on mt8173-elm-hana.

LAVA run of the test on mt8173-elm-hana: https://lava.collabora.dev/scheduler/job/7797317