### PR TITLE
test-configs.yaml: Only test mainline and -next on QDF2400

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1523,8 +1523,7 @@ device_types:
     arch: arm64
     boot_method: grub
     filters:
-      - passlist: {defconfig: ['defconfig']}
-      - blocklist: {kernel: ['v3.']}
+      - regex: {'tree': '(next|mainline)'}
     params:
       boot_timeout: '10'
 


### PR DESCRIPTION
The QDF2400 is rather slow to boot, taking about 5 minutes to run even a baseline test, meaning that when exposed to the full set of trees we end up spending most of our time running boot tests. Constrain the set of trees covered to just mainline and -next where it's most interesting, allowing us to use it for broader coverage of test cases. The device has a unique microarchitecture but is not widely deployed, though we do have few ACPI machines which is unfortunate.

While we're at it drop the filters for v3.x (that's not really relevant any more) and for defconfig (which passes a lot of defconfig+X anyway).

Signed-off-by: Mark Brown <broonie@kernel.org>