### PR TITLE
CHROMEOS test-configs-chromeos.yaml: Add updated cros-flash for arm64

### DIFF
--- a/config/core/test-configs-chromeos.yaml
+++ b/config/core/test-configs-chromeos.yaml
@@ -466,7 +466,7 @@ device_types:
       - passlist: {defconfig: ['chromiumos-qualcomm']}
     params: &chromebook-arm64-params
       cros_flash_nfs:
-        base_url: 'https://storage.staging.kernelci.org/images/rootfs/debian/bullseye-cros-flash/20221205.0/arm64/'
+        base_url: 'https://storage.chromeos.kernelci.org/images/rootfs/debian/bullseye-cros-flash/20221230.0/arm64/'
         initrd: 'initrd.cpio.gz'
         initrd_compression: 'gz'
         rootfs: 'full.rootfs.tar.xz'
@@ -478,7 +478,7 @@ device_types:
         modules_compression: 'xz'
         dtb: 'dtbs/qcom/sc7180-trogdor-lazor-limozeen-nots-r5.dtb'
       cros_image:
-        base_url: 'https://storage.staging.kernelci.org/images/rootfs/debian/bullseye-cros-flash/20221205.0/arm64/'
+        base_url: 'https://storage.chromeos.kernelci.org/images/rootfs/debian/bullseye-cros-flash/20221230.0/arm64/'
         flash_tarball: 'full-cros-flash.tar.gz'
         flash_tarball_compression: 'gz'
         tast_tarball: 'tast.tgz'


### PR DESCRIPTION
Current arm64 missing latest updates for modules-install script, update it to most recent, tested build.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>