### PR TITLE
T39140 kernelci/config: fix YAML configuration load failure

### DIFF
--- a/kernelci/config/__init__.py
+++ b/kernelci/config/__init__.py
@@ -74,7 +74,7 @@ def load_yaml(config_path, validate_entries=None):
             elif hasattr(config_value, 'extend'):
                 config_value.extend(value)
             else:
-                config[k] = v
+                config[name] = value
     return config
 
 


### PR DESCRIPTION
Fixes https://github.com/kernelci/kernelci-core/issues/1528

Need to fix "NameError: name 'v' is not defined" from `load_yaml` function when try to load YAML configurations from a file.

Fixes: 4f9c0db2 ("kernelci.config: add _iterate_yaml_files() to simplify code")
Signed-off-by: Jeny Sadadia <jeny.sadadia@collabora.com>