### PR TITLE
rootfs-configs.yaml: Add more userspace filesystem utilities for LTP

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -219,8 +219,10 @@ rootfs_configs:
       - arm64
       - armhf
     extra_packages:
+      - dosfstools
       - gdb-minimal
       - libnuma-dev
+      - ntfs-3g
     script: "scripts/bullseye-ltp.sh"
 
   bullseye-rt:


### PR DESCRIPTION
Some of the LTP tests (eg, syscalls) can use the NTFS and VFAT utilities to expand coverage so add them to the LTP rootfs.  They are fairly small.

Signed-off-by: Mark Brown <broonie@kernel.org>