### PR TITLE
Add ChromeOS support for arm64 and one arm64 Chromebook

### DIFF
--- a/config/core/test-configs-chromeos.yaml
+++ b/config/core/test-configs-chromeos.yaml
@@ -456,6 +456,37 @@ device_types:
     filters:
       - passlist: {defconfig: ['chromiumos-x86_64']}
 
+  sc7180-trogdor-lazor-limozeen_chromeos: &chromebook-arm64-type
+    base_name: sc7180-trogdor-lazor-limozeen
+    mach: qcom
+    class: arm64-dtb
+    boot_method: depthcharge
+    dtb: 'qcom/sc7180-trogdor-lazor-limozeen-nots-r5.dtb'
+    filters: &qualcomm-filter
+      - passlist: {defconfig: ['chromiumos-qualcomm']}
+    params: &chromebook-arm64-params
+      cros_flash_nfs:
+        base_url: 'https://storage.staging.kernelci.org/images/rootfs/debian/bullseye-cros-flash/20221205.0/arm64/'
+        initrd: 'initrd.cpio.gz'
+        initrd_compression: 'gz'
+        rootfs: 'full.rootfs.tar.xz'
+        rootfs_compression: 'xz'
+      cros_flash_kernel:
+        base_url: 'https://storage.chromeos.kernelci.org/images/kernel/v5.19-qualcomm/'
+        image: 'kernel/Image'
+        modules: 'modules.tar.xz'
+        modules_compression: 'xz'
+        dtb: 'dtbs/qcom/sc7180-trogdor-lazor-limozeen-nots-r5.dtb'
+      cros_image:
+        base_url: 'https://storage.staging.kernelci.org/images/rootfs/debian/bullseye-cros-flash/20221205.0/arm64/'
+        flash_tarball: 'full-cros-flash.tar.gz'
+        flash_tarball_compression: 'gz'
+        tast_tarball: 'tast.tgz'
+      reference_kernel:
+        image: 'https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-trogdor/20221212.0/arm64/Image'
+        modules: 'https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-trogdor/20221212.0/arm64/modules.tar.xz'
+        dtb: 'https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-trogdor/20221212.0/arm64/dtbs/qcom/sc7180-trogdor-lazor-limozeen-nots-r5.dtb'
+      block_device: detect
 
 test_configs:
 
@@ -512,3 +543,6 @@ test_configs:
       - cros-tast-perf_qemu
       - cros-tast-platform_qemu
       - cros-tast-video_qemu
+
+  - device_type: sc7180-trogdor-lazor-limozeen_chromeos
+    test_plans: *chromebook-test-plans

--- a/config/lava/chromeos/cros-boot.jinja2
+++ b/config/lava/chromeos/cros-boot.jinja2
@@ -35,6 +35,10 @@ actions:
     ramdisk:
       url: {{ cros_flash_nfs.base_url }}{{ cros_flash_nfs.initrd }}
       compression: {{ cros_flash_nfs.initrd_compression }}
+{%- if cros_flash_kernel.dtb %}
+    dtb:
+      url: {{ cros_flash_kernel.base_url }}{{ cros_flash_kernel.dtb }}
+{%- endif %}
     os: oe
 
 - boot:
@@ -88,6 +92,18 @@ actions:
 {%- else %}
       # Fixed reference kernel
       url: {{ reference_kernel.image }}
+{%- endif %}
+
+{%- if dtb_url %}
+# If dtb_url present, this arch need dtb
+{%- if fixed_kernel is not defined %}
+    dtb:
+      url: {{ dtb_url }}
+{%- else %}
+    # Fixed reference dtb
+    dtb:
+      url: {{ reference_kernel.dtb }}
+{%- endif %}
 {%- endif %}
     os: oe
 

--- a/kernelci/test.py
+++ b/kernelci/test.py
@@ -58,17 +58,20 @@ def match_configs(configs, meta, lab):
     match = set()
 
     for test_config in configs:
+        dtb_missing = False
         if not test_config.match(arch, flags, filters):
             continue
         dtb = test_config.device_type.dtb
         if dtb and (not dtbs or dtb not in dtbs):
-            continue
+            dtb_missing = True
         for plan_name, plan in test_config.test_plans.items():
             if not plan.match(filters):
                 continue
             filters['plan'] = plan_name
             if lab.match(filters):
-                match.add((test_config.device_type, plan))
+                if not dtb_missing or \
+                   'fixed_kernel' in plan.params:
+                    match.add((test_config.device_type, plan))
 
     return match
 


### PR DESCRIPTION
This series of patches add support for arm64 Chromebooks and enable one of them sc7180-trogdor-lazor-limozeen, which have rootfs generated and almost ready for testing.