### PR TITLE
kernelci.build: fix mkdir firmware-files

### DIFF
--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -1204,7 +1204,7 @@ class FetchFirmware(Step):
 firmware/linux-firmware.git'
         clone_git(repourl, fwdir, 'main')
         # We need to extract files and symlinks using copy-firmware.sh
-        shell_cmd(f"mkdir {fwfiles}")
+        shell_cmd(f"rm -rf {fwfiles} && mkdir {fwfiles}")
         shell_cmd(f"cd {fwdir};./copy-firmware.sh {fwfiles};cd -")
         # We need to override directory where firmware stored
         self._kernel_config_setkey('CONFIG_EXTRA_FIRMWARE_DIR',


### PR DESCRIPTION
When doing incremental builds, the firmware-files output directory is still present from the previous build which results in mkdir to fail. To take this use-case into account, which is required for manual builds and the automated bisection, always delete any firmware-files output directory first.

Fixes: 71fca1277c1d ("build.py: Add proper handling for linux-firmware by copy-firmware.sh")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>