### PR TITLE
build-configs: rust: disable IBT/Retpoline/Rethunk for the moment

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -237,6 +237,9 @@ fragments:
   rust:
     path: "kernel/configs/rust.config"
     configs:
+      - '# CONFIG_X86_KERNEL_IBT is not set'
+      - '# CONFIG_RETPOLINE is not set'
+      - '# CONFIG_RETHUNK is not set'
       - 'CONFIG_RUST=y'
 
   rust-for-linux-samples:


### PR DESCRIPTION
Until we have the needed pieces in place in `rustc` and the kernel to support IBT/Retpoline/Rethunk (which will take at least a couple months); disable the relevant configs for the moment.

This avoids the 2000+ warnings from `objtool` that we currently generate in the logs.

Link: https://storage.kernelci.org/mainline/master/v6.1-11554-g785d21ba2f44/x86_64/x86_64_defconfig+rust/rustc-1.62/logs/build-warnings.log
Link: https://github.com/Rust-for-Linux/linux/issues/945
Signed-off-by: Miguel Ojeda <ojeda@kernel.org>