### PR TITLE
Add kselftest-landlock on x86 sona

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2272,6 +2272,7 @@ test_configs:
       - cros-ec
       - kselftest-alsa
       - kselftest-cpufreq
+      - kselftest-landlock
 
   - device_type: hp-x360-12b-ca0500na-n4000-octopus
     test_plans:

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -291,6 +291,12 @@ test_plans:
       kselftest_collections: "kvm"
     filters: *kselftest_no_fragment
 
+  kselftest-landlock:
+    <<: *kselftest
+    params:
+      job_timeout: '10'
+      kselftest_collections: "landlock"
+
   kselftest-lib:
     <<: *kselftest
     params:


### PR DESCRIPTION
This 2 commits intended to enable kselftest on sona (nami baseboard) Chromebook.
Related to: 
https://github.com/kernelci/kernelci-core/pull/1507
https://github.com/kernelci/kernelci-core/pull/1505
https://github.com/kernelci/kernelci-core/pull/1506