### PR TITLE
docker/rustc: update bindgen to 0.63.0

### DIFF
--- a/config/docker/rustc-1.62.jinja2
+++ b/config/docker/rustc-1.62.jinja2
@@ -4,7 +4,7 @@
 {{ super() }}
 
 ARG RUST_VER=1.62.0
-ARG BINDGEN_VER=0.56.0
+ARG BINDGEN_VER=0.63.0
 
 ARG RUST_TRIPLE=rust-${RUST_VER}-x86_64-unknown-linux-gnu
 


### PR DESCRIPTION
This PR for been merged depend on the following PR
https://github.com/Rust-for-Linux/linux/pull/931


Signed-off-by: Alice Ferrazzi <alice.ferrazzi@miraclelinux.com>