### PR TITLE
T39494 kernelci_api: Add enum class for node states

### DIFF
--- a/kernelci/db/kernelci_api.py
+++ b/kernelci/db/kernelci_api.py
@@ -48,6 +48,12 @@ class KernelCI_API(Database):
             'Content-Type': 'application/json',
         }
         self._filters = {}
+        self._node_states = NodeStates
+
+    @property
+    def node_states(self):
+        """Get node states"""
+        return self._node_states
 
     def _make_url(self, path):
         return urllib.parse.urljoin(self.config.url, path)

--- a/kernelci/db/kernelci_api.py
+++ b/kernelci/db/kernelci_api.py
@@ -16,12 +16,25 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 import json
+import enum
 import requests
 import urllib.parse
 
 from cloudevents.http import from_json
 
 from kernelci.db import Database
+
+
+class NodeStates(enum.Enum):
+    """Enumeration for node states
+    This is a temporary implementation until we have API versioning
+    in place. Once we have it, we can directly use a version specific
+    endpoint to get node states"""
+
+    RUNNING = 'running'
+    AVAILABLE = 'available'
+    CLOSING = 'closing'
+    DONE = 'done'
 
 
 class KernelCI_API(Database):


### PR DESCRIPTION
Add an enum class for holding pending Node states. 
Add instance variable`_pending_node_states` to `KernelCI_API` class store enum for pending node states.
Implement method `get_pending_node_states` to get pending node states to use in pipeline client services.
This is to align the node states with API until we have a mechanism to get the states from API in place.