### PR TITLE
kernelci.config fixes

### DIFF
--- a/config/core/lab-configs.yaml
+++ b/config/core/lab-configs.yaml
@@ -3,7 +3,6 @@ labs:
   # ToDo: also run jobs with callbacks sent to BayLibre's KernelCI backend
   lab-baylibre:
     lab_type: lava.lava_xmlrpc
-    config_path: 'lava'
     url: 'https://lava.baylibre.com/RPC2/'
     queue_timeout:
       days: 1
@@ -18,7 +17,6 @@ labs:
 
   lab-broonie:
     lab_type: lava.lava_xmlrpc
-    config_path: 'lava'
     url: 'https://lava.sirena.org.uk/RPC2/'
     priority_min: 0
     priority_max: 40
@@ -29,7 +27,6 @@ labs:
 
   lab-cip:
     lab_type: lava.lava_xmlrpc
-    config_path: 'lava'
     url: 'https://lava.ciplatform.org/RPC2/'
     priority: low
     filters:
@@ -70,7 +67,6 @@ labs:
 
   lab-clabbe:
     lab_type: lava.lava_xmlrpc
-    config_path: 'lava'
     url: 'https://lava.montjoie.ovh/RPC2/'
     queue_timeout:
       hours: 24
@@ -88,7 +84,6 @@ labs:
 
   lab-collabora:
     lab_type: lava.lava_rest
-    config_path: 'lava'
     url: 'https://lava.collabora.dev/'
     priority: '45'
     queue_timeout:
@@ -99,7 +94,6 @@ labs:
 
   lab-collabora-staging:
     lab_type: lava.lava_rest
-    config_path: 'lava'
     url: 'https://staging.lava.collabora.dev/'
     priority: '45'
     queue_timeout:
@@ -108,7 +102,6 @@ labs:
 
   lab-kontron:
     lab_type: lava.lava_rest
-    config_path: 'lava'
     url: 'https://lavalab.kontron.com/'
     filters:
       - passlist:
@@ -117,7 +110,6 @@ labs:
 
   lab-linaro-lkft:
     lab_type: lava.lava_rest
-    config_path: 'lava'
     url: 'https://lkft.validation.linaro.org/'
     priority_min: 0
     priority_max: 25
@@ -137,7 +129,6 @@ labs:
 
   lab-nxp:
     lab_type: lava.lava_rest
-    config_path: 'lava'
     url: 'https://lavalab.nxp.com/'
     filters:
       - passlist:
@@ -146,7 +137,6 @@ labs:
 
   lab-pengutronix:
     lab_type: lava.lava_rest
-    config_path: 'lava'
     url: 'https://hekla.openlab.pengutronix.de/'
     filters:
       - passlist:
@@ -155,7 +145,6 @@ labs:
 
   lab-theobroma-systems:
     lab_type: lava.lava_xmlrpc
-    config_path: 'lava'
     url: 'https://lava.theobroma-systems.com/RPC2/'
     filters:
       - passlist:
@@ -164,4 +153,3 @@ labs:
 
   shell:
     lab_type: shell
-    config_path: 'scripts'

--- a/config/core/lab-configs.yaml
+++ b/config/core/lab-configs.yaml
@@ -85,7 +85,7 @@ labs:
   lab-collabora:
     lab_type: lava.lava_rest
     url: 'https://lava.collabora.dev/'
-    priority: '45'
+    priority: 45
     queue_timeout:
       days: 2
     filters: &collabora-filters
@@ -95,7 +95,7 @@ labs:
   lab-collabora-staging:
     lab_type: lava.lava_rest
     url: 'https://staging.lava.collabora.dev/'
-    priority: '45'
+    priority: 45
     queue_timeout:
       hours: 1
     filters: *collabora-filters

--- a/kernelci/config/base.py
+++ b/kernelci/config/base.py
@@ -38,7 +38,8 @@ class YAMLObject:
         constructors.
         """
         return {
-            k: v for k, v in ((k, data.get(k)) for k in args) if v
+            k: v for k, v in ((k, data.get(k)) for k in args)
+            if v is not None
         } if data else dict()
 
     def _get_attrs(self):


### PR DESCRIPTION
These are a handful of fixes in the `kernelci.config` package:

* Drop unused `config_path` attribute in `lab-configs.yaml`
* Use numerical values rather than strings for LAVA lab min/max priorities
* Allow 0 to be a valid YAML attribute value