### PR TITLE
build-configs.yaml: Fix branch for sound-fixes

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -651,7 +651,7 @@ build_configs:
 
   broonie-sound-fixes:
     tree: broonie-sound
-    branch: 'for-next-linus'
+    branch: 'for-linus'
 
   broonie-spi:
     tree: broonie-spi


### PR DESCRIPTION
The branch name got corrupted somehow.

Signed-off-by: Mark Brown <broonie@kernel.org>