### PR TITLE
job-build.jinja2: Limit job retries

### DIFF
--- a/config/k8s/job-build.jinja2
+++ b/config/k8s/job-build.jinja2
@@ -10,6 +10,7 @@ metadata:
     kernelci/buildconfig: "{{ "FIXME" | env_override('BUILD_CONFIG') }}"
 spec:
   completions: 1
+  backoffLimit: 20
   template:
     spec:
       restartPolicy: OnFailure


### PR DESCRIPTION
In some cases, for example when specified docker image is not available, job might loop infinitely and if there is many of them, it can occupy all nodes and block all builders.
Fixes #1492

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>