### PR TITLE
build-configs.yaml: Add more missing files for AMD Stoneyridge Chromebooks

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -292,7 +292,9 @@ fragments:
       - 'CONFIG_NFS_V4=y'
       - 'CONFIG_ROOT_NFS=y'
       - 'CONFIG_EXTRA_FIRMWARE="
+      amdgpu/raven2_asd.bin
       amdgpu/raven2_gpu_info.bin
+      amdgpu/raven2_sdma.bin
       amdgpu/stoney_ce.bin
       amdgpu/stoney_me.bin
       amdgpu/stoney_mec.bin


### PR DESCRIPTION

After adding initial file, it appeared AMD drivers require more files to operate properly.
Based on test results:
https://storage.chromeos.kernelci.org/kernelci/chromeos-stable/chromeos-stable-20221121.0/x86_64/cros---chromeos-5.15-x86_64-chromeos-amd-stoneyridge.flavour.config+x86-chromebook+CONFIG_MODULE_COMPRESS_GZIP=n/clang-14/lab-collabora/cros-tast-platform-lenovo-TPad-C13-Yoga-zork_chromeos.html https://storage.chromeos.kernelci.org/kernelci/chromeos-stable/chromeos-stable-20221121.0/x86_64/cros---chromeos-5.15-x86_64-chromeos-amd-stoneyridge.flavour.config+x86-chromebook+CONFIG_MODULE_COMPRESS_GZIP=n/clang-14/lab-collabora/cros-tast-platform-asus-CM1400CXA-dalboz_chromeos.html

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>