### PR TITLE
CHROMEOS cros-boot.jinja2: Add lava-test-raise for modules-install

### DIFF
--- a/config/lava/chromeos/cros-boot.jinja2
+++ b/config/lava/chromeos/cros-boot.jinja2
@@ -69,12 +69,13 @@ actions:
         run:
           steps:
             - >-
-              lava-test-case modules --shell /opt/chromeos/install-modules
+              /opt/chromeos/install-modules
 {%- if fixed_kernel is not defined %}
               {{ modules_url }}
 {%- else %}
               {{ reference_kernel.modules }}
 {%- endif %}
+              || lava-test-raise "modules-install"
       from: inline
       name: modules
       path: inline/modules.yaml


### PR DESCRIPTION
If we fail installing modules there is no point to continue test, as in best case it will fail, and in worst it will give false results

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>