### PR TITLE
test-configs.yaml: Remove kselftest from baseline* blocklist

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -69,7 +69,7 @@ test_plans:
     params:
       priority: 90
     filters:
-      - blocklist: *kselftest_defconfig_filter
+      - blocklist: {}
 
   baseline-fastboot:
     rootfs: buildroot-baseline_ramdisk
@@ -84,7 +84,7 @@ test_plans:
     params:
       priority: 85
     filters:
-      - blocklist: *kselftest_defconfig_filter
+      - blocklist: {}
 
   baseline_qemu:
     base_name: baseline


### PR DESCRIPTION
As real use cases show - we need to test kselftest kernels on baseline/baseline-nfs, because for example it looks like some boards unable to boot +kselftest builds, but booting fine with similar build without this fragment.
baseline tests help a lot with testing general "bootability" of kernel.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>