### PR TITLE
build-configs.yaml: Add missing firmware files for zork

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -332,8 +332,17 @@ fragments:
       - 'CONFIG_ROOT_NFS=y'
       - 'CONFIG_EXTRA_FIRMWARE="
       amdgpu/raven2_asd.bin
+      amdgpu/raven2_ce.bin
       amdgpu/raven2_gpu_info.bin
+      amdgpu/raven2_me.bin
+      amdgpu/raven2_mec2.bin
+      amdgpu/raven2_mec.bin
+      amdgpu/raven2_pfp.bin
+      amdgpu/raven2_rlc.bin
       amdgpu/raven2_sdma.bin
+      amdgpu/raven2_ta.bin
+      amdgpu/raven2_vcn.bin
+      amdgpu/raven_kicker_rlc.bin
       amdgpu/stoney_ce.bin
       amdgpu/stoney_me.bin
       amdgpu/stoney_mec.bin


### PR DESCRIPTION
It seems AMD GPU fetch many small firmware files that are hard to know/find list, so i had to build kernel again and again, to figure out list required for particular Chromebook lenovo-TPad-C13-Yoga-zork. Expected outcome that Tast tests finally will run properly on Chromebooks with AMD Raven chipset.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>