### PR TITLE
Enable LTP syscalls tests

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2805,6 +2805,7 @@ test_configs:
       - ltp-ipc
       # ltp-mm - Runs board out of memory
       - ltp-pty
+      - ltp-syscalls
       - ltp-timers
 
   - device_type: meson-gxm-khadas-vim2


### PR DESCRIPTION
The LTP syscalls test is a big suite but does cover a lot of ground in the ABI, enable it on BeagleBone Black so we get some coverage from it.