### PR TITLE
build-configs: add rust next trees

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -921,6 +921,13 @@ build_configs:
         architectures:
           <<: *arch_clang_configs
 
+      rustc-1.62:
+        build_environment: rustc-1.62
+        fragments: [rust, rust-samples, kselftest]
+        architectures:
+          x86_64:
+            base_defconfig: 'x86_64_defconfig'
+
   next_pending-fixes:
     tree: next
     branch: 'pending-fixes'
@@ -1029,6 +1036,17 @@ build_configs:
       rustc-1.62:
         build_environment: rustc-1.62
         fragments: [rust, rust-for-linux-samples, kselftest]
+        architectures:
+          x86_64:
+            base_defconfig: 'x86_64_defconfig'
+
+  rust-for-linux_rust-next:
+    tree: rust-for-linux
+    branch: 'rust-next'
+    variants:
+      rustc-1.62:
+        build_environment: rustc-1.62
+        fragments: [rust, rust-samples, kselftest]
         architectures:
           x86_64:
             base_defconfig: 'x86_64_defconfig'

--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -1029,7 +1029,7 @@ build_configs:
     branch: 'v5.15-rt'
     variants: *preempt_rt_variants
 
-  rust-for-linux:
+  rust-for-linux_rust:
     tree: rust-for-linux
     branch: 'rust'
     variants:


### PR DESCRIPTION
commit 58f7ecbe7574fb1071ac8c92ec645c7ff3402f41                                                                                           
Author: Adrian Ratiu <adrian.ratiu@collabora.com>
Date:   Fri Dec 2 16:03:03 2022 +0200

    build-configs: add rust next trees
    
    This adds a rust build to the linux-next integration tree as well
    as the maintainer 'rust-next' tree.
    
    Suggested-by: Guillaume Tucker <guillaume.tucker@collabora.com>
    Signed-off-by: Adrian Ratiu <adrian.ratiu@collabora.com>