### PR TITLE
Enable ALSA selftests for AT91SAM9G20-EK

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2333,6 +2333,7 @@ test_configs:
     test_plans:
       - baseline
       - baseline-nfs
+      - kselftest-alsa
 
   - device_type: bcm2711-rpi-4-b
     test_plans:

--- a/kernelci/test.py
+++ b/kernelci/test.py
@@ -167,6 +167,7 @@ def get_params(meta, target, plan_config, storage, device_id):
         'base_url': base_url,
         'endian': endian,
         'arch': arch,
+        'arch_variant': variant,
         'git_branch': rev['branch'],
         'git_commit': rev['commit'],
         'git_describe': describe,


### PR DESCRIPTION
This series works around the lack of skipgen support for older ARM systems in the kselftest template then uses that to enable running the ALSA selftests on AT91SAM9G20-EK.

This isn't the most elegant thing ever but given the generally sparing use of skiplists at all and the level of effort required to either port Go or rewrite skipgen it seems like the improvement in test coverage is more than worth the fairly small and non-invasive changes.