### PR TITLE
Enable landlock selftests on BeagleBone Black

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2336,6 +2336,7 @@ test_configs:
       - kselftest-filesystems
       - kselftest-futex
       - kselftest-kcmp
+      - kselftest-landlock
       - kselftest-lib
       - kselftest-membarrier
       - kselftest-mincore


### PR DESCRIPTION
Enable landlock selftests on BeagleBone Black