### PR TITLE
Misc rust build fixes

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -834,6 +834,12 @@ build_configs:
       clang-15:
         build_environment: clang-15
         architectures: *arch_clang_configs
+      rustc-1.62:
+        build_environment: rustc-1.62
+        fragments: [rust, rust-samples, kselftest]
+        architectures:
+          x86_64:
+            base_defconfig: 'x86_64_defconfig'
 
   matthiasbgg-for-next:
     tree: matthiasbgg
@@ -1007,16 +1013,6 @@ build_configs:
     branch: 'v5.15-rt'
     variants: *preempt_rt_variants
 
-  rust:
-    tree: mainline
-    branch: 'master'
-    variants:
-      rustc-1.62:
-        build_environment: rustc-1.62
-        fragments: [rust, rust-samples, kselftest]
-        architectures:
-          x86_64: *x86_64_arch
-
   rust-for-linux:
     tree: rust-for-linux
     branch: 'rust'
@@ -1025,7 +1021,8 @@ build_configs:
         build_environment: rustc-1.62
         fragments: [rust, rust-for-linux-samples, kselftest]
         architectures:
-          x86_64: *x86_64_arch
+          x86_64:
+            base_defconfig: 'x86_64_defconfig'
 
   samsung:
     tree: samsung

--- a/config/docker/rustc-1.62.jinja2
+++ b/config/docker/rustc-1.62.jinja2
@@ -36,4 +36,8 @@ RUN git clone --recurse-submodules --branch $RUST_VER \
 
 RUN cargo install --locked --version ${BINDGEN_VER} bindgen
 
+# kernel build generates some rust code and tries to format it, if rustfmt is
+# missing it will print non-fatal error noise
+RUN cargo install rustfmt
+
 {%- endblock %}

--- a/config/docker/rustc-1.62.jinja2
+++ b/config/docker/rustc-1.62.jinja2
@@ -24,11 +24,11 @@ RUN tar -xf ${RUST_TRIPLE}.tar.gz  -C /tmp/ && \
     rm -rf /tmp/${RUST_TRIPLE} && \
     rm /${RUST_TRIPLE}*
 
-# This image is based on clang-*jinja2 which only has clang installed but rustc
-# defaults to linker "cc" which calls the non-existing GNU stack (gcc, libgcc).
-# So we point cargo/rustc to use the LLVM stack via the clang linker entrypoint.
-RUN mkdir -p ${CARGO_HOME} && \
-    printf '[build]\nrustflags = ["-C", "linker=clang"]' > ${CARGO_HOME}/config.toml
+# This image is based on clang-*jinja2 which only has clang installed, but rustc
+# defaults to linker "cc" which usually points to the GNU/GCC stack. Pointing cc
+# to clang ensures both cargo and kernel build rustc invocations use llvm/clang.
+RUN update-alternatives --install /usr/bin/cc cc $(which clang) 30 && \
+    update-alternatives --set cc $(which clang)
 
 RUN git clone --recurse-submodules --branch $RUST_VER \
         https://github.com/rust-lang/rust \


### PR DESCRIPTION
commit 7d846c58ce8d82552372213a955bbe9c2fd309fa
Author: Adrian Ratiu <adrian.ratiu@collabora.com>
Date:   Tue Dec 6 15:15:02 2022 +0200

    build-configs: move rust builds under mainline cfg
    
    PR #1468 added the mainline rust build in a separate
    `rust` build configuration instead of adding to the
    already existing mainline config which can cause
    unnecessary builds. Move it in the proper place.
    
    While at it also change the x86_64_arch anchor to
    build just the base x86_64_defconfig to avoid
    unnecessary allmodconfig rebuilds.
    
    Fixes: 43875d0e47f2 ("config: add rust build configurations")
    Suggested-by: Guillaume Tucker <guillaume.tucker@collabora.com>
    Reviewed-by: Miguel Ojeda <ojeda@kernel.org>
    Reviewed-by: Alice Ferrazzi <alice.ferrazzi@miraclelinux.com>
    Signed-off-by: Adrian Ratiu <adrian.ratiu@collabora.com>

commit f5b5769d8de3e4047365fb4676d2c07a8c0ad009
Author: Adrian Ratiu <adrian.ratiu@collabora.com>
Date:   Tue Dec 6 14:43:35 2022 +0200

    config/docker: ensure rustc always uses cc = clang
    
    Even though the cargo rustc invocations got pointed
    to clang via config.toml, the kernel builds can still
    do some rustc invocations outside cargo which would
    fail because cc is not properly set.
    
    Fixes: 43875d0e47f2 ("config: add rust build configurations")
    Reviewed-by: Miguel Ojeda <ojeda@kernel.org>
    Reviewed-by: Alice Ferrazzi <alice.ferrazzi@miraclelinux.com>
    Signed-off-by: Adrian Ratiu <adrian.ratiu@collabora.com>

commit 937c587f1a154083adabd5d47318700250a13250
Author: Adrian Ratiu <adrian.ratiu@collabora.com>
Date:   Tue Dec 6 14:38:22 2022 +0200

    config/docker: add rustfmt to rust images
    
    While testing rust-enabled kernel builds it was noticed that
    some non-fatal errors are printed due to missing rustfmt
    because the build generates code and tries to format it:
    
      BINDGEN rust/bindings/bindings_generated.rs
      BINDGEN rust/bindings/bindings_helpers_generated.rs
    Failed to run rustfmt: No such file or directory (os error 2) (non-fatal, continuing)
      RUSTC L rust/core.o
    Failed to run rustfmt: No such file or directory (os error 2) (non-fatal, continuing)
    
    Silence these by installing rustfmt.
    
    Reviewed-by: Reviewed-by: Miguel Ojeda <ojeda@kernel.org>
    Reviewed-by: Alice Ferrazzi <alice.ferrazzi@miraclelinux.com>
    Signed-off-by: Adrian Ratiu <adrian.ratiu@collabora.com>