### PR TITLE
build-configs.yaml: Add QCOM_QFPROM option for QCOM GPU

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -233,6 +233,7 @@ fragments:
       - 'CONFIG_SX9310=m'
       - 'CONFIG_SX9324=m'
       - 'CONFIG_TCG_TIS_I2C_CR50=y'
+      - 'CONFIG_QCOM_QFPROM=y'
       # Mediatek specific options start here
       - 'CONFIG_RTC_DRV_PM8XXX=y'
       - 'CONFIG_SND_SOC_MT8183=y'


### PR DESCRIPTION
As discovered in https://github.com/kernelci/kernelci-core/issues/1696 Qualcomm GPU need this option to retrieve some data relevant to GPU.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>