### PR TITLE
test-configs.yaml: Use config fragment for KVM selftests

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -326,7 +326,6 @@ test_plans:
     params:
       job_timeout: '15'
       kselftest_collections: "kvm"
-    filters: *kselftest_no_fragment
 
   kselftest-landlock:
     <<: *kselftest


### PR DESCRIPTION
The KVM selftests do actually have a config fragment which is needed on architectures other than arm64 to get KVM actually built, and will be needed on architectures other than S/390 to get the page_fault_test test to run once a fix is merged upstream.

Signed-off-by: Mark Brown <broonie@kernel.org>