### PR TITLE
rootfs-configs.yaml: Fix qcom/venus-5.4/venus firmware files issues

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -268,12 +268,8 @@ rootfs_configs:
       - e2fslibs
       - e2fsprogs
     extra_firmware:
-        - qcom/venus-5.4/venus.b00
-        - qcom/venus-5.4/venus.b01
-        - qcom/venus-5.4/venus.b02
-        - qcom/venus-5.4/venus.b03
-        - qcom/venus-5.4/venus.b04
         - qcom/venus-5.4/venus.mdt
+        - qcom/venus-5.4/venus.mbn
     script: "scripts/bullseye-v4l2.sh"
     test_overlay: "overlays/v4l2"
 


### PR DESCRIPTION
Recently firmware structure was changed in commit: https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/commit/?id=ad9fdba
So now we have just two files.
But one of them missing due mistake.
I've sent fix upstream also: https://lore.kernel.org/linux-firmware/5dc7081a8b793baf08f20df6b641a86a80c9e15c.camel@collabora.com/T/#u
Fixes: https://github.com/kernelci/kernelci-core/issues/1619

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>