### PR TITLE
kernelci.config.base: Do not corrupt default filter lists

### DIFF
--- a/kernelci/config/base.py
+++ b/kernelci/config/base.py
@@ -17,6 +17,7 @@
 
 import re
 import yaml
+import copy
 
 
 # -----------------------------------------------------------------------------
@@ -222,7 +223,13 @@ class FilterFactory(YAMLObject):
                         break
                 else:
                     filter_cls = cls._classes[filter_type]
-                    filter_instance = filter_cls(items)
+                    # We need to provide the new filter with its own
+                    # item arrays, so that we don't accidentally
+                    # corrupt the initial dictionary we were
+                    # passed. That can cause bleed-through, where our
+                    # filter terms start being applied in other places
+                    # unexpectedly.
+                    filter_instance = filter_cls(copy.deepcopy(items))
                     filters.setdefault(filter_type, list()).append(
                         filter_instance)
                     filter_list.append(filter_instance)


### PR DESCRIPTION
This is an unexpected consequence of filter merging: the arrays inside the default filter items we accidentally shared with the filter instances, which meant that, unexpectedly, when merging in new filter items we also corrupted the default filters. This in turn led to filter items being applied inappropriately in other places, in a way that was impossible to predict from the surface YAML.

Signed-off-by: Ed Smith <ed.smith@collabora.com>