### PR TITLE
job-build.jinja2: Set image pull policy as Always

### DIFF
--- a/config/k8s/job-build.jinja2
+++ b/config/k8s/job-build.jinja2
@@ -44,6 +44,7 @@ spec:
       containers:
       - name: kci-build
         image: {{ "FIXME" | env_override('DOCKER_BASE') }}{{ "FIXME" | env_override('DOCKER_IMAGE') }}
+        imagePullPolicy: Always
 
         volumeMounts:
         - mountPath: "/scratch"


### PR DESCRIPTION
As reported and observed we have numerous issues with stale docker images on k8s builders. One of possible reasons is that by default pull policy for image with specified tag is **IfNotPresent**, which we need to change to **Always**.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>