### PR TITLE
CHROMEOS cros-boot.jinja2: Leave only PARTUUID option

### DIFF
--- a/config/lava/chromeos/cros-boot.jinja2
+++ b/config/lava/chromeos/cros-boot.jinja2
@@ -113,11 +113,7 @@ actions:
       minutes: 5
     method: depthcharge
     commands: emmc
-{%- if block_device == 'detect' %}
     extra_kernel_args: cros_secure cros_debug root=PARTUUID=566f7961-6765-7220-746f-20756e697665 rootwait ro
-{%- else %}
-    extra_kernel_args: cros_secure cros_debug root=/dev/{{ block_device }}p3 rootwait ro
-{%- endif %}
     prompts:
       - 'localhost(.*)~(.*)#'
     auto_login:


### PR DESCRIPTION
As all ChromiumOS installs we have unified PARTUUID, we dont need anymore block device name. We can mount all by PARTUUID.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>