### PR TITLE
revert "set hifive as riscv64" (PR #1487)

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -13,7 +13,6 @@ file_system_types:
       armel:   [{arch: arm}]
       x86:     [{arch: i386}, {arch: x86_64}]
       mipsel:  [{arch: mips}]
-      riscv:  [{arch: riscv64}]
 
   buildroot-staging:
     <<: *buildroot
@@ -882,7 +881,7 @@ device_types:
 
   hifive-unleashed-a00:
     mach: sifive
-    class: riscv64-dtb
+    class: riscv-dtb
     boot_method: uboot
     filters:
     # no console in tinyconfig

--- a/kernelci/config/test.py
+++ b/kernelci/config/test.py
@@ -164,14 +164,6 @@ class DeviceType_riscv(DeviceType):
         super().__init__(name, mach, arch, *args, **kw)
 
 
-class DeviceType_riscv64(DeviceType):
-
-    def __init__(self, name, mach, arch='riscv64', *args, **kw):
-        """RISCV device type with a device tree."""
-        kw.setdefault('dtb', '{}/{}.dtb'.format(mach, name))
-        super().__init__(name, mach, arch, *args, **kw)
-
-
 class DeviceType_shell(DeviceType):
 
     def __init__(self, name, mach=None, arch=None, boot_method=None,
@@ -196,7 +188,6 @@ class DeviceTypeFactory(YAMLObject):
         'arm-dtb': DeviceType_arm,
         'arm64-dtb': DeviceType_arm64,
         'riscv-dtb': DeviceType_riscv,
-        'riscv64-dtb': DeviceType_riscv64,
         'shell': DeviceType_shell,
         'kubernetes': DeviceType_kubernetes,
     }


### PR DESCRIPTION
as discussed in PR #1487 , this is not correct and should be reverted.