### PR TITLE
kernelci.cli: move Args.storage to kernelci.legacy

### DIFF
--- a/kci_test
+++ b/kci_test
@@ -32,6 +32,7 @@ import kernelci.config.lab
 import kernelci.config.test
 import kernelci.build
 import kernelci.lab
+import kernelci.legacy
 import kernelci.test
 
 RELEASE_RE = re.compile(r'(.*)([0-9.]{10})(.*)')
@@ -269,7 +270,7 @@ class cmd_get_lab_info(Command):
 
 class cmd_generate(Command):
     help = "Generate the job definition for a given build"
-    args = [Args.lab_config, Args.storage]
+    args = [Args.lab_config, kernelci.legacy.Args.storage]
     opt_args = [Args.plan, Args.target, Args.output,
                 Args.build_output, Args.install_path,
                 Args.lab_json, Args.user, Args.lab_token, Args.db_config,

--- a/kernelci/cli/base.py
+++ b/kernelci/cli/base.py
@@ -281,11 +281,6 @@ class Args:  # pylint: disable=too-few-public-methods
         'choices': ('debos', 'buildroot', 'chromiumos')
     }
 
-    storage = {
-        'name': '--storage',
-        'help': "Storage URL",
-    }
-
     storage_config = {
         'name': '--storage-config',
         'help': "Storage configuration name",

--- a/kernelci/legacy.py
+++ b/kernelci/legacy.py
@@ -21,6 +21,14 @@ from urllib.parse import urljoin
 from kernelci.build import get_branch_head, git_describe, make_tarball
 
 
+class Args:
+
+    storage = {
+        'name': '--storage',
+        'help': "Storage URL",
+    }
+
+
 def _upload_files(api, token, path, input_files):
     """Upload rootfs to KernelCI backend.
 


### PR DESCRIPTION
The --storage command line argument is only used with legacy commands now so move it to kernelci.legacy accordingly.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>