### PR TITLE
test-configs.yaml: Enable kselftest-tpm2 on sona

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2273,6 +2273,7 @@ test_configs:
       - kselftest-alsa
       - kselftest-cpufreq
       - kselftest-landlock
+      - kselftest-tpm2
 
   - device_type: hp-x360-12b-ca0500na-n4000-octopus
     test_plans:


### PR DESCRIPTION
The TPM chip here is the same as the one in grunt, the cr50, but on this platform the chip is accessible through a SPI bus instead of an i2c one, thus requiring different drivers.

So while the TPM operation is identical to grunt, adding the test to this platform gets us a second x86 platform running the test, as well as ensuring that the SPI driver for the cr50 works correctly.

Signed-off-by: Nícolas F. R. A. Prado <nfraprado@collabora.com>
Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>