### PR TITLE
duplicate testplans for riscv

### DIFF
--- a/config/core/rootfs-images.yaml
+++ b/config/core/rootfs-images.yaml
@@ -99,6 +99,13 @@ file_systems:
     ramdisk: sid-kselftest/20221125.0/{arch}/initrd.cpio.gz
     root_type: nfs
     type: debian
+  debian_sid-kselftest_ramdisk:
+    boot_protocol: tftp
+    params: {}
+    prompt: '/ #'
+    ramdisk: sid-kselftest/20221125.0/{arch}/rootfs.cpio.gz
+    root_type: ramdisk
+    type: debian
   debian_sid-ltp_nfs:
     boot_protocol: tftp
     nfs: sid-ltp/20221125.0/{arch}/full.rootfs.tar.xz

--- a/config/core/rootfs-images.yaml
+++ b/config/core/rootfs-images.yaml
@@ -90,3 +90,20 @@ file_systems:
     ramdisk: bullseye/20221125.0/{arch}/rootfs.cpio.gz
     root_type: ramdisk
     type: debian
+  debian_sid-kselftest_nfs:
+    boot_protocol: tftp
+    nfs: sid-kselftest/20221125.0/{arch}/full.rootfs.tar.xz
+    params:
+      os_config: debian
+    prompt: '/ #'
+    ramdisk: sid-kselftest/20221125.0/{arch}/initrd.cpio.gz
+    root_type: nfs
+    type: debian
+  debian_sid-ltp_nfs:
+    boot_protocol: tftp
+    nfs: sid-ltp/20221125.0/{arch}/full.rootfs.tar.xz
+    params: {}
+    prompt: '/ #'
+    ramdisk: sid-ltp/20221125.0/{arch}/initrd.cpio.gz
+    root_type: nfs
+    type: debian

--- a/config/core/rootfs-images.yaml
+++ b/config/core/rootfs-images.yaml
@@ -107,3 +107,10 @@ file_systems:
     ramdisk: sid-ltp/20221125.0/{arch}/initrd.cpio.gz
     root_type: nfs
     type: debian
+  debian_sid-ltp_ramdisk:
+    boot_protocol: tftp
+    params: {}
+    prompt: '/ #'
+    ramdisk: sid-ltp/20221125.0/{arch}/rootfs.cpio.gz
+    root_type: ramdisk
+    type: debian

--- a/config/core/test-configs-riscv.yaml
+++ b/config/core/test-configs-riscv.yaml
@@ -15,8 +15,27 @@ test_plans:
     filters:
       - passlist: {defconfig: ['kselftest']}
 
+  kselftest-all_riscv_qemu: &kselftest_riscv_qemu
+    rootfs: debian_sid-kselftest_ramdisk
+    pattern: 'kselftest/{category}-{method}-{rootfs}-kselftest-template.jinja2'
+    filters:
+      - passlist: {defconfig: ['kselftest']}
+      - passlist: &qemu_labs_filter
+          lab:
+            - 'lab-baylibre'
+            - 'lab-broonie'
+            - 'lab-collabora'
+            - 'lab-collabora-staging'
+
   kselftest-cgroup_riscv:
     <<: *kselftest_riscv
+    base_name: kselftest-cgroup
+    params:
+      job_timeout: '10'
+      kselftest_collections: "cgroup"
+
+  kselftest-cgroup_riscv_qemu:
+    <<: *kselftest_riscv_qemu
     base_name: kselftest-cgroup
     params:
       job_timeout: '10'
@@ -29,8 +48,22 @@ test_plans:
       job_timeout: '10'
       kselftest_collections: "filesystems"
 
+  kselftest-filesystems_riscv_qemu:
+    <<: *kselftest_riscv_qemu
+    base_name: kselftest-filesystems
+    params:
+      job_timeout: '10'
+      kselftest_collections: "filesystems"
+
   kselftest-futex_riscv:
     <<: *kselftest_riscv
+    base_name: kselftest-futex
+    params:
+      job_timeout: '10'
+      kselftest_collections: "futex"
+
+  kselftest-futex_riscv_qemu:
+    <<: *kselftest_riscv_qemu
     base_name: kselftest-futex
     params:
       job_timeout: '10'
@@ -43,8 +76,22 @@ test_plans:
       job_timeout: '10'
       kselftest_collections: "kcmp"
 
+  kselftest-kcmp_riscv_qemu:
+    <<: *kselftest_riscv_qemu
+    base_name: kselftest-kcmp
+    params:
+      job_timeout: '10'
+      kselftest_collections: "kcmp"
+
   kselftest-membarrier_riscv:
     <<: *kselftest_riscv
+    base_name: kselftest-membarrier
+    params:
+      job_timeout: '10'
+      kselftest_collections: "membarrier"
+
+  kselftest-membarrier_riscv_qemu:
+    <<: *kselftest_riscv_qemu
     base_name: kselftest-membarrier
     params:
       job_timeout: '10'
@@ -57,8 +104,22 @@ test_plans:
       job_timeout: '10'
       kselftest_collections: "mincore"
 
+  kselftest-mincore_riscv_qemu:
+    <<: *kselftest_riscv_qemu
+    base_name: kselftest-mincore
+    params:
+      job_timeout: '10'
+      kselftest_collections: "mincore"
+
   kselftest-timers_riscv:
     <<: *kselftest_riscv
+    base_name: kselftest-timers
+    params:
+      job_timeout: '15'
+      kselftest_collections: "timers"
+
+  kselftest-timers_riscv_qemu:
+    <<: *kselftest_riscv_qemu
     base_name: kselftest-timers
     params:
       job_timeout: '15'
@@ -82,12 +143,7 @@ test_plans:
     pattern: 'ltp/{category}-{method}-{rootfs}-ltp-template.jinja2'
     filters:
       - blocklist: *kselftest_defconfig_filter
-      - passlist: &qemu_labs_filter
-          lab:
-            - 'lab-baylibre'
-            - 'lab-broonie'
-            - 'lab-collabora'
-            - 'lab-collabora-staging'
+      - passlist: *qemu_labs_filter
     params:
       <<: *ltp-params_riscv
 

--- a/config/core/test-configs-riscv.yaml
+++ b/config/core/test-configs-riscv.yaml
@@ -76,6 +76,21 @@ test_plans:
       job_timeout: '15'
       skipfile: skipfile-lkft.yaml
 
+  ltp-all_riscv_qemu: &ltp_riscv_qemu
+    base_name: ltp
+    rootfs: debian_sid-ltp_ramdisk
+    pattern: 'ltp/{category}-{method}-{rootfs}-ltp-template.jinja2'
+    filters:
+      - blocklist: *kselftest_defconfig_filter
+      - passlist: &qemu_labs_filter
+          lab:
+            - 'lab-baylibre'
+            - 'lab-broonie'
+            - 'lab-collabora'
+            - 'lab-collabora-staging'
+    params:
+      <<: *ltp-params_riscv
+
   ltp-crypto_riscv:
     <<: *ltp_riscv
     base_name: ltp-crypto
@@ -94,8 +109,22 @@ test_plans:
       <<: *ltp-params_riscv
       tst_cmdfiles: "fcntl-locktests"
 
+  ltp-fcntl-locktests_riscv_qemu:
+    <<: *ltp_riscv_qemu
+    base_name: ltp-fcntl-locktests
+    params:
+      <<: *ltp-params_riscv
+      tst_cmdfiles: "fcntl-locktests"
+
   ltp-ipc_riscv:
     <<: *ltp_riscv
+    base_name: ltp-ipc
+    params:
+      <<: *ltp-params_riscv
+      tst_cmdfiles: "ipc"
+
+  ltp-ipc_riscv_qemu:
+    <<: *ltp_riscv_qemu
     base_name: ltp-ipc
     params:
       <<: *ltp-params_riscv
@@ -110,10 +139,29 @@ test_plans:
       job_timeout: '25'
       priority: 0
 
+  ltp-pty_riscv_qemu:
+    <<: *ltp_riscv_qemu
+    base_name: ltp-pty
+    params:
+      <<: *ltp-params_riscv
+      tst_cmdfiles: "pty"
+      job_timeout: '25'
+      priority: 0
+
   ltp-timers_riscv:
     <<: *ltp_riscv
     base_name: ltp-timers
     pattern: 'ltp/{category}-{method}-{protocol}-{rootfs}-ltp-open-posix-template.jinja2'
+    params:
+      <<: *ltp-params_riscv
+      grp_test: "TMR"
+      job_timeout: '30'
+      priority: 0
+
+  ltp-timers_riscv_qemu:
+    <<: *ltp_riscv_qemu
+    base_name: ltp-timers
+    pattern: 'ltp/{category}-{method}-{rootfs}-ltp-open-posix-template.jinja2'
     params:
       <<: *ltp-params_riscv
       grp_test: "TMR"

--- a/config/core/test-configs-riscv.yaml
+++ b/config/core/test-configs-riscv.yaml
@@ -1,0 +1,121 @@
+default_filters:
+
+  test_plans:
+
+    - blocklist: &kselftest_defconfig_filter
+        defconfig: ['kselftest']
+
+
+test_plans:
+
+  kselftest-all_riscv: &kselftest_riscv
+    base_name: kselftest
+    rootfs: debian_sid-kselftest_nfs
+    pattern: 'kselftest/{category}-{method}-{protocol}-{rootfs}-kselftest-template.jinja2'
+    filters:
+      - passlist: {defconfig: ['kselftest']}
+
+  kselftest-cgroup_riscv:
+    <<: *kselftest_riscv
+    base_name: kselftest-cgroup
+    params:
+      job_timeout: '10'
+      kselftest_collections: "cgroup"
+
+  kselftest-filesystems_riscv:
+    <<: *kselftest_riscv
+    base_name: kselftest-filesystems
+    params:
+      job_timeout: '10'
+      kselftest_collections: "filesystems"
+
+  kselftest-futex_riscv:
+    <<: *kselftest_riscv
+    base_name: kselftest-futex
+    params:
+      job_timeout: '10'
+      kselftest_collections: "futex"
+
+  kselftest-kcmp_riscv:
+    <<: *kselftest_riscv
+    base_name: kselftest-kcmp
+    params:
+      job_timeout: '10'
+      kselftest_collections: "kcmp"
+
+  kselftest-membarrier_riscv:
+    <<: *kselftest_riscv
+    base_name: kselftest-membarrier
+    params:
+      job_timeout: '10'
+      kselftest_collections: "membarrier"
+
+  kselftest-mincore_riscv:
+    <<: *kselftest_riscv
+    base_name: kselftest-mincore
+    params:
+      job_timeout: '10'
+      kselftest_collections: "mincore"
+
+  kselftest-timers_riscv:
+    <<: *kselftest_riscv
+    base_name: kselftest-timers
+    params:
+      job_timeout: '15'
+      kselftest_collections: "timers"
+
+  ltp-all_riscv: &ltp_riscv
+    base_name: ltp
+    rootfs: debian_sid-ltp_nfs
+    pattern: 'ltp/{category}-{method}-{protocol}-{rootfs}-ltp-template.jinja2'
+    filters:
+      - blocklist: *kselftest_defconfig_filter
+    params: &ltp-params_riscv
+      skip_install: "true"
+      tst_cmdfiles: ""
+      job_timeout: '15'
+      skipfile: skipfile-lkft.yaml
+
+  ltp-crypto_riscv:
+    <<: *ltp_riscv
+    base_name: ltp-crypto
+    params:
+      <<: *ltp-params_riscv
+      tst_cmdfiles: "crypto"
+    filters:
+      - passlist:
+          defconfig:
+            - '+crypto'
+
+  ltp-fcntl-locktests_riscv:
+    <<: *ltp_riscv
+    base_name: ltp-fcntl-locktests
+    params:
+      <<: *ltp-params_riscv
+      tst_cmdfiles: "fcntl-locktests"
+
+  ltp-ipc_riscv:
+    <<: *ltp_riscv
+    base_name: ltp-ipc
+    params:
+      <<: *ltp-params_riscv
+      tst_cmdfiles: "ipc"
+
+  ltp-pty_riscv:
+    <<: *ltp_riscv
+    base_name: ltp-pty
+    params:
+      <<: *ltp-params_riscv
+      tst_cmdfiles: "pty"
+      job_timeout: '25'
+      priority: 0
+
+  ltp-timers_riscv:
+    <<: *ltp_riscv
+    base_name: ltp-timers
+    pattern: 'ltp/{category}-{method}-{protocol}-{rootfs}-ltp-open-posix-template.jinja2'
+    params:
+      <<: *ltp-params_riscv
+      grp_test: "TMR"
+      job_timeout: '30'
+      priority: 0

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2233,6 +2233,18 @@ test_configs:
   - device_type: hifive-unleashed-a00
     test_plans:
       - baseline
+      - kselftest-cgroup_riscv
+      - kselftest-filesystems_riscv
+      - kselftest-futex_riscv
+      - kselftest-kcmp_riscv
+      - kselftest-membarrier_riscv
+      - kselftest-mincore_riscv
+      - kselftest-timers_riscv
+      - ltp-crypto_riscv
+      - ltp-fcntl-locktests_riscv
+      - ltp-ipc_riscv
+      - ltp-pty_riscv
+      - ltp-timers_riscv
 
   - device_type: hip07-d05
     test_plans:

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2793,6 +2793,13 @@ test_configs:
   - device_type: qemu_riscv64
     test_plans:
       - baseline_qemu
+      - kselftest-cgroup_riscv_qemu
+      - kselftest-filesystems_riscv_qemu
+      - kselftest-futex_riscv_qemu
+      - kselftest-kcmp_riscv_qemu
+      - kselftest-membarrier_riscv_qemu
+      - kselftest-mincore_riscv_qemu
+      - kselftest-timers_riscv_qemu
       - ltp-fcntl-locktests_riscv_qemu
       - ltp-ipc_riscv_qemu
       - ltp-pty_riscv_qemu

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2793,6 +2793,10 @@ test_configs:
   - device_type: qemu_riscv64
     test_plans:
       - baseline_qemu
+      - ltp-fcntl-locktests_riscv_qemu
+      - ltp-ipc_riscv_qemu
+      - ltp-pty_riscv_qemu
+      - ltp-timers_riscv_qemu
 
   - device_type: qemu_x86_64
     test_plans:

--- a/config/lava/kselftest/generic-qemu-ramdisk-kselftest-template.jinja2
+++ b/config/lava/kselftest/generic-qemu-ramdisk-kselftest-template.jinja2
@@ -1,0 +1,11 @@
+{% extends 'boot/generic-qemu-boot-template.jinja2' %}
+{% block actions %}
+{{ super () }}
+
+{% include 'kselftest/kselftest.jinja2' %}
+
+{% endblock %}
+
+{%- block image_arg %}
+        image_arg: '-kernel {kernel} -append "console={{ console_dev }},115200 root=/dev/ram0 debug verbose {{ extra_kernel_args }}"'
+{%- endblock %}

--- a/config/lava/ltp/generic-qemu-ramdisk-ltp-template.jinja2
+++ b/config/lava/ltp/generic-qemu-ramdisk-ltp-template.jinja2
@@ -1,0 +1,12 @@
+{% extends 'boot/generic-qemu-boot-template.jinja2' %}
+{% block actions %}
+{{ super () }}
+
+{% include 'ltp/ltp.jinja2' %}
+
+{% endblock %}
+
+{%- block image_arg %}
+        image_arg: '-kernel {kernel} -append "console={{ console_dev }},115200 root=/dev/ram0 debug verbose {{ extra_kernel_args }}"'
+{%- endblock %}
+


### PR DESCRIPTION
Duplicating the test plans that are planned to be run on the hifive-unleased platform.
In the future, more or less the same will be added for the qemu_riscv64 platform.

This approach has the advantage of being easily "revertable" when riscv is finally supported by the stable debian and it does not change the kernelci internal logic.

Note that the riscv64 test plan success depends on https://github.com/kernelci/kernelci-core/pull/1467

Also I ignored the CI checks failing due to the test plans not being in an alphabetical order, prefering to group the riscv test plans.

This PR follows https://github.com/kernelci/kernelci-core/pull/1478 