### PR TITLE
config: add tests and use yaml.YAMLObject

### DIFF
--- a/kernelci/config/base.py
+++ b/kernelci/config/base.py
@@ -24,7 +24,7 @@ import copy
 # Common classes for all config types
 #
 
-class YAMLObject:
+class _YAMLObject:
     """Base class with helper methods to initialise objects from YAML data."""
 
     @classmethod
@@ -32,7 +32,7 @@ class YAMLObject:
         """Load the YAML configuration
 
         Load the YAML configuration passed as a *config* data structure with a
-        given *name*.  This method should return an instance of a YAMLObject
+        given *name*.  This method should return an instance of a _YAMLObject
         subclass.
         """
         yaml_attributes = cls._get_yaml_attributes()
@@ -221,7 +221,7 @@ class Combination(Filter):
         return True
 
 
-class FilterFactory(YAMLObject):
+class FilterFactory(_YAMLObject):
     """Factory to create filters from YAML data."""
 
     _classes = {

--- a/kernelci/config/base.py
+++ b/kernelci/config/base.py
@@ -24,6 +24,55 @@ import copy
 # Common classes for all config types
 #
 
+class YAMLConfigObject(yaml.YAMLObject):
+    """Base class with helper methods to handle configuration YAML data
+
+    This class contains methods to help constructing configuration objects from
+    YAML data.  Then each subclass should implement its standard `to_yaml()`
+    method to be able to dump the whole configuration hierarchy back to YAML.
+    """
+
+    @classmethod
+    def load_from_yaml(cls, config, **kwargs):
+        """Load the YAML configuration
+
+        Load the YAML configuration passed as a *config* data structure with a
+        given *name*.  This method should return an instance of a
+        YAMLConfigObject subclass.
+        """
+        yaml_attributes = cls._get_yaml_attributes()
+        kwargs.update(cls._kw_from_yaml(config, yaml_attributes))
+        return cls(**kwargs)
+
+    @classmethod
+    def _kw_from_yaml(cls, data, attributes):
+        """Create some keyword arguments based on a YAML dictionary
+
+        Return a dictionary suitable to be used as Python keyword arguments in
+        an object constructor using values from some YAML *data*.  The
+        *attributes* are a list of keys to look up from the *data* and convert
+        to a dictionary.  Keys that are not in the YAML data are simply omitted
+        from the returned keywords, relying on default values in object
+        constructors.
+
+        """
+        return {
+            k: v for k, v in ((k, data.get(k))for k in attributes)
+            if v is not None
+        } if data else dict()
+
+    @classmethod
+    def _get_yaml_attributes(cls):
+        """Get a set of YAML attribute names
+
+        Get a set object with all the YAML configuration attribute names for
+        the configuration class.  This can be used to make keyword arguments
+        when creating a configuration object as well as when serialising it
+        back to YAML.
+        """
+        return set()
+
+
 class _YAMLObject:
     """Base class with helper methods to initialise objects from YAML data."""
 

--- a/kernelci/config/build.py
+++ b/kernelci/config/build.py
@@ -17,10 +17,10 @@
 
 import yaml
 
-from kernelci.config.base import FilterFactory, YAMLObject
+from kernelci.config.base import FilterFactory, _YAMLObject
 
 
-class Tree(YAMLObject):
+class Tree(_YAMLObject):
     """Kernel git tree model."""
 
     def __init__(self, name, url):
@@ -47,7 +47,7 @@ class Tree(YAMLObject):
         return attrs
 
 
-class Reference(YAMLObject):
+class Reference(_YAMLObject):
     """Kernel reference tree and branch model."""
 
     def __init__(self, tree, branch):
@@ -74,7 +74,7 @@ class Reference(YAMLObject):
         return self._branch
 
 
-class Fragment(YAMLObject):
+class Fragment(_YAMLObject):
     """Kernel config fragment model."""
 
     def __init__(self, name, path, configs=None, defconfig=None):
@@ -122,7 +122,7 @@ class Fragment(YAMLObject):
         return attrs
 
 
-class Architecture(YAMLObject):
+class Architecture(_YAMLObject):
     """CPU architecture attributes."""
 
     def __init__(self, name, base_defconfig='defconfig', extra_configs=None,
@@ -183,7 +183,7 @@ class Architecture(YAMLObject):
         return all(f.match(**params) for f in self._filters)
 
 
-class BuildEnvironment(YAMLObject):
+class BuildEnvironment(_YAMLObject):
     """Kernel build environment model."""
 
     def __init__(self, name, cc, cc_version, arch_params=None):
@@ -248,7 +248,7 @@ class BuildEnvironment(YAMLObject):
         return params.get('cross_compile_compat', '')
 
 
-class BuildVariant(YAMLObject):
+class BuildVariant(_YAMLObject):
     """A variant of a given build configuration."""
 
     def __init__(self, name, architectures, build_environment, fragments=None):
@@ -315,7 +315,7 @@ class BuildVariant(YAMLObject):
         return list(self._fragments)
 
 
-class BuildConfig(YAMLObject):
+class BuildConfig(_YAMLObject):
     """Build configuration model."""
 
     def __init__(self, name, tree, branch, variants, reference=None):

--- a/kernelci/config/build.py
+++ b/kernelci/config/build.py
@@ -17,11 +17,13 @@
 
 import yaml
 
-from kernelci.config.base import FilterFactory, _YAMLObject
+from kernelci.config.base import FilterFactory, _YAMLObject, YAMLConfigObject
 
 
-class Tree(_YAMLObject):
+class Tree(YAMLConfigObject):
     """Kernel git tree model."""
+
+    yaml_tag = u'!Tree'
 
     def __init__(self, name, url):
         """A kernel git tree is essentially a repository with kernel branches.
@@ -45,6 +47,12 @@ class Tree(_YAMLObject):
         attrs = super()._get_yaml_attributes()
         attrs.update({'url'})
         return attrs
+
+    @classmethod
+    def to_yaml(cls, dumper, data):
+        return dumper.represent_mapping(
+            u'tag:yaml.org,2002:map', {'url': data.url}
+        )
 
 
 class Reference(_YAMLObject):
@@ -391,7 +399,7 @@ class BuildConfig(_YAMLObject):
 
 def from_yaml(data, filters):
     trees = {
-        name: Tree.from_yaml(config, name=name)
+        name: Tree.load_from_yaml(config, name=name)
         for name, config in data.get('trees', {}).items()
     }
 

--- a/kernelci/config/db.py
+++ b/kernelci/config/db.py
@@ -16,10 +16,10 @@
 # along with this library; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-from kernelci.config.base import YAMLObject
+from kernelci.config.base import _YAMLObject
 
 
-class Database(YAMLObject):
+class Database(_YAMLObject):
 
     def __init__(self, name, db_type):
         self._name = name
@@ -57,7 +57,7 @@ class DatabaseAPI(Database):
         return attrs
 
 
-class DatabaseFactory(YAMLObject):
+class DatabaseFactory(_YAMLObject):
     _db_types = {
         "kernelci_backend": DatabaseAPI,
         "kernelci_api": DatabaseAPI,

--- a/kernelci/config/lab.py
+++ b/kernelci/config/lab.py
@@ -17,10 +17,10 @@
 
 import yaml
 
-from kernelci.config.base import FilterFactory, YAMLObject
+from kernelci.config.base import FilterFactory, _YAMLObject
 
 
-class Lab(YAMLObject):
+class Lab(_YAMLObject):
     """Test lab model."""
 
     def __init__(self, name, lab_type, filters=None):
@@ -140,7 +140,7 @@ class Lab_LAVA(LabAPI):
         return attrs
 
 
-class LabFactory(YAMLObject):
+class LabFactory(_YAMLObject):
     """Factory to create lab objects from YAML data."""
 
     _lab_types = {

--- a/kernelci/config/rootfs.py
+++ b/kernelci/config/rootfs.py
@@ -19,10 +19,10 @@ import sys
 import yaml
 
 from kernelci import sort_check
-from kernelci.config.base import YAMLObject
+from kernelci.config.base import _YAMLObject
 
 
-class RootFS(YAMLObject):
+class RootFS(_YAMLObject):
     def __init__(self, name, rootfs_type):
         self._name = name
         self._rootfs_type = rootfs_type
@@ -241,7 +241,7 @@ class RootFS_ChromiumOS(RootFS):
         return attrs
 
 
-class RootFSFactory(YAMLObject):
+class RootFSFactory(_YAMLObject):
     _rootfs_types = {
         'debos': RootFS_Debos,
         'buildroot': RootFS_Buildroot,

--- a/kernelci/config/storage.py
+++ b/kernelci/config/storage.py
@@ -17,10 +17,10 @@
 
 import yaml
 
-from kernelci.config.base import YAMLObject
+from kernelci.config.base import _YAMLObject
 
 
-class Storage(YAMLObject):
+class Storage(_YAMLObject):
     """Base configuration class for Storage implementations"""
 
     def __init__(self, name, storage_type, base_url):
@@ -114,7 +114,7 @@ class Storage_ssh(Storage):
         return attrs
 
 
-class StorageFactory(YAMLObject):
+class StorageFactory(_YAMLObject):
     """Factory to create storage objects from YAML data."""
 
     _storage_types = {

--- a/kernelci/config/test.py
+++ b/kernelci/config/test.py
@@ -17,10 +17,10 @@
 
 import yaml
 
-from kernelci.config.base import FilterFactory, YAMLObject
+from kernelci.config.base import FilterFactory, _YAMLObject
 
 
-class DeviceType(YAMLObject):
+class DeviceType(_YAMLObject):
     """Device type model."""
 
     def __init__(self, name, mach, arch, boot_method, dtb=None, base_name=None,
@@ -180,7 +180,7 @@ class DeviceType_kubernetes(DeviceType):
         super().__init__(name, mach, arch, boot_method, *args, **kwargs)
 
 
-class DeviceTypeFactory(YAMLObject):
+class DeviceTypeFactory(_YAMLObject):
     """Factory to create device types from YAML data."""
 
     _classes = {
@@ -205,7 +205,7 @@ class DeviceTypeFactory(YAMLObject):
         return device_cls.from_yaml(config, **kw)
 
 
-class RootFSType(YAMLObject):
+class RootFSType(_YAMLObject):
     """Root file system type model."""
 
     def __init__(self, name, url, arch_map=None):
@@ -265,7 +265,7 @@ class RootFSType(YAMLObject):
         return arch_name
 
 
-class RootFS(YAMLObject):
+class RootFS(_YAMLObject):
     """Root file system model."""
 
     def __init__(self, fs_type, boot_protocol='tftp', root_type=None,
@@ -372,7 +372,7 @@ class RootFS(YAMLObject):
         return fmt.format(arch=arch_name)
 
 
-class TestPlan(YAMLObject):
+class TestPlan(_YAMLObject):
     """Test plan model."""
 
     _pattern = \
@@ -480,7 +480,7 @@ class TestPlan(YAMLObject):
         return all(f.match(**config) for f in self._filters)
 
 
-class TestConfig(YAMLObject):
+class TestConfig(_YAMLObject):
     """Test configuration model."""
 
     def __init__(self, device_type, test_plans, filters=None):

--- a/kernelci/config/test.py
+++ b/kernelci/config/test.py
@@ -17,7 +17,7 @@
 
 import yaml
 
-from kernelci.config.base import FilterFactory, _YAMLObject
+from kernelci.config.base import FilterFactory, _YAMLObject, YAMLConfigObject
 
 
 class DeviceType(_YAMLObject):
@@ -205,8 +205,10 @@ class DeviceTypeFactory(_YAMLObject):
         return device_cls.from_yaml(config, **kw)
 
 
-class RootFSType(_YAMLObject):
+class RootFSType(YAMLConfigObject):
     """Root file system type model."""
+
+    yaml_tag = u'!RootFSType'
 
     def __init__(self, name, url, arch_map=None):
         """A root file system type covers common file system features.
@@ -252,6 +254,15 @@ class RootFSType(_YAMLObject):
         attrs = super()._get_yaml_attributes()
         attrs.update({'url', 'arch_map'})
         return attrs
+
+    @classmethod
+    def to_yaml(cls, dumper, data):
+        return dumper.represent_mapping(
+            u'tag:yaml.org,2002:map', {
+                'url': data.url,
+                'arch_map': data.arch_map,
+            }
+        )
 
     def get_arch_name(self, arch, variant, endian):
         arch_key = ('arch', arch)
@@ -535,7 +546,7 @@ class TestConfig(_YAMLObject):
 
 def from_yaml(data, filters):
     fs_types = {
-        name: RootFSType.from_yaml(fs_type, name=name)
+        name: RootFSType.load_from_yaml(fs_type, name=name)
         for name, fs_type in data.get('file_system_types', {}).items()
     }
 

--- a/tests/configs/file-system-types.yaml
+++ b/tests/configs/file-system-types.yaml
@@ -1,0 +1,20 @@
+file_system_types:
+
+  buildroot:
+    url: 'http://storage.kernelci.org/images/rootfs/buildroot'
+    arch_map:
+      arm64be: [{arch: arm64, endian: big}]
+      armeb:   [{arch: arm,   endian: big}]
+      armel:   [{arch: arm}]
+      x86:     [{arch: i386}, {arch: x86_64}]
+      mipsel:  [{arch: mips}]
+
+  debian:
+    url: 'http://storage.kernelci.org/images/rootfs/debian'
+    arch_map:
+      armel: [{arch: arm, variant: v4t},
+              {arch: arm, variant: v5},
+              {arch: arm, variant: v6}]
+      armhf: [{arch: arm}]
+      amd64: [{arch: x86_64}]
+      riscv64: [{arch: riscv}]

--- a/tests/configs/trees.yaml
+++ b/tests/configs/trees.yaml
@@ -1,0 +1,9 @@
+trees:
+  kselftest:
+    url: 'https://git.kernel.org/pub/scm/linux/kernel/git/shuah/linux-kselftest.git'
+
+  mainline:
+    url: 'https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git'
+
+  next:
+    url: 'https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git'

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -84,13 +84,8 @@ def test_file_system_types():
     fs_names = ['buildroot', 'debian']
     assert all(name in ref_data['file_system_types'] for name in fs_names)
     config = kernelci.config.load(yaml_file_path)
-    fs_dump = {
-        name: config.to_yaml()
-        for name, config in config['file_system_types'].items()
-    }
-    fs_config = {
-        name: yaml.safe_load(config) for name, config in fs_dump.items()
-    }
+    fs_dump = yaml.dump(config['file_system_types'])
+    fs_config = yaml.safe_load(fs_dump)
     assert all(name in fs_config for name in fs_names)
     assert ref_data['file_system_types'] == fs_config
     assert (

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -18,6 +18,8 @@
 # along with this library; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+import yaml
+
 import kernelci.config
 import kernelci.config.build
 import kernelci.config.test
@@ -55,3 +57,25 @@ def test_architecture_init_name_only():
     assert architecture.extra_configs == []
     assert architecture.fragments == []
     assert architecture._filters == []  # filters does not have a property..
+
+
+def test_trees():
+    # ToDo: use relative path to test module 'configs/trees.yaml'
+    yaml_file_path = 'tests/configs/trees.yaml'
+    with open(yaml_file_path) as yaml_file:
+        ref_data = yaml.safe_load(yaml_file)
+    tree_names = ['kselftest', 'mainline', 'next']
+    assert all(name in ref_data['trees'] for name in tree_names)
+    config = kernelci.config.load(yaml_file_path)
+    trees_dump = {
+        name: config.to_yaml() for name, config in config['trees'].items()
+    }
+    trees_config = {
+        name: yaml.safe_load(config) for name, config in trees_dump.items()
+    }
+    assert all(name in trees_config for name in tree_names)
+    assert ref_data['trees'] == trees_config
+    assert (
+        trees_config['next']['url'] ==
+        'https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git'
+    )

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -67,12 +67,8 @@ def test_trees():
     tree_names = ['kselftest', 'mainline', 'next']
     assert all(name in ref_data['trees'] for name in tree_names)
     config = kernelci.config.load(yaml_file_path)
-    trees_dump = {
-        name: config.to_yaml() for name, config in config['trees'].items()
-    }
-    trees_config = {
-        name: yaml.safe_load(config) for name, config in trees_dump.items()
-    }
+    trees_dump = yaml.dump(config['trees'])
+    trees_config = yaml.safe_load(trees_dump)
     assert all(name in trees_config for name in tree_names)
     assert ref_data['trees'] == trees_config
     assert (

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -79,3 +79,25 @@ def test_trees():
         trees_config['next']['url'] ==
         'https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git'
     )
+
+
+def test_file_system_types():
+    yaml_file_path = 'tests/configs/file-system-types.yaml'
+    with open(yaml_file_path) as yaml_file:
+        ref_data = yaml.safe_load(yaml_file)
+    fs_names = ['buildroot', 'debian']
+    assert all(name in ref_data['file_system_types'] for name in fs_names)
+    config = kernelci.config.load(yaml_file_path)
+    fs_dump = {
+        name: config.to_yaml()
+        for name, config in config['file_system_types'].items()
+    }
+    fs_config = {
+        name: yaml.safe_load(config) for name, config in fs_dump.items()
+    }
+    assert all(name in fs_config for name in fs_names)
+    assert ref_data['file_system_types'] == fs_config
+    assert (
+        fs_config['debian']['url'] ==
+        'http://storage.kernelci.org/images/rootfs/debian'
+    )

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -67,15 +67,21 @@ class TestConfigs:
         config = kernelci.config.load(yaml_file_path)
         return ref_data, config
 
+    def _reload(self, ref_data, config, name):
+        assert name in config
+        assert name in ref_data
+        dump = yaml.dump(config[name])
+        loaded = yaml.safe_load(dump)
+        assert ref_data[name] == loaded
+        return loaded
+
     def test_trees(self):
         # ToDo: use relative path to test module 'configs/trees.yaml'
         ref_data, config = self._load_config('tests/configs/trees.yaml')
+        trees_config = self._reload(ref_data, config, 'trees')
         tree_names = ['kselftest', 'mainline', 'next']
         assert all(name in ref_data['trees'] for name in tree_names)
-        trees_dump = yaml.dump(config['trees'])
-        trees_config = yaml.safe_load(trees_dump)
         assert all(name in trees_config for name in tree_names)
-        assert ref_data['trees'] == trees_config
         assert (
             trees_config['next']['url'] ==
             'https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git'  # noqa
@@ -85,12 +91,10 @@ class TestConfigs:
         ref_data, config = self._load_config(
             'tests/configs/file-system-types.yaml'
         )
+        fs_config = self._reload(ref_data, config, 'file_system_types')
         fs_names = ['buildroot', 'debian']
         assert all(name in ref_data['file_system_types'] for name in fs_names)
-        fs_dump = yaml.dump(config['file_system_types'])
-        fs_config = yaml.safe_load(fs_dump)
         assert all(name in fs_config for name in fs_names)
-        assert ref_data['file_system_types'] == fs_config
         assert (
             fs_config['debian']['url'] ==
             'http://storage.kernelci.org/images/rootfs/debian'

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -59,36 +59,39 @@ def test_architecture_init_name_only():
     assert architecture._filters == []  # filters does not have a property..
 
 
-def test_trees():
-    # ToDo: use relative path to test module 'configs/trees.yaml'
-    yaml_file_path = 'tests/configs/trees.yaml'
-    with open(yaml_file_path) as yaml_file:
-        ref_data = yaml.safe_load(yaml_file)
-    tree_names = ['kselftest', 'mainline', 'next']
-    assert all(name in ref_data['trees'] for name in tree_names)
-    config = kernelci.config.load(yaml_file_path)
-    trees_dump = yaml.dump(config['trees'])
-    trees_config = yaml.safe_load(trees_dump)
-    assert all(name in trees_config for name in tree_names)
-    assert ref_data['trees'] == trees_config
-    assert (
-        trees_config['next']['url'] ==
-        'https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git'
-    )
+class TestConfigs:
 
+    def _load_config(self, yaml_file_path):
+        with open(yaml_file_path) as yaml_file:
+            ref_data = yaml.safe_load(yaml_file)
+        config = kernelci.config.load(yaml_file_path)
+        return ref_data, config
 
-def test_file_system_types():
-    yaml_file_path = 'tests/configs/file-system-types.yaml'
-    with open(yaml_file_path) as yaml_file:
-        ref_data = yaml.safe_load(yaml_file)
-    fs_names = ['buildroot', 'debian']
-    assert all(name in ref_data['file_system_types'] for name in fs_names)
-    config = kernelci.config.load(yaml_file_path)
-    fs_dump = yaml.dump(config['file_system_types'])
-    fs_config = yaml.safe_load(fs_dump)
-    assert all(name in fs_config for name in fs_names)
-    assert ref_data['file_system_types'] == fs_config
-    assert (
-        fs_config['debian']['url'] ==
-        'http://storage.kernelci.org/images/rootfs/debian'
-    )
+    def test_trees(self):
+        # ToDo: use relative path to test module 'configs/trees.yaml'
+        ref_data, config = self._load_config('tests/configs/trees.yaml')
+        tree_names = ['kselftest', 'mainline', 'next']
+        assert all(name in ref_data['trees'] for name in tree_names)
+        trees_dump = yaml.dump(config['trees'])
+        trees_config = yaml.safe_load(trees_dump)
+        assert all(name in trees_config for name in tree_names)
+        assert ref_data['trees'] == trees_config
+        assert (
+            trees_config['next']['url'] ==
+            'https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git'  # noqa
+        )
+
+    def test_file_system_types(self):
+        ref_data, config = self._load_config(
+            'tests/configs/file-system-types.yaml'
+        )
+        fs_names = ['buildroot', 'debian']
+        assert all(name in ref_data['file_system_types'] for name in fs_names)
+        fs_dump = yaml.dump(config['file_system_types'])
+        fs_config = yaml.safe_load(fs_dump)
+        assert all(name in fs_config for name in fs_names)
+        assert ref_data['file_system_types'] == fs_config
+        assert (
+            fs_config['debian']['url'] ==
+            'http://storage.kernelci.org/images/rootfs/debian'
+        )


### PR DESCRIPTION
Add test cases using `unittest` for loading, dumping and loading again the configuration to check the generated YAML is correct.  Also start using `yaml.YAMLObject` as a base class for the `Tree` and `RootFSType` objects to make the standard code dump them automatically with `yaml.dump()`.