### PR TITLE
CHROMEOS db-configs.yaml: Add ChromeOS storage config

### DIFF
--- a/config/core/db-configs.yaml
+++ b/config/core/db-configs.yaml
@@ -19,6 +19,12 @@ db_configs:
 
 storage_configs:
 
+  chromeos.kernelci.org:
+    storage_type: backend
+    host: chromeos.kernelci.org
+    base_url: http://storage.chromeos.kernelci.org/
+    api_url: https://api.chromeos.kernelci.org
+
   kernelci.org:
     storage_type: backend
     host: kernelci.org


### PR DESCRIPTION
After storage rework PR we need to add back storage config for ChromeOS instance.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>