### PR TITLE
Force bringup of network by default

### DIFF
--- a/config/lava/base/kernel-ci-base.jinja2
+++ b/config/lava/base/kernel-ci-base.jinja2
@@ -1,4 +1,4 @@
-{% set extra_kernel_args = "console_msg_format=syslog earlycon" %}
+{% set extra_kernel_args = "console_msg_format=syslog earlycon ip=dhcp" %}
 
 {%- block metadata %}
 metadata:


### PR DESCRIPTION
For more testing, we need to force network to be up. This will permit to detect more breakage.

The easiest to achieve this is to set ip=dhcp on cmdline.

Signed-off-by: Corentin LABBE <clabbe@baylibre.com>