### PR TITLE
build-configs.yaml: Add missing firmware files for Chromebooks

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -289,6 +289,7 @@ fragments:
       - 'CONFIG_NFS_V4=y'
       - 'CONFIG_ROOT_NFS=y'
       - 'CONFIG_EXTRA_FIRMWARE="
+      amdgpu/raven2_gpu_info.bin
       amdgpu/stoney_ce.bin
       amdgpu/stoney_me.bin
       amdgpu/stoney_mec.bin
@@ -297,6 +298,9 @@ fragments:
       amdgpu/stoney_sdma.bin
       amdgpu/stoney_uvd.bin
       amdgpu/stoney_vce.bin
+      i915/glk_dmc_ver1_04.bin
+      i915/kbl_dmc_ver1_04.bin
+      rtl_nic/rtl8153a-4.fw
       rtl_nic/rtl8153b-2.fw
       "'
 


### PR DESCRIPTION
Several Chromebooks require firmware files that need to be loaded early, so it should be built in kernel.
* amdgpu/raven2_gpu_info.bin required by zork
* i915/glk_dmc_ver1_04.bin by octopus
* i915/kbl_dmc_ver1_04.bin by sona, hatch, rammus
* rtl_nic/rtl8153a-4.fw by sarien, volteer, dedede

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>