### PR TITLE
rootfs-configs.yaml: Add rockchip igt firmware

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -151,6 +151,7 @@ rootfs_configs:
         - i915/bxt_dmc_ver1_07.bin
         - i915/kbl_dmc_ver1_04.bin
         - i915/glk_dmc_ver1_04.bin
+        - rockchip/dptx.bin
     linux_fw_version: d526e044bddaa2c2ad855c7296147e49be0ab03c
     script: "scripts/bullseye-igt.sh"
     test_overlay: "overlays/igt"


### PR DESCRIPTION
igt-gpu-panfrost tests failing on rk3399-gru-kevin
```
 1818 10:44:06.503539  <4>[   45.184361] cdn-dp fec00000.dp: Direct firmware load for rockchip/dptx.bin failed with error -2
 1819 10:44:06.504647
 1820 10:44:22.631415  <4>[   61.312402] cdn-dp fec00000.dp: Direct firmware load for rockchip/dptx.bin failed with error -2
 1821 10:44:56.680389  <3>[   95.360170] cdn-dp fec00000.dp: [drm:cdn_dp_pd_event_work [rockchipdrm]] *ERROR* Timed out trying to load firmware
```
Adding missing firmware should fix that.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>