### PR TITLE
Revert "build.py: Add printout of HTTP error code during last commit retrieval

### DIFF
--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -87,8 +87,6 @@ def get_last_commit(config, storage):
         file_name=_get_last_commit_file_name(config))
     last_commit_resp = requests.get(last_commit_url)
     if last_commit_resp.status_code != 200:
-        print(f'get_last_commit(): Failed to retrieve the last commit.'
-              'HTTP code: {last_commit_resp.status_code}')
         return False
     return last_commit_resp.text.strip()
 


### PR DESCRIPTION
This reverts commit 839b2d5aba9f0b11589fbcbe52d70a7d4a20211d. Jenkins expect to see sha1 only, it doesn't expect any error message.