### PR TITLE
Enable libhugetlbfs testsuite

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -211,6 +211,21 @@ rootfs_configs:
     script: "scripts/bullseye-libcamera.sh"
     test_overlay: "overlays/libcamera"
 
+  bullseye-libhugetlbfs:
+    rootfs_type: debos
+    debian_release: bullseye
+    arch_list:
+      - amd64
+      - arm64
+      - armhf
+    extra_packages:
+      - python-is-python2
+    extra_packages_remove:
+      - bash
+      - e2fslibs
+      - e2fsprogs
+    script: "scripts/bullseye-libhugetlbfs.sh"
+
   bullseye-ltp:
     rootfs_type: debos
     debian_release: bullseye

--- a/config/core/rootfs-images.yaml
+++ b/config/core/rootfs-images.yaml
@@ -54,6 +54,23 @@ file_systems:
     ramdisk: bullseye-libcamera/20230114.0/{arch}/initrd.cpio.gz
     root_type: nfs
     type: debian
+  debian_bullseye-libhugetlbfs_nfs:
+    boot_protocol: tftp
+    nfs: bullseye-libhugetlbfs/20230116.1/{arch}/full.rootfs.tar.xz
+    params:
+      os_config: debian
+    prompt: '/ #'
+    ramdisk: bullseye-libhugetlbfs/20230116.1/{arch}/initrd.cpio.gz
+    root_type: nfs
+    type: debian
+  debian_bullseye-libhugetlbfs_ramdisk:
+    boot_protocol: ramdisk
+    params:
+      os_config: debian
+    prompt: '/ #'
+    ramdisk: bullseye-libhugetlbfs/20230116.1/{arch}/rootfs.cpio.gz
+    root_type: ramdisk
+    type: debian
   debian_bullseye-ltp_nfs:
     boot_protocol: tftp
     nfs: bullseye-ltp/20230114.0/{arch}/full.rootfs.tar.xz

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -424,6 +424,12 @@ test_plans:
     params:
       job_timeout: '45'
 
+  libhugetlbfs:
+    rootfs: debian_bullseye-libhugetlbfs_nfs
+    pattern: 'libhugetlbfs/{category}-{method}-{protocol}-{rootfs}-libhugetlbfs-template.jinja2'
+    params:
+      job_timeout: '20'
+
   ltp: &ltp
     rootfs: debian_bullseye-ltp_nfs
     pattern: 'ltp/{category}-{method}-{protocol}-{rootfs}-ltp-template.jinja2'

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -3106,6 +3106,7 @@ test_configs:
       - kselftest-rseq
       - kselftest-seccomp
       - kselftest-timers
+      - libhugetlbfs
       - ltp-crypto
       - preempt-rt
 

--- a/config/lava/libhugetlbfs/generic-barebox-tftp-nfs-libhugetlbfs-template.jinja2
+++ b/config/lava/libhugetlbfs/generic-barebox-tftp-nfs-libhugetlbfs-template.jinja2
@@ -1,0 +1,8 @@
+{% extends 'boot-nfs/generic-barebox-tftp-nfs-template.jinja2' %}
+
+{% block actions %}
+{{ super () }}
+
+{% include 'libhugetlbfs/kselftest.jinja2' %}
+
+{% endblock %}

--- a/config/lava/libhugetlbfs/generic-depthcharge-tftp-nfs-libhugetlbfs-template.jinja2
+++ b/config/lava/libhugetlbfs/generic-depthcharge-tftp-nfs-libhugetlbfs-template.jinja2
@@ -1,0 +1,8 @@
+{% extends 'boot-nfs/generic-depthcharge-tftp-nfs-template.jinja2' %}
+
+{% block actions %}
+{{ super () }}
+
+{% include 'libhugetlbfs/libhugetlbfs.jinja2' %}
+
+{% endblock %}

--- a/config/lava/libhugetlbfs/generic-grub-tftp-nfs-libhugetlbfs-template.jinja2
+++ b/config/lava/libhugetlbfs/generic-grub-tftp-nfs-libhugetlbfs-template.jinja2
@@ -1,0 +1,8 @@
+{% extends 'boot-nfs/generic-grub-tftp-nfs-template.jinja2' %}
+
+{% block actions %}
+{{ super () }}
+
+{% include 'libhugetlbfs/libhugetlbfs.jinja2' %}
+
+{% endblock %}

--- a/config/lava/libhugetlbfs/generic-qemu-ramdisk-libhugetlbfs-template.jinja2
+++ b/config/lava/libhugetlbfs/generic-qemu-ramdisk-libhugetlbfs-template.jinja2
@@ -1,0 +1,11 @@
+{% extends 'boot/generic-qemu-boot-template.jinja2' %}
+{% block actions %}
+{{ super () }}
+
+{% include 'libhugetlbfs/libhugetlbfs.jinja2' %}
+
+{% endblock %}
+
+{%- block image_arg %}
+        image_arg: '-kernel {kernel} -append "console={{ console_dev }},115200 root=/dev/ram0 debug verbose {{ extra_kernel_args }}"'
+{%- endblock %}

--- a/config/lava/libhugetlbfs/generic-uboot-tftp-nfs-libhugetlbfs-template.jinja2
+++ b/config/lava/libhugetlbfs/generic-uboot-tftp-nfs-libhugetlbfs-template.jinja2
@@ -1,0 +1,8 @@
+{% extends 'boot-nfs/generic-uboot-tftp-nfs-template.jinja2' %}
+
+{% block actions %}
+{{ super () }}
+
+{% include 'libhugetlbfs/libhugetlbfs.jinja2' %}
+
+{% endblock %}

--- a/config/lava/libhugetlbfs/libhugetlbfs.jinja2
+++ b/config/lava/libhugetlbfs/libhugetlbfs.jinja2
@@ -1,0 +1,32 @@
+- test:
+    timeout:
+      minutes: {{ job_timeout }}
+    definitions:
+    - from: inline
+      repository:
+        metadata:
+          format: Lava-Test Test Definition 1.0
+          name: timesync-off
+          description: Disable systemd time sync services
+        run:
+          steps:
+          - systemctl stop systemd-timesyncd || true
+      name: timesync-off
+      path: inline/timesync-off.yaml
+
+    - repository: https://github.com/kernelci/test-definitions.git
+      from: git
+      revision: kernelci.org
+      path: automated/linux/libhugetlbfs/libhugetlbfs.yaml
+      name: libhugetlbfs
+      parameters:
+        SKIP_INSTALL: True
+{% if arch == 'arm' %}
+        WORD_SIZE: 32
+{% endif %}
+{% if arch == 'arm64' %}
+        WORD_SIZE: 64
+{% endif %}
+{% if arch == 'x86_64' %}
+        WORD_SIZE: 64
+{% endif %}

--- a/config/rootfs/debos/scripts/bullseye-libhugetlbfs.sh
+++ b/config/rootfs/debos/scripts/bullseye-libhugetlbfs.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Important: This script is run under QEMU
+
+set -e
+
+RELEASE=02df38e93e25e07f4d54edae94fb4ec90b7a2824
+
+BUILD_DEPS="\
+      gcc \
+      git \
+      ca-certificates \
+      libc6-dev \
+      make \
+      wget \
+"
+
+apt-get install --no-install-recommends -y ${BUILD_DEPS}
+
+# test-definitions is going to go looking for /usr/lib*/libhugetlbfs
+# so build there
+mkdir /usr/libhugetlbfs
+cd /usr/libhugetlbfs
+git clone https://github.com/libhugetlbfs/libhugetlbfs
+cd libhugetlbfs
+git reset --hard ${RELEASE}
+make BUILDTYPE=NATIVEONLY
+
+# Cleanup: remove files and packages we don't want in the images 
+apt-get remove --purge -y ${BUILD_DEPS}
+apt-get remove --purge -y libgtest-dev
+apt-get autoremove --purge -y
+apt-get clean


### PR DESCRIPTION
The libhugetlbfs testsuite is a small, quick running and reliable testsuite which is really good for finding issues in the kernel's memory management subsystem, let's enable it for use in KernelCI. This involves the addition of a new filesystem image containing the testsuite which we then use with the existing LAVA test definitions.