### PR TITLE
Enable smaller LTP test sets

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -3170,7 +3170,14 @@ test_configs:
       - kselftest-seccomp
       - kselftest-timers
       - libhugetlbfs
+      - ltp-cpuhotplug
       - ltp-crypto
+      - ltp-dio
+      - ltp-fsx
+      - ltp-hugetlb
+      - ltp-io
+      - ltp-sched
+      - ltp-smoketest
       - preempt-rt
 
   - device_type: sun50i-h5-nanopi-neo-plus2

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -441,6 +441,18 @@ test_plans:
       job_timeout: '15'
       skipfile: skipfile-lkft.yaml
 
+  ltp-cap-bounds:
+    <<: *ltp
+    params:
+      <<: *ltp-params
+      tst_cmdfiles: "cap_bounds"
+
+  ltp-cpuhotplug:
+    <<: *ltp
+    params:
+      <<: *ltp-params
+      tst_cmdfiles: "cpuhotplug"
+
   ltp-crypto:
     <<: *ltp
     params:
@@ -451,11 +463,35 @@ test_plans:
           defconfig:
             - '+crypto'
 
+  ltp-dio:
+    <<: *ltp
+    params:
+      <<: *ltp-params
+      tst_cmdfiles: "dio"
+
   ltp-fcntl-locktests:
     <<: *ltp
     params:
       <<: *ltp-params
       tst_cmdfiles: "fcntl-locktests"
+
+  ltp-filecaps:
+    <<: *ltp
+    params:
+      <<: *ltp-params
+      tst_cmdfiles: "filecaps"
+
+  ltp-fsx:
+    <<: *ltp
+    params:
+      <<: *ltp-params
+      tst_cmdfiles: "fsx"
+
+  ltp-hugetlb:
+    <<: *ltp
+    params:
+      <<: *ltp-params
+      tst_cmdfiles: "hugetlb"
 
   ltp-ima:
     <<: *ltp
@@ -466,6 +502,13 @@ test_plans:
       - passlist:
           defconfig:
             - '+ima'
+
+  ltp-io:
+    <<: *ltp
+    params:
+      <<: *ltp-params
+      tst_cmdfiles: "io"
+
   ltp-ipc:
     <<: *ltp
     params:
@@ -486,6 +529,18 @@ test_plans:
       tst_cmdfiles: "pty"
       job_timeout: '25'
       priority: 0
+
+  ltp-sched:
+    <<: *ltp
+    params:
+      <<: *ltp-params
+      tst_cmdfiles: "sched"
+
+  ltp-smoketest:
+    <<: *ltp
+    params:
+      <<: *ltp-params
+      tst_cmdfiles: "smoketest"
 
   ltp-syscalls:
     <<: *ltp

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2285,7 +2285,11 @@ test_configs:
       - kselftest-seccomp
       - kselftest-timers
       - ltp-crypto
+      - ltp-dio
+      - ltp-fsx
+      - ltp-io
       - ltp-ipc
+      - ltp-smoketest
       - preempt-rt
 
   - device_type: cubietruck

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -487,6 +487,14 @@ test_plans:
       job_timeout: '25'
       priority: 0
 
+  ltp-syscalls:
+    <<: *ltp
+    params:
+      <<: *ltp-params
+      tst_cmdfiles: "syscalls"
+      job_timeout: '120'
+      priority: 0
+
   ltp-timers:
     <<: *ltp
     pattern: 'ltp/{category}-{method}-{protocol}-{rootfs}-ltp-open-posix-template.jinja2'


### PR DESCRIPTION
There are a number of smaller LTP test sets that provide some kernel level coverage which we don't currently run. This pull request provides the basic mapping of these tests into KernelCI.

To make merging a bit easier all the tests are only enabled on Tritium for now. In order to avoid conflicts in staging it also incorporates the commit adding the basic stanza for the larger syscalls test set, that is also in a separate pull request to enable that test set which adds enablement of the test set.

If this gets merged then there should most likely be followups revisiting where we run the tests.