### PR TITLE
Enable kvm-unit-tests

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -43,6 +43,22 @@ rootfs_configs:
       - xz-utils
     script: "scripts/bookworm-kselftest.sh"
 
+  bookworm-kvm-unit-tests:
+    rootfs_type: debos
+    debian_release: bookworm
+    arch_list:
+      - amd64
+      - arm64
+    extra_packages:
+      - python3-minimal
+      - qemu-system
+    extra_packages_remove:
+      - bash
+      - e2fslibs
+      - e2fsprogs
+    debos_scratchsize: "10G"
+    script: "scripts/bookworm-kvm-unit-tests.sh"
+
   buildroot-baseline:
     rootfs_type: buildroot
     git_url: https://github.com/kernelci/buildroot

--- a/config/core/rootfs-images.yaml
+++ b/config/core/rootfs-images.yaml
@@ -80,6 +80,23 @@ file_systems:
     ramdisk: bullseye-kselftest/20230623.0/{arch}/rootfs.cpio.gz
     root_type: ramdisk
     type: debian
+  debian_bookworm-kvm-unit-tests_nfs:
+    boot_protocol: tftp
+    nfs: bookworm-kvm-unit-tests/20230114.0/{arch}/full.rootfs.tar.xz
+    params:
+      os_config: debian
+    prompt: '/ #'
+    ramdisk: bookworm-kvm-unit-tests/20230114.0/{arch}/initrd.cpio.gz
+    root_type: nfs
+    type: debian
+  debian_bookworm-kvm-unit-tests_ramdisk:
+    boot_protocol: ramdisk
+    params:
+      os_config: debian
+    prompt: '/ #'
+    ramdisk: bookworm-kvm-unit-tests/20221230.0/{arch}/rootfs.cpio.gz
+    root_type: ramdisk
+    type: debian
   debian_bullseye-libcamera_nfs:
     boot_protocol: tftp
     nfs: bullseye-libcamera/20230623.0/{arch}/full.rootfs.tar.xz

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2546,6 +2546,7 @@ test_configs:
       - kselftest-alsa
       - kselftest-arm64
       - kselftest-dt
+      - kvm-unit-tests
       - ltp-dio
       - ltp-fsx
       - ltp-smoketest
@@ -3106,6 +3107,7 @@ test_configs:
       - kselftest-kvm
       - kselftest-lib
       - kselftest-seccomp
+      - kvm-unit-tests
       - ltp-crypto
       - ltp-fcntl-locktests
       - ltp-ipc

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -496,6 +496,12 @@ test_plans:
           defconfig: ['kselftest']
           kernel: ['v3.', 'v4.', 'v5.', 'v6.0', 'v6,1', 'v6.2']
 
+  kvm-unit-tests:
+    rootfs: debian_bookworm-kvm-unit-tests_nfs
+    pattern: 'kvm-unit-tests/{category}-{method}-{protocol}-{rootfs}-kvm-unit-tests-template.jinja2'
+    params:
+      job_timeout: '45'
+
   lc-compliance:
     rootfs: debian_bullseye-libcamera_nfs
     pattern: 'lc-compliance/{category}-{method}-{protocol}-{rootfs}-lc-compliance-template.jinja2'

--- a/config/lava/kvm-unit-tests/generic-barebox-tftp-nfs-kvm-unit-tests-template.jinja2
+++ b/config/lava/kvm-unit-tests/generic-barebox-tftp-nfs-kvm-unit-tests-template.jinja2
@@ -1,0 +1,8 @@
+{% extends 'boot-nfs/generic-barebox-tftp-nfs-template.jinja2' %}
+
+{% block actions %}
+{{ super () }}
+
+{% include 'kvm-unit-tests/kvm-unit-tests.jinja2' %}
+
+{% endblock %}

--- a/config/lava/kvm-unit-tests/generic-depthcharge-tftp-nfs-kvm-unit-tests-template.jinja2
+++ b/config/lava/kvm-unit-tests/generic-depthcharge-tftp-nfs-kvm-unit-tests-template.jinja2
@@ -1,0 +1,8 @@
+{% extends 'boot-nfs/generic-depthcharge-tftp-nfs-template.jinja2' %}
+
+{% block actions %}
+{{ super () }}
+
+{% include 'kvm-unit-tests/kvm-unit-tests.jinja2' %}
+
+{% endblock %}

--- a/config/lava/kvm-unit-tests/generic-grub-tftp-nfs-kvm-unit-tests-template.jinja2
+++ b/config/lava/kvm-unit-tests/generic-grub-tftp-nfs-kvm-unit-tests-template.jinja2
@@ -1,0 +1,8 @@
+{% extends 'boot-nfs/generic-grub-tftp-nfs-template.jinja2' %}
+
+{% block actions %}
+{{ super () }}
+
+{% include 'kvm-unit-tests/kvm-unit-tests.jinja2' %}
+
+{% endblock %}

--- a/config/lava/kvm-unit-tests/generic-qemu-ramdisk-kvm-unit-tests-template.jinja2
+++ b/config/lava/kvm-unit-tests/generic-qemu-ramdisk-kvm-unit-tests-template.jinja2
@@ -1,0 +1,11 @@
+{% extends 'boot/generic-qemu-boot-template.jinja2' %}
+{% block actions %}
+{{ super () }}
+
+{% include 'kvm-unit-tests/kvm-unit-tests.jinja2' %}
+
+{% endblock %}
+
+{%- block image_arg %}
+        image_arg: '-kernel {kernel} -append "console={{ console_dev }},115200 root=/dev/ram0 debug verbose {{ extra_kernel_args }}"'
+{%- endblock %}

--- a/config/lava/kvm-unit-tests/generic-uboot-tftp-nfs-kvm-unit-tests-template.jinja2
+++ b/config/lava/kvm-unit-tests/generic-uboot-tftp-nfs-kvm-unit-tests-template.jinja2
@@ -1,0 +1,8 @@
+{% extends 'boot-nfs/generic-uboot-tftp-nfs-template.jinja2' %}
+
+{% block actions %}
+{{ super () }}
+
+{% include 'kvm-unit-tests/kvm-unit-tests.jinja2' %}
+
+{% endblock %}

--- a/config/lava/kvm-unit-tests/kvm-unit-tests.jinja2
+++ b/config/lava/kvm-unit-tests/kvm-unit-tests.jinja2
@@ -1,0 +1,23 @@
+- test:
+    timeout:
+      minutes: {{ job_timeout }}
+    definitions:
+    - from: inline
+      repository:
+        metadata:
+          format: Lava-Test Test Definition 1.0
+          name: timesync-off
+          description: Disable systemd time sync services
+        run:
+          steps:
+          - systemctl stop systemd-timesyncd || true
+      name: timesync-off
+      path: inline/timesync-off.yaml
+
+    - repository: https://github.com/kernelci/test-definitions.git
+      from: git
+      revision: kernelci.org
+      path: automated/linux/kvm-unit-tests/kvm-unit-tests.yaml
+      name: kvm-unit-tests
+      parameters:
+        SKIP_INSTALL: True

--- a/config/rootfs/debos/scripts/bookworm-kvm-unit-tests.sh
+++ b/config/rootfs/debos/scripts/bookworm-kvm-unit-tests.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Important: This script is run under QEMU
+
+set -e
+
+RELEASE=3c1736b1344b9831f17fbd64f95ea89c279564c6
+
+BUILD_DEPS="\
+      gcc \
+      git \
+      ca-certificates \
+      libc6-dev \
+      make \
+"
+
+apt-get install --no-install-recommends -y ${BUILD_DEPS}
+
+# test-definitions is going to go looking for /opt/kvm-unit-tests
+# so build there
+mkdir -p /opt
+cd /opt
+git clone https://gitlab.com/kvm-unit-tests/kvm-unit-tests
+cd /opt/kvm-unit-tests
+git reset --hard ${RELEASE}
+./configure
+make
+
+# Cleanup: remove files and packages we don't want in the images
+apt-get remove --purge -y ${BUILD_DEPS}
+apt-get remove --purge -y libgtest-dev
+apt-get autoremove --purge -y
+apt-get clean


### PR DESCRIPTION
The kvm-unit-tests provide low level coverage of KVM functionality, as the name suggests being very simple low level guests which exercise functionality in a much more focused fashion than running a full guest OS would.

This series depends on the very latest test definitions upstream, specifically https://github.com/Linaro/test-definitions/commit/755466ad638e89c4ddd95a93f3479b24f6e23ad3 - otherwise the only option is to build the testsuite at runtime.