### PR TITLE
Enable rseq kselftests

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -3081,6 +3081,7 @@ test_configs:
       - kselftest-membarrier
       - kselftest-mincore
       - kselftest-openat2
+      - kselftest-rseq
       - kselftest-seccomp
       - kselftest-timers
       - ltp-crypto

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -356,6 +356,13 @@ test_plans:
       kselftest_collections: "openat2"
     filters: *kselftest_no_fragment
 
+  kselftest-rseq:
+    <<: *kselftest
+    params:
+      job_timeout: '10'
+      kselftest_collections: "rseq"
+    filters: *kselftest_no_fragment
+
   kselftest-rtc:
     <<: *kselftest
     params:


### PR DESCRIPTION
Ideally we'd cover more boards (rseq is supported on x86 too and a big.LITTLE board wouldn't go amiss for arm64) but this gets things going.