### PR TITLE
Revert "build.py: Add printout of HTTP error code during last commit …

### DIFF
--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -87,8 +87,6 @@ def get_last_commit(config, storage):
         file_name=_get_last_commit_file_name(config))
     last_commit_resp = requests.get(last_commit_url)
     if last_commit_resp.status_code != 200:
-        print(f'get_last_commit(): Failed to retrieve the last commit.'
-              'HTTP code: {last_commit_resp.status_code}')
         return False
     return last_commit_resp.text.strip()
 


### PR DESCRIPTION
…retrieval"

This reverts commit 7a1fd0182ab73a476d72e750a3269d6e668975b5.

This commit introduced some error message which gets interpreted as the git sha1, causing the Jenkins monitor jobs to fail with new build configurations that don't have a tree on the production storage yet.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>