### PR TITLE
debos: create init link for full rootfs

### DIFF
--- a/config/rootfs/debos/rootfs.yaml
+++ b/config/rootfs/debos/rootfs.yaml
@@ -116,6 +116,11 @@ actions:
     command: rm /usr/lib/tmpfiles.d/dbus.conf
 
   - action: run
+    description: Set symbolic link to init
+    chroot: true
+    command: ln -s /usr/bin/systemd /init
+
+  - action: run
     description: Create full archive
     chroot: false
     command: cd ${ROOTDIR} ; tar cvfJ  ${ARTIFACTDIR}/{{ $basename -}}/full.rootfs.tar.xz .
@@ -186,11 +191,6 @@ actions:
         done
       done
 {{ end }}
-
-  - action: run
-    description: Set symbolic link to init
-    chroot: true
-    command: ln -s /usr/bin/systemd /init
 
   - action: run
     description: Create cpio archive


### PR DESCRIPTION
Current full rootfs lack an init link and so are unbootable. The init link is create after full rootfs are generated but before the minimal ones. Move the init link creation before full rootfs are generated.

Signed-off-by: Corentin LABBE <clabbe@baylibre.com>