### PR TITLE
Allow configuration to be loaded from multiple sources

### DIFF
--- a/kci_bisect
+++ b/kci_bisect
@@ -62,6 +62,6 @@ class cmd_get_mbox(Command):
 
 if __name__ == '__main__':
     opts = parse_opts("kci_bisect", globals())
-    configs = kernelci.config.load(opts.yaml_config)
+    configs = kernelci.config.load_all(opts.get_yaml_configs())
     status = opts.command(configs, opts)
     sys.exit(0 if status is True else 1)

--- a/kci_build
+++ b/kci_build
@@ -447,6 +447,6 @@ class cmd_pull_tarball(Command):
 
 if __name__ == '__main__':
     opts = parse_opts("kci_build", globals())
-    configs = kernelci.config.load(opts.yaml_config)
+    configs = kernelci.config.load_all(opts.get_yaml_configs())
     status = opts.command(configs, opts)
     sys.exit(0 if status is True else 1)

--- a/kci_data
+++ b/kci_data
@@ -99,6 +99,6 @@ class cmd_submit_test(Command):
 
 if __name__ == '__main__':
     opts = parse_opts("kci_data", globals())
-    configs = kernelci.config.load(opts.yaml_config)
+    configs = kernelci.config.load_all(opts.get_yaml_configs())
     status = opts.command(configs, opts)
     sys.exit(0 if status is True else 1)

--- a/kci_rootfs
+++ b/kci_rootfs
@@ -142,6 +142,6 @@ class cmd_upload(Command):
 
 if __name__ == '__main__':
     opts = parse_opts("kci_rootfs", globals())
-    configs = kernelci.config.load(opts.yaml_config)
+    configs = kernelci.config.load_all(opts.get_yaml_configs())
     status = opts.command(configs, opts)
     sys.exit(0 if status is True else 1)

--- a/kci_test
+++ b/kci_test
@@ -389,6 +389,6 @@ class cmd_submit(Command):
 
 if __name__ == '__main__':
     opts = parse_opts("kci_test", globals())
-    configs = kernelci.config.load(opts.yaml_config)
+    configs = kernelci.config.load_all(opts.get_yaml_configs())
     status = opts.command(configs, opts)
     sys.exit(0 if status is True else 1)

--- a/kernelci/cli.py
+++ b/kernelci/cli.py
@@ -495,6 +495,10 @@ class Options:
                 missing_args.append(arg_name)
         return missing_args
 
+    def get_yaml_configs(self):
+        """Get a list of all the YAML configuration files."""
+        return [self._cli_args.yaml_config] + self._cli_args.extra_config
+
 
 def make_parser(title, default_config_path):
     """Helper to make a parser object from argparse.
@@ -503,10 +507,21 @@ def make_parser(title, default_config_path):
     *default_config_path* is the default YAML config directory to use
     """
     parser = argparse.ArgumentParser(title)
-    parser.add_argument("--yaml-config", default=default_config_path,
-                        help="Path to the directory with YAML config files")
-    parser.add_argument("--settings",
-                        help="Path to the settings file")
+    parser.add_argument(
+        "--yaml-config",
+        default=default_config_path,
+        help="Path to the Kernel CI directory with YAML config files",
+    )
+    parser.add_argument(
+        "--extra-config",
+        action='append',
+        default=list(),
+        help="Path to additional YAML site config files",
+    )
+    parser.add_argument(
+        "--settings",
+        help="Path to the settings file",
+    )
     return parser
 
 

--- a/kernelci/config/__init__.py
+++ b/kernelci/config/__init__.py
@@ -63,7 +63,9 @@ def load_yaml(config_path, validate_entries=None):
     will be merged together under the same top-level dictionary key.
 
     *config_path* is the path to the YAML config directory, or alternative a
-                  single YAML file
+                  single YAML file.
+
+    *validate_entries* is currently unused.
     """
     config = dict()
     for yaml_path, data in _iterate_yaml_files(config_path):
@@ -75,6 +77,64 @@ def load_yaml(config_path, validate_entries=None):
                 config_value.extend(value)
             else:
                 config[k] = v
+    return config
+
+
+def _merge_trees(old, update):
+    """Merge two values loaded from YAML
+
+    This combines two values recursively that have been loaded from
+    YAML.  The data from *update* will be overlaid onto *old*
+    according to the rules:
+
+    - If *old* and *update* are dictionaries, their keys will be
+      unified, with the values for any keys present in both
+      dictionaries being merged recursively.
+
+    - If *old* and *update* are lists, the result is the concatenation
+      of the two lists.
+
+    - Otherwise, *update* replaces *old*.
+
+    Neither *old* nor *update* is modified; any modifications required
+    lead to a new value being returned.
+
+    """
+    if isinstance(old, dict) and isinstance(update, dict):
+        res = dict()
+        for k in (set(old) | set(update)):
+            if (k in old) and (k in update):
+                res[k] = _merge_trees(old[k], update[k])
+            elif k in old:
+                res[k] = old[k]
+            else:
+                res[k] = update[k]
+        return res
+    elif isinstance(old, list) and isinstance(update, list):
+        return old + update
+    else:
+        return update
+
+
+def load_all_yaml(config_paths, validate_entries=None):
+    """Load the YAML configuration
+
+    Load all the YAML files in all the specific configuration
+    directories and aggregate them together. Later directories take
+    precedence over earlier ones. This enables combining sources of
+    configuration data from multiple places.
+
+    *config_paths* is an ordered list of YAML configuration
+                   directories or YAML files, with later entries
+                   having higher priority.
+
+    *validate_entries* is passed to `load_yaml()`
+
+    """
+    config = dict()
+    for path in config_paths:
+        data = load_yaml(path, validate_entries)
+        config = _merge_trees(config, data)
     return config
 
 
@@ -102,9 +162,27 @@ def load(config_path):
     Load all the YAML files found in the configuration directory then create
     a dictionary containing the configuration objects and return it.
 
-    *config_path* is the path to the YAML config directory
+    *config_path* is the path to the YAML config directory or a
+    unified file
+
     """
     if config_path is None:
         return {}
     data = load_yaml(config_path)
+    return from_data(data)
+
+
+def load_all(config_paths):
+    """Load the configuration from YAML files
+
+    Load all the YAML files found in all the configuration
+    directories, then create a dictionary containing the configuration
+    objects and return it. Note that the config paths are in priority
+    order, with later entries overriding earlier ones.
+
+    *config_paths* is a list of YAML config directories (or unified
+     files)
+
+    """
+    data = load_all_yaml(config_paths)
     return from_data(data)

--- a/kernelci/config/__init__.py
+++ b/kernelci/config/__init__.py
@@ -166,7 +166,7 @@ def load(config_path):
     unified file
 
     """
-    if config_path is None:
+    if not config_path:
         return {}
     data = load_yaml(config_path)
     return from_data(data)

--- a/kernelci/config/base.py
+++ b/kernelci/config/base.py
@@ -80,6 +80,31 @@ class Filter:
         """Return True if the given *kw* keywords match the filter."""
         raise NotImplementedError("Filter.match() is not implemented")
 
+    def combine(self, items):
+        """Try to avoid making a new filter if we can make a combined
+        filter matching both our existing data and the new items.
+
+        The *items* can be any data used to filter configurations.
+        Return True if we can combine, False otherwise.
+        """
+        return False
+
+
+def _merge_filter_lists(old, update):
+    """Merge the items for a Blocklist or Passlist.
+
+    *old*    is the items from the existing filter list that we
+             have already created.
+
+    *update* are the items of a new filter list, of the same type as
+             *old*, loaded from another configuration source. We are
+             going represent this second filter list declaration by
+             updating *old*, rather than by having a new object to
+             represent it.
+    """
+    for key, value in update.items():
+        old.setdefault(key, list()).extend(value)
+
 
 class Blocklist(Filter):
     """Blocklist filter to discard certain configurations.
@@ -99,6 +124,10 @@ class Blocklist(Filter):
 
         return True
 
+    def combine(self, items):
+        _merge_filter_lists(self._items, items)
+        return True
+
 
 class Passlist(Filter):
     """Passlist filter to only accept certain configurations.
@@ -116,6 +145,10 @@ class Passlist(Filter):
             if not any(x in v for x in wl):
                 return False
 
+        return True
+
+    def combine(self, items):
+        _merge_filter_lists(self._items, items)
         return True
 
 
@@ -156,6 +189,14 @@ class Combination(Filter):
         filter_values = tuple(kw.get(k) for k in self._keys)
         return filter_values in self._values
 
+    def combine(self, items):
+        keys = tuple(items['keys'])
+        if keys != self._keys:
+            return False
+
+        self._values.extend([tuple(values) for values in items['values']])
+        return True
+
 
 class FilterFactory(YAMLObject):
     """Factory to create filters from YAML data."""
@@ -171,10 +212,20 @@ class FilterFactory(YAMLObject):
     def from_yaml(cls, filter_params):
         """Iterate through the YAML filters and return Filter objects."""
         filter_list = []
+        filters = {}
+
         for f in filter_params:
             for filter_type, items in f.items():
-                filter_cls = cls._classes[filter_type]
-                filter_list.append(filter_cls(items))
+                for g in filters.get(filter_type, []):
+                    if g.combine(items):
+                        break
+                else:
+                    filter_cls = cls._classes[filter_type]
+                    filter_instance = filter_cls(items)
+                    filters.setdefault(filter_type, list()).append(
+                        filter_instance)
+                    filter_list.append(filter_instance)
+
         return filter_list
 
     @classmethod


### PR DESCRIPTION
This permits separating the configuration for a local KernelCI instance used in a conventional CI pipeline into two parts:

- The default configuration data can be taken directly from KernelCI itself (or a fork thereof, as required).
- The local configuration can specified separately, and merged in on top of the defaults KernelCI provides.

For example, in one common case of testing local kernel tree in CI, we can provide our own LAVA lab, own device types, own test suites on top of the KernelCI provided backbone, without maintaining a mandatory fork of KernelCI that contains our configuration data, and adds maintenance burden. 