### PR TITLE
build-configs.yaml: Block haps_hs_smp_defconfig builds from old kernels

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -468,6 +468,8 @@ build_configs_defaults:
                   - 'nsim_700_defconfig'
                   - 'nsimosci_defconfig'
                   - 'tb10x_defconfig'
+            # haps_hs_smp_defconfig not available in some old kernels
+                kernel: ['v3.', 'v4.4', 'v4.9']
 
         arm: &arm_arch
           base_defconfig: 'multi_v7_defconfig'


### PR DESCRIPTION
Right now attempt to build this config in kernel 4.9 and older causes error and noise in reports:
```
*** Can't find default configuration "arch/arc/configs/haps_hs_smp_defconfig"!
```
Add blocklist entry to not build this config in too old kernels.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>