### PR TITLE
config/k8s: add set -e to build jobs

### DIFF
--- a/config/k8s/job-build.jinja2
+++ b/config/k8s/job-build.jinja2
@@ -84,7 +84,7 @@ install: true\n\
 [kci_data]\n\
 output: ${KDIR}/build\n\
 \" > kernelci.conf; \
-set -x; \
+set -xe; \
 \
 kci_build pull_tarball \
   --url ${SRC_TARBALL} \


### PR DESCRIPTION
Add set -e to the build job template so that if any command fails the job aborts rather than trying to run subsequent commands as that's destined to keep piling up more failure.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>