### PR TITLE
build-configs: add clang-15 for riscv trees

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -1026,6 +1026,13 @@ build_configs:
             base_defconfig: 'defconfig'
             extra_configs:
               - 'defconfig+CONFIG_SMP=n'
+      clang-15:
+        build_environment: clang-15
+        architectures:
+          riscv:
+            base_defconfig: 'defconfig'
+            extra_configs:
+              - 'defconfig+CONFIG_SMP=n'
 
   riscv_for-next:
     <<: *riscv-tree


### PR DESCRIPTION
Add clang-15 builds for the riscv trees.  
The riscv trees are only built for ARCH=riscv and a small subset of defconfigs.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>