### PR TITLE
Revert "config/k8s: add set -e to build jobs"

### DIFF
--- a/config/k8s/job-build.jinja2
+++ b/config/k8s/job-build.jinja2
@@ -87,7 +87,7 @@ install: true\n\
 [kci_data]\n\
 output: ${KDIR}/build\n\
 \" > kernelci.conf; \
-set -xe; \
+set -x; \
 \
 kci_build pull_tarball \
   --url ${SRC_TARBALL} \


### PR DESCRIPTION
Being discussed in https://github.com/kernelci/kernelci-core/issues/1677 
This reverts commit 46976d4df272d2d16edfda80fdf57e44f72b9e52.