### PR TITLE
config/lava/kselftest: Don't install dependencies for kselftest at runtime

### DIFF
--- a/config/lava/kselftest/kselftest.jinja2
+++ b/config/lava/kselftest/kselftest.jinja2
@@ -26,3 +26,4 @@
         TST_CASENAME: {{ kselftest_tests }}
         BOARD: {{ device_type }}
         BRANCH: {{ tree }}
+        SKIP_INSTALL: True


### PR DESCRIPTION
We build our kselftest rootfs images with all the dependencies for kselftest already installed and therefore do not need to install the incomplete set that the test-defintions tempalte attempts to install at runtime, skip doing so in order to speed up our kselftest jobs and allow them to run on very low memory systems where apt struggles without swap.

Signed-off-by: Mark Brown <broonie@kernel.org>