### PR TITLE
test-configs.yaml: Reduce tests on odroid-xu3

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2662,9 +2662,13 @@ test_configs:
   - device_type: odroid-xu3
     test_plans:
       - baseline
-      - baseline-nfs
-      - igt-kms-exynos
-      - kselftest-alsa
+# Only one device available in lab-collabora
+#      - baseline-nfs
+#      - igt-kms-exynos
+#      - kselftest-alsa
+    filters:
+      - passlist: {defconfig: ['defconfig']}
+
 
   - device_type: orion5x-rd88f5182-nas
     test_plans:


### PR DESCRIPTION
As only one device available in lab-collabora and it have very long queue of tests scheduled, reduce amount of tests to bare minimum

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>