### PR TITLE
kernelci.lab.lava: Fix priority scaling

### DIFF
--- a/kernelci/lab/lava/__init__.py
+++ b/kernelci/lab/lava/__init__.py
@@ -37,17 +37,22 @@ class LavaAPI(LabAPI):
 
         # Scale the job priority (from 0-100) within the available levels
         # for the lab, or use the lowest by default.
-        plan_priority = plan_config.params.get('priority', 20)
-        if all((self.config.priority_max, self.config.priority_min)):
-            prio_range = self.config.priority_max - self.config.priority_min
-            prio_min = self.config.priority_min
-            plan_priority = int((plan_priority * prio_range / 100) + prio_min)
+        if 'priority' in plan_config.params:
+            priority = plan_config.params['priority']
+            if priority > 100:
+                priority = 100
+        else:
+            priority = 20
+
+        prio_range = self.config._priority_max - self.config._priority_min
+        priority = int(((priority * prio_range) / 100) +
+                       self.config._priority_min)
 
         params.update({
             'queue_timeout': self.config.queue_timeout,
             'lab_name': self.config.name,
             'base_device_type': self._alias_device_type(base_name),
-            'priority': plan_priority,
+            'priority': priority,
         })
         if callback_opts:
             self._add_callback_params(params, callback_opts)


### PR DESCRIPTION
Since 96d636627f ("kernelci.lab.lava: rework priority scale") jobs submitted to at least my lab have been ignoring the configured priority range and using the full range of available priorities.  The commit has the logic to scale plan priorities but it doesn't seem to be taking effect for reasons that are not obvious to me, possibly due to confusion over the treatment of a 0 priority value as a logical value.

This is severely disrupting my own use of my lab since the baseline jobs are submitted with vastly higher priority than any of my normal jobs so juts revert the commit for now.

Signed-off-by: Mark Brown <broonie@kernel.org>