### PR TITLE
create_initrd_ramdisk.sh: Add script for ethernet device wait

### DIFF
--- a/config/rootfs/debos/scripts/create_initrd_ramdisk.sh
+++ b/config/rootfs/debos/scripts/create_initrd_ramdisk.sh
@@ -20,6 +20,35 @@ index 4ec926c..ca06c0b 100644
  	# Load ubi with the correct MTD partition and return since fstype
 EOF
 
+patch -p1 << 'EOF'
+--- a/usr/share/initramfs-tools/scripts/nfs-premount/wait_ethernet	1970-01-01 02:00:00.000000000 +0200
++++ b/usr/share/initramfs-tools/scripts/nfs-premount/wait_ethernet	2022-11-25 12:38:46.037498198 +0200
+@@ -0,0 +1,21 @@
++#!/bin/sh
++. /scripts/functions
++
++wait_ethernet() {
++  local netdevwait=60
++  echo "Waiting up to ${netdevwait} secs for any ethernet to become available"
++  while [ "$(time_elapsed)" -lt "$netdevwait" ]; do
++    for device in /sys/class/net/* ; do
++      if [ -f "$device/type" ]; then
++        current_type=$(cat "$device/type")
++        if [ "${current_type}" = "1" ]; then
++          echo "Device ${device} found"
++          return
++        fi
++      fi
++    done
++    sleep 1
++  done
++}
++
++wait_ethernet
+EOF
+
+chmod +x /usr/share/initramfs-tools/scripts/nfs-premount/wait_ethernet
+
 KVER=min
 
 # update-initramfs uses kernel config to decide how to compress ramdisk


### PR DESCRIPTION
If initramfs expects nfs we need to have also ethernet device to be available. In some cases network device are really slow to detect and it cases panic on ipconfig stage
Fixes https://github.com/kernelci/kernelci-core/issues/1532

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>