### PR TITLE
config/lava/base: Support optional recovery image section for TFTP de…

### DIFF
--- a/config/lava/base/kernel-ci-base-tftp-deploy.jinja2
+++ b/config/lava/base/kernel-ci-base-tftp-deploy.jinja2
@@ -7,6 +7,15 @@
 {% endblock %}
 {% block deploy %}
 actions:
+{%- if recovery_image_url %}
+- deploy:
+    timeout:
+      minutes: 10
+    to: {{ recovery_deploy }}
+    images:
+      recovery_image:
+        url: {{ recovery_image_url }}
+{%- endif %}
 - deploy:
     timeout:
       minutes: 10


### PR DESCRIPTION
…ploys

Some LAVA device types support a recovery image which can be used to get the board into a known state, as well as being used for actual recovery this is sometimes used for switching between multiple firmwares in jobs. The various Arm reference platforms are one example of this.

Add an optional block in our base TFTP deploy template which allows a recovery image to be added to the job if recovery_image_url and recovery_deploy are defined in the parameters generated for the job.

Signed-off-by: Mark Brown <broonie@kernel.org>