### PR TITLE
Enable landlock selftests on Le Potato

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2632,6 +2632,7 @@ test_configs:
       - kselftest-cpufreq
       - kselftest-futex
       - kselftest-kvm
+      - kselftest-landlock
       - kselftest-lib
       - kselftest-seccomp
       - ltp-crypto


### PR DESCRIPTION
Enable landlock selftests on Le Potato.