### PR TITLE
config/docker: Get specific libs for the riscv clang templates

### DIFF
--- a/config/docker/clang-11-riscv64.jinja2
+++ b/config/docker/clang-11-riscv64.jinja2
@@ -1,5 +1,11 @@
-{#
- # TBD - toolchain packages are different.
--#}
-
+{%- set sub_arch = 'riscv64' %}
 {% extends 'clang-11.jinja2' %}
+
+{% block packages %}
+{{ super() }}
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    libgcc-10-dev-riscv64-cross
+
+{%- endblock %}
+

--- a/config/docker/clang-14-riscv64.jinja2
+++ b/config/docker/clang-14-riscv64.jinja2
@@ -1,5 +1,11 @@
-{#
- # TBD - toolchain packages are different.
--#}
-
+{%- set sub_arch = 'riscv64' %}
 {% extends 'clang-14.jinja2' %}
+
+{% block packages %}
+{{ super() }}
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    libgcc-10-dev-riscv64-cross
+
+{%- endblock %}
+

--- a/config/docker/clang-15-riscv64.jinja2
+++ b/config/docker/clang-15-riscv64.jinja2
@@ -1,5 +1,11 @@
-{#
- # TBD - toolchain packages are different.
--#}
-
+{%- set sub_arch = 'riscv64' %}
 {% extends 'clang-15.jinja2' %}
+
+{% block packages %}
+{{ super() }}
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    libgcc-10-dev-riscv64-cross
+
+{%- endblock %}
+

--- a/config/docker/clang-16-riscv64.jinja2
+++ b/config/docker/clang-16-riscv64.jinja2
@@ -1,5 +1,11 @@
-{#
- # TBD - toolchain packages are different.
--#}
-
+{%- set sub_arch = 'riscv64' %}
 {% extends 'clang-16.jinja2' %}
+
+{% block packages %}
+{{ super() }}
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    libgcc-10-dev-riscv64-cross
+
+{%- endblock %}
+


### PR DESCRIPTION
In order to have the kselftests built correctly when using the riscv clang templates, install the riscv cross compiled version of libgcc-10-dev.