### PR TITLE
build-configs.yaml: Add android14-6.1

### DIFF
--- a/config/core/build-configs-android.yaml
+++ b/config/core/build-configs-android.yaml
@@ -53,11 +53,6 @@ build_configs:
     branch: 'android-4.9-p'
     variants: *android_variants
 
-  android_4.9-q:
-    tree: android
-    branch: 'android-4.9-q'
-    variants: *android_variants
-
   android_4.9-q-release:
     tree: android
     branch: 'android-4.9-q-release'
@@ -68,11 +63,6 @@ build_configs:
     branch: 'android-4.14-p'
     variants: *android_variants
 
-  android_4.14-q:
-    tree: android
-    branch: 'android-4.14-q'
-    variants: *android_variants
-
   android_4.14-q-release:
     tree: android
     branch: 'android-4.14-q-release'
@@ -81,11 +71,6 @@ build_configs:
   android_4.14-stable:
     tree: android
     branch: 'android-4.14-stable'
-    variants: *android_variants
-
-  android_4.19-q:
-    tree: android
-    branch: 'android-4.19-q'
     variants: *android_variants
 
   android_4.19-q-release:
@@ -178,5 +163,11 @@ build_configs:
   android14-5.15:
     tree: android
     branch: 'android14-5.15'
+    variants:
+      <<: *android_variants
+
+  android14-6.1:
+    tree: android
+    branch: 'android14-6.1'
     variants:
       <<: *android_variants


### PR DESCRIPTION
Add new Android tree as requested, and remove old tree (also as suggest in maillist),
as we are reaching peak capacity on large builds.
Reference: https://groups.io/g/kernelci/topic/please_add_android14_6_1/95717503
Fixes https://github.com/kernelci/kernelci-core/issues/1659

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>