### PR TITLE
install-bootrr.sh: Update bootrr to latest commit

### DIFF
--- a/config/rootfs/debos/scripts/install-bootrr.sh
+++ b/config/rootfs/debos/scripts/install-bootrr.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 BOOTRR_SITE=https://github.com/kernelci/bootrr.git
-BOOTRR_VERSION=e0a316de59153ecd4373b14063b0280505ce6e2e
+BOOTRR_VERSION=94dbf0b19d6e01489ce71c98cd3613b63c15f661
 
 BUILD_DEPS="\
     build-essential \


### PR DESCRIPTION
As tested on staging, bootrr need to be updated to latest commit Because it was forgotten on last update and LAVA template is changed, this is especially important to do before next rootfs update

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>