### PR TITLE
build.py: Add printout of HTTP error code during last commit retrieval

### DIFF
--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -87,6 +87,8 @@ def get_last_commit(config, storage):
         file_name=_get_last_commit_file_name(config))
     last_commit_resp = requests.get(last_commit_url)
     if last_commit_resp.status_code != 200:
+        print(f'get_last_commit(): Failed to retrieve the last commit.'
+              'HTTP code: {last_commit_resp.status_code}')
         return False
     return last_commit_resp.text.strip()
 


### PR DESCRIPTION
If we check for last commit, and it fails - we just get return code 1. But it is important to differentiate, if tree got deleted it might fail with 404 code, if it is just temporary git problems it will produce different HTTP error code.
It will be useful to do periodic cleanup of git trees that are dont exist anymore, by checking jenkins logs.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>