### PR TITLE
kernelci.config rework: add get_yaml_attributes() method

### DIFF
--- a/kernelci/config/base.py
+++ b/kernelci/config/base.py
@@ -44,8 +44,15 @@ class YAMLObject:
             if v is not None
         } if data else dict()
 
-    def _get_attrs(self):
-        """Return a set of attribute names for .to_dict() and .to_yaml()"""
+    @classmethod
+    def _get_yaml_attributes(cls):
+        """Get a set of YAML attribute names
+
+        Get a set object with all the YAML configuration attribute names for
+        the configuration class.  This can be used to make keyword arguments
+        when creating a configuration object as well as when serialising it
+        back to YAML.
+        """
         return set()
 
     def to_dict(self):
@@ -57,7 +64,8 @@ class YAMLObject:
         """
         return {
             attr: value for attr, value in (
-                (attr, getattr(self, attr)) for attr in self._get_attrs()
+                (attr, getattr(self, attr))
+                for attr in self._get_yaml_attributes()
             ) if value is not None
         }
 

--- a/kernelci/config/base.py
+++ b/kernelci/config/base.py
@@ -28,18 +28,19 @@ class YAMLObject:
     """Base class with helper methods to initialise objects from YAML data."""
 
     @classmethod
-    def _kw_from_yaml(cls, data, args):
+    def _kw_from_yaml(cls, data, attributes):
         """Create some keyword arguments based on a YAML dictionary
 
         Return a dictionary suitable to be used as Python keyword arguments in
-        an object constructor using values from some YAML *data*.  The *args*
-        is a list of keys to look up from the *data* and convert to a
-        dictionary.  Keys that are not in the YAML data are simply omitted from
-        the returned keywords, relying on default values in object
+        an object constructor using values from some YAML *data*.  The
+        *attributes* are a list of keys to look up from the *data* and convert
+        to a dictionary.  Keys that are not in the YAML data are simply omitted
+        from the returned keywords, relying on default values in object
         constructors.
+
         """
         return {
-            k: v for k, v in ((k, data.get(k)) for k in args)
+            k: v for k, v in ((k, data.get(k))for k in attributes)
             if v is not None
         } if data else dict()
 

--- a/kernelci/config/base.py
+++ b/kernelci/config/base.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018, 2019, 2021 Collabora Limited
+# Copyright (C) 2018-2023 Collabora Limited
 # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
 #
 # This module is free software; you can redistribute it and/or modify it under
@@ -26,6 +26,18 @@ import copy
 
 class YAMLObject:
     """Base class with helper methods to initialise objects from YAML data."""
+
+    @classmethod
+    def from_yaml(cls, config, **kwargs):
+        """Load the YAML configuration
+
+        Load the YAML configuration passed as a *config* data structure with a
+        given *name*.  This method should return an instance of a YAMLObject
+        subclass.
+        """
+        yaml_attributes = cls._get_yaml_attributes()
+        kwargs.update(cls._kw_from_yaml(config, yaml_attributes))
+        return cls(**kwargs)
 
     @classmethod
     def _kw_from_yaml(cls, data, attributes):

--- a/kernelci/config/build.py
+++ b/kernelci/config/build.py
@@ -32,16 +32,6 @@ class Tree(YAMLObject):
         self._name = name
         self._url = url
 
-    @classmethod
-    def from_yaml(cls, config, name):
-        kw = {
-            'name': name,
-        }
-        kw.update(cls._kw_from_yaml(config, [
-            'url', 'name',
-        ]))
-        return cls(**kw)
-
     @property
     def name(self):
         return self._name
@@ -49,6 +39,12 @@ class Tree(YAMLObject):
     @property
     def url(self):
         return self._url
+
+    @classmethod
+    def _get_yaml_attributes(cls):
+        attrs = super()._get_yaml_attributes()
+        attrs.update({'url'})
+        return attrs
 
 
 class Reference(YAMLObject):
@@ -103,16 +99,6 @@ class Fragment(YAMLObject):
         self._configs = configs or list()
         self._defconfig = defconfig
 
-    @classmethod
-    def from_yaml(cls, config, name):
-        kw = {
-            'name': name,
-        }
-        kw.update(cls._kw_from_yaml(config, [
-            'name', 'path', 'configs', 'defconfig',
-        ]))
-        return cls(**kw)
-
     @property
     def name(self):
         return self._name
@@ -128,6 +114,12 @@ class Fragment(YAMLObject):
     @property
     def defconfig(self):
         return self._defconfig
+
+    @classmethod
+    def _get_yaml_attributes(cls):
+        attrs = super()._get_yaml_attributes()
+        attrs.update({'path', 'configs', 'defconfig'})
+        return attrs
 
 
 class Architecture(YAMLObject):
@@ -217,16 +209,6 @@ class BuildEnvironment(YAMLObject):
         self._cc_version = str(cc_version)
         self._arch_params = arch_params or dict()
 
-    @classmethod
-    def from_yaml(cls, config, name):
-        kw = {
-            'name': name,
-        }
-        kw.update(cls._kw_from_yaml(config, [
-            'name', 'cc', 'cc_version', 'arch_params',
-        ]))
-        return cls(**kw)
-
     @property
     def name(self):
         return self._name
@@ -238,6 +220,16 @@ class BuildEnvironment(YAMLObject):
     @property
     def cc_version(self):
         return self._cc_version
+
+    @property
+    def arch_params(self):
+        return self._arch_params.copy()
+
+    @classmethod
+    def _get_yaml_attributes(cls):
+        attrs = super()._get_yaml_attributes()
+        attrs.update({'cc', 'cc_version', 'arch_params'})
+        return attrs
 
     def get_arch_name(self, kernel_arch):
         params = self._arch_params.get(kernel_arch) or dict()
@@ -399,17 +391,17 @@ class BuildConfig(YAMLObject):
 
 def from_yaml(data, filters):
     trees = {
-        name: Tree.from_yaml(config, name)
+        name: Tree.from_yaml(config, name=name)
         for name, config in data.get('trees', {}).items()
     }
 
     fragments = {
-        name: Fragment.from_yaml(config, name)
+        name: Fragment.from_yaml(config, name=name)
         for name, config in data.get('fragments', {}).items()
     }
 
     build_environments = {
-        name: BuildEnvironment.from_yaml(config, name)
+        name: BuildEnvironment.from_yaml(config, name=name)
         for name, config in data.get('build_environments', {}).items()
     }
 

--- a/kernelci/config/db.py
+++ b/kernelci/config/db.py
@@ -1,5 +1,6 @@
-# Copyright (C) 2020 Collabora Limited
+# Copyright (C) 2020-2023 Collabora Limited
 # Author: Michal Galka <michal.galka@collabora.com>
+# Author: Guillaume Tucker <guillaume.tucker@collabora.com>
 #
 # This module is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
@@ -15,19 +16,14 @@
 # along with this library; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-import yaml
-
 from kernelci.config.base import YAMLObject
 
 
 class Database(YAMLObject):
+
     def __init__(self, name, db_type):
         self._name = name
         self._db_type = db_type
-
-    @classmethod
-    def from_yaml(cls, db, kw):
-        return cls(**kw)
 
     @property
     def name(self):
@@ -40,24 +36,15 @@ class Database(YAMLObject):
     @classmethod
     def _get_yaml_attributes(cls):
         attrs = super()._get_yaml_attributes()
-        attrs.update({'name', 'db_type'})
+        attrs.update({'db_type'})
         return attrs
 
 
 class DatabaseAPI(Database):
+
     def __init__(self, name, db_type, url):
         super().__init__(name, db_type)
         self._url = url
-
-    @classmethod
-    def from_yaml(cls, config, name):
-        kw = {
-            'name': name,
-        }
-        kw.update(cls._kw_from_yaml(config, [
-            'db_type', 'url',
-        ]))
-        return cls(**kw)
 
     @property
     def url(self):
@@ -77,8 +64,8 @@ class DatabaseFactory(YAMLObject):
     }
 
     @classmethod
-    def from_yaml(cls, name, db):
-        db_type = db.get('db_type')
+    def from_yaml(cls, config, name):
+        db_type = config.get('db_type')
         if db_type is None:
             raise TypeError("db_type cannot be Empty")
 
@@ -86,12 +73,12 @@ class DatabaseFactory(YAMLObject):
         if db_cls is None:
             raise ValueError("Unsupported database type: {}".format(db_type))
 
-        return db_cls.from_yaml(db, name)
+        return db_cls.from_yaml(config, name=name)
 
 
 def from_yaml(data, filters):
     db_configs = {
-        name: DatabaseFactory.from_yaml(name, db)
+        name: DatabaseFactory.from_yaml(db, name)
         for name, db in data.get('db_configs', {}).items()
     }
 

--- a/kernelci/config/db.py
+++ b/kernelci/config/db.py
@@ -37,8 +37,9 @@ class Database(YAMLObject):
     def db_type(self):
         return self._db_type
 
-    def _get_attrs(self):
-        attrs = super()._get_attrs()
+    @classmethod
+    def _get_yaml_attributes(cls):
+        attrs = super()._get_yaml_attributes()
         attrs.update({'name', 'db_type'})
         return attrs
 
@@ -62,8 +63,9 @@ class DatabaseAPI(Database):
     def url(self):
         return self._url
 
-    def _get_attrs(self):
-        attrs = super()._get_attrs()
+    @classmethod
+    def _get_yaml_attributes(cls):
+        attrs = super()._get_yaml_attributes()
         attrs.update({'url'})
         return attrs
 

--- a/kernelci/config/rootfs.py
+++ b/kernelci/config/rootfs.py
@@ -27,10 +27,6 @@ class RootFS(YAMLObject):
         self._name = name
         self._rootfs_type = rootfs_type
 
-    @classmethod
-    def from_yaml(cls, rootfs, kw):
-        return cls(**kw)
-
     @property
     def name(self):
         return self._name
@@ -38,6 +34,12 @@ class RootFS(YAMLObject):
     @property
     def rootfs_type(self):
         return self._rootfs_type
+
+    @classmethod
+    def _get_yaml_attributes(cls):
+        attrs = super()._get_yaml_attributes()
+        attrs.update({'rootfs_type'})
+        return attrs
 
 
 class RootFS_Debos(RootFS):
@@ -140,6 +142,26 @@ class RootFS_Debos(RootFS):
     def keyring_file(self):
         return self._keyring_file
 
+    @classmethod
+    def _get_yaml_attributes(cls):
+        attrs = super()._get_yaml_attributes()
+        attrs.update({
+            'debian_release',
+            'arch_list',
+            'debian_mirror',
+            'keyring_package',
+            'keyring_file',
+            'extra_packages',
+            'extra_packages_remove',
+            'extra_files_remove',
+            'extra_firmware',
+            'linux_fw_version',
+            'script',
+            'test_overlay',
+            'crush_image_options',
+        })
+        return attrs
+
 
 class RootFS_Buildroot(RootFS):
     def __init__(self, name, rootfs_type, git_url, git_branch,
@@ -150,18 +172,6 @@ class RootFS_Buildroot(RootFS):
         self._arch_list = arch_list or list()
         self._frags = frags or list()
         self._attrs = set()
-
-    @classmethod
-    def from_yaml(cls, config, name):
-        kw = {
-            'name': name,
-        }
-        kw.update(cls._kw_from_yaml(config, [
-            'rootfs_type', 'arch_list', 'git_url', 'git_branch', 'frags',
-        ]))
-        obj = cls(**kw)
-        obj._set_attrs(kw.keys())
-        return obj
 
     @property
     def git_url(self):
@@ -185,7 +195,12 @@ class RootFS_Buildroot(RootFS):
     @classmethod
     def _get_yaml_attributes(cls):
         attrs = super()._get_yaml_attributes()
-        attrs.update(self._attrs)
+        attrs.update({
+            'arch_list',
+            'git_url',
+            'git_branch',
+            'frags',
+        })
         return attrs
 
 
@@ -198,16 +213,6 @@ class RootFS_ChromiumOS(RootFS):
         self._branch = branch
         self._serial = serial
 
-    @classmethod
-    def from_yaml(cls, config, name):
-        kw = {
-            'name': name,
-        }
-        kw.update(cls._kw_from_yaml(config, [
-            'rootfs_type', 'arch_list', 'board', 'branch', 'serial'
-        ]))
-        return cls(**kw)
-
     @property
     def arch_list(self):
         return list(self._arch_list)
@@ -217,12 +222,23 @@ class RootFS_ChromiumOS(RootFS):
         return self._board
 
     @property
+    def branch(self):
+        return self._branch
+
+    @property
     def serial(self):
         return self._serial
 
-    @property
-    def branch(self):
-        return self._branch
+    @classmethod
+    def _get_yaml_attributes(cls):
+        attrs = super()._get_yaml_attributes()
+        attrs.update({
+            'arch_list',
+            'board',
+            'branch',
+            'serial',
+        })
+        return attrs
 
 
 class RootFSFactory(YAMLObject):
@@ -242,7 +258,7 @@ class RootFSFactory(YAMLObject):
         if rootfs_cls is None:
             raise ValueError("Unsupported value {}".format(rootfs_type))
 
-        return rootfs_cls.from_yaml(rootfs, name)
+        return rootfs_cls.from_yaml(rootfs, name=name)
 
 
 def from_yaml(data, filters):

--- a/kernelci/config/rootfs.py
+++ b/kernelci/config/rootfs.py
@@ -182,8 +182,9 @@ class RootFS_Buildroot(RootFS):
     def _set_attrs(self, attrs):
         self._attrs = set(attrs)
 
-    def _get_attrs(self):
-        attrs = super()._get_attrs()
+    @classmethod
+    def _get_yaml_attributes(cls):
+        attrs = super()._get_yaml_attributes()
         attrs.update(self._attrs)
         return attrs
 

--- a/kernelci/config/storage.py
+++ b/kernelci/config/storage.py
@@ -34,10 +34,6 @@ class Storage(YAMLObject):
         self._storage_type = storage_type
         self._base_url = base_url
 
-    @classmethod
-    def get_kwargs(cls, config):
-        return {}
-
     @property
     def name(self):
         return self._name
@@ -50,6 +46,12 @@ class Storage(YAMLObject):
     def base_url(self):
         return self._base_url
 
+    @classmethod
+    def _get_yaml_attributes(cls):
+        attrs = super()._get_yaml_attributes()
+        attrs.update({'storage_type', 'base_url'})
+        return attrs
+
 
 class Storage_backend(Storage):
 
@@ -61,13 +63,15 @@ class Storage_backend(Storage):
         super().__init__(*args, **kwargs)
         self._api_url = api_url
 
-    @classmethod
-    def get_kwargs(cls, config):
-        return cls._kw_from_yaml(config, ['api_url'])
-
     @property
     def api_url(self):
         return self._api_url
+
+    @classmethod
+    def _get_yaml_attributes(cls):
+        attrs = super()._get_yaml_attributes()
+        attrs.update({'api_url'})
+        return attrs
 
 
 class Storage_ssh(Storage):
@@ -87,10 +91,6 @@ class Storage_ssh(Storage):
         self._user = user
         self._path = path
 
-    @classmethod
-    def get_kwargs(cls, config):
-        return cls._kw_from_yaml(config, ['host', 'port', 'user', 'path'])
-
     @property
     def host(self):
         return self._host
@@ -106,6 +106,12 @@ class Storage_ssh(Storage):
     @property
     def path(self):
         return self._path
+
+    @classmethod
+    def _get_yaml_attributes(cls):
+        attrs = super()._get_yaml_attributes()
+        attrs.update({'host', 'port', 'user', 'path'})
+        return attrs
 
 
 class StorageFactory(YAMLObject):
@@ -124,9 +130,7 @@ class StorageFactory(YAMLObject):
             'name': name,
             'storage_type': storage_type,
         }
-        kw.update(cls._kw_from_yaml(config, ['base_url']))
-        kw.update(storage_cls.get_kwargs(config))
-        return storage_cls(**kw)
+        return storage_cls.from_yaml(config, **kw)
 
 
 def from_yaml(data, filters):

--- a/kernelci/config/test.py
+++ b/kernelci/config/test.py
@@ -97,8 +97,9 @@ class DeviceType(YAMLObject):
     def context(self):
         return self._context
 
-    def _get_attrs(self):
-        attrs = super()._get_attrs()
+    @classmethod
+    def _get_yaml_attributes(cls):
+        attrs = super()._get_yaml_attributes()
         attrs.update({
             'arch',
             'variant',
@@ -255,8 +256,9 @@ class RootFSType(YAMLObject):
     def url(self):
         return self._url
 
-    def _get_attrs(self):
-        attrs = super()._get_attrs()
+    @classmethod
+    def _get_yaml_attributes(cls):
+        attrs = super()._get_yaml_attributes()
         attrs.update({'url', 'arch_map'})
         return attrs
 
@@ -349,8 +351,9 @@ class RootFS(YAMLObject):
     def params(self):
         return dict(self._params)
 
-    def _get_attrs(self):
-        attrs = super()._get_attrs()
+    @classmethod
+    def _get_yaml_attributes(cls):
+        attrs = super()._get_yaml_attributes()
         attrs.update({
             'boot_protocol',
             'nfs',
@@ -454,8 +457,9 @@ class TestPlan(YAMLObject):
     def params(self):
         return dict(self._params)
 
-    def _get_attrs(self):
-        attrs = super()._get_attrs()
+    @classmethod
+    def _get_yaml_attributes(cls):
+        attrs = super()._get_yaml_attributes()
         attrs.update({
             'base_name',
             'category'

--- a/kernelci/config/test.py
+++ b/kernelci/config/test.py
@@ -194,25 +194,21 @@ class DeviceTypeFactory(YAMLObject):
     }
 
     @classmethod
-    def from_yaml(cls, name, device_type, default_filters=None):
+    def from_yaml(cls, name, config, default_filters=None):
         kw = {
             'name': name,
-            'base_name': device_type.get('base_name'),
-            'filters': FilterFactory.from_data(device_type, default_filters),
+            'base_name': config.get('base_name'),
+            'filters': FilterFactory.from_data(config, default_filters),
         }
-        kw.update(cls._kw_from_yaml(device_type, [
-            'mach', 'arch', 'variant', 'boot_method',
-            'dtb', 'flags', 'context', 'params',
-        ]))
-        cls_name = device_type.get('class')
+        cls_name = config.get('class')
         device_cls = cls._classes[cls_name] if cls_name else DeviceType
-        return device_cls(**kw)
+        return device_cls.from_yaml(config, **kw)
 
 
 class RootFSType(YAMLObject):
     """Root file system type model."""
 
-    def __init__(self, name, url, arch_dict=None):
+    def __init__(self, name, url, arch_map=None):
         """A root file system type covers common file system features.
 
         *name* is the file system type name e.g. 'debian' or 'buildroot'
@@ -230,23 +226,14 @@ class RootFSType(YAMLObject):
         """
         self._name = name
         self._url = url
-        self._arch_dict = arch_dict or dict()
+        self._arch_map = arch_map or {}
+        self._arch_dict = {}
 
-    @classmethod
-    def from_yaml(cls, name, fs_type):
-        kw = {
-            'name': name,
-        }
-        kw.update(cls._kw_from_yaml(fs_type, ['url']))
-        arch_map = fs_type.get('arch_map')
-        if arch_map:
-            arch_dict = {}
-            for arch_name, arch_dicts in arch_map.items():
+        if self._arch_map:
+            for arch_name, arch_dicts in self._arch_map.items():
                 for d in arch_dicts:
                     key = tuple((k, v) for (k, v) in d.items())
-                    arch_dict[key] = arch_name
-            kw['arch_dict'] = arch_dict
-        return cls(**kw)
+                    self._arch_dict[key] = arch_name
 
     @property
     def name(self):
@@ -255,6 +242,10 @@ class RootFSType(YAMLObject):
     @property
     def url(self):
         return self._url
+
+    @property
+    def arch_map(self):
+        return self._arch_map.copy()
 
     @classmethod
     def _get_yaml_attributes(cls):
@@ -544,7 +535,7 @@ class TestConfig(YAMLObject):
 
 def from_yaml(data, filters):
     fs_types = {
-        name: RootFSType.from_yaml(name, fs_type)
+        name: RootFSType.from_yaml(fs_type, name=name)
         for name, fs_type in data.get('file_system_types', {}).items()
     }
 

--- a/kernelci/lab/lava/__init__.py
+++ b/kernelci/lab/lava/__init__.py
@@ -37,22 +37,17 @@ class LavaAPI(LabAPI):
 
         # Scale the job priority (from 0-100) within the available levels
         # for the lab, or use the lowest by default.
-        if 'priority' in plan_config.params:
-            priority = plan_config.params['priority']
-            if priority > 100:
-                priority = 100
-        else:
-            priority = 20
-
-        prio_range = self.config._priority_max - self.config._priority_min
-        priority = int(((priority * prio_range) / 100) +
-                       self.config._priority_min)
+        plan_priority = plan_config.params.get('priority', 20)
+        if all((self.config.priority_max, self.config.priority_min)):
+            prio_range = self.config.priority_max - self.config.priority_min
+            prio_min = self.config.priority_min
+            plan_priority = int((plan_priority * prio_range / 100) + prio_min)
 
         params.update({
             'queue_timeout': self.config.queue_timeout,
             'lab_name': self.config.name,
             'base_device_type': self._alias_device_type(base_name),
-            'priority': priority,
+            'priority': plan_priority,
         })
         if callback_opts:
             self._add_callback_params(params, callback_opts)


### PR DESCRIPTION
Introduce a new method `._get_yaml_attributes()` as an intermediate step towards getting all the configuration objects inherit `yaml.YAMLObject` so they can be parsed and dumped directly by the `yaml` package.  This PR covers all the primitive configuration attributes and leaves out special ones that relate to other specific config objects.  It enables many objects to be serialised back to YAML already.