### PR TITLE
config/docker: Add architecture specific clang templates

### DIFF
--- a/config/docker/clang-11-arm.jinja2
+++ b/config/docker/clang-11-arm.jinja2
@@ -1,0 +1,13 @@
+{%- set sub_arch = 'armhf' %}
+{% extends 'clang-11.jinja2' %}
+
+{% block packages %}
+{{ super() }}
+
+RUN dpkg --add-architecture armhf
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    libgcc-10-dev:armhf
+
+{%- endblock %}
+

--- a/config/docker/clang-11-arm64.jinja2
+++ b/config/docker/clang-11-arm64.jinja2
@@ -1,0 +1,13 @@
+{%- set sub_arch = 'arm64' %}
+{% extends 'clang-11.jinja2' %}
+
+{% block packages %}
+{{ super() }}
+
+RUN dpkg --add-architecture arm64
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    libgcc-10-dev:arm64
+
+{%- endblock %}
+

--- a/config/docker/clang-11-armv5.jinja2
+++ b/config/docker/clang-11-armv5.jinja2
@@ -1,0 +1,13 @@
+{%- set sub_arch = 'armel' %}
+{% extends 'clang-11.jinja2' %}
+
+{% block packages %}
+{{ super() }}
+
+RUN dpkg --add-architecture armel
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    libgcc-10-dev:armel
+
+{%- endblock %}
+

--- a/config/docker/clang-11-mips.jinja2
+++ b/config/docker/clang-11-mips.jinja2
@@ -1,0 +1,5 @@
+{#
+ # Userspace builds currently don't work for GCC either.
+-#}
+
+{% extends 'clang-11.jinja2' %}

--- a/config/docker/clang-11-riscv64.jinja2
+++ b/config/docker/clang-11-riscv64.jinja2
@@ -1,0 +1,5 @@
+{#
+ # TBD - toolchain packages are different.
+-#}
+
+{% extends 'clang-11.jinja2' %}

--- a/config/docker/clang-11-x86.jinja2
+++ b/config/docker/clang-11-x86.jinja2
@@ -1,0 +1,13 @@
+{%- set sub_arch = 'amd64' %}
+{% extends 'clang-11.jinja2' %}
+
+{% block packages %}
+{{ super() }}
+
+RUN dpkg --add-architecture amd64
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    libgcc-10-dev:amd64
+
+{%- endblock %}
+

--- a/config/docker/clang-14-arm.jinja2
+++ b/config/docker/clang-14-arm.jinja2
@@ -1,0 +1,13 @@
+{%- set sub_arch = 'armhf' %}
+{% extends 'clang-14.jinja2' %}
+
+{% block packages %}
+{{ super() }}
+
+RUN dpkg --add-architecture armhf
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    libgcc-10-dev:armhf
+
+{%- endblock %}
+

--- a/config/docker/clang-14-arm64.jinja2
+++ b/config/docker/clang-14-arm64.jinja2
@@ -1,0 +1,13 @@
+{%- set sub_arch = 'arm64' %}
+{% extends 'clang-14.jinja2' %}
+
+{% block packages %}
+{{ super() }}
+
+RUN dpkg --add-architecture arm64
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    libgcc-10-dev:arm64
+
+{%- endblock %}
+

--- a/config/docker/clang-14-armv5.jinja2
+++ b/config/docker/clang-14-armv5.jinja2
@@ -1,0 +1,13 @@
+{%- set sub_arch = 'armel' %}
+{% extends 'clang-14.jinja2' %}
+
+{% block packages %}
+{{ super() }}
+
+RUN dpkg --add-architecture armel
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    libgcc-10-dev:armel
+
+{%- endblock %}
+

--- a/config/docker/clang-14-mips.jinja2
+++ b/config/docker/clang-14-mips.jinja2
@@ -1,0 +1,5 @@
+{#
+ # Userspace builds currently don't work for GCC either.
+-#}
+
+{% extends 'clang-14.jinja2' %}

--- a/config/docker/clang-14-riscv64.jinja2
+++ b/config/docker/clang-14-riscv64.jinja2
@@ -1,0 +1,5 @@
+{#
+ # TBD - toolchain packages are different.
+-#}
+
+{% extends 'clang-14.jinja2' %}

--- a/config/docker/clang-14-x86.jinja2
+++ b/config/docker/clang-14-x86.jinja2
@@ -1,0 +1,13 @@
+{%- set sub_arch = 'amd64' %}
+{% extends 'clang-14.jinja2' %}
+
+{% block packages %}
+{{ super() }}
+
+RUN dpkg --add-architecture amd64
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    libgcc-10-dev:amd64
+
+{%- endblock %}
+

--- a/config/docker/clang-15-arm.jinja2
+++ b/config/docker/clang-15-arm.jinja2
@@ -1,0 +1,13 @@
+{%- set sub_arch = 'armhf' %}
+{% extends 'clang-15.jinja2' %}
+
+{% block packages %}
+{{ super() }}
+
+RUN dpkg --add-architecture armhf
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    libgcc-10-dev:armhf
+
+{%- endblock %}
+

--- a/config/docker/clang-15-arm64.jinja2
+++ b/config/docker/clang-15-arm64.jinja2
@@ -1,0 +1,13 @@
+{%- set sub_arch = 'arm64' %}
+{% extends 'clang-15.jinja2' %}
+
+{% block packages %}
+{{ super() }}
+
+RUN dpkg --add-architecture arm64
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    libgcc-10-dev:arm64
+
+{%- endblock %}
+

--- a/config/docker/clang-15-armv5.jinja2
+++ b/config/docker/clang-15-armv5.jinja2
@@ -1,0 +1,13 @@
+{%- set sub_arch = 'armel' %}
+{% extends 'clang-15.jinja2' %}
+
+{% block packages %}
+{{ super() }}
+
+RUN dpkg --add-architecture armel
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    libgcc-10-dev:armel
+
+{%- endblock %}
+

--- a/config/docker/clang-15-mips.jinja2
+++ b/config/docker/clang-15-mips.jinja2
@@ -1,0 +1,5 @@
+{#
+ # Userspace builds currently don't work for GCC either.
+-#}
+
+{% extends 'clang-15.jinja2' %}

--- a/config/docker/clang-15-riscv64.jinja2
+++ b/config/docker/clang-15-riscv64.jinja2
@@ -1,0 +1,5 @@
+{#
+ # TBD - toolchain packages are different.
+-#}
+
+{% extends 'clang-15.jinja2' %}

--- a/config/docker/clang-15-x86.jinja2
+++ b/config/docker/clang-15-x86.jinja2
@@ -1,0 +1,13 @@
+{%- set sub_arch = 'amd64' %}
+{% extends 'clang-15.jinja2' %}
+
+{% block packages %}
+{{ super() }}
+
+RUN dpkg --add-architecture amd64
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    libgcc-10-dev:amd64
+
+{%- endblock %}
+

--- a/config/docker/clang-16-arm.jinja2
+++ b/config/docker/clang-16-arm.jinja2
@@ -1,0 +1,13 @@
+{%- set sub_arch = 'armhf' %}
+{% extends 'clang-16.jinja2' %}
+
+{% block packages %}
+{{ super() }}
+
+RUN dpkg --add-architecture armhf
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    libgcc-10-dev:armhf
+
+{%- endblock %}
+

--- a/config/docker/clang-16-arm64.jinja2
+++ b/config/docker/clang-16-arm64.jinja2
@@ -1,0 +1,13 @@
+{%- set sub_arch = 'arm64' %}
+{% extends 'clang-16.jinja2' %}
+
+{% block packages %}
+{{ super() }}
+
+RUN dpkg --add-architecture arm64
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    libgcc-10-dev:arm64
+
+{%- endblock %}
+

--- a/config/docker/clang-16-armv5.jinja2
+++ b/config/docker/clang-16-armv5.jinja2
@@ -1,0 +1,13 @@
+{%- set sub_arch = 'armel' %}
+{% extends 'clang-16.jinja2' %}
+
+{% block packages %}
+{{ super() }}
+
+RUN dpkg --add-architecture armel
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    libgcc-10-dev:armel
+
+{%- endblock %}
+

--- a/config/docker/clang-16-mips.jinja2
+++ b/config/docker/clang-16-mips.jinja2
@@ -1,0 +1,5 @@
+{#
+ # Userspace builds currently don't work for GCC either.
+-#}
+
+{% extends 'clang-16.jinja2' %}

--- a/config/docker/clang-16-riscv64.jinja2
+++ b/config/docker/clang-16-riscv64.jinja2
@@ -1,0 +1,5 @@
+{#
+ # TBD - toolchain packages are different.
+-#}
+
+{% extends 'clang-16.jinja2' %}

--- a/config/docker/clang-16-x86.jinja2
+++ b/config/docker/clang-16-x86.jinja2
@@ -1,0 +1,13 @@
+{%- set sub_arch = 'amd64' %}
+{% extends 'clang-16.jinja2' %}
+
+{% block packages %}
+{{ super() }}
+
+RUN dpkg --add-architecture amd64
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    libgcc-10-dev:amd64
+
+{%- endblock %}
+


### PR DESCRIPTION
Since clang provides a single toolchain binary which supports all target architectures we currently provide a single clang container for each version which is used for all architecture builds.  These containers include some very basic cross compilation support required for things like the vDSO but do not include enough to build real userspace applications since those generally also need libgcc, and adding our current kselftest fragments will only pull in the libraries for one architecture.

Rather than installing all userspace libraries for all architectures follow the pattern for GCC and add per architecture clang templates, layerd on top of the existing architecture neutral ones.  These templates add libgcc and can also be used with the kselftest fragment or other fragments that install userspace libraries.  The existing templates are left in place so existing usage is not disrupted during deployment and so that we share as much of the layers for each clang version as possible.

As well as enabling much more succesful kselftest builds with clang this will allow us to remove some of the compiler dependent special casing.

The MIPS and RISC-V templates are currently stub templates which will not actually work for userspace, this at least allows builds to be converted to use the per-architecture packages without causing regressions for them or requring per architecture special casing.  In the case of MIPS the existing GCC template also does not work for userspace builds and it is not clear what should be done, especially given the multiple subarchitectures.  In the case of RISC-V it is an external Debian port with different toolchain packaging that doesn't follow the same pattern so will need handling appropriate to that packaging.

Signed-off-by: Mark Brown <broonie@kernel.org>