### PR TITLE
baseline.jinja2: Update bootrr helpers path

### DIFF
--- a/config/lava/baseline/baseline.jinja2
+++ b/config/lava/baseline/baseline.jinja2
@@ -46,8 +46,8 @@
             - lava-test-shell
         run:
           steps:
-            - export PATH=/opt/bootrr/helpers:$PATH
-            - cd /opt/bootrr && sh helpers/bootrr-auto
+            - export PATH=/opt/bootrr/libexec/bootrr/helpers:$PATH
+            - cd /opt/bootrr/libexec/bootrr && sh helpers/bootrr-auto
       lava-signal: kmsg
       from: inline
       name: bootrr


### PR DESCRIPTION
As upstream version use slightly different path for helpers we need to update LAVA definition to use that properly.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>