### PR TITLE
Rework all build config and test YAML dump / reload

### DIFF
--- a/kernelci/config/base.py
+++ b/kernelci/config/base.py
@@ -195,6 +195,7 @@ class Blocklist(Filter):
     """
 
     yaml_tag = u'!BlockList'
+    name = 'blocklist'
 
     def match(self, **kw):
         for k, v in kw.items():
@@ -220,6 +221,7 @@ class Passlist(Filter):
     """
 
     yaml_tag = u'!PassList'
+    name = 'passlist'
 
     def match(self, **kw):
         for k, wl in self._items.items():
@@ -246,6 +248,7 @@ class Regex(Filter):
     """
 
     yaml_tag = u'!Regex'
+    name = 'regex'
 
     def __init__(self, *args, **kw):
         super().__init__(*args, **kw)
@@ -268,6 +271,7 @@ class Combination(Filter):
     """
 
     yaml_tag = u'!Combination'
+    name = 'combination'
 
     def __init__(self, items):
         super().__init__(items)
@@ -291,10 +295,12 @@ class FilterFactory:
     """Factory to create filters from YAML data."""
 
     _classes = {
-        'blocklist': Blocklist,
-        'passlist': Passlist,
-        'regex': Regex,
-        'combination': Combination,
+        cls.name: cls for cls in [
+            Blocklist,
+            Passlist,
+            Regex,
+            Combination,
+        ]
     }
 
     @classmethod

--- a/kernelci/config/build.py
+++ b/kernelci/config/build.py
@@ -55,8 +55,10 @@ class Tree(YAMLConfigObject):
         )
 
 
-class Reference(_YAMLObject):
+class Reference(YAMLConfigObject):
     """Kernel reference tree and branch model."""
+
+    yaml_tag = u'!Reference'
 
     def __init__(self, tree, branch):
         """Reference is a tree and branch used for bisections
@@ -68,7 +70,7 @@ class Reference(_YAMLObject):
         self._branch = branch
 
     @classmethod
-    def from_yaml(cls, reference, trees):
+    def load_from_yaml(cls, reference, trees):
         kw = cls._kw_from_yaml(reference, ['tree', 'branch'])
         kw['tree'] = trees[kw['tree']]
         return cls(**kw)
@@ -80,6 +82,15 @@ class Reference(_YAMLObject):
     @property
     def branch(self):
         return self._branch
+
+    @classmethod
+    def to_yaml(cls, dumper, data):
+        return dumper.represent_mapping(
+            u'tag:yaml.org,2002:map', {
+                'tree': data.tree.name,
+                'branch': data.branch,
+            }
+        )
 
 
 class Fragment(YAMLConfigObject):
@@ -394,7 +405,7 @@ class BuildConfig(_YAMLObject):
         kw['variants'] = {v.name: v for v in variants}
         reference = config.get('reference', defaults.get('reference'))
         if reference:
-            kw['reference'] = Reference.from_yaml(reference, trees)
+            kw['reference'] = Reference.load_from_yaml(reference, trees)
         return cls(**kw)
 
     @property

--- a/kernelci/config/build.py
+++ b/kernelci/config/build.py
@@ -203,8 +203,10 @@ class Architecture(_YAMLObject):
         return all(f.match(**params) for f in self._filters)
 
 
-class BuildEnvironment(_YAMLObject):
+class BuildEnvironment(YAMLConfigObject):
     """Kernel build environment model."""
+
+    yaml_tag = u'!BuildEnvironment'
 
     def __init__(self, name, cc, cc_version, arch_params=None):
         """A build environment is a compiler and tools to build a kernel.
@@ -250,6 +252,16 @@ class BuildEnvironment(_YAMLObject):
         attrs = super()._get_yaml_attributes()
         attrs.update({'cc', 'cc_version', 'arch_params'})
         return attrs
+
+    @classmethod
+    def to_yaml(cls, dumper, data):
+        return dumper.represent_mapping(
+            u'tag:yaml.org,2002:map', {
+                'cc': data.cc,
+                'cc_version': data.cc_version,
+                'arch_params': data.arch_params,
+            }
+        )
 
     def get_arch_name(self, kernel_arch):
         params = self._arch_params.get(kernel_arch) or dict()
@@ -421,7 +433,7 @@ def from_yaml(data, filters):
     }
 
     build_environments = {
-        name: BuildEnvironment.from_yaml(config, name=name)
+        name: BuildEnvironment.load_from_yaml(config, name=name)
         for name, config in data.get('build_environments', {}).items()
     }
 

--- a/kernelci/config/build.py
+++ b/kernelci/config/build.py
@@ -82,8 +82,10 @@ class Reference(_YAMLObject):
         return self._branch
 
 
-class Fragment(_YAMLObject):
+class Fragment(YAMLConfigObject):
     """Kernel config fragment model."""
+
+    yaml_tag = u'!Fragment'
 
     def __init__(self, name, path, configs=None, defconfig=None):
         """A kernel config fragment is a list of config options in file.
@@ -128,6 +130,16 @@ class Fragment(_YAMLObject):
         attrs = super()._get_yaml_attributes()
         attrs.update({'path', 'configs', 'defconfig'})
         return attrs
+
+    @classmethod
+    def to_yaml(cls, dumper, data):
+        return dumper.represent_mapping(
+            u'tag:yaml.org,2002:map', {
+                'path': data.path,
+                'configs': data.configs,
+                'defconfig': data.defconfig,
+            }
+        )
 
 
 class Architecture(_YAMLObject):
@@ -404,7 +416,7 @@ def from_yaml(data, filters):
     }
 
     fragments = {
-        name: Fragment.from_yaml(config, name=name)
+        name: Fragment.load_from_yaml(config, name=name)
         for name, config in data.get('fragments', {}).items()
     }
 

--- a/tests/configs/build-environments.yaml
+++ b/tests/configs/build-environments.yaml
@@ -1,0 +1,61 @@
+build_environments:
+
+  gcc-10:
+    cc: 'gcc'
+    cc_version: '10'
+    arch_params:
+      arc:
+        cross_compile: 'arc-elf32-'
+      arm:
+        cross_compile: 'arm-linux-gnueabihf-'
+      arm64:
+        cross_compile: 'aarch64-linux-gnu-'
+        cross_compile_compat: 'arm-linux-gnueabihf-'
+      i386:
+        name: 'x86'
+      mips:
+        cross_compile: 'mips-linux-gnu-'
+      sparc:
+        cross_compile: 'sparc64-linux-gnu-'
+      x86_64:
+        name: 'x86'
+      riscv:
+        name: 'riscv64'
+        cross_compile: 'riscv64-linux-gnu-'
+
+  clang-11:
+    cc: 'clang'
+    cc_version: '11'
+    arch_params: &clang_11_arch_params
+      arm:
+        cross_compile: 'arm-linux-gnueabihf-'
+        name:
+      arm64:
+        cross_compile: 'aarch64-linux-gnu-'
+        cross_compile_compat: 'arm-linux-gnueabihf-'
+        name:
+      i386:
+        name:
+      mips:
+        cross_compile: 'mips-linux-gnu-'
+        name:
+      x86_64:
+        name:
+
+  clang-12:
+    cc: clang
+    cc_version: '12'
+    arch_params:
+      <<: *clang_11_arch_params
+      riscv:
+        name:
+        opts:
+          LLVM_IAS: '1'
+          LD: 'riscv64-linux-gnu-ld'
+
+  rustc-1.62:
+    cc: 'clang'
+    cc_version: '15'
+    arch_params:
+      x86_64:
+        name:

--- a/tests/configs/builds.yaml
+++ b/tests/configs/builds.yaml
@@ -7,6 +7,34 @@ trees:
     url: 'https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git'
 
 
+fragments:
+
+  debug:
+    path: "kernel/configs/debug.config"
+    configs: []
+    defconfig:
+
+  amdgpu:
+    path: "kernel/configs/amdgpu.config"
+    defconfig:
+    configs:
+      - 'CONFIG_DRM_AMDGPU=y'
+      - 'CONFIG_DRM_AMDGPU_USERPTR=y'
+
+  ima:
+    path: "kernel/configs/ima.config"
+    defconfig:
+    configs:
+      - 'CONFIG_INTEGRITY=y'
+      - 'CONFIG_IMA=y'
+      - 'CONFIG_IMA_READ_POLICY=y'
+
+  x86_kvm_guest:
+    path: "kernel/configs/kvm_guest.config"
+    defconfig:
+    configs: []
+
+
 build_environments:
 
   gcc-10:
@@ -18,6 +46,17 @@ build_environments:
         cross_compile_compat: 'arm-linux-gnueabihf-'
       x86_64:
         name: 'x86'
+
+  clang-11:
+    cc: 'clang'
+    cc_version: '11'
+    arch_params:
+      arm64:
+        cross_compile: 'aarch64-linux-gnu-'
+        cross_compile_compat: 'arm-linux-gnueabihf-'
+        name:
+      x86_64:
+        name:
 
 
 build_configs:
@@ -31,9 +70,51 @@ build_configs:
     variants:
       gcc-10:
         build_environment: gcc-10
+        fragments: []
         architectures:
+          arc:
+            base_defconfig: 'haps_hs_smp_defconfig'
+            extra_configs: ['allnoconfig']
+            fragments: []
+            filters:
+              - blocklist:
+                  defconfig: ['axs101_defconfig', 'nps_defconfig']
+                  kernel: ['v3.', 'v4.4', 'v4.9']
           arm64:
             base_defconfig: 'defconfig'
             extra_configs:
               - 'allmodconfig'
               - 'allnoconfig'
+            fragments: []
+            filters: []
+          x86_64:
+            base_defconfig: 'x86_64_defconfig'
+            extra_configs: ['allmodconfig']
+            fragments: [amdgpu, ima, x86_kvm_guest]
+            filters: []
+
+  mainline:
+    tree: mainline
+    branch: 'master'
+    reference:
+      tree: mainline
+      branch: 'master'
+    variants:
+      gcc-10:
+        build_environment: gcc-10
+        fragments: []
+        architectures:
+          x86_64:
+            base_defconfig: 'x86_64_defconfig'
+            extra_configs: ['allmodconfig']
+            fragments: [amdgpu, ima, x86_kvm_guest]
+            filters: []
+      clang-11:
+        build_environment: clang-11
+        fragments: []
+        architectures:
+          arm64:
+            base_defconfig: 'defconfig'
+            extra_configs: ['allmodconfig']
+            fragments: [debug]
+            filters: []

--- a/tests/configs/builds.yaml
+++ b/tests/configs/builds.yaml
@@ -1,0 +1,39 @@
+trees:
+
+  arm64:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git"
+
+  mainline:
+    url: 'https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git'
+
+
+build_environments:
+
+  gcc-10:
+    cc: gcc
+    cc_version: 10
+    arch_params:
+      arm64:
+        cross_compile: 'aarch64-linux-gnu-'
+        cross_compile_compat: 'arm-linux-gnueabihf-'
+      x86_64:
+        name: 'x86'
+
+
+build_configs:
+
+  arm64:
+    tree: arm64
+    branch: 'for-kernelci'
+    reference:
+      tree: mainline
+      branch: 'master'
+    variants:
+      gcc-10:
+        build_environment: gcc-10
+        architectures:
+          arm64:
+            base_defconfig: 'defconfig'
+            extra_configs:
+              - 'allmodconfig'
+              - 'allnoconfig'

--- a/tests/configs/fragments.yaml
+++ b/tests/configs/fragments.yaml
@@ -1,0 +1,88 @@
+fragments:
+
+  debug:
+    path: "kernel/configs/debug.config"
+    configs: []
+    defconfig:
+
+  ima:
+    path: "kernel/configs/ima.config"
+    defconfig:
+    configs:
+      - 'CONFIG_INTEGRITY=y'
+      - 'CONFIG_IMA=y'
+      - 'CONFIG_IMA_READ_POLICY=y'
+
+  x86-chromebook:
+    path: "kernel/configs/x86-chromebook.config"
+    defconfig:
+    configs:
+      - 'CONFIG_SERIAL_8250=y'
+      - 'CONFIG_SERIAL_8250_DW=y'
+      - 'CONFIG_X86_AMD_PLATFORM_DEVICE=y'
+      - 'CONFIG_MFD_INTEL_LPSS_PCI=y'
+      - 'CONFIG_USB_GADGET=y'
+      - 'CONFIG_USB_ETH=y'
+      - 'CONFIG_USB_RTL8152=y'
+      - 'CONFIG_MMC=y'
+      - 'CONFIG_MMC_SDHCI=y'
+      - 'CONFIG_MMC_SDHCI_PCI=y'
+      - 'CONFIG_MMC_SDHCI_ACPI=y'
+      - 'CONFIG_CHROME_PLATFORMS=y'
+      - 'CONFIG_CHROMEOS_LAPTOP=y'
+      - 'CONFIG_CHROMEOS_TBMC=y'
+      - 'CONFIG_CROS_EC=y'
+      - 'CONFIG_CROS_EC_LPC=y'
+      - 'CONFIG_CROS_EC_I2C=y'
+      - 'CONFIG_IIO=m'
+      - 'CONFIG_IIO_CROS_EC_SENSORS_CORE=m'
+      - 'CONFIG_IIO_CROS_EC_SENSORS=m'
+      - 'CONFIG_MFD_CROS_EC_DEV=m'
+      - 'CONFIG_I2C_DESIGNWARE_PLATFORM=y'
+      - 'CONFIG_TCG_TPM=y'
+      - 'CONFIG_TCG_TIS=y'
+      - 'CONFIG_TCG_TIS_SPI=y'
+      - 'CONFIG_TCG_TIS_SPI_CR50=y'
+      - 'CONFIG_TCG_TIS_I2C_CR50=y'
+      - 'CONFIG_SPI=y'
+      - 'CONFIG_SPI_PXA2XX=y'
+      - 'CONFIG_PINCTRL_AMD=y'
+      - 'CONFIG_NVME_CORE=y'
+      - 'CONFIG_BLK_DEV_NVME=y'
+      - 'CONFIG_NFS_FS=y'
+      - 'CONFIG_NFS_V2=y'
+      - 'CONFIG_NFS_V3=y'
+      - 'CONFIG_NFS_V3_ACL=y'
+      - 'CONFIG_NFS_V4=y'
+      - 'CONFIG_ROOT_NFS=y'
+      - 'CONFIG_EXTRA_FIRMWARE="
+      amdgpu/raven2_asd.bin
+      amdgpu/raven2_ce.bin
+      amdgpu/raven2_gpu_info.bin
+      amdgpu/raven2_me.bin
+      amdgpu/raven2_mec2.bin
+      amdgpu/raven2_mec.bin
+      amdgpu/raven2_pfp.bin
+      amdgpu/raven2_rlc.bin
+      amdgpu/raven2_sdma.bin
+      amdgpu/raven2_ta.bin
+      amdgpu/raven2_vcn.bin
+      amdgpu/raven_kicker_rlc.bin
+      amdgpu/stoney_ce.bin
+      amdgpu/stoney_me.bin
+      amdgpu/stoney_mec.bin
+      amdgpu/stoney_pfp.bin
+      amdgpu/stoney_rlc.bin
+      amdgpu/stoney_sdma.bin
+      amdgpu/stoney_uvd.bin
+      amdgpu/stoney_vce.bin
+      i915/glk_dmc_ver1_04.bin
+      i915/kbl_dmc_ver1_04.bin
+      rtl_nic/rtl8153a-4.fw
+      rtl_nic/rtl8153b-2.fw
+      "'
+
+  x86_kvm_guest:
+    path: "kernel/configs/kvm_guest.config"
+    configs: []
+    defconfig:

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -95,6 +95,24 @@ class TestConfigs:
         assert all(name in frag_config for name in frag_names)
         assert frag_config['debug']['path'] == 'kernel/configs/debug.config'
 
+    def test_build_environments(self):
+        ref_data, config = self._load_config(
+            'tests/configs/build-environments.yaml'
+        )
+        be_config = self._reload(ref_data, config, 'build_environments')
+        be_names = ['gcc-10', 'clang-11', 'clang-12', 'rustc-1.62']
+        assert all(name in ref_data['build_environments'] for name in be_names)
+        assert all(name in be_config for name in be_names)
+        assert be_config['clang-12']['cc_version'] == '12'
+        clang12 = config['build_environments']['clang-12']
+        assert (
+            clang12.get_cross_compile_compat('arm64') ==
+            'arm-linux-gnueabihf-'
+        )
+        assert (
+            clang12.get_arch_opts('riscv')['LLVM_IAS'] == '1'
+        )
+
     def test_file_system_types(self):
         ref_data, config = self._load_config(
             'tests/configs/file-system-types.yaml'

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -113,6 +113,20 @@ class TestConfigs:
             clang12.get_arch_opts('riscv')['LLVM_IAS'] == '1'
         )
 
+    def test_reference_tree(self):
+        ref_data, config = self._load_config('tests/configs/builds.yaml')
+        assert 'build_configs' in ref_data
+        build_configs = ref_data['build_configs']
+        assert 'arm64' in build_configs
+        arm64 = build_configs['arm64']
+        assert 'reference' in arm64
+        reference = arm64['reference']
+        reference_config = config['build_configs']['arm64'].reference
+        assert reference_config.tree.name == 'mainline'
+        reference_dump = yaml.dump(reference_config)
+        reference_check = yaml.safe_load(reference_dump)
+        assert reference == reference_check
+
     def test_file_system_types(self):
         ref_data, config = self._load_config(
             'tests/configs/file-system-types.yaml'

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -87,6 +87,14 @@ class TestConfigs:
             'https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git'  # noqa
         )
 
+    def test_fragments(self):
+        ref_data, config = self._load_config('tests/configs/fragments.yaml')
+        frag_config = self._reload(ref_data, config, 'fragments')
+        frag_names = ['debug', 'ima', 'x86-chromebook', 'x86_kvm_guest']
+        assert all(name in ref_data['fragments'] for name in frag_names)
+        assert all(name in frag_config for name in frag_names)
+        assert frag_config['debug']['path'] == 'kernel/configs/debug.config'
+
     def test_file_system_types(self):
         ref_data, config = self._load_config(
             'tests/configs/file-system-types.yaml'

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -75,6 +75,9 @@ class TestConfigs:
         assert ref_data[name] == loaded
         return loaded
 
+
+class TestBuildConfigs(TestConfigs):
+
     def test_trees(self):
         # ToDo: use relative path to test module 'configs/trees.yaml'
         ref_data, config = self._load_config('tests/configs/trees.yaml')
@@ -126,6 +129,17 @@ class TestConfigs:
         reference_dump = yaml.dump(reference_config)
         reference_check = yaml.safe_load(reference_dump)
         assert reference == reference_check
+
+    def test_build_configs(self):
+        ref_data, config = self._load_config('tests/configs/builds.yaml')
+        build_configs = self._reload(ref_data, config, 'build_configs')
+        config_names = ['arm64', 'mainline']
+        assert all(name in ref_data['build_configs'] for name in config_names)
+        assert all(name in build_configs for name in config_names)
+        assert build_configs['mainline']['tree'] == 'mainline'
+
+
+class TestTestConfigs(TestConfigs):
 
     def test_file_system_types(self):
         ref_data, config = self._load_config(


### PR DESCRIPTION
Rework all the build configuration classes to be based on `YAMLConfigObject` and update tests accordingly to cover all the YAML dump and reload for the build configs using sample files.