### PR TITLE
Revert "config/docker: Add missing yaml/requests python dependency"

### DIFF
--- a/config/docker/base/debos.jinja2
+++ b/config/docker/base/debos.jinja2
@@ -31,8 +31,6 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     qemu-system-x86 \
     qemu-user-static \
     systemd-container \
-    python3-requests \
-    python3-yaml \
     xz-utils
 
 # Jenkins hacks


### PR DESCRIPTION
This reverts commit 8d79b262ab977655a69734cf450bc8e2ac73ce5e.

kernelci package which includes the kci_* command line tools is now part of the kernelci fragment added on top of the base debos image and pushed with the "kernelci" tag to the docker hub. PyYAML and requests packages are no longer needed as a part of the base debos image.

To use kci_* tools from the debos docker image use kernelci/debos:kernelci image instead of the vanilla one.

Signed-off-by: Michal Galka <michal.galka@collabora.com>