### PR TITLE
Rust 1.66.0

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -1106,8 +1106,8 @@ build_configs:
     tree: rust-for-linux
     branch: 'rust'
     variants:
-      rustc-1.62:
-        build_environment: rustc-1.62
+      rustc-1.66:
+        build_environment: rustc-1.66
         fragments: [rust, rust-for-linux-samples, kselftest]
         architectures:
           x86_64:

--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -499,6 +499,14 @@ build_environments:
         <<: *x86_64_params
         name:
 
+  rustc-1.66:
+    cc: clang
+    cc_version: 15
+    arch_params:
+      x86_64:
+        <<: *x86_64_params
+        name:
+
 # Default config with full build coverage
 build_configs_defaults:
   variants:

--- a/config/docker/rustc-1.66.jinja2
+++ b/config/docker/rustc-1.66.jinja2
@@ -1,0 +1,43 @@
+{% extends 'clang-15.jinja2' %}
+
+{% block packages %}
+{{ super() }}
+
+ARG RUST_VER=1.66.0
+ARG BINDGEN_VER=0.56.0
+
+ARG RUST_TRIPLE=rust-${RUST_VER}-x86_64-unknown-linux-gnu
+
+ENV CARGO_HOME=/home/kernelci/.cargo
+ENV PATH=/usr/${RUST_TRIPLE}/bin:${CARGO_HOME}/bin:${PATH}
+
+ARG SHA256SUM=f6ff8b7a38bab7d8f3cb7b70c7201494a5485c2cf12e84a13c9e232fa51ebfe7
+
+# fetch, verify the toolchain
+RUN wget https://static.rust-lang.org/dist/${RUST_TRIPLE}.tar.gz && \
+    echo "${SHA256SUM} ${RUST_TRIPLE}.tar.gz" | sha256sum --check --quiet
+
+# install & cleanup tmp files
+RUN tar -xf ${RUST_TRIPLE}.tar.gz  -C /tmp/ && \
+    /tmp/${RUST_TRIPLE}/install.sh --prefix=/usr/${RUST_TRIPLE} \
+        --components=rustc,cargo,rust-std-x86_64-unknown-linux-gnu && \
+    rm -rf /tmp/${RUST_TRIPLE} && \
+    rm /${RUST_TRIPLE}*
+
+# This image is based on clang-*jinja2 which only has clang installed, but rustc
+# defaults to linker "cc" which usually points to the GNU/GCC stack. Pointing cc
+# to clang ensures both cargo and kernel build rustc invocations use llvm/clang.
+RUN update-alternatives --install /usr/bin/cc cc $(which clang) 30 && \
+    update-alternatives --set cc $(which clang)
+
+RUN git clone --recurse-submodules --branch $RUST_VER \
+        https://github.com/rust-lang/rust \
+        $(rustc --print sysroot)/lib/rustlib/src/rust
+
+RUN cargo install --locked --version ${BINDGEN_VER} bindgen
+
+# kernel build generates some rust code and tries to format it, if rustfmt is
+# missing it will print non-fatal error noise
+RUN cargo install rustfmt
+
+{%- endblock %}


### PR DESCRIPTION
Rust 1.66.0 will be the next version supported by the kernel [1].

Therefore, add `rustc-1.66` as a new build environment alongside `rustc-1.62` (which can be removed later on when the new version hits mainline), and then move `rust-for-linux_rust` to it.

Link: https://github.com/Rust-for-Linux/linux/pull/947 [1]
Signed-off-by: Miguel Ojeda <ojeda@kernel.org>