### PR TITLE
build-configs-cip: Use cip-kernel-configs for kernels (5.10.y-cip, 4.4.y-cip)

### DIFF
--- a/config/core/build-configs-cip.yaml
+++ b/config/core/build-configs-cip.yaml
@@ -143,6 +143,10 @@ build_configs:
             extra_configs:
               - 'allnoconfig'
               - 'cip://4.4.y-cip/arm/qemu_arm_defconfig'
+            filters:
+              - blocklist: {
+                defconfig: ['rpc_defconfig'] # gcc-10 not supported
+              }
           x86_64:
             base_defconfig: 'x86_64_defconfig'
             fragments: [x86-chromebook]
@@ -172,6 +176,10 @@ build_configs:
             extra_configs:
               - 'allnoconfig'
               - 'cip://4.19.y-cip/arm/qemu_arm_defconfig'
+            filters:
+              - blocklist: {
+                defconfig: ['rpc_defconfig'] # gcc-10 not supported
+              }
           arm64:
             fragments: [arm64-chromebook]
             extra_configs:
@@ -206,6 +214,10 @@ build_configs:
             extra_configs:
               - 'allnoconfig'
               - 'cip://5.10.y-cip/arm/qemu_arm_defconfig'
+            filters:
+              - blocklist: {
+                defconfig: ['rpc_defconfig'] # gcc-10 not supported
+              }
           arm64:
             fragments: [arm64-chromebook]
             extra_configs:

--- a/config/core/build-configs-cip.yaml
+++ b/config/core/build-configs-cip.yaml
@@ -134,7 +134,21 @@ build_configs:
   cip_4.4:
     tree: cip
     branch: 'linux-4.4.y-cip'
-    variants: *cip_variants_4_4
+    variants:
+      gcc-10:
+        build_environment: gcc-10
+        architectures:
+          arm:
+            base_defconfig: 'multi_v7_defconfig'
+            extra_configs:
+              - 'allnoconfig'
+              - 'cip://4.4.y-cip/arm/qemu_arm_defconfig'
+          x86_64:
+            base_defconfig: 'x86_64_defconfig'
+            fragments: [x86-chromebook]
+            extra_configs:
+              - 'allnoconfig'
+              - 'cip://4.4.y-cip/x86/cip_qemu_defconfig'
 
   cip_4.4-rc:
     tree: cip-gitlab

--- a/config/core/build-configs-cip.yaml
+++ b/config/core/build-configs-cip.yaml
@@ -183,7 +183,31 @@ build_configs:
   cip_5.10:
     tree: cip
     branch: 'linux-5.10.y-cip'
-    variants: *cip_variants_kselftest
+    variants:
+      gcc-10:
+        build_environment: gcc-10
+        architectures:
+          arm:
+            base_defconfig: 'multi_v7_defconfig'
+            extra_configs:
+              - 'allnoconfig'
+              - 'cip://5.10.y-cip/arm/qemu_arm_defconfig'
+          arm64:
+            fragments: [arm64-chromebook]
+            extra_configs:
+              - 'allnoconfig'
+              - 'cip://5.10.y-cip/arm64/qemu_arm64_defconfig'
+          x86_64:
+            base_defconfig: 'x86_64_defconfig'
+            fragments: [x86-chromebook]
+            extra_configs:
+              - 'allnoconfig'
+              - 'cip://5.10.y-cip/x86/cip_qemu_defconfig'
+          riscv:
+            base_defconfig: 'riscv_defconfig'
+            extra_configs:
+              - 'allnoconfig'
+              - 'cip://5.10.y-cip/riscv/qemu_riscv64_defconfig'
 
   cip_5.10-rc:
     tree: cip-gitlab

--- a/config/core/build-configs-cip.yaml
+++ b/config/core/build-configs-cip.yaml
@@ -173,6 +173,7 @@ build_configs:
         architectures:
           arm:
             base_defconfig: 'multi_v7_defconfig'
+            fragments: [kselftest]
             extra_configs:
               - 'allnoconfig'
               - 'cip://4.19.y-cip/arm/qemu_arm_defconfig'
@@ -181,13 +182,13 @@ build_configs:
                 defconfig: ['rpc_defconfig'] # gcc-10 not supported
               }
           arm64:
-            fragments: [arm64-chromebook]
+            fragments: [kselftest, arm64-chromebook]
             extra_configs:
               - 'allnoconfig'
               - 'cip://4.19.y-cip/arm64/qemu_arm64_defconfig'
           x86_64:
             base_defconfig: 'x86_64_defconfig'
-            fragments: [x86-chromebook]
+            fragments: [kselftest, x86-chromebook]
             extra_configs:
               - 'allnoconfig'
               - 'cip://4.19.y-cip/x86/cip_qemu_defconfig'
@@ -219,18 +220,19 @@ build_configs:
                 defconfig: ['rpc_defconfig'] # gcc-10 not supported
               }
           arm64:
-            fragments: [arm64-chromebook]
+            fragments: [kselftest, arm64-chromebook]
             extra_configs:
               - 'allnoconfig'
               - 'cip://5.10.y-cip/arm64/qemu_arm64_defconfig'
           x86_64:
             base_defconfig: 'x86_64_defconfig'
-            fragments: [x86-chromebook]
+            fragments: [kselftest, x86-chromebook]
             extra_configs:
               - 'allnoconfig'
               - 'cip://5.10.y-cip/x86/cip_qemu_defconfig'
           riscv:
             base_defconfig: 'riscv_defconfig'
+            fragments: [kselftest]
             extra_configs:
               - 'allnoconfig'
               - 'cip://5.10.y-cip/riscv/qemu_riscv64_defconfig'


### PR DESCRIPTION
Also add Riscv configuration for 5.10.y-cip

Signed-off-by: Alice Ferrazzi <alice.ferrazzi@miraclelinux.com>