### PR TITLE
CHROMEOS build-configs-chromeos.yaml: Remove 5.10 from ChromeOS tests

### DIFF
--- a/config/core/build-configs-chromeos.yaml
+++ b/config/core/build-configs-chromeos.yaml
@@ -4,49 +4,6 @@ trees:
     url: "https://github.com/kernelci/linux.git"
 
 
-chromeos_5.10_variants: &chromeos_5_10_variants
-  chromeos-clang-14:
-    build_environment: clang-14
-    architectures:
-      arm:
-        base_defconfig: 'cros://chromeos-5.10/armel/chromiumos-arm.flavour.config'
-        extra_configs:
-          - 'cros://chromeos-5.10/armel/chromiumos-rockchip.flavour.config'
-        filters: &cros-filters
-          - regex: { defconfig: 'cros' }
-      arm64:
-        base_defconfig: 'cros://chromeos-5.10/arm64/chromiumos-arm64.flavour.config'
-        fragments: [arm64-chromebook]
-        extra_configs:
-          - 'cros://chromeos-5.10/arm64/chromiumos-mediatek.flavour.config+arm64-chromebook'
-          - 'cros://chromeos-5.10/arm64/chromiumos-qualcomm.flavour.config+arm64-chromebook'
-          - 'cros://chromeos-5.10/arm64/chromiumos-rockchip64.flavour.config+arm64-chromebook'
-        filters: *cros-filters
-      x86_64:
-        base_defconfig: 'cros://chromeos-5.10/x86_64/chromiumos-x86_64.flavour.config'
-        fragments: [x86-chromebook]
-        extra_configs:
-          - 'cros://chromeos-5.10/x86_64/chromeos-amd-stoneyridge.flavour.config+x86-chromebook+CONFIG_MODULE_COMPRESS=n'
-          - 'cros://chromeos-5.10/x86_64/chromeos-intel-denverton.flavour.config+x86-chromebook+CONFIG_MODULE_COMPRESS=n'
-          - 'cros://chromeos-5.10/x86_64/chromeos-intel-pineview.flavour.config+x86-chromebook+CONFIG_MODULE_COMPRESS=n'
-          - 'cros://chromeos-5.10/x86_64/chromiumos-x86_64.flavour.config+x86-chromebook+CONFIG_MODULE_COMPRESS=n'
-        filters: *cros-filters
-
-  clang-14: &clang-14
-    build_environment: clang-14
-    architectures:
-      arm64:
-        base_defconfig: 'defconfig'
-        fragments: [arm64-chromebook]
-        filters:
-          - passlist: { defconfig: ['arm64-chromebook'] }
-      x86_64:
-        base_defconfig: 'x86_64_defconfig'
-        fragments: [x86-chromebook]
-        filters:
-          - passlist: { defconfig: ['x86-chromebook'] }
-
-
 chromeos_5.15_variants: &chromeos_5_15_variants
   chromeos-clang-14:
     build_environment: clang-14
@@ -55,7 +12,8 @@ chromeos_5.15_variants: &chromeos_5_15_variants
         base_defconfig: 'cros://chromeos-5.15/armel/chromiumos-arm.flavour.config'
         extra_configs:
           - 'cros://chromeos-5.15/armel/chromiumos-rockchip.flavour.config'
-        filters: *cros-filters
+        filters: &cros-filters
+          - regex: { defconfig: 'cros' }
       arm64:
         base_defconfig: 'cros://chromeos-5.15/arm64/chromiumos-arm64.flavour.config'
         fragments: [arm64-chromebook]
@@ -74,7 +32,19 @@ chromeos_5.15_variants: &chromeos_5_15_variants
           - 'cros://chromeos-5.15/x86_64/chromiumos-x86_64.flavour.config+x86-chromebook+CONFIG_MODULE_COMPRESS_GZIP=n'
         filters: *cros-filters
 
-  clang-14: *clang-14
+  clang-14: &clang-14
+    build_environment: clang-14
+    architectures:
+      arm64:
+        base_defconfig: 'defconfig'
+        fragments: [arm64-chromebook]
+        filters:
+          - passlist: { defconfig: ['arm64-chromebook'] }
+      x86_64:
+        base_defconfig: 'x86_64_defconfig'
+        fragments: [x86-chromebook]
+        filters:
+          - passlist: { defconfig: ['x86-chromebook'] }
 
 
 chromeos_6.1_variants: &chromeos_6_1_variants
@@ -114,11 +84,6 @@ build_configs:
     tree: next
     branch: 'master'
     variants: *chromeos_6_1_variants
-
-  chromeos-stable_5.10:
-    tree: stable
-    branch: 'linux-5.10.y'
-    variants: *chromeos_5_10_variants
 
   chromeos-stable_5.15:
     tree: stable


### PR DESCRIPTION
Kernel 5.10 is no more relevant for ChromeOS testing, remove it from configuration files.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>