### PR TITLE
CHROMEOS build-configs-chromeos.yaml: Add Kernel 6.1 builds

### DIFF
--- a/config/core/build-configs-chromeos.yaml
+++ b/config/core/build-configs-chromeos.yaml
@@ -77,13 +77,43 @@ chromeos_5.15_variants: &chromeos_5_15_variants
   clang-14: *clang-14
 
 
+chromeos_6.1_variants: &chromeos_6_1_variants
+  chromeos-clang-14:
+    build_environment: clang-14
+    architectures:
+      arm:
+        base_defconfig: 'cros://chromeos-6.1/armel/chromiumos-arm.flavour.config'
+        extra_configs:
+          - 'cros://chromeos-6.1/armel/chromiumos-rockchip.flavour.config'
+        filters: *cros-filters
+      arm64:
+        base_defconfig: 'cros://chromeos-6.1/arm64/chromiumos-arm64.flavour.config'
+        fragments: [arm64-chromebook]
+        extra_configs:
+          - 'cros://chromeos-6.1/arm64/chromiumos-mediatek.flavour.config+arm64-chromebook'
+          - 'cros://chromeos-6.1/arm64/chromiumos-qualcomm.flavour.config+arm64-chromebook'
+          - 'cros://chromeos-6.1/arm64/chromiumos-rockchip64.flavour.config+arm64-chromebook'
+        filters: *cros-filters
+      x86_64:
+        base_defconfig: 'cros://chromeos-6.1/x86_64/chromiumos-x86_64.flavour.config'
+        fragments: [x86-chromebook]
+        extra_configs:
+          - 'cros://chromeos-6.1/x86_64/chromeos-amd-stoneyridge.flavour.config+x86-chromebook+CONFIG_MODULE_COMPRESS_GZIP=n'
+          - 'cros://chromeos-6.1/x86_64/chromeos-intel-denverton.flavour.config+x86-chromebook+CONFIG_MODULE_COMPRESS_GZIP=n'
+          - 'cros://chromeos-6.1/x86_64/chromeos-intel-pineview.flavour.config+x86-chromebook+CONFIG_MODULE_COMPRESS_GZIP=n'
+          - 'cros://chromeos-6.1/x86_64/chromiumos-x86_64.flavour.config+x86-chromebook+CONFIG_MODULE_COMPRESS_GZIP=n'
+        filters: *cros-filters
+
+  clang-14: *clang-14
+
+
 
 build_configs:
 
   chromeos-next:
     tree: next
     branch: 'master'
-    variants: *chromeos_5_15_variants
+    variants: *chromeos_6_1_variants
 
   chromeos-stable_5.10:
     tree: stable
@@ -95,7 +125,12 @@ build_configs:
     branch: 'linux-5.15.y'
     variants: *chromeos_5_15_variants
 
+  chromeos-stable_6.1:
+    tree: stable
+    branch: 'linux-6.1.y'
+    variants: *chromeos_6_1_variants
+
   kernelci_chromeos-stable:
     tree: kernelci
     branch: 'chromeos-stable'
-    variants: *chromeos_5_15_variants
+    variants: *chromeos_6_1_variants


### PR DESCRIPTION
Update and add to build variants Kernel 6.1 as it is new LTS, and possible target for future uprevs.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>