### PR TITLE
test-configs: add riscv to arch map

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -26,6 +26,7 @@ file_system_types:
               {arch: arm, variant: v6}]
       armhf: [{arch: arm}]
       amd64: [{arch: x86_64}]
+      riscv64: [{arch: riscv}]
 
   # Convenience to test new rootfs images on staging.kernelci.org
   debian-staging:


### PR DESCRIPTION
Map the kernel arch name "riscv" to debian arch name "riscv64"

Signed-off-by: Kevin Hilman <khilman@baylibre.com>