### PR TITLE
kci_rootfs: add missing import kernelci.config

### DIFF
--- a/kci_rootfs
+++ b/kci_rootfs
@@ -20,6 +20,7 @@
 import sys
 
 from kernelci.cli import Args, Command, parse_opts
+import kernelci.config
 import kernelci.rootfs
 import kernelci.config.rootfs
 


### PR DESCRIPTION
Add mising import kernelci.config which is used in this script. Somehow it worked before by having it imported implictly by some lucky mechanism.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>