### PR TITLE
Fix firmware handling

### DIFF
--- a/config/rootfs/debos/scripts/install-firmware.sh
+++ b/config/rootfs/debos/scripts/install-firmware.sh
@@ -40,11 +40,19 @@ mkdir -p $DEST
 # git init hack to fetch a single shallow commit to minimize time,
 # space and network bandwidth
 TMP_REPO=/tmp/linux-firmware
+# As we cannot use git "as-is" we need to "process" git to
+# intermediate directory by using copy-firmware.sh script
+TMP_FW=/tmp/linux-firmware-parsed
+mkdir -p $TMP_FW
 mkdir -p $TMP_REPO && cd $TMP_REPO
+
 git init
 git remote add origin $FIRMWARE_SITE
 git fetch --depth 1 origin $version
 git checkout FETCH_HEAD
+
+./copy-firmware.sh ${TMP_FW}
+cd ${TMP_FW}
 
 for fw_file in "${files[@]}"
 do
@@ -55,3 +63,4 @@ done
 # Cleanup: remove downloaded firmware files
 ########################################################################
 rm -rf $TMP_REPO
+rm -rf $TMP_FW

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -1192,6 +1192,7 @@ class FetchFirmware(Step):
         # CONFIG_EXTRA_FIRMWARE_DIR need absolute path
         full_path = os.path.abspath(self._output_path)
         fwdir = os.path.join(full_path, 'linux-firmware')
+        fwfiles = os.path.join(full_path, 'firmware-files')
         key = self._kernel_config_getkey('CONFIG_EXTRA_FIRMWARE')
         if key and key == '""':
             if verbose:
@@ -1202,9 +1203,12 @@ class FetchFirmware(Step):
         repourl = 'git://git.kernel.org/pub/scm/linux/kernel/git/\
 firmware/linux-firmware.git'
         clone_git(repourl, fwdir, 'main')
+        # We need to extract files and symlinks using copy-firmware.sh
+        shell_cmd(f"mkdir {fwfiles}")
+        shell_cmd(f"cd {fwdir};./copy-firmware.sh {fwfiles};cd -")
         # We need to override directory where firmware stored
         self._kernel_config_setkey('CONFIG_EXTRA_FIRMWARE_DIR',
-                                   f'"{fwdir}"')
+                                   f'"{fwfiles}"')
         bmeta = self._meta.get('bmeta')
         fbmeta = bmeta.setdefault('firmware', dict())
         fbmeta['commit'] = kernelci.build.head_commit(fwdir)


### PR DESCRIPTION
Two patches to fix firmware handling using copy-firmware.sh, as without it we doesn't have symlinked firmware files.
First to address firmware extraction for rootfs, second to address firmware extraction for building in-kernel.