### PR TITLE
kci_test: Add missing return value of cmd_update_rootfs_urls

### DIFF
--- a/kci_test
+++ b/kci_test
@@ -183,6 +183,7 @@ class cmd_update_rootfs_urls(Command):
             output_file.write(f"# Automatically generated ({args.release})\n")
             data = {'file_systems': new_configs}
             yaml.dump(data, output_file, default_flow_style=False)
+        return True
 
 
 class cmd_list_jobs(Command):


### PR DESCRIPTION
Missing return value from the __call__ method of cmd_update_rootfs_urls class was causing kci_test update_rootfs_urls command exiting with 1 instead of 0.
This commit adds return value for the method.
