### PR TITLE
kernelci.legacy: Install vmlinux to aid debugging

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -1147,6 +1147,7 @@ build_configs:
   next:
     tree: next
     branch: 'master'
+    install_vmlinux: True
     variants:
       gcc-10:
         build_environment: gcc-10

--- a/kci_build
+++ b/kci_build
@@ -301,7 +301,7 @@ class MakeCommand(Command):
         opts = self._get_opts(args, configs)
         res = step.run(args.j, args.verbose, opts)
         if args.install:
-            install_res = self._install_step(step, args)
+            install_res = self._install_step(step, configs, args)
             res = res and install_res
         return res
 
@@ -313,8 +313,8 @@ class MakeCommand(Command):
     def _get_opts(self, args, configs):
         return dict()
 
-    def _install_step(self, step, args):
-        return step.install(args.verbose)
+    def _install_step(self, step, configs, args):
+        return step.install(args.verbose, configs)
 
 
 class cmd_make_config(MakeCommand):
@@ -343,7 +343,7 @@ class cmd_make_modules(MakeCommand):
     help = "Build kernel modules"
     step_cls = kernelci.build.MakeModules
 
-    def _install_step(self, step, args):
+    def _install_step(self, step, configs, args):
         return step.install(args.verbose, args.j)
 
 

--- a/kernelci/config/build.py
+++ b/kernelci/config/build.py
@@ -359,7 +359,8 @@ class BuildConfig(YAMLConfigObject):
 
     yaml_tag = u'!BuildConfig'
 
-    def __init__(self, name, tree, branch, variants, reference=None):
+    def __init__(self, name, tree, branch, variants, reference=None,
+                 install_vmlinux=False):
         """A build configuration defines the actual kernels to be built.
 
         *name* is the name of the build configuration.  It is arbitrary and
@@ -378,12 +379,15 @@ class BuildConfig(YAMLConfigObject):
                     bisections when no base commit is found for the good and
                     bad revisions.  It can also be None if no reference branch
                     can be used with this build configuration.
+
+        *install_vmlinux* is True if vmlinux should be installed
         """
         self._name = name
         self._tree = tree
         self._branch = branch
         self._variants = variants
         self._reference = reference
+        self._install_vmlinux = install_vmlinux
 
     @classmethod
     def load_from_yaml(cls, config, name, trees, fragments, b_envs, defaults):
@@ -391,7 +395,7 @@ class BuildConfig(YAMLConfigObject):
             'name': name,
         }
         kw.update(cls._kw_from_yaml(config, [
-            'name', 'tree', 'branch',
+            'name', 'tree', 'branch', 'install_vmlinux'
         ]))
         kw['tree'] = trees[kw['tree']]
         default_variants = defaults.get('variants', {})
@@ -428,6 +432,10 @@ class BuildConfig(YAMLConfigObject):
     @property
     def reference(self):
         return self._reference
+
+    @property
+    def install_vmlinux(self):
+        return self._install_vmlinux
 
     @classmethod
     def to_yaml(cls, dumper, data):


### PR DESCRIPTION
Some debugging, such as the use of scripts/decode_stacktrace.sh and other things involving looking at the disassembly of the built kernel, need the vmlinux to get debug information which doesn't make it into the image files deployed in onto targets for most architectures. Support such uses by including the vmlinux in our shipped artefacts.

Since this is frequently a large file but compresses well use xz to compress as we install. For example, a build I have here is 176M but with xz we can compress it down to 52M. gzip is much less effective at 80M although it is faster, the tradeoff seems worth it given that the binaries are likely to be used infrequently.

Signed-off-by: Mark Brown <broonie@kernel.org>