### PR TITLE
baseline.jinja2: Add failure_retry to test

### DIFF
--- a/config/lava/baseline/baseline.jinja2
+++ b/config/lava/baseline/baseline.jinja2
@@ -4,6 +4,7 @@
 {%- endif %}
     timeout:
       minutes: 1
+    failure_retry: 5
     definitions:
     - repository:
         metadata:
@@ -30,6 +31,7 @@
 {%- endif %}
     timeout:
       minutes: 1
+    failure_retry: 5
     definitions:
     - repository:
         metadata:

--- a/config/lava/cros-ec/cros-ec.jinja2
+++ b/config/lava/cros-ec/cros-ec.jinja2
@@ -1,6 +1,7 @@
 - test:
     timeout:
       minutes: 5
+    failure_retry: 5
     definitions:
     - repository:
         metadata:


### PR DESCRIPTION
We can try to use retry option in case of serial corruption, to improve reliability of jobs on devices with slow or unreliable serial console. It should decrease rate of false positive on baseline test failures.
For example failed test:

```
 1455 17:17:20.117173  + KERNELCI_LAVA=y /bin/sh /opt/kernelci/dmesg.sh
 1456 17:17:20.142263  <8>[   17.024549] <LAVA_SIGNAL_TESTCASE TEST_CASE_ID=crit RESULT=pass UNITS=lines MEASUREMENT=0>
 1457 17:17:20.142531  Received signal: <TESTCASE> TEST_CASE_ID=crit RESULT=pass UNITS=lines MEASUREMENT=0
 1458 17:17:20.142631  Unknown test uuid. The STARTRUN signal for this test action was not received correctly.
 1460 17:17:20.142813  end: 3.1 lava-test-shell (duration 00:00:00) [common]
 1462 17:17:20.143021  lava-test-retry failed: 1 of 1 attempts. 'Invalid TESTCASE signal'
```

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>