### PR TITLE
Add pylint to the GitHub checks for all new code

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,6 +48,10 @@ jobs:
           pycodestyle kci_*
           pycodestyle scripts/*
 
+      - name: Run pylint
+        run: |
+          pylint kci
+
       - name: Run YAML config validation
         run: |
           ./kci validate yaml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,6 +51,7 @@ jobs:
       - name: Run pylint
         run: |
           pylint kci
+          pylint kernelci.cli
 
       - name: Run YAML config validation
         run: |

--- a/kci
+++ b/kci
@@ -5,6 +5,13 @@
 # Copyright (C) 2022 Collabora Limited
 # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
 
+"""KernelCI Command Line Tool
+
+This executable script is the entry point for all the new KernelCI command line
+tools which support the new API & Pipeline design.  See the documentation for
+more details: https://kernelci.org/docs/api/.
+"""
+
 import argparse
 import sys
 

--- a/kernelci/cli/__init__.py
+++ b/kernelci/cli/__init__.py
@@ -3,6 +3,8 @@
 # Copyright (C) 2022 Collabora Limited
 # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
 
+"""KernelCI command line utility package"""
+
 import sys
 
 from .base import Args, Command, parse_opts, sub_main

--- a/kernelci/cli/base.py
+++ b/kernelci/cli/base.py
@@ -370,7 +370,7 @@ class Command:
 
         """
         if not self.help:
-            raise AttributeError("Missing help message for {}".format(name))
+            self.help = self.__doc__
         self._parser = sub_parser.add_parser(name, help=self.help)
         for arg_list in [self.args, self.opt_args]:
             if arg_list:

--- a/kernelci/cli/base.py
+++ b/kernelci/cli/base.py
@@ -385,7 +385,12 @@ class Command:
                     for arg in arg_list
                 })
 
-    def __call__(self, *args, **kw):
+    def __call__(self, configs, args):
+        """Call the command
+
+        *configs* is a dictionary with configuration objects parsed from YAML
+        *args* is the parsed command line arguments
+        """
         raise NotImplementedError("Command not implemented")
 
     def _add_arg(self, arg):

--- a/kernelci/cli/validate.py
+++ b/kernelci/cli/validate.py
@@ -3,14 +3,16 @@
 # Copyright (C) 2022 Collabora Limited
 # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
 
-import sys
+# pylint: disable=C0103
 
-from .base import Args, Command, parse_opts, sub_main
+"""Tool to validate the KernelCI configuration"""
+
 import kernelci.config
+from .base import Args, Command, sub_main
 
 
 class cmd_yaml(Command):
-    help = "Validate the YAML configuration"
+    """Validate the YAML configuration"""
     opt_args = [Args.verbose]
 
     def __call__(self, configs, args):
@@ -29,4 +31,5 @@ class cmd_yaml(Command):
 
 
 def main(args=None):
+    """Entry point for the command line tool"""
     sub_main("validate", globals(), args)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 -r requirements.txt
 pycodestyle==2.8.0
+pylint==2.12.2

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,8 @@ setuptools.setup(
     ],
     extras_require={
         'dev': [
-            'pycodestyle'
+            'pycodestyle',
+            'pylint',
         ]
     }
 )


### PR DESCRIPTION
Enable `pylint` to run on the new `kci` script and the `kernelci.cli` package.  The intention is to keep enabling it on all the code that will be used with the new KernelCI API & Pipeline implementation.

Depends on #1585 