### PR TITLE
Sync with latest cros-ec test changes

### DIFF
--- a/config/lava/cros-ec/cros-ec.jinja2
+++ b/config/lava/cros-ec/cros-ec.jinja2
@@ -14,7 +14,7 @@
           - functional
         run:
           steps:
-            - python3 -m cros.runners.lava_runner
+            - python3 -m cros.runners.lava_runner --verbosity 2
       lava-signal: kmsg
       from: inline
       name: {{ plan }}

--- a/config/rootfs/debos/scripts/bullseye-cros-ec-tests.sh
+++ b/config/rootfs/debos/scripts/bullseye-cros-ec-tests.sh
@@ -26,7 +26,7 @@ echo '{  "tests_suites": [' >> $BUILDFILE
 # Build and install tests                                              #
 ########################################################################
 
-CROS_URL="https://git.kernel.org/pub/scm/linux/kernel/git/chrome-platform/cros-ec-tests.git"
+CROS_URL="https://github.com/hardboprobot/cros-ec-tests.git"
 CROS_SHA=$(git ls-remote ${CROS_URL} | head -n 1 | cut -f 1)
 
 pip3 install git+${CROS_URL}@${CROS_SHA}


### PR DESCRIPTION
I inherited the cros-ec tests repo ownership from Enric and they now live here: https://github.com/hardboprobot/cros-ec-tests

Also, I made a few changes in the tests to enable a `--verbosity` option and to sync some of the tests to the current (as of v6.0) IIO ABI so that they go back to green.