### PR TITLE
CHROMEOS test-configs-chromeos.yaml: Exclude PstoreConsoleRamoops test

### DIFF
--- a/config/core/test-configs-chromeos.yaml
+++ b/config/core/test-configs-chromeos.yaml
@@ -106,7 +106,17 @@ test_plans:
     params:
       <<: *cros-tast-base-params
       tests: &cros-tast-kernel-tests >
-        kernel.*
+        kernel.Bloat
+        kernel.ConfigVerify
+        kernel.CPUCgroup
+        kernel.Cpuidle
+        kernel.CryptoAPI
+        kernel.CryptoDigest
+        kernel.ECDeviceNode
+        kernel.HighResTimers
+        kernel.Limits
+        kernel.LoopDeviceBehaviour
+        kernel.PerfCallgraph
 
   cros-tast-kernel_qemu:
     <<: *cros-tast-base-qemu


### PR DESCRIPTION
Test kernel.PstoreConsoleRamoops require/does system reboot, which doesn't work well in current LAVA test process workflow. We need to disable this test for now.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>