### PR TITLE
rootfs-images.yaml: update rootfs URLs to 20230109.0

### DIFF
--- a/config/core/rootfs-images.yaml
+++ b/config/core/rootfs-images.yaml
@@ -1,71 +1,71 @@
-# Automatically generated (20221230.0)
+# Automatically generated (20230109.0)
 file_systems:
   buildroot-baseline_ramdisk:
     boot_protocol: tftp
     params: {}
     prompt: '/ #'
-    ramdisk: buildroot-baseline/20221230.0/{arch}/rootfs.cpio.gz
+    ramdisk: buildroot-baseline/20230109.0/{arch}/rootfs.cpio.gz
     root_type: ramdisk
     type: buildroot
   debian_bullseye-cros-ec_ramdisk:
     boot_protocol: tftp
     params: {}
     prompt: '/ #'
-    ramdisk: bullseye-cros-ec/20221230.0/{arch}/rootfs.cpio.gz
+    ramdisk: bullseye-cros-ec/20230109.0/{arch}/rootfs.cpio.gz
     root_type: ramdisk
     type: debian
   debian_bullseye-gst-fluster_nfs:
     boot_protocol: tftp
-    nfs: bullseye-gst-fluster/20221230.0/{arch}/full.rootfs.tar.xz
+    nfs: bullseye-gst-fluster/20230109.0/{arch}/full.rootfs.tar.xz
     params: {}
     prompt: '/ #'
-    ramdisk: bullseye-gst-fluster/20221230.0/{arch}/initrd.cpio.gz
+    ramdisk: bullseye-gst-fluster/20230109.0/{arch}/initrd.cpio.gz
     root_type: nfs
     type: debian
   debian_bullseye-igt_ramdisk:
     boot_protocol: tftp
     params: {}
     prompt: '/ #'
-    ramdisk: bullseye-igt/20221230.0/{arch}/rootfs.cpio.gz
+    ramdisk: bullseye-igt/20230109.0/{arch}/rootfs.cpio.gz
     root_type: ramdisk
     type: debian
   debian_bullseye-kselftest_nfs:
     boot_protocol: tftp
-    nfs: bullseye-kselftest/20221230.0/{arch}/full.rootfs.tar.xz
+    nfs: bullseye-kselftest/20230109.0/{arch}/full.rootfs.tar.xz
     params:
       os_config: debian
     prompt: '/ #'
-    ramdisk: bullseye-kselftest/20221230.0/{arch}/initrd.cpio.gz
+    ramdisk: bullseye-kselftest/20230109.0/{arch}/initrd.cpio.gz
     root_type: nfs
     type: debian
   debian_bullseye-libcamera_nfs:
     boot_protocol: tftp
-    nfs: bullseye-libcamera/20221230.0/{arch}/full.rootfs.tar.xz
+    nfs: bullseye-libcamera/20230109.0/{arch}/full.rootfs.tar.xz
     params: {}
     prompt: '/ #'
-    ramdisk: bullseye-libcamera/20221230.0/{arch}/initrd.cpio.gz
+    ramdisk: bullseye-libcamera/20230109.0/{arch}/initrd.cpio.gz
     root_type: nfs
     type: debian
   debian_bullseye-ltp_nfs:
     boot_protocol: tftp
-    nfs: bullseye-ltp/20221230.0/{arch}/full.rootfs.tar.xz
+    nfs: bullseye-ltp/20230109.0/{arch}/full.rootfs.tar.xz
     params: {}
     prompt: '/ #'
-    ramdisk: bullseye-ltp/20221230.0/{arch}/initrd.cpio.gz
+    ramdisk: bullseye-ltp/20230109.0/{arch}/initrd.cpio.gz
     root_type: nfs
     type: debian
   debian_bullseye-ltp_ramdisk:
     boot_protocol: tftp
     params: {}
     prompt: '/ #'
-    ramdisk: bullseye-ltp/20221230.0/{arch}/rootfs.cpio.gz
+    ramdisk: bullseye-ltp/20230109.0/{arch}/rootfs.cpio.gz
     root_type: ramdisk
     type: debian
   debian_bullseye-rt_ramdisk:
     boot_protocol: tftp
     params: {}
     prompt: '/ #'
-    ramdisk: bullseye-rt/20221230.0/{arch}/rootfs.cpio.gz
+    ramdisk: bullseye-rt/20230109.0/{arch}/rootfs.cpio.gz
     root_type: ramdisk
     type: debian
   debian_bullseye-v4l2_ramdisk:
@@ -77,47 +77,47 @@ file_systems:
     type: debian
   debian_bullseye_nfs:
     boot_protocol: tftp
-    nfs: bullseye/20221230.0/{arch}/full.rootfs.tar.xz
+    nfs: bullseye/20230109.0/{arch}/full.rootfs.tar.xz
     params: {}
     prompt: '/ #'
-    ramdisk: bullseye/20221230.0/{arch}/initrd.cpio.gz
+    ramdisk: bullseye/20230109.0/{arch}/initrd.cpio.gz
     root_type: nfs
     type: debian
   debian_bullseye_ramdisk:
     boot_protocol: tftp
     params: {}
     prompt: '/ #'
-    ramdisk: bullseye/20221230.0/{arch}/rootfs.cpio.gz
+    ramdisk: bullseye/20230109.0/{arch}/rootfs.cpio.gz
     root_type: ramdisk
     type: debian
   debian_sid-kselftest_nfs:
     boot_protocol: tftp
-    nfs: sid-kselftest/20221230.0/{arch}/full.rootfs.tar.xz
+    nfs: sid-kselftest/20230109.0/{arch}/full.rootfs.tar.xz
     params:
       os_config: debian
     prompt: '/ #'
-    ramdisk: sid-kselftest/20221230.0/{arch}/initrd.cpio.gz
+    ramdisk: sid-kselftest/20230109.0/{arch}/initrd.cpio.gz
     root_type: nfs
     type: debian
   debian_sid-kselftest_ramdisk:
     boot_protocol: tftp
     params: {}
     prompt: '/ #'
-    ramdisk: sid-kselftest/20221230.0/{arch}/rootfs.cpio.gz
+    ramdisk: sid-kselftest/20230109.0/{arch}/rootfs.cpio.gz
     root_type: ramdisk
     type: debian
   debian_sid-ltp_nfs:
     boot_protocol: tftp
-    nfs: sid-ltp/20221230.0/{arch}/full.rootfs.tar.xz
+    nfs: sid-ltp/20230109.0/{arch}/full.rootfs.tar.xz
     params: {}
     prompt: '/ #'
-    ramdisk: sid-ltp/20221230.0/{arch}/initrd.cpio.gz
+    ramdisk: sid-ltp/20230109.0/{arch}/initrd.cpio.gz
     root_type: nfs
     type: debian
   debian_sid-ltp_ramdisk:
     boot_protocol: tftp
     params: {}
     prompt: '/ #'
-    ramdisk: sid-ltp/20221230.0/{arch}/rootfs.cpio.gz
+    ramdisk: sid-ltp/20230109.0/{arch}/rootfs.cpio.gz
     root_type: ramdisk
     type: debian


### PR DESCRIPTION
Skipping bullseye-v4l2 due to build failure #1619.

Signed-off-by: kernelci.org bot <bot@kernelci.org>