### PR TITLE
test-configs: Enable arm64 kselftests on qemu

### DIFF
--- a/config/core/rootfs-images.yaml
+++ b/config/core/rootfs-images.yaml
@@ -38,6 +38,14 @@ file_systems:
     ramdisk: bullseye-kselftest/20221230.0/{arch}/initrd.cpio.gz
     root_type: nfs
     type: debian
+  debian_bullseye-kselftest_ramdisk:
+    boot_protocol: ramdisk
+    params:
+      os_config: debian
+    prompt: '/ #'
+    ramdisk: bullseye-kselftest/20221230.0/{arch}/rootfs.cpio.gz
+    root_type: ramdisk
+    type: debian
   debian_bullseye-libcamera_nfs:
     boot_protocol: tftp
     nfs: bullseye-libcamera/20221230.0/{arch}/full.rootfs.tar.xz

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -228,6 +228,14 @@ test_plans:
     filters:
       - passlist: {defconfig: ['kselftest']}
 
+  # Add _a_ into the name so we can keep this before the individual
+  # definitions
+  kselftest_a_qemu: &kselftest_qemu
+    rootfs: debian_bullseye-kselftest_ramdisk
+    pattern: 'kselftest/{category}-{method}-{rootfs}-kselftest-template.jinja2'
+    filters:
+      - passlist: {defconfig: ['kselftest']}
+
   kselftest-alsa:
     <<: *kselftest
     params:
@@ -238,6 +246,13 @@ test_plans:
 
   kselftest-arm64:
     <<: *kselftest
+    params:
+      job_timeout: '10'
+      kselftest_collections: "arm64"
+    filters: *kselftest_no_fragment
+
+  kselftest-arm64_qemu:
+    <<: *kselftest_qemu
     params:
       job_timeout: '10'
       kselftest_collections: "arm64"
@@ -2820,6 +2835,7 @@ test_configs:
   - device_type: qemu_arm64-virt-gicv3
     test_plans:
       - baseline_qemu
+      - kselftest-arm64_qemu
       - v4l2-compliance-vivid
 
   - device_type: qemu_arm64-virt-gicv3-uefi


### PR DESCRIPTION
In order to get coverage of new architecture extension that are only available in emulation enable the arm64 selftests in qemu, using a ramdisk for the filesystem as we do for the RISC-V kselftests running qemu.

Signed-off-by: Mark Brown <broonie@kernel.org>