### PR TITLE
misc riscv updates, cleanups

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -980,6 +980,8 @@ build_configs:
         architectures:
           riscv:
             base_defconfig: 'defconfig'
+            extra_configs:
+              - 'defconfig+CONFIG_SMP=n'
 
   riscv-for-next:
     <<: *riscv-tree

--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -971,7 +971,7 @@ build_configs:
     tree: renesas
     branch: 'next'
 
-  riscv-fixes: &riscv-tree
+  riscv_fixes: &riscv-tree
     tree: riscv
     branch: 'fixes'
     variants:
@@ -983,7 +983,7 @@ build_configs:
             extra_configs:
               - 'defconfig+CONFIG_SMP=n'
 
-  riscv-for-next:
+  riscv_for-next:
     <<: *riscv-tree
     branch: 'for-next'
 

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -885,10 +885,8 @@ device_types:
     class: riscv-dtb
     boot_method: uboot
     filters:
-    # no console in tinyconfig
-      - blocklist:
-          defconfig: ['tinyconfig']
-          kernel: ['v4.']
+      - blocklist: *device_config_filter
+      - regex: {defconfig: '^defconfig'}
 
   hip07-d05:
     mach: hisilicon
@@ -1122,6 +1120,9 @@ device_types:
     class: riscv-dtb
     boot_method: uboot
     dtb: 'starfive/jh7100-starfive-visionfive-v1.dtb'
+    filters:
+      - blocklist: *device_config_filter
+      - regex: {defconfig: '^defconfig'}
 
   juno-uboot:
     mach: vexpress
@@ -1583,7 +1584,8 @@ device_types:
       memory: 1024
       extra_options: ['-bios default -device virtio-net,netdev=main -netdev user,id=main']
     filters:
-      - passlist: {defconfig: ['defconfig']}
+      - blocklist: *device_config_filter
+      - regex: {defconfig: '^defconfig'}
 
   qemu_x86_64: &qemu_x86_64
     base_name: qemu


### PR DESCRIPTION
Add a riscv build for SMP-disabled (e.g. `CONFIG_SMP=n`)
Align riscv tree/branch names to naming convention.
Update test plan filters for riscv platforms.