### PR TITLE
Add docker image versioning

### DIFF
--- a/config/docker/kci_docker
+++ b/config/docker/kci_docker
@@ -74,7 +74,10 @@ def _dump_push_log(log):
 def main(args):
     base_name = args.prefix + args.image
     tag_strings = ([args.arch] if args.arch else []) + (args.fragment or [])
+    if args.image_version:
+        tag_strings.append(args.image_version)
     tag_name = '-'.join(tag_strings)
+
     name = ':'.join((base_name, tag_name)) if tag_name else base_name
     if args.command == 'name':
         print(name)
@@ -123,6 +126,8 @@ if __name__ == '__main__':
                         help="Docker image name, e.g. gcc-10:x86")
     parser.add_argument('--prefix', default='kernelci/',
                         help="Docker image tag prefix")
+    parser.add_argument('--image-version', '-V',
+                        help='Docker image version tag e.g. 20221011.0')
     parser.add_argument('--arch',
                         help="CPU architecture, e.g. x86")
     parser.add_argument('--fragment', action='append',

--- a/setup.py
+++ b/setup.py
@@ -80,5 +80,10 @@ setuptools.setup(
         "pytest",
         "pyyaml",
         "requests",
-    ]
+    ],
+    extras_require={
+        'dev': [
+            'pycodestyle'
+        ]
+    }
 )


### PR DESCRIPTION
**kci_docker: Enable adding version to image tag**

Introduce `--image-version/-V` to specify image version which will be added at the end of the image tag.
    
**setup.py: Add extras_require with development dependencies**
    
Define extras_require with development packages. It's now possible to use pip to install kernelci package in a regular or development version.

E.g.
```    
pip install kernelci  # install regular version
    
pip install kernelci[dev]  # install development versio
```