### PR TITLE
build-configs-stable.yaml: Remove 5.20 trees as they return 404

### DIFF
--- a/config/core/build-configs-stable.yaml
+++ b/config/core/build-configs-stable.yaml
@@ -154,11 +154,6 @@ build_configs:
     branch: 'linux-5.19.y'
     variants: *stable_variants
 
-  stable_5.20:
-    tree: stable
-    branch: 'linux-5.20.y'
-    variants: *stable_variants
-
   stable-rc_3.16:
     tree: stable-rc
     branch: 'linux-3.16.y'
@@ -263,14 +258,6 @@ build_configs:
       tree: stable
       branch: 'linux-5.19.y'
 
-  stable-rc_5.20:
-    tree: stable-rc
-    branch: 'linux-5.20.y'
-    variants: *stable_variants
-    reference:
-      tree: stable
-      branch: 'linux-5.20.y'
-
   stable-rc_queue-4.4:
     tree: stable-rc
     branch: 'queue/4.4'
@@ -366,11 +353,3 @@ build_configs:
     reference:
       tree: stable
       branch: 'linux-5.19.y'
-
-  stable-rc_queue-5.20:
-    tree: stable-rc
-    branch: 'queue/5.20'
-    variants: *stable_variants
-    reference:
-      tree: stable
-      branch: 'linux-5.20.y'


### PR DESCRIPTION
As some trees fail to checkout - better to remove them.
```
Failed to check stable_5.20, retyring: hudson.AbortException: script returned exit code 1
Failed to check stable-rc_5.20, retyring: hudson.AbortException: script returned exit code 1
Failed to check stable-rc_queue-5.20, retyring: hudson.AbortException: script returned exit code 1
```

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>