### PR TITLE
kernelci.storage.ssh: Replace scp binary calls with paramiko

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
 cloudevents==1.2.0
 jinja2==3.1.1
 kubernetes==23.3.0
+paramiko==2.12.0
 pyelftools==0.28
 pytest==7.1.2
 pyyaml==6.0
 requests==2.27.1
+scp==0.14.4

--- a/setup.py
+++ b/setup.py
@@ -76,9 +76,11 @@ setuptools.setup(
         "cloudevents",
         "jinja2",
         "kubernetes",
+        "paramiko",
         "pyelftools",
         "pytest",
         "pyyaml",
         "requests",
+        "scp"
     ]
 )


### PR DESCRIPTION
Storage_ssh class implementation relied on scp binary being installed in the operating system. Implementation based on paramiko and scp Python packages reduces the dependency on underlying system tools and adds better control of the file transfer.
