### PR TITLE
build-configs.yaml: Add NFS options to arm64-chromebook

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -157,6 +157,12 @@ fragments:
   arm64-chromebook:
     path: "kernel/configs/arm64-chromebook.config"
     configs:
+      - 'CONFIG_NFS_FS=y'
+      - 'CONFIG_NFS_V2=y'
+      - 'CONFIG_NFS_V3=y'
+      - 'CONFIG_NFS_V3_ACL=y'
+      - 'CONFIG_NFS_V4=y'
+      - 'CONFIG_ROOT_NFS=y'
       - 'CONFIG_REGULATOR_DA9211=y'
       - 'CONFIG_ARM_MEDIATEK_CPUFREQ=y'
       - 'CONFIG_RTC_DRV_MT6397=y'


### PR DESCRIPTION
As we have some configs with this fragment without defconfig, we need to add NFS options, so kernel configuration can pass baseline-nfs tests.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>