### PR TITLE
Add support for jh7100-starfive-visionfive-v1

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1117,6 +1117,12 @@ device_types:
       - blocklist: *device_config_filter
       - blocklist: {defconfig: ['multi_v7_defconfig+kselftest']}
 
+  jh7100-starfive-visionfive-v1:
+    mach: starfive
+    class: riscv-dtb
+    boot_method: uboot
+    dtb: 'starfive/jh7100-starfive-visionfive-v1.dtb'
+
   juno-uboot:
     mach: vexpress
     class: arm64-dtb
@@ -2449,6 +2455,10 @@ test_configs:
     test_plans:
       - baseline
       - baseline-nfs
+
+  - device_type: jh7100-starfive-visionfive-v1
+    test_plans:
+      - baseline
 
   - device_type: juno-uboot
     test_plans:


### PR DESCRIPTION
jh7100-starfive-visionfive-v1 is a RISCV board which is now supported and can be booted from mainline since a few days (but only from linux-next for today).
LAVA already have support for it https://git.lavasoftware.org/lava/lava/-/merge_requests/1878

Signed-off-by: Corentin LABBE <clabbe@baylibre.com>