### PR TITLE
lab-configs: lab-baylibre: use passlist

### DIFF
--- a/config/core/lab-configs.yaml
+++ b/config/core/lab-configs.yaml
@@ -7,11 +7,17 @@ labs:
     queue_timeout:
       days: 1
     filters:
-      - blocklist:
-          tree:
-            - drm-tip
-            - android
       - passlist:
+          tree:
+            - staging
+            - mainline
+            - next
+            - stable
+            - arm64
+            - riscv
+            - soc
+            - amlogic
+            - matthiasbgg
           plan:
             - baseline
             - kselftest


### PR DESCRIPTION
lab-baylibre is having large queues of jobs that don't finish in time for (useful) KernelCI results.  Let's attempt to reduce the load on teh lab by limiting the number of trees that are tested in lab-baylibre.  To be expanded later after reevaluating lab load.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>