### PR TITLE
test-configs.yaml: Cover NFS boots on Raspberry Pi 1B

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -893,6 +893,7 @@ device_types:
   bcm2835-rpi-b-rev2:
     mach: broadcom
     class: arm-dtb
+    variant: v6
     boot_method: uboot
     filters:
       - passlist: {defconfig: ['bcm2835_defconfig']}
@@ -2322,6 +2323,7 @@ test_configs:
   - device_type: bcm2835-rpi-b-rev2
     test_plans:
       - baseline
+      - baseline-nfs
 
   - device_type: bcm2836-rpi-2-b
     test_plans:


### PR DESCRIPTION
The ethernet works fine on these boards so we can cover NFS.

Signed-off-by: Mark Brown <broonie@kernel.org>