### PR TITLE
Add kci node sub-command

### DIFF
--- a/kernelci/cli/__init__.py
+++ b/kernelci/cli/__init__.py
@@ -8,9 +8,13 @@
 import sys
 
 from .base import Args, Command, parse_opts, sub_main
-from . import validate
+from . import (
+    node,
+    validate,
+)
 
 _COMMANDS = {
+    'node': node.main,
     'validate': validate.main,
 }
 

--- a/kernelci/cli/base.py
+++ b/kernelci/cli/base.py
@@ -10,6 +10,7 @@ can't be defined in __init__.py as it would create a circular dependency due to
 the commands registration mechanism.
 """
 
+import abc
 import argparse
 import configparser
 import os.path
@@ -357,7 +358,7 @@ class Args:  # pylint: disable=too-few-public-methods
     }
 
 
-class Command:
+class Command(abc.ABC):
     """A command helper class.
 
     It contains several class attributes:
@@ -399,13 +400,13 @@ class Command:
                     for arg in arg_list
                 })
 
+    @abc.abstractmethod
     def __call__(self, configs, args):
         """Call the command
 
         *configs* is a dictionary with configuration objects parsed from YAML
         *args* is the parsed command line arguments
         """
-        raise NotImplementedError("Command not implemented")
 
     def _add_arg(self, arg):
         kwargs = arg.copy()

--- a/kernelci/cli/base.py
+++ b/kernelci/cli/base.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 #
-# Copyright (C) 2018-2022 Collabora Limited
+# Copyright (C) 2018-2023 Collabora Limited
 # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
 
 """Common definitions for KernelCI command line tools
@@ -31,6 +31,7 @@ class Args:  # pylint: disable=too-few-public-methods
     add_argument() method of the parser object from argparse.  There should
     also always be a `help` attribute, as this is needed by the Command class.
     """
+    SECTION_API = ('api', 'api_config')
     SECTION_DB = ('db', 'db_config')
     SECTION_LAB = ('lab', 'lab_config')
     SECTION_STORAGE = ('storage', 'storage_config')
@@ -44,6 +45,17 @@ class Args:  # pylint: disable=too-few-public-methods
         'name': '--api',
         'help': "Backend API URL",
         'section': SECTION_DB,
+    }
+
+    api_config = {
+        'name': '--api-config',
+        'help': "KernelCI API configuration",
+    }
+
+    api_token = {
+        'name': '--api-token',
+        'help': "KernelCI API token",
+        'section': SECTION_API,
     }
 
     build_output = {

--- a/kernelci/cli/node.py
+++ b/kernelci/cli/node.py
@@ -5,6 +5,8 @@
 
 """Tool to manage KernelCI API node objects"""
 
+import json
+
 from kernelci.db import kernelci_api
 from .base import Args, Command, sub_main
 
@@ -14,7 +16,12 @@ class NodeCommand(Command):  # pylint: disable=too-few-public-methods
     args = [
         Args.api_config, Args.api_token,
     ]
-    opt_args = []
+    opt_args = [
+        {
+            'name': '--indent',
+            'help': "Indentation string in JSON output",
+        },
+    ]
 
     @classmethod
     def _get_api(cls, configs, args):
@@ -37,7 +44,7 @@ class cmd_get(NodeCommand):  # pylint: disable=invalid-name
     def __call__(self, configs, args):
         api = self._get_api(configs, args)
         node = api.get_node(args.id)
-        print(node)
+        print(json.dumps(node, indent=args.indent))
         return True
 
 
@@ -69,7 +76,7 @@ class cmd_find(NodeCommand):  # pylint: disable=invalid-name
             tuple(param.split('=')) for param in args.params
         )
         nodes = api.get_nodes(params, args.offset, args.limit)
-        print(nodes)
+        print(json.dumps(nodes, indent=args.indent))
         return True
 
 

--- a/kernelci/cli/node.py
+++ b/kernelci/cli/node.py
@@ -31,10 +31,10 @@ class NodeCommand(Command):  # pylint: disable=too-few-public-methods
 
 class NodeAttributesCommand(NodeCommand):
     """Base command class for node queries with arbitrary attributes"""
-    args = NodeCommand.args + [
+    opt_args = NodeCommand.opt_args + [
         {
             'name': 'attributes',
-            'nargs': '+',
+            'nargs': '*',
             'help': "Attributes to find nodes in name=value format",
         },
     ]
@@ -43,7 +43,7 @@ class NodeAttributesCommand(NodeCommand):
     def _split_attributes(cls, attributes):
         return dict(
             tuple(attr.split('=')) for attr in attributes
-        )
+        ) if attributes else {}
 
 
 class cmd_get(NodeCommand):  # pylint: disable=invalid-name

--- a/kernelci/cli/node.py
+++ b/kernelci/cli/node.py
@@ -27,6 +27,40 @@ class cmd_get(Command):  # pylint: disable=invalid-name
         return True
 
 
+class cmd_find(Command):  # pylint: disable=invalid-name
+    """Find nodes with arbitrary parameters"""
+    args = [
+        Args.api_config, Args.api_token,
+        {
+            'name': 'params',
+            'nargs': '+',
+            'help': "Parameters to find nodes in param=value format",
+        },
+    ]
+    opt_args = [
+        {
+            'name': '--limit',
+            'type': int,
+            'help': "Maximum number of nodes to retrieve",
+        },
+        {
+            'name': '--offset',
+            'type': int,
+            'help': "Offset when paginating results with a number of nodes",
+        },
+    ]
+
+    def __call__(self, configs, args):
+        config = configs['api_configs'][args.api_config]
+        api = kernelci_api.KernelCI_API(config, args.api_token)
+        params = dict(
+            tuple(param.split('=')) for param in args.params
+        )
+        nodes = api.get_nodes(params, args.offset, args.limit)
+        print(nodes)
+        return True
+
+
 def main(args=None):
     """Entry point for the command line tool"""
     sub_main("node", globals(), args)

--- a/kernelci/cli/node.py
+++ b/kernelci/cli/node.py
@@ -28,9 +28,6 @@ class NodeCommand(Command):  # pylint: disable=too-few-public-methods
         config = configs['api_configs'][args.api_config]
         return kernelci_api.KernelCI_API(config, args.api_token)
 
-    def __call__(self, configs, args):
-        pass
-
 
 class NodeAttributesCommand(NodeCommand):
     """Base command class for node queries with arbitrary attributes"""

--- a/kernelci/cli/node.py
+++ b/kernelci/cli/node.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2022-2023 Collabora Limited
+# Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+
+"""Tool to manage KernelCI API node objects"""
+
+from kernelci.db import kernelci_api
+from .base import Args, Command, sub_main
+
+
+class cmd_get(Command):  # pylint: disable=invalid-name
+    """Get a node with a given ID"""
+    args = [
+        Args.api_config, Args.api_token,
+        {
+            'name': 'id',
+            'help': "Node id",
+        },
+    ]
+
+    def __call__(self, configs, args):
+        config = configs['api_configs'][args.api_config]
+        api = kernelci_api.KernelCI_API(config, args.api_token)
+        node = api.get_node(args.id)
+        print(node)
+        return True
+
+
+def main(args=None):
+    """Entry point for the command line tool"""
+    sub_main("node", globals(), args)

--- a/kernelci/cli/node.py
+++ b/kernelci/cli/node.py
@@ -68,7 +68,11 @@ class cmd_find(NodeAttributesCommand):  # pylint: disable=invalid-name
         {
             'name': '--limit',
             'type': int,
-            'help': "Maximum number of nodes to retrieve",
+            'help': """\
+Maximum number of nodes to retrieve. When set to 0, no limit is used and all
+the matching nodes are retrieved.\
+""",
+            'default': 10,
         },
         {
             'name': '--offset',


### PR DESCRIPTION
Add an initial sub-command `kci node` with the following syntax:
```
kci node get <ID>
kci node find attr1=value attr2=value
kci node count attr1=value attr2=value
```

Sample `kernelci.conf`:
```ini
[DEFAULT]
verbose: True
api_config: docker-host

[api:docker-host]
api_token: <secret token here>

[node]
```

For example:
```
kernelci@015bba541c79:~/kernelci-core$ ./kci node get 6374b725e778513908e04384 --indent='  '
{
  "_id": "6374b725e778513908e04384",
  "kind": "node",
  "name": "checkout",
  "path": [
    "checkout"
  ],
  "group": null,
  "revision": {
    "tree": "mainline",
    "url": "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git",
    "branch": "master",
    "commit": "59d0d52c30d4991ac4b329f049cc37118e00f5b0",
    "describe": null,
    "version": null
  },
  "parent": null,
  "state": "done",
  "result": null,
  "artifacts": null,
  "created": "2022-11-16T10:10:45.120000",
  "updated": "2022-11-16T10:11:05.139000",
  "timeout": "2022-11-16T10:11:05.120000",
  "holdoff": "2022-11-16T10:11:05.120000"
}
```

```
kernelci@015bba541c79:~/kernelci-core$ ./kci node find --limit=2 revision.tree=mainline 
[{"_id": "6374b725e778513908e04384", "kind": "node", "name": "checkout", "path": ["checkout"], "group": null, "revision": {"tree": "mainline", "url": "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git", "branch": "master", "commit": "59d0d52c30d4991ac4b329f049cc37118e00f5b0", "describe": null, "version": null}, "parent": null, "state": "done", "result": null, "artifacts": null, "created": "2022-11-16T10:10:45.120000", "updated": "2022-11-16T10:11:05.139000", "timeout": "2022-11-16T10:11:05.120000", "holdoff": "2022-11-16T10:11:05.120000"}, {"_id": "6374b86b559dc6bb05f7c6c5", "kind": "node", "name": "checkout", "path": ["checkout"], "group": null, "revision": {"tree": "mainline", "url": "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git", "branch": "master", "commit": "59d0d52c30d4991ac4b329f049cc37118e00f5b0", "describe": null, "version": null}, "parent": null, "state": "done", "result": null, "artifacts": null, "created": "2022-11-16T10:16:11.810000", "updated": "2022-11-16T10:18:11.842000", "timeout": "2022-11-16T10:18:11.800000", "holdoff": "2022-11-16T10:16:11.810000"}]
```

```
kernelci@015bba541c79:~/kernelci-core$ ./kci node count revision.tree=mainline 
118
```
