### PR TITLE
build-configs.yaml: Remove GRE as it interferes with nfs boot

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -399,6 +399,8 @@ fragments:
     path: "kernel/configs/kselftest.config"
     configs:
       - '# CONFIG_DUMMY is not set'
+      - 'CONFIG_NET_IPGRE=m'
+      - 'CONFIG_NET_IPGRE_DEMUX=m'
 
   preempt_rt:
     path: "kernel/configs/preempt_rt.config"


### PR DESCRIPTION
In-kernel built GRE (enabled by bpf tests) enables gretap0 and erspan0 interfaces that will interfere with NFS mounting process.
```

[   85.853957] IP-Config: Retrying forever (NFS root)...
[   85.859646] 8021q: adding VLAN 0 to HW filter on device bond0
[   85.865790] IP-Config: Failed to open gretap0
[   85.870388] IP-Config: Failed to open erspan0
[   85.893370] Sending DHCP requests ...... timed out!
[  174.558388] IP-Config: Retrying forever (NFS root)...
[  174.563981] 8021q: adding VLAN 0 to HW filter on device bond0
[  174.570159] IP-Config: Failed to open gretap0
[  174.574766] IP-Config: Failed to open erspan0
[  174.597406] Sending DHCP requests ...... timed out!
[  256.873757] IP-Config: Retrying forever (NFS root)...
[  256.879563] 8021q: adding VLAN 0 to HW filter on device bond0
[  256.885857] IP-Config: Failed to open gretap0
[  256.890475] IP-Config: Failed to open erspan0
```

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>