### PR TITLE
T39784 Add API version to url

### DIFF
--- a/kernelci/db/kernelci_api.py
+++ b/kernelci/db/kernelci_api.py
@@ -35,6 +35,11 @@ class KernelCI_API(Database):
             'Content-Type': 'application/json',
         }
         self._filters = {}
+        self._api_version = 'latest'
+
+    def _get_path_with_version_prefix(self, path):
+        """Insert API version prefix to the URL path"""
+        return self._api_version + '/' + path
 
     def _make_url(self, path):
         return urllib.parse.urljoin(self.config.url, path)

--- a/kernelci/db/kernelci_api.py
+++ b/kernelci/db/kernelci_api.py
@@ -42,6 +42,7 @@ class KernelCI_API(Database):
         return self._api_version + '/' + path
 
     def _make_url(self, path):
+        path = self._get_path_with_version_prefix(path)
         return urllib.parse.urljoin(self.config.url, path)
 
     def _print_http_error(self, http_error, verbose=False):


### PR DESCRIPTION
Depends on https://github.com/kernelci/kernelci-api/pull/209

Implement `KernelCI_API._get_path_with_version_prefix()` to prefix version number to path i.e. `v0/PATH`.
Use the method to create URLs from the provided path in `_make_url` function.