### PR TITLE
Make the install_path argument work for kci_build too

### DIFF
--- a/kci_build
+++ b/kci_build
@@ -238,7 +238,7 @@ class cmd_init_bmeta(Command):
     opt_args = [Args.output, Args.build_config, Args.install,
                 Args.tree_name, Args.tree_url, Args.branch,
                 Args.commit, Args.describe, Args.describe_verbose,
-                Args.build_env, Args.arch]
+                Args.build_env, Args.arch, Args.install_path]
 
     def __call__(self, configs, args):
         if args.build_config:
@@ -259,7 +259,9 @@ or
 """)
             return False
 
-        step = kernelci.build.RevisionData(args.kdir, args.output, reset=True)
+        step = kernelci.build.RevisionData(
+            args.kdir, args.output, reset=True,
+            install_path=args.install_path)
         print("Initialising build meta-data in {}".format(step.output_path))
         res = step.run(opts={
             'tree': tree_name,
@@ -280,7 +282,8 @@ or
 Invalid arguments, --build-env and --arch need to be used together.""")
                 return False
             build_env = configs['build_environments'][args.build_env]
-            step = kernelci.build.EnvironmentData(args.kdir, args.output)
+            step = kernelci.build.EnvironmentData(
+                args.kdir, args.output, install_path=args.install_path)
             res = step.run(opts={'build_env': build_env, 'arch': args.arch})
             if args.install:
                 step.install()
@@ -290,7 +293,8 @@ Invalid arguments, --build-env and --arch need to be used together.""")
 
 class MakeCommand(Command):
     args = [Args.kdir]
-    opt_args = [Args.verbose, Args.output, Args.j, Args.log, Args.install]
+    opt_args = [Args.verbose, Args.output, Args.j, Args.log, Args.install,
+                Args.install_path]
     step_cls = None
 
     def __call__(self, configs, args):
@@ -308,7 +312,8 @@ class MakeCommand(Command):
     def _get_step(self, args):
         if self.step_cls is None:
             raise ValueError("Step class not defined.")
-        return self.step_cls(args.kdir, args.output, args.log)
+        return self.step_cls(args.kdir, args.output, args.log,
+                             install_path=args.install_path)
 
     def _get_opts(self, args, configs):
         return dict()
@@ -360,7 +365,7 @@ class cmd_make_kselftest(MakeCommand):
 class cmd_push_kernel(Command):
     help = "Push the kernel build artifacts"
     args = [Args.kdir, Args.storage_config]
-    opt_args = [Args.storage_cred, Args.output]
+    opt_args = [Args.storage_cred, Args.output, Args.install_path]
 
     def _compress_gki_artifacts(self, install):
         # gki_defconfig kernel builds are exceptional and generate hundreds of
@@ -389,7 +394,8 @@ class cmd_push_kernel(Command):
         return artifacts
 
     def __call__(self, configs, args):
-        install = kernelci.build.Step.get_install_path(args.kdir, args.output)
+        install = kernelci.build.Step.get_install_path(args.kdir, args.output,
+                                                       args.install_path)
         meta = kernelci.build.Metadata(install)
 
         defconfig = meta.get('bmeta', 'kernel', 'defconfig')

--- a/kci_build
+++ b/kci_build
@@ -235,7 +235,7 @@ class cmd_list_kernel_configs(Command):
 class cmd_init_bmeta(Command):
     help = "Create initial bmeta.json"
     args = [Args.kdir]
-    opt_args = [Args.output, Args.build_config, Args.install,
+    opt_args = [Args.output, Args.build_config,
                 Args.tree_name, Args.tree_url, Args.branch,
                 Args.commit, Args.describe, Args.describe_verbose,
                 Args.build_env, Args.arch, Args.install_path]
@@ -272,9 +272,8 @@ or
             'describe_verbose': args.describe_verbose
         })
 
-        if args.install:
-            print("Install directory: {}".format(step.install_path))
-            step.install()
+        print("Install directory: {}".format(step.install_path))
+        step.install()
 
         if res and (args.build_env or args.arch):
             if not (args.build_env and args.arch):
@@ -285,15 +284,14 @@ Invalid arguments, --build-env and --arch need to be used together.""")
             step = kernelci.build.EnvironmentData(
                 args.kdir, args.output, install_path=args.install_path)
             res = step.run(opts={'build_env': build_env, 'arch': args.arch})
-            if args.install:
-                step.install()
+            step.install()
 
         return res
 
 
 class MakeCommand(Command):
     args = [Args.kdir]
-    opt_args = [Args.verbose, Args.output, Args.j, Args.log, Args.install,
+    opt_args = [Args.verbose, Args.output, Args.j, Args.log,
                 Args.install_path]
     step_cls = None
 
@@ -304,9 +302,8 @@ class MakeCommand(Command):
             return True
         opts = self._get_opts(args, configs)
         res = step.run(args.j, args.verbose, opts)
-        if args.install:
-            install_res = self._install_step(step, args)
-            res = res and install_res
+        install_res = self._install_step(step, args)
+        res = res and install_res
         return res
 
     def _get_step(self, args):

--- a/kci_data
+++ b/kci_data
@@ -74,11 +74,12 @@ class cmd_submit(Command):
 class cmd_submit_build(Command):
     help = "Submit meta-data for a kernel build"
     args = [Args.kdir, Args.db_config]
-    opt_args = [Args.db_token, Args.output, Args.verbose]
+    opt_args = [Args.db_token, Args.output, Args.verbose, Args.install_path]
 
     def __call__(self, config_data, args):
         config = config_data['db_configs'][args.db_config]
-        install = kernelci.build.Step.get_install_path(args.kdir, args.output)
+        install = kernelci.build.Step.get_install_path(args.kdir, args.output,
+                                                       args.install_path)
         meta = kernelci.build.Metadata(install)
         db = kernelci.db.get_db(config, args.db_token)
         return db.submit_build(meta, args.verbose)

--- a/kci_test
+++ b/kci_test
@@ -199,10 +199,8 @@ class cmd_list_jobs(Command):
             print("Either --build-output or --install-path is required")
             return False
 
-        install = (
-            args.install_path if args.install_path else
-            kernelci.build.Step.get_install_path(None, args.build_output)
-        )
+        install = kernelci.build.Step.get_install_path(None, args.build_output,
+                                                       args.install_path)
         meta = kernelci.build.Metadata(install)
 
         if meta.get('bmeta', 'build', 'status') != "PASS":
@@ -288,10 +286,8 @@ class cmd_generate(Command):
             print("Either --build-output or --install-path is required")
             return False
 
-        install = (
-            args.install_path
-            or kernelci.build.Step.get_install_path(None, args.build_output)
-        )
+        install = kernelci.build.Step.get_install_path(None, args.build_output,
+                                                       args.install_path)
         meta = kernelci.build.Metadata(install)
 
         if meta.get('bmeta', 'build', 'status') != "PASS":

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -609,7 +609,8 @@ class Step:
 
     KVER_RE = re.compile(r'^v([\d]+)\.([\d]+)')
 
-    def __init__(self, kdir, output_path=None, log=None, reset=False):
+    def __init__(self, kdir, output_path=None, log=None, reset=False,
+                 install_path=None):
         """Each Step deals with a part of the build and its related meta-data
 
         This abstract class handles the common code to run any kernel build
@@ -631,7 +632,8 @@ class Step:
         self._output_path = output_path or self.get_default_output_path(kdir)
         if not os.path.exists(self._output_path):
             os.mkdir(self._output_path)
-        self._install_path = self.get_install_path(kdir, self._output_path)
+        self._install_path = self.get_install_path(kdir, self._output_path,
+                                                   install_path)
         self._create_install_dir(reset)
         self._meta = Metadata(self._output_path, reset)
         self._meta.clear_artifacts(self.name)
@@ -666,7 +668,7 @@ class Step:
         return os.path.join(kdir, 'build')
 
     @classmethod
-    def get_install_path(cls, kdir=None, output_path=None):
+    def get_install_path(cls, kdir=None, output_path=None, install_path=None):
         """Get the default build install path
 
         Get the default path where the kernel build artifacts get installed
@@ -679,6 +681,9 @@ class Step:
         *kdir* is the optional path to the kernel source directory
         *output_path* is the optional path to the kernel build output
         """
+        if install_path:
+            return install_path
+
         if output_path is None:
             if kdir is None:
                 output_path = ''

--- a/kernelci/cli/base.py
+++ b/kernelci/cli/base.py
@@ -157,12 +157,6 @@ class Args:  # pylint: disable=too-few-public-methods
         'help': "Path to the dtbs.json file",
     }
 
-    install = {
-        'name': '--install',
-        'action': 'store_true',
-        'help': "Install the build artifacts ",
-    }
-
     install_path = {
         'name': '--install-path',
         'help':


### PR DESCRIPTION
This allows you to pick the directory into which kci_build will install the built kernel and modules, rather than forcing it to be `_install_` within the built kernel's tree. This is convenient for some automated processes, where we want to control what the generated path is, without copying.