### PR TITLE
build-configs.yaml: Add missing firmware for Mediatek and Rockchip

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -332,6 +332,11 @@ fragments:
       - 'CONFIG_VIDEO_OV02A10=m'
       - 'CONFIG_VIDEO_OV5695=m'
       - 'CONFIG_VIDEO_OV8856=m'
+      - 'CONFIG_EXTRA_FIRMWARE="
+      mediatek/mt8173/vpu_d.bin
+      mediatek/mt8173/vpu_p.bin
+      rockchip/dptx.bin
+      "'
 
 
   crypto:


### PR DESCRIPTION
Mediatek and Rockchip emit a lot of error messages about missing firmware even on baseline job, which might affect tests not only by fact of missing firmware, but also repeating messages disrupting LAVA console. As firmware is relative small we can add it directly to Chromebook kernels.
Fixes: https://github.com/kernelci/kernelci-core/issues/1652

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>