### PR TITLE
config/v4l2-decoder-conformance: set decoding timeout in fluster

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1668,6 +1668,8 @@ device_types:
     class: arm64-dtb
     boot_method: depthcharge
     filters: *arm64-chromebook-filters
+    params:
+      videodec_timeout: 90
 
   rk3399-puma-haikou:
     mach: rockchip

--- a/config/lava/v4l2-decoder-conformance/v4l2-decoder-conformance.jinja2
+++ b/config/lava/v4l2-decoder-conformance/v4l2-decoder-conformance.jinja2
@@ -13,7 +13,7 @@
           - functional
         run:
           steps:
-          - python3 /usr/bin/fluster_parser.py -ts {{ testsuite }}
+          - python3 /usr/bin/fluster_parser.py -ts {{ testsuite }} -t {{ videodec_timeout|default('30') }}
       from: inline
       name: {{ plan }}
       path: inline/{{ plan }}.yaml

--- a/config/rootfs/debos/overlays/fluster/usr/bin/fluster_parser.py
+++ b/config/rootfs/debos/overlays/fluster/usr/bin/fluster_parser.py
@@ -67,12 +67,14 @@ def _load_results_file(filename):
     return ret
 
 
-def _run_fluster(test_suite=None):
+def _run_fluster(test_suite=None, timeout=None):
     cmd = ['python3', 'fluster.py', '-ne', 'run',
            '-j1', '-f', 'junitxml', '-so', RESULTS_FILE]
 
     if test_suite:
         cmd.extend(['-ts', test_suite])
+    if timeout:
+        cmd.extend(['-t', timeout])
 
     subprocess.run(cmd, cwd=FLUSTER_PATH, check=False)
 
@@ -87,7 +89,7 @@ def main(args):
         cmd = cmd.fromkeys(cmd, 'echo')
 
     # run fluster tests
-    _run_fluster(args.test_suite)
+    _run_fluster(args.test_suite, args.timeout)
 
     # load test results
     junitxml = _load_results_file(f'{FLUSTER_PATH}/{RESULTS_FILE}')
@@ -119,5 +121,6 @@ def main(args):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('-ts', '--test-suite')
+    parser.add_argument('-t', '--timeout')
     args = parser.parse_args()
     sys.exit(main(args))


### PR DESCRIPTION
Use -t option in fluster to set a timeout for each decoding. Keep 30s as default value and set a 90s timeout for `rk3399-gru-kevin`.