### PR TITLE
Storage rework

### DIFF
--- a/config/k8s/job-build.jinja2
+++ b/config/k8s/job-build.jinja2
@@ -69,11 +69,14 @@ echo -e \"\
 kdir: ${KDIR}\n\
 verbose: true\n\
 db_config: ${KCI_DB_CONFIG}\n\
+storage_config: ${KCI_STORAGE_CONFIG}\n\
 \n\
 [db:${KCI_DB_CONFIG}]\n\
 db_token: ${KCI_API_TOKEN}\n\
 api: ${KCI_API_URL}\n\
 \n\
+[storage:${KCI_STORAGE_CONFIG}]\n\
+storage_cred: ${KCI_API_TOKEN}\n\
 [kci_build]\n\
 ${jopt}\
 build_env: ${BUILD_ENVIRONMENT}\n\
@@ -138,6 +141,8 @@ exit 0; \
           value: "{{ "FIXME" | env_override('BUILD_CONFIG') }}"
         - name: KCI_DB_CONFIG
           value: "{{ "FIXME" | env_override('KCI_DB_CONFIG') }}"
+        - name: KCI_STORAGE_CONFIG
+          value: "{{ "FIXME" | env_override('KCI_STORAGE_CONFIG') }}"
         - name: KCI_API_URL
           value: "{{ "FIXME" | env_override('KCI_API_URL') }}"
         - name: KCI_API_TOKEN

--- a/kci_build
+++ b/kci_build
@@ -453,13 +453,17 @@ class cmd_update_last_commit(Command):
 
 class cmd_push_tarball(Command):
     help = "Create and up a source tarball to the remote storage server"
-    args = [Args.build_config, Args.kdir, Args.storage,
+    args = [Args.build_config, Args.kdir, Args.storage_config,
             Args.api, Args.db_token]
     opt_args = [Args.db_config]  # This should become mandatory
 
     def __call__(self, configs, args):
-        conf = configs['build_configs'][args.build_config]
-        func_args = (conf, args.kdir, args.storage, args.api, args.db_token)
+        build_conf = configs['build_configs'][args.build_config]
+        storage_conf = configs['storage_configs'][args.storage_config]
+        func_args = (
+            build_conf, args.kdir, storage_conf.base_url,
+            args.api, args.db_token
+        )
         if not all(func_args):
             print("Invalid arguments")
             return False

--- a/kci_build
+++ b/kci_build
@@ -359,35 +359,49 @@ class cmd_make_kselftest(MakeCommand):
 
 class cmd_push_kernel(Command):
     help = "Push the kernel build artifacts"
-    args = [Args.kdir, Args.api, Args.db_token]
-    opt_args = [Args.output, Args.db_config]
+    args = [Args.kdir, Args.storage_config]
+    opt_args = [Args.storage_cred, Args.output]
+
+    def _compress_gki_artifacts(self, install):
+        # gki_defconfig kernel builds are exceptional and generate hundreds of
+        # megabytes in several files.  This requires compression to work around
+        # upload limits with kernelci-backend.
+        kernel_image_name = meta.get('bmeta', 'kernel', 'image')
+        artifacts = ["logs/kernel.log"]
+        artifacts.append('/'.join(["kernel", kernel_image_name]))
+        for e in artifacts:
+            source_filename = os.path.join(install, e)
+            data = open(source_filename, 'rb').read()
+            zf = xz.open(f'{source_filename}.xz', mode='wb',
+                         format=xz.FORMAT_XZ, preset=9)
+            zf.write(data)
+            zf.close()
+            os.unlink(source_filename)
+
+    def _discover_files(self, path):
+        artifacts = []
+        for root, _, files in os.walk(path):
+            for fname in files:
+                px = os.path.relpath(root, path)
+                artifacts.append(
+                    (os.path.join(root, fname), os.path.join(px, fname))
+                )
+        return artifacts
 
     def __call__(self, configs, args):
         install = kernelci.build.Step.get_install_path(args.kdir, args.output)
         meta = kernelci.build.Metadata(install)
-        publish_path = meta.get('bmeta', 'kernel', 'publish_path')
+
         defconfig = meta.get('bmeta', 'kernel', 'defconfig')
-        # gki_defconfig is exceptional and generate hundreds of megabytes
-        # several files, which require compression
-        # to workaround current upload limits
         if defconfig == "gki_defconfig":
-            kernel_image_name = meta.get('bmeta', 'kernel', 'image')
-            compressed_artifacts = ["logs/kernel.log"]
-            compressed_artifacts.append('/'.join(["kernel",
-                                        kernel_image_name]))
-            for e in compressed_artifacts:
-                source_filename = os.path.join(install, e)
-                data = open(source_filename, 'rb').read()
-                zf = xz.open(f'{source_filename}.xz', mode='wb',
-                             format=xz.FORMAT_XZ, preset=9)
-                zf.write(data)
-                zf.close()
-                os.unlink(source_filename)
-        artifacts = kernelci.storage.discover_files(install)
+            self._compress_gki_artifacts(install)
+
+        storage_conf = configs['storage_configs'][args.storage_config]
+        storage = kernelci.storage.get_storage(storage_conf, args.storage_cred)
+        artifacts = self._discover_files(install)
+        publish_path = meta.get('bmeta', 'kernel', 'publish_path')
         print("Upload path: {}".format(publish_path))
-        kernelci.storage.upload_files(
-            args.api, args.db_token, publish_path, artifacts
-        )
+        storage.upload_multiple(artifacts, publish_path)
         return True
 
 

--- a/kci_build
+++ b/kci_build
@@ -427,11 +427,13 @@ class cmd_pull_tarball(Command):
 
 class cmd_check_new_commit(Command):
     help = "Check if a new commit is available on a branch"
-    args = [Args.build_config, Args.storage]
+    args = [Args.build_config, Args.storage_config]
 
     def __call__(self, configs, args):
-        conf = configs['build_configs'][args.build_config]
-        update = kernelci.legacy.check_new_commit(conf, args.storage)
+        build_conf = configs['build_configs'][args.build_config]
+        storage_conf = configs['storage_configs'][args.storage_config]
+        storage_url = storage_conf.base_url
+        update = kernelci.legacy.check_new_commit(build_conf, storage_url)
         if update is False or update is True:
             return update
         print(update)

--- a/kci_build
+++ b/kci_build
@@ -147,25 +147,6 @@ class cmd_expand_fragments(Command):
         return True
 
 
-class cmd_push_tarball(Command):
-    help = "Create and up a source tarball to the remote storage server"
-    args = [Args.build_config, Args.kdir, Args.storage,
-            Args.api, Args.db_token]
-    opt_args = [Args.db_config]  # This should become mandatory
-
-    def __call__(self, configs, args):
-        conf = configs['build_configs'][args.build_config]
-        func_args = (conf, args.kdir, args.storage, args.api, args.db_token)
-        if not all(func_args):
-            print("Invalid arguments")
-            return False
-        tarball_url = kernelci.build.push_tarball(*func_args)
-        if not tarball_url:
-            return False
-        print(tarball_url)
-        return True
-
-
 class cmd_list_variants(Command):
     help = "Print the list of build variants for a given build configuration"
     args = [Args.build_config]
@@ -451,6 +432,25 @@ class cmd_update_last_commit(Command):
         conf = configs['build_configs'][args.build_config]
         kernelci.legacy.set_last_commit(
             conf, args.api, args.db_token, args.commit)
+        return True
+
+
+class cmd_push_tarball(Command):
+    help = "Create and up a source tarball to the remote storage server"
+    args = [Args.build_config, Args.kdir, Args.storage,
+            Args.api, Args.db_token]
+    opt_args = [Args.db_config]  # This should become mandatory
+
+    def __call__(self, configs, args):
+        conf = configs['build_configs'][args.build_config]
+        func_args = (conf, args.kdir, args.storage, args.api, args.db_token)
+        if not all(func_args):
+            print("Invalid arguments")
+            return False
+        tarball_url = kernelci.legacy.push_tarball(*func_args)
+        if not tarball_url:
+            return False
+        print(tarball_url)
         return True
 
 

--- a/kci_build
+++ b/kci_build
@@ -25,6 +25,7 @@ from kernelci.cli import Args, Command, parse_opts
 import kernelci
 import kernelci.build
 import kernelci.config
+import kernelci.legacy
 import kernelci.storage
 
 
@@ -52,30 +53,6 @@ class cmd_list_configs(Command):
     def __call__(self, configs, args):
         for conf_name in list(configs['build_configs'].keys()):
             print(conf_name)
-        return True
-
-
-class cmd_check_new_commit(Command):
-    help = "Check if a new commit is available on a branch"
-    args = [Args.build_config, Args.storage]
-
-    def __call__(self, configs, args):
-        conf = configs['build_configs'][args.build_config]
-        update = kernelci.build.check_new_commit(conf, args.storage)
-        if update is False or update is True:
-            return update
-        print(update)
-        return True
-
-
-class cmd_update_last_commit(Command):
-    help = "Update the last commit file on the remote storage server"
-    args = [Args.build_config, Args.api, Args.db_token, Args.commit]
-
-    def __call__(self, configs, args):
-        conf = configs['build_configs'][args.build_config]
-        kernelci.build.set_last_commit(
-            conf, args.api, args.db_token, args.commit)
         return True
 
 
@@ -443,6 +420,38 @@ class cmd_pull_tarball(Command):
         tarball = args.kernel_tarball or 'linux-src.tar.gz'
         return kernelci.build.pull_tarball(
             args.kdir, args.url, tarball, retries, args.delete)
+
+# -----------------------------------------------------------------------------
+# Legacy commands
+#
+# These commands don't follow the new API design with a separate storage, so
+# they may use the kernelci-backend API to upload files directly.  Still they
+# should be using the Storage configuration object to get the base URL rather
+# than --storage which is now deprecated.
+
+
+class cmd_check_new_commit(Command):
+    help = "Check if a new commit is available on a branch"
+    args = [Args.build_config, Args.storage]
+
+    def __call__(self, configs, args):
+        conf = configs['build_configs'][args.build_config]
+        update = kernelci.legacy.check_new_commit(conf, args.storage)
+        if update is False or update is True:
+            return update
+        print(update)
+        return True
+
+
+class cmd_update_last_commit(Command):
+    help = "Update the last commit file on the remote storage server"
+    args = [Args.build_config, Args.api, Args.db_token, Args.commit]
+
+    def __call__(self, configs, args):
+        conf = configs['build_configs'][args.build_config]
+        kernelci.legacy.set_last_commit(
+            conf, args.api, args.db_token, args.commit)
+        return True
 
 
 if __name__ == '__main__':

--- a/kci_rootfs
+++ b/kci_rootfs
@@ -22,7 +22,7 @@ import sys
 from kernelci.cli import Args, Command, parse_opts
 import kernelci.config
 import kernelci.rootfs
-import kernelci.config.rootfs
+import kernelci.storage
 
 
 # -----------------------------------------------------------------------------
@@ -129,11 +129,13 @@ class cmd_build(Command):
 
 class cmd_upload(Command):
     help = "Upload a rootfs image"
-    args = [Args.rootfs_dir, Args.upload_path, Args.api, Args.db_token]
+    args = [Args.rootfs_dir, Args.upload_path, Args.storage_config]
+    opt_args = [Args.storage_cred]
 
-    def __call__(self, config_data, args):
-        kernelci.rootfs.upload(args.api, args.db_token, args.upload_path,
-                               args.rootfs_dir)
+    def __call__(self, configs, args):
+        storage_conf = configs['storage_configs'][args.storage_config]
+        storage = kernelci.storage.get_storage(storage_conf, args.storage_cred)
+        kernelci.rootfs.upload(storage, args.upload_path, args.rootfs_dir)
         return True
 
 

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -69,40 +69,6 @@ KERNEL_IMAGE_NAMES = {
 }
 
 
-def _get_last_commit_file_name(config):
-    return '_'.join(['last-commit', config.name])
-
-
-def get_last_commit(config, storage):
-    """Get the last commit SHA that was built for a given build configuration
-
-    *config* is a BuildConfig object
-    *storage* is the base URL for the storage server
-
-    The returned value is the SHA of the last git commit that was built, or
-    None if an error occurred or if the configuration has never been built.
-    """
-    last_commit_url = "{storage}/{tree}/{file_name}".format(
-        storage=storage, tree=config.tree.name,
-        file_name=_get_last_commit_file_name(config))
-    last_commit_resp = requests.get(last_commit_url)
-    if last_commit_resp.status_code != 200:
-        return False
-    return last_commit_resp.text.strip()
-
-
-def set_last_commit(config, api, token, commit):
-    """Set the last commit SHA that was built for a given build configuration
-
-    *config* is a BuildConfig object
-    *api* is the URL of the KernelCI backend API
-    *token* is the backend API token to use
-    *commit* is the git SHA to send
-    """
-    upload_files(api, token, config.tree.name,
-                 {_get_last_commit_file_name(config): commit})
-
-
 def get_branch_head(config):
     """Get the commit SHA for the head of the branch of a given configuration
 
@@ -117,26 +83,6 @@ def get_branch_head(config):
     if not head:
         return False
     return head.split()[0]
-
-
-def check_new_commit(config, storage):
-    """Check if there is a new commit that hasn't been built yet
-
-    *config* is a BuildConfig object
-    *storage* is the base URL of the storage server
-
-    The returned value is the git SHA of a new commit to be built if there is
-    one, or True if the last built commit is the same as the branch head
-    (nothing to do), or False if an error occurred.
-    """
-    last_commit = get_last_commit(config, storage)
-    branch_head = get_branch_head(config)
-    if not branch_head:
-        return False
-    elif last_commit == branch_head:
-        return True
-    else:
-        return branch_head
 
 
 def _update_remote(config, path):

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -30,7 +30,6 @@ import urllib.parse
 import requests
 from kernelci import shell_cmd, print_flush, __version__ as kernelci_version
 import kernelci.elf
-from kernelci.storage import upload_files
 import kernelci.config
 
 # This is used to get the mainline tags as a minimum for git describe
@@ -291,36 +290,6 @@ def generate_fragments(config, kdir):
             generate_kselftest_fragment(frag, kdir)
         elif frag.configs:
             generate_config_fragment(frag, kdir)
-
-
-def push_tarball(config, kdir, storage, api, token):
-    """Create and push a linux kernel source tarball to the storage server
-
-    If a tarball with a same name is already on the storage server, no new
-    tarball is uploaded.  Otherwise, a tarball is created
-
-    *config* is a BuildConfig object
-    *kdir* is the path to a kernel source directory
-    *storage* is the base URL of the storage server
-    *api* is the URL of the KernelCI backend API
-    *token* is the token to use with the KernelCI backend API
-
-    The returned value is the URL of the uploaded tarball.
-    """
-    tarball_name = "linux-src_{}.tar.gz".format(config.name)
-    describe = git_describe(config.tree.name, kdir)
-    path = '/'.join(list(item.replace('/', '-') for item in [
-        config.tree.name, config.branch, describe
-    ]))
-    tarball_url = urllib.parse.urljoin(storage, '/'.join([path, tarball_name]))
-    resp = requests.head(tarball_url)
-    if resp.status_code == 200:
-        return tarball_url
-    tarball = "{}.tar.gz".format(config.name)
-    make_tarball(kdir, tarball)
-    upload_files(api, token, path, {tarball_name: open(tarball, 'rb')})
-    os.unlink(tarball)
-    return tarball_url
 
 
 def _download_file(url, dest_filename, chunk_size=1024):

--- a/kernelci/cli.py
+++ b/kernelci/cli.py
@@ -35,6 +35,7 @@ class Args:
     """
     SECTION_DB = ('db', 'db_config')
     SECTION_LAB = ('lab', 'lab_config')
+    SECTION_STORAGE = ('storage', 'storage_config')
 
     arch = {
         'name': '--arch',
@@ -285,6 +286,17 @@ class Args:
     storage = {
         'name': '--storage',
         'help': "Storage URL",
+    }
+
+    storage_config = {
+        'name': '--storage-config',
+        'help': "Storage configuration name",
+    }
+
+    storage_cred = {
+        'name': '--storage-cred',
+        'help': "Credentials to be used with the storage service",
+        'section': SECTION_STORAGE,
     }
 
     target = {

--- a/kernelci/legacy.py
+++ b/kernelci/legacy.py
@@ -1,0 +1,73 @@
+# Copyright (C) 2022 Collabora Limited
+# Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+#
+# This module is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+from kernelci.build import get_branch_head
+from kernelci.storage import upload_files
+
+
+def _get_last_commit_file_name(config):
+    return '_'.join(['last-commit', config.name])
+
+
+def get_last_commit(config, storage):
+    """Get the last commit SHA that was built for a given build configuration
+
+    *config* is a BuildConfig object
+    *storage* is the base URL for the storage server
+
+    The returned value is the SHA of the last git commit that was built, or
+    None if an error occurred or if the configuration has never been built.
+    """
+    last_commit_url = "{storage}/{tree}/{file_name}".format(
+        storage=storage, tree=config.tree.name,
+        file_name=_get_last_commit_file_name(config))
+    last_commit_resp = requests.get(last_commit_url)
+    if last_commit_resp.status_code != 200:
+        return False
+    return last_commit_resp.text.strip()
+
+
+def set_last_commit(config, api, token, commit):
+    """Set the last commit SHA that was built for a given build configuration
+
+    *config* is a BuildConfig object
+    *api* is the URL of the KernelCI backend API
+    *token* is the backend API token to use
+    *commit* is the git SHA to send
+    """
+    upload_files(api, token, config.tree.name,
+                 {_get_last_commit_file_name(config): commit})
+
+
+def check_new_commit(config, storage):
+    """Check if there is a new commit that hasn't been built yet
+
+    *config* is a BuildConfig object
+    *storage* is the base URL of the storage server
+
+    The returned value is the git SHA of a new commit to be built if there is
+    one, or True if the last built commit is the same as the branch head
+    (nothing to do), or False if an error occurred.
+    """
+    last_commit = get_last_commit(config, storage)
+    branch_head = get_branch_head(config)
+    if not branch_head:
+        return False
+    elif last_commit == branch_head:
+        return True
+    else:
+        return branch_head

--- a/kernelci/rootfs.py
+++ b/kernelci/rootfs.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019, 2020, 2021 Collabora Limited
+# Copyright (C) 2019, 2020, 2021, 2022 Collabora Limited
 # Author: Lakshmipathi G <lakshmipathi.ganapathi@collabora.com>
 # Author: Michal Galka <michal.galka@collabora.com>
 #
@@ -17,7 +17,6 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 from kernelci import shell_cmd
-from kernelci.storage import upload_files
 import os
 import shutil
 
@@ -185,17 +184,18 @@ def build(name, config, data_path, arch, output):
     return builder.build(config, data_path, arch, output)
 
 
-def upload(api, token, upload_path, input_dir):
+def upload(storage, upload_path, input_dir):
     """Upload rootfs to KernelCI backend.
 
-    *api* is the URL of the KernelCI backend API
-    *token* is the backend API token to use
+    *storage* is a Storage object
     *upload_path* is the target on KernelCI backend
     *input_dir* is the local rootfs directory path to upload
     """
-    artifacts = {}
+    paths = []
     for root, _, files in os.walk(input_dir):
         for f in files:
+            src = os.path.join(root, f)
             px = os.path.relpath(root, input_dir)
-            artifacts[os.path.join(px, f)] = open(os.path.join(root, f), "rb")
-    upload_files(api, token, upload_path, artifacts)
+            dst = os.path.join(px, f)
+            paths.append((src, dst))
+    storage.upload_multiple(paths, upload_path)

--- a/kernelci/storage/__init__.py
+++ b/kernelci/storage/__init__.py
@@ -18,32 +18,8 @@
 
 import importlib
 import os
-import requests
 from urllib.parse import urljoin
 from kernelci import shell_cmd
-
-
-def upload_files(api, token, path, input_files):
-    """Upload rootfs to KernelCI backend.
-
-    *api* is the URL of the KernelCI backend API
-    *token* is the backend API token to use
-    *path* is the target on KernelCI backend
-    *input_files* dictionary of input files
-    """
-    headers = {
-        'Authorization': token,
-    }
-    data = {
-        'path': path,
-    }
-    files = {
-        'file{}'.format(i): (name, fobj)
-        for i, (name, fobj) in enumerate(input_files.items())
-    }
-    url = urljoin(api, 'upload')
-    resp = requests.post(url, headers=headers, data=data, files=files)
-    resp.raise_for_status()
 
 
 class Storage:

--- a/kernelci/storage/__init__.py
+++ b/kernelci/storage/__init__.py
@@ -91,33 +91,46 @@ class Storage:
     def upload_single(self, file_path, dest_path=''):
         """Upload a single file to storage
 
-        Upload the file located in *file_path* to the storage at the
-        destination specified by *dest_path*.  Path elements from *file_path*
-        are not included in the destination path.  The returned value is the
+        Upload the file specified by the *file_path* 2-tuple as (local, remote)
+        file names to the storage at the destination directory specified by
+        *dest_path*.  Any path elements in the 2nd item of *file_path* will be
+        used as part as the full destination path.  The returned value is the
         full public URL that can be used to retrieve the file again.
+
+        For example:
+
+            s.upload_single(('path/to/local-file.txt', 'file.txt'), '.')
         """
         self._upload([file_path], dest_path)
         return urljoin(
             self.config.base_url,
-            '/'.join([dest_path, os.path.basename(file_path)])
+            '/'.join([dest_path, file_path[1]])
         )
 
     def upload_multiple(self, file_paths, dest_path=''):
         """Upload multiple files to storage
 
-        Upload all the files listed in *file_paths* to storage at the
-        destination speciified by *dest_path*.  The path elements in the file
-        paths are not included in the destination paths.  The returned value is
-        a list with the public URL to retrieve each file matching the input
-        list in *file_paths*.
+        Upload all the files *file_paths* as a list of 2-tuples with (local,
+        remote) file names to storage at the destination directory specified by
+        *dest_path*.  Any path elements in the remove file paths will be
+        included in the final destination paths.  The returned value is a list
+        with the public URL to retrieve each file matching the input list in
+        *file_paths*.
+
+        For example:
+
+            s.upload_multiple(
+                [
+                    ('path/to/local-file.txt', 'file.txt'),
+                    ('path/to/other-file.txt', 'subdir/other.txt'),
+                ],
+                'data/path'
+            )
         """
         self._upload(file_paths, dest_path)
         return [
-            urljoin(
-                self.config.base_url,
-                '/'.join([dest_path, os.path.basename(file_path)])
-            )
-            for file_path in file_paths
+            urljoin(self.config.base_url, '/'.join([dest_path, file_dst]))
+            for (file_src, file_dst) in file_paths
         ]
 
 

--- a/kernelci/storage/__init__.py
+++ b/kernelci/storage/__init__.py
@@ -23,24 +23,6 @@ from urllib.parse import urljoin
 from kernelci import shell_cmd
 
 
-def discover_files(path):
-    """Discover files recustively so they can then be uploaded
-
-    Recursively walk through a file hierarchy and return a dictionary with the
-    file paths and open file objects which can then be passed directly to
-    upload_files().
-
-    *path* is the path to the file hierarchy where to look for files
-    """
-    artifacts = {}
-    for root, _, files in os.walk(path):
-        for fname in files:
-            px = os.path.relpath(root, path)
-            artifacts[os.path.join(px, fname)] = open(
-                os.path.join(root, fname), "rb")
-    return artifacts
-
-
 def upload_files(api, token, path, input_files):
     """Upload rootfs to KernelCI backend.
 

--- a/kernelci/storage/backend.py
+++ b/kernelci/storage/backend.py
@@ -36,8 +36,8 @@ class Storage_backend(Storage):
             'path': dest_path,
         }
         files = {
-            f'file{i}': (os.path.basename(file_path), open(file_path, 'rb'))
-            for i, file_path in enumerate(file_paths)
+            f'file{i}': (file_dst, open(file_src, 'rb'))
+            for i, (file_src, file_dst) in enumerate(file_paths)
         }
         url = urljoin(self.config.api_url, 'upload')
         resp = requests.post(url, headers=headers, data=data, files=files)

--- a/kernelci/storage/ssh.py
+++ b/kernelci/storage/ssh.py
@@ -28,19 +28,27 @@ class Storage_ssh(Storage):
     """
 
     def _upload(self, file_paths, dest_path):
-        cmd = """\
+        for src, dst in file_paths:
+            dst_file = os.path.join(self.config.path, dest_path, dst)
+            dst_dir = os.path.dirname(dst_file)
+            kernelci.shell_cmd("""\
+ssh \
+  -i {key} \
+  -p {port} \
+  -o StrictHostKeyChecking=no \
+  -o UserKnownHostsFile=/dev/null \
+  {user}@{host} \
+  mkdir -p {dst_dir} && \
 scp \
   -i {key} \
   -P {port} \
   -o StrictHostKeyChecking=no \
   -o UserKnownHostsFile=/dev/null \
   {src} \
-  {user}@{host}:{dst}
-""".format(host=self.config.host, port=self.config.port,
+  {user}@{host}:{dst_file}
+""".format(host=self.config.host, port=self.config.port,  # noqa
            key=self.credentials, user=self.config.user,
-           src=' '.join(file_paths),
-           dst=os.path.join(self.config.path, dest_path))
-        kernelci.shell_cmd(cmd)
+           src=src, dst_dir=dst_dir, dst_file=dst_file))
 
 
 def get_storage(config, credentials):


### PR DESCRIPTION
Rework the `kci_build` and `kci_rootfs` commands to use the new Storage class whenever appropriate.  Move old legacy code to `kernelci.legacy` and don't update it to use the new Storage as this code is specific to the backend / storage interaction and can only be used with the backend API.