### PR TITLE
build-configs-stable.yaml: Add CIP 4.4-stable branches

### DIFF
--- a/config/core/build-configs-stable.yaml
+++ b/config/core/build-configs-stable.yaml
@@ -1,5 +1,8 @@
 trees:
 
+  cip:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/cip/linux-cip.git"
+
   kernelci:
     url: "https://github.com/kernelci/linux.git"
 
@@ -82,6 +85,26 @@ stable_variants_kselftest: &stable_variants_kselftest
 
 
 build_configs:
+
+  cip_stable_4.4:
+    tree: cip
+    branch: 'linux-4.4.y-st'
+    variants: *stable_variants
+
+  cip_stable_4.4-rc:
+    tree: cip
+    branch: 'linux-4.4.y-st-rc'
+    variants: *stable_variants
+
+  cip_stable_4.4-rt:
+    tree: cip
+    branch: 'linux-4.4.y-st-rt'
+    variants: *stable_variants
+
+  cip_stable_4.4-rt-rebase:
+    tree: cip
+    branch: 'linux-4.4.y-st-rt-rebase'
+    variants: *stable_variants
 
   kernelci:
     tree: kernelci


### PR DESCRIPTION
Now that 4.4.y LTS has reached EOL, the CIP project have picked up long term stable maintenance for 4.4.y.

* linux-4.4.y-st: Essentially 4.4 LTS
* linux-4.4.y-st-rc: Release candidate branch
* linux-4.4.y-st-rt: linux-4.4.y-st + PREEMPT-RT support
* linux-4.4.y-st-rt-rebase: linux-4.4.y-st-rt but with all RT patches rebased on top

This is for issue https://github.com/kernelci/kernelci-core/issues/1543