### PR TITLE
build-configs.yaml: Enable chromeos_acpi support

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -482,6 +482,7 @@ fragments:
   x86-chromebook:
     path: "kernel/configs/x86-chromebook.config"
     configs:
+      - 'CONFIG_CHROMEOS_ACPI=y'
       - 'CONFIG_SERIAL_8250=y'
       - 'CONFIG_SERIAL_8250_DW=y'
       - 'CONFIG_X86_AMD_PLATFORM_DEVICE=y'


### PR DESCRIPTION
As TPM reset and several other features that require NVRAM offset lookups - we need to enable newly added option for acpi tables exported on Chromebooks. It will allow to lookup for NVRAM offset to manage such things like TPM ownership.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>