### PR TITLE
build-configs.yaml: Disable ARMv3 platforms from gcc-10

### DIFF
--- a/config/core/build-configs-stable.yaml
+++ b/config/core/build-configs-stable.yaml
@@ -33,6 +33,10 @@ stable_variants: &stable_variants
       arm:
         base_defconfig: 'multi_v7_defconfig'
         extra_configs: ['allnoconfig']
+        filters:
+          - blocklist:
+              defconfig:
+                - 'rpc_defconfig'
       arm64:
         extra_configs: ['allnoconfig']
         fragments: [arm64-chromebook]


### PR DESCRIPTION
ARMv3 was removed in gcc-9, so there is no point trying to compile this platforms with gcc.
Fixes https://github.com/kernelci/kernelci-core/issues/1508

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>