### PR TITLE
Add Lee's backlight and mfd trees

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -64,6 +64,9 @@ trees:
   lee-backlight:
     url: "https://git.kernel.org/pub/scm/linux/kernel/git/lee/backlight.git"
 
+  lee-mfd:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/lee/mfd.git"
+
   linusw:
     url: "https://git.kernel.org/pub/scm/linux/kernel/git/linusw/linux-gpio.git/"
 
@@ -992,6 +995,11 @@ build_configs:
   lee_backlight:
     tree: lee-backlight
     branch: 'for-backlight-next'
+    variants: *minimal_variants
+
+  lee_mfd:
+    tree: lee-mfd
+    branch: 'for-mfd-next'
     variants: *minimal_variants
 
   linusw_devel:

--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -61,6 +61,9 @@ trees:
   kselftest:
     url: 'https://git.kernel.org/pub/scm/linux/kernel/git/shuah/linux-kselftest.git'
 
+  lee-backlight:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/lee/backlight.git"
+
   linusw:
     url: "https://git.kernel.org/pub/scm/linux/kernel/git/linusw/linux-gpio.git/"
 
@@ -985,6 +988,11 @@ build_configs:
   kselftest_next:
     <<: *kselftest-tree
     branch: 'next'
+
+  lee_backlight:
+    tree: lee-backlight
+    branch: 'for-backlight-next'
+    variants: *minimal_variants
 
   linusw_devel:
     tree: linusw


### PR DESCRIPTION
Add Lee's backlight and mfd git trees and build configs with minimal variants.  Drop the Android 3.18 tree as it has reached its end of life now.

Replaces #459