### PR TITLE
CHROMEOS test-configs-chromeos.yaml: Disable QEMU

### DIFF
--- a/config/core/test-configs-chromeos.yaml
+++ b/config/core/test-configs-chromeos.yaml
@@ -595,37 +595,38 @@ device_types:
         dtb: 'https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-asurada/20230208.0/arm64/dtbs/mediatek/mt8192-asurada-spherion-r0.dtb'
       block_device: detect
 
-  qemu_x86_64-uefi-chromeos:
-    base_name: qemu
-    mach: qemu
-    arch: x86_64
-    boot_method: qemu
-    params:
-      bios_url: 'http://storage.kernelci.org/images/uefi/edk2-stable202005/x86_64/OVMF.fd'
-      cros_image:
-        base_url: 'https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-amd64-generic/20220816.0/amd64/'
-        image: 'chromiumos_test_image.bin.gz'
-        tast_tarball: 'tast.tgz'
-      reference_kernel:
-        image: 'https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-amd64-generic/20220816.0/amd64/bzImage'
-        modules: 'https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-amd64-generic/20220816.0/amd64/modules.tar.xz'
-    context:
-      arch: x86_64
-      cpu: 'qemu64'
-      guestfs_interface: 'virtio'
-      extra_options:
-        - '-device pcie-root-port,port=0x10,chassis=1,id=pci.1,bus=pcie.0,multifunction=on,addr=0x2'
-        - '-device pcie-root-port,port=0x15,chassis=6,id=pci.6,bus=pcie.0,addr=0x2.0x5'
-        - '-device qemu-xhci,p2=15,p3=15,id=usb,bus=pci.6,addr=0x0'
-        - '-device usb-storage,bus=usb.0,drive=lavatest2'
-        - '-m 2048'
-        - '-device usb-tablet,id=input0,bus=usb.0,port=2'
-        - '-device pcie-root-port,port=0x11,chassis=2,id=pci.2,bus=pcie.0,addr=0x2.0x1'
-        - '-device virtio-vga,id=video0,virgl=on,max_outputs=1,bus=pcie.0,addr=0x3'
-        - '-device ich9-intel-hda,id=sound0,bus=pcie.0,addr=0x1b'
-        - '-machine pc-q35-5.2,accel=kvm,usb=off,vmport=off,dump-guest-core=off'
-    filters:
-      - passlist: {defconfig: ['chromiumos-x86_64']}
+# Test plans temporarily disabled as QEMU build doesnt work
+#  qemu_x86_64-uefi-chromeos:
+#    base_name: qemu
+#    mach: qemu
+#    arch: x86_64
+#    boot_method: qemu
+#    params:
+#      bios_url: 'http://storage.kernelci.org/images/uefi/edk2-stable202005/x86_64/OVMF.fd'
+#      cros_image:
+#        base_url: 'https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-amd64-generic/20220816.0/amd64/'
+#        image: 'chromiumos_test_image.bin.gz'
+#        tast_tarball: 'tast.tgz'
+#      reference_kernel:
+#        image: 'https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-amd64-generic/20220816.0/amd64/bzImage'
+#        modules: 'https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-amd64-generic/20220816.0/amd64/modules.tar.xz'
+#    context:
+#      arch: x86_64
+#      cpu: 'qemu64'
+#      guestfs_interface: 'virtio'
+#      extra_options:
+#        - '-device pcie-root-port,port=0x10,chassis=1,id=pci.1,bus=pcie.0,multifunction=on,addr=0x2'
+#        - '-device pcie-root-port,port=0x15,chassis=6,id=pci.6,bus=pcie.0,addr=0x2.0x5'
+#        - '-device qemu-xhci,p2=15,p3=15,id=usb,bus=pci.6,addr=0x0'
+#        - '-device usb-storage,bus=usb.0,drive=lavatest2'
+#        - '-m 2048'
+#        - '-device usb-tablet,id=input0,bus=usb.0,port=2'
+#        - '-device pcie-root-port,port=0x11,chassis=2,id=pci.2,bus=pcie.0,addr=0x2.0x1'
+#        - '-device virtio-vga,id=video0,virgl=on,max_outputs=1,bus=pcie.0,addr=0x3'
+#        - '-device ich9-intel-hda,id=sound0,bus=pcie.0,addr=0x1b'
+#        - '-machine pc-q35-5.2,accel=kvm,usb=off,vmport=off,dump-guest-core=off'
+#    filters:
+#      - passlist: {defconfig: ['chromiumos-x86_64']}
 
   sc7180-trogdor-kingoftown_chromeos:
     <<: *chromebook-arm64-type
@@ -746,13 +747,14 @@ test_configs:
   - device_type: mt8192-asurada-spherion-r0_chromeos
     test_plans: *chromebook-arm64-test-plans
 
-  - device_type: qemu_x86_64-uefi-chromeos
-    test_plans:
-      - cros-baseline_qemu
-      - cros-tast-kernel_qemu
-      - cros-tast-perf_qemu
-      - cros-tast-platform_qemu
-      - cros-tast-video_qemu
+# Test plans temporarily disabled as QEMU build doesnt work
+#  - device_type: qemu_x86_64-uefi-chromeos
+#    test_plans:
+#      - cros-baseline_qemu
+#      - cros-tast-kernel_qemu
+#      - cros-tast-perf_qemu
+#      - cros-tast-platform_qemu
+#      - cros-tast-video_qemu
 
   - device_type: sc7180-trogdor-kingoftown_chromeos
     test_plans: *chromebook-arm64-test-plans


### PR DESCRIPTION
For last 2 releases QEMU is broken for ChromeOS, and it doesn't look there is easy solution to fix that.
I am commenting temporary all relevant entries with hope, that in new releases it might work or issue might be fixed. Also commenting is important to not waste lab QEMU resources and docker pull limits.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>