### PR TITLE
    config/docker: add liburing to kselftest fragment

### DIFF
--- a/config/docker/fragment/kselftest.jinja2
+++ b/config/docker/fragment/kselftest.jinja2
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
    libhugetlbfs-dev{{ pkgarch }} \
    libmnl-dev{{ pkgarch }} \
    libnuma-dev{{ pkgarch }} \
+   liburing-dev{{ pkgarch }} \
    libpopt-dev{{ pkgarch }} \
    patch \
    pkg-config

--- a/config/docker/fragment/kselftest.jinja2
+++ b/config/docker/fragment/kselftest.jinja2
@@ -10,6 +10,8 @@
     {%- endif %}
 {%- endif %}
 RUN apt-get update && apt-get install --no-install-recommends -y \
+   libasound2-dev \
+   libasound2-dev{{ pkgarch }} \
    libc6-dev{{ libc6_pkgarch }} \
    libcap-dev{{ pkgarch }} \
    libcap-ng-dev{{ pkgarch }} \
@@ -19,7 +21,5 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
    libmnl-dev{{ pkgarch }} \
    libnuma-dev{{ pkgarch }} \
    libpopt-dev{{ pkgarch }} \
-   libasound2-dev{{ pkgarch }} \
-   libasound2-dev \
    patch \
    pkg-config


### PR DESCRIPTION
    Add liburing-dev to the list of libraries installed by the kselftest
    fragment.  This is required in particular for the vm tests, to fix
    this build warning:
    
      Warning: missing liburing support. Some COW tests will be skipped.
