### PR TITLE
Add kernelci.config.api

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,7 @@ jobs:
         run: |
           pylint kci
           pylint kernelci.cli
+          pylint kernelci.config.api
           pylint kernelci.storage
 
       - name: Run YAML config validation

--- a/config/core/api-configs.yaml
+++ b/config/core/api-configs.yaml
@@ -1,0 +1,7 @@
+api_configs:
+
+  docker-host:
+    url: http://172.17.0.1:8001
+
+  staging.kernelci.org:
+    url: https://staging.kernelci.org:9000

--- a/config/runtime/base/python.jinja2
+++ b/config/runtime/base/python.jinja2
@@ -16,13 +16,13 @@ import yaml
 {% endblock %}
 
 {%- block python_local_imports %}
-import kernelci.db
+from kernelci.db import kernelci_api
 import kernelci.config
 {%- endblock %}
 
 {%- block python_globals %}
-DB_CONFIG_YAML = """
-{{ db_config_yaml }}"""
+API_CONFIG_YAML = """
+{{ api_config_yaml }}"""
 NODE_ID = '{{ node_id }}'
 TARBALL_URL = '{{ tarball_url }}'
 WORKSPACE = '/tmp/kci'
@@ -34,18 +34,18 @@ class BaseJob:
     def __init__(self, workspace):
         self._workspace = workspace
 
-    def _get_db(self, db_config_yaml):
-        db_config = kernelci.config.db.DatabaseFactory.from_yaml(
-            'db', yaml.load(db_config_yaml, Loader=yaml.CLoader)
+    def _get_api(self, api_config_yaml):
+        api_config = kernelci.config.api.API.load_from_yaml(
+            yaml.safe_load(api_config_yaml), name='api'
         )
-        if not db_config:
-            return None
+        if not api_config:
+            raise ValueError("API configuration not found")
 
         api_token = os.getenv('API_TOKEN')
         if not api_token:
-            return None
+            raise ValueError("API_TOKEN environment variable not found")
 
-        return kernelci.db.get_db(db_config, api_token)
+        return kernelci_api.KernelCI_API(api_config, api_token)
 
     def _get_source(self, url):
         resp = requests.get(url, stream=True)
@@ -59,13 +59,13 @@ class BaseJob:
     def _run(self, src_path):
         raise NotImplementedError("_run() method required to run job")
 
-    def _submit(self, result, node_id, db):
-        node = db.get_node(node_id)
+    def _submit(self, result, node_id, api):
+        node = api.get_node(node_id)
         node.update({
             'result': result,
             'state': 'done',
         })
-        db.submit({'node': node})
+        api.submit({'node': node})
         return node
 
     def run(self, tarball_url):
@@ -75,10 +75,9 @@ class BaseJob:
         print("Running job...")
         return self._run(src_path)
 
-    def submit(self, result, node_id, db_config_yaml):
-        db = self._get_db(db_config_yaml)
-        if db:
-            self._submit(result, node_id, db)
+    def submit(self, result, node_id, api_config_yaml):
+        api = self._get_api(api_config_yaml)
+        self._submit(result, node_id, api)
 {% endblock %}
 
 {% block python_job -%}
@@ -95,8 +94,8 @@ def main(args):
         print(traceback.format_exc())
         results = None
 
-    if NODE_ID and DB_CONFIG_YAML:
-        job.submit(results, NODE_ID, DB_CONFIG_YAML)
+    if NODE_ID and API_CONFIG_YAML:
+        job.submit(results, NODE_ID, API_CONFIG_YAML)
 
     return results
 

--- a/kernelci/config/__init__.py
+++ b/kernelci/config/__init__.py
@@ -21,6 +21,7 @@ import yaml
 
 import kernelci
 import kernelci.config
+import kernelci.config.api
 import kernelci.config.build
 import kernelci.config.db
 import kernelci.config.lab
@@ -149,6 +150,7 @@ def from_data(data):
     """
     config = dict()
     filters = kernelci.config.base.default_filters_from_yaml(data)
+    config.update(kernelci.config.api.from_yaml(data, filters))
     config.update(kernelci.config.build.from_yaml(data, filters))
     config.update(kernelci.config.db.from_yaml(data, filters))
     config.update(kernelci.config.lab.from_yaml(data, filters))

--- a/kernelci/config/api.py
+++ b/kernelci/config/api.py
@@ -13,9 +13,10 @@ class API(YAMLConfigObject):
 
     yaml_tag = '!API'
 
-    def __init__(self, name, url):
+    def __init__(self, name, url, version='latest'):
         self._name = name
         self._url = url
+        self._version = version
 
     @property
     def name(self):
@@ -27,16 +28,24 @@ class API(YAMLConfigObject):
         """Full URL to use the API"""
         return self._url
 
+    @property
+    def version(self):
+        """API version"""
+        return self._version
+
     @classmethod
     def _get_yaml_attributes(cls):
         attrs = super()._get_yaml_attributes()
-        attrs.update({'url'})
+        attrs.update({'url', 'version'})
         return attrs
 
     @classmethod
     def to_yaml(cls, dumper, data):
         return dumper.represent_mapping(
-            'tag:yaml.org,2002:map', {'url': data.url}
+            'tag:yaml.org,2002:map', {
+                'url': data.url,
+                'version': data.version,
+            }
         )
 
 

--- a/kernelci/config/api.py
+++ b/kernelci/config/api.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2022 Collabora Limited
+# Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+
+"""KernelCI API object configuration"""
+
+from kernelci.config.base import YAMLConfigObject
+
+
+class API(YAMLConfigObject):
+    """Base KernelCI API configuration object"""
+
+    yaml_tag = '!API'
+
+    def __init__(self, name, url):
+        self._name = name
+        self._url = url
+
+    @property
+    def name(self):
+        """Name of the API configuration or instance"""
+        return self._name
+
+    @property
+    def url(self):
+        """Full URL to use the API"""
+        return self._url
+
+    @classmethod
+    def _get_yaml_attributes(cls):
+        attrs = super()._get_yaml_attributes()
+        attrs.update({'url'})
+        return attrs
+
+    @classmethod
+    def to_yaml(cls, dumper, data):
+        return dumper.represent_mapping(
+            'tag:yaml.org,2002:map', {'url': data.url}
+        )
+
+
+def from_yaml(data, _):
+    """Create the API configs using data loaded from YAML"""
+    api_configs = {
+        name: API.load_from_yaml(config, name=name)
+        for name, config in data.get('api_configs', {}).items()
+    }
+
+    return {
+        'api_configs': api_configs,
+    }

--- a/kernelci/db/kernelci_api.py
+++ b/kernelci/db/kernelci_api.py
@@ -37,7 +37,8 @@ class KernelCI_API(Database):
         self._filters = {}
 
     def _make_url(self, path):
-        return urllib.parse.urljoin(self.config.url, path)
+        version_path = '/'.join((self.config.version, path))
+        return urllib.parse.urljoin(self.config.url, version_path)
 
     def _print_http_error(self, http_error, verbose=False):
         print(http_error)

--- a/tests/configs/api-configs.yaml
+++ b/tests/configs/api-configs.yaml
@@ -1,0 +1,4 @@
+api_configs:
+
+  docker-host:
+    url: http://172.17.0.1:8001

--- a/tests/configs/api-configs.yaml
+++ b/tests/configs/api-configs.yaml
@@ -2,3 +2,4 @@ api_configs:
 
   docker-host:
     url: http://172.17.0.1:8001
+    version: latest

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -153,3 +153,16 @@ class TestTestConfigs(TestConfigs):
             fs_config['debian']['url'] ==
             'http://storage.kernelci.org/images/rootfs/debian'
         )
+
+
+class TestAPIConfigs(TestConfigs):
+
+    def test_apis(self):
+        ref_data, config = self._load_config('tests/configs/api-configs.yaml')
+        api_config = self._reload(ref_data, config, 'api_configs')
+        api_names = ['docker-host']
+        assert all(name in ref_data['api_configs'] for name in api_names)
+        assert all(name in api_config for name in api_names)
+        assert (
+            api_config['docker-host']['url'] == 'http://172.17.0.1:8001'
+        )


### PR DESCRIPTION
Add kernelci.config.api to load the YAML configuration required to access a KernelCI API instance.  This is intended to replace the config.db which was about providing an abstraction layer for various API and backend / database implementations.