### PR TITLE
BuildEnvironment: drop arch_params property

### DIFF
--- a/kci_build
+++ b/kci_build
@@ -175,9 +175,9 @@ def _show_build_env(build_env, arch=None):
     print(build_env.cc)
     print(build_env.cc_version)
     if arch:
-        print(build_env.get_arch_name(arch) or '')
-        print(build_env.get_cross_compile(arch) or '')
-        print(build_env.get_cross_compile_compat(arch) or '')
+        print(build_env.get_arch_param(arch, 'name') or arch)
+        for param in 'cross_compile', 'cross_compile_compat':
+            print(build_env.get_arch_param(arch, param) or '')
 
 
 class cmd_get_build_env(Command):

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -960,14 +960,16 @@ class EnvironmentData(Step):
             return False
 
         build_env, arch = (opts[key] for key in keys)
-        cross_compile = build_env.get_cross_compile(arch) or ''
-        cross_compile_compat = build_env.get_cross_compile_compat(arch) or ''
+        cross_compile, cross_compile_compat = (
+            build_env.get_arch_param(arch, param) or ''
+            for param in ('cross_compile', 'cross_compile_compat')
+        )
         cc = build_env.cc
         cc_version_cmd = "{}{} --version 2>&1".format(
             cross_compile if cross_compile and cc == 'gcc' else '', cc)
         cc_version_full = shell_cmd(cc_version_cmd).splitlines()[0]
         make_opts = {'KBUILD_BUILD_USER': 'KernelCI'}
-        make_opts.update(build_env.get_arch_opts(arch))
+        make_opts.update(build_env.get_arch_param(arch, 'opts') or {})
         platform_data = {'uname': platform.uname()}
 
         self._meta.get('bmeta')['environment'] = {

--- a/kernelci/config/build.py
+++ b/kernelci/config/build.py
@@ -267,10 +267,6 @@ class BuildEnvironment(YAMLConfigObject):
     def cc_version(self):
         return self._cc_version
 
-    @property
-    def arch_params(self):
-        return self._arch_params.copy()
-
     @classmethod
     def _get_yaml_attributes(cls):
         attrs = super()._get_yaml_attributes()
@@ -283,25 +279,16 @@ class BuildEnvironment(YAMLConfigObject):
             u'tag:yaml.org,2002:map', {
                 'cc': data.cc,
                 'cc_version': data.cc_version,
-                'arch_params': data.arch_params,
+                'arch_params': data._arch_params,
             }
         )
 
-    def get_arch_name(self, kernel_arch):
-        params = self._arch_params.get(kernel_arch) or dict()
-        return params.get('name', kernel_arch)
-
-    def get_arch_opts(self, arch):
-        params = self._arch_params.get(arch) or dict()
-        return params.get('opts') or dict()
-
-    def get_cross_compile(self, arch):
-        params = self._arch_params.get(arch) or dict()
-        return params.get('cross_compile', '')
-
-    def get_cross_compile_compat(self, arch):
-        params = self._arch_params.get(arch) or dict()
-        return params.get('cross_compile_compat', '')
+    def get_arch_param(self, arch, param):
+        arch_params = self._arch_params.get(arch, dict())
+        param = arch_params.get(param)
+        if isinstance(param, dict):
+            return param.copy()
+        return param
 
 
 class BuildVariant(YAMLConfigObject):

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -109,11 +109,11 @@ class TestBuildConfigs(TestConfigs):
         assert be_config['clang-12']['cc_version'] == '12'
         clang12 = config['build_environments']['clang-12']
         assert (
-            clang12.get_cross_compile_compat('arm64') ==
+            clang12.get_arch_param('arm64', 'cross_compile_compat') ==
             'arm-linux-gnueabihf-'
         )
         assert (
-            clang12.get_arch_opts('riscv')['LLVM_IAS'] == '1'
+            clang12.get_arch_param('riscv', 'opts')['LLVM_IAS'] == '1'
         )
 
     def test_reference_tree(self):


### PR DESCRIPTION
Drop the kernelci.config.build.BuildEnvironment.arch_params
property which was returning a shallow copy of the _arch_params
dictionary.  This caused some misleading use-cases as the
property could appear mutable while it wasn't.  For example,
benv.arch_params.update({...})  would not actually change the
data stored in build_env.
    
As there already were methods for retrieving the arch_params
data, refactor these methods to be more generic with
.get_arch_param() to directly return any parameter for a given
architecture.  If the parameter is a dictionary, a copy is
returned to still ensure this is a read-only operation.
    
Update the .to_yaml() implementation accordingly by reading the
internal _arch_params as well as the unit tests.