### PR TITLE
config/core/test-configs: remove smc test from qemu

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2731,7 +2731,6 @@ test_configs:
   - device_type: qemu_arm-virt-gicv3
     test_plans:
       - baseline_qemu
-      - smc_qemu
       - v4l2-compliance-vivid
 
   - device_type: qemu_arm-virt-gicv3-uefi
@@ -2749,7 +2748,6 @@ test_configs:
   - device_type: qemu_arm64-virt-gicv3
     test_plans:
       - baseline_qemu
-      - smc_qemu
       - v4l2-compliance-vivid
 
   - device_type: qemu_arm64-virt-gicv3-uefi
@@ -2776,7 +2774,6 @@ test_configs:
     test_plans:
       - baseline_qemu
       - ltp-timers_qemu
-      - smc_qemu
       - v4l2-compliance-vivid
 
   - device_type: qemu_x86_64-uefi


### PR DESCRIPTION
Remove smc tests on qemu, as it can create false positive.

Signed-off-by: Alice Ferrazzi <alice.ferrazzi@miraclelinux.com>