### PR TITLE
 T39237 db/kernelci_api: drop unused method related to regression

### DIFF
--- a/kernelci/db/kernelci_api.py
+++ b/kernelci/db/kernelci_api.py
@@ -127,15 +127,6 @@ class KernelCI_API(Database):
         resp = self._get('/'.join(['get_root_node', node_id]))
         return json.loads(resp.text)
 
-    def get_regressions_by_node_id(self, node_id):
-        """ Get a list of regressions matching node_id"""
-        params = {
-            "kind": "regression",
-            "parent": node_id
-        }
-        resp = self._get('nodes', params=params)
-        return resp.json()['items']
-
     def pubsub_event_filter(self, sub_id, event):
         """Filter Pub/Sub events
 


### PR DESCRIPTION
Drop `get_regressions_by_node_id` method as it is
not needed anymore for regression tracking.

Signed-off-by: Jeny Sadadia <jeny.sadadia@collabora.com>