### PR TITLE
HACK/DONOTMERGE: update temporary rootfs images to test bootrr properly

### DIFF
--- a/config/core/rootfs-images.yaml
+++ b/config/core/rootfs-images.yaml
@@ -4,9 +4,9 @@ file_systems:
     boot_protocol: tftp
     params: {}
     prompt: '/ #'
-    ramdisk: buildroot-baseline/20221209.0/{arch}/rootfs.cpio.gz
+    ramdisk: buildroot-baseline/20221215.0/{arch}/rootfs.cpio.gz
     root_type: ramdisk
-    type: buildroot
+    type: buildroot-staging
   debian_bullseye-cros-ec_ramdisk:
     boot_protocol: tftp
     params: {}
@@ -77,19 +77,19 @@ file_systems:
     type: debian
   debian_bullseye_nfs:
     boot_protocol: tftp
-    nfs: bullseye/20221209.0/{arch}/full.rootfs.tar.xz
+    nfs: bullseye/20221214.0/{arch}/full.rootfs.tar.xz
     params: {}
     prompt: '/ #'
-    ramdisk: bullseye/20221209.0/{arch}/initrd.cpio.gz
+    ramdisk: bullseye/20221214.0/{arch}/initrd.cpio.gz
     root_type: nfs
-    type: debian
+    type: debian-staging
   debian_bullseye_ramdisk:
     boot_protocol: tftp
     params: {}
     prompt: '/ #'
-    ramdisk: bullseye/20221209.0/{arch}/rootfs.cpio.gz
+    ramdisk: bullseye/20221214.0/{arch}/rootfs.cpio.gz
     root_type: ramdisk
-    type: debian
+    type: debian-staging
   debian_sid-kselftest_nfs:
     boot_protocol: tftp
     nfs: sid-kselftest/20221125.0/{arch}/full.rootfs.tar.xz


### PR DESCRIPTION
As we rebased bootrr, we need to check if it is working well with bullseye and buildroot.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>