### PR TITLE
build-configs.yaml: Add 2 riscv trees to monitor

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -97,6 +97,9 @@ trees:
   renesas:
     url: "https://git.kernel.org/pub/scm/linux/kernel/git/geert/renesas-devel.git"
 
+  riscv:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/riscv/linux.git"
+
   rmk:
     url: "git://git.armlinux.org.uk/~rmk/linux-arm.git"
 
@@ -965,6 +968,20 @@ build_configs:
   renesas_next:
     tree: renesas
     branch: 'next'
+
+  riscv-fixes: &riscv-tree
+    tree: riscv
+    branch: 'fixes'
+    variants:
+      gcc-10:
+        build_environment: gcc-10
+        architectures:
+          riscv:
+            base_defconfig: 'defconfig'
+
+  riscv-for-next:
+    <<: *riscv-tree
+    branch: 'for-next'
 
   rmk_for-next:
     tree: rmk


### PR DESCRIPTION
As requested by Kevin Hilman, adding two trees for riscv, testing all available riscv configurations.

Fixes https://github.com/kernelci/kernelci-core/issues/1463

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>