### PR TITLE
test-configs-riscv.yaml: fix conflict with global default_filters

### DIFF
--- a/config/core/test-configs-riscv.yaml
+++ b/config/core/test-configs-riscv.yaml
@@ -1,9 +1,7 @@
-default_filters:
+riscv_default_filters:
 
-  test_plans:
-
-    - blocklist: &kselftest_defconfig_filter
-        defconfig: ['kselftest']
+  - blocklist: &kselftest_defconfig_filter
+      defconfig: ['kselftest']
 
 
 test_plans:


### PR DESCRIPTION
Rename the default_filters top-level tag with as riscv_default_filters to avoid conflict with the global default_filters defined in test-configs.yaml.  As all the YAML files are loaded together, this was overriding the defaults for all the configs and not just riscv.

Also, as the filters defined in riscv_default_filters are used with anchors, it's just a place to define them within this file so the test_plans tag is not needed.  It is however used with the special default_filters tag as defaults for the Python code that loads the configs and not just YAML anchors.

Fixes: 39d2645e7e4a ("test-configs.yaml: Duplicate the tests to be run on riscv64")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>