### PR TITLE
build-configs-stable.yaml: Add Linux 6.1 LTS stable trees testing

### DIFF
--- a/config/core/build-configs-stable.yaml
+++ b/config/core/build-configs-stable.yaml
@@ -181,6 +181,11 @@ build_configs:
     branch: 'linux-5.19.y'
     variants: *stable_variants
 
+  stable_6.1:
+    tree: stable
+    branch: 'linux-6.1.y'
+    variants: *stable_variants
+
   stable-rc_3.16:
     tree: stable-rc
     branch: 'linux-3.16.y'
@@ -285,6 +290,14 @@ build_configs:
       tree: stable
       branch: 'linux-5.19.y'
 
+  stable-rc_6.1:
+    tree: stable-rc
+    branch: 'linux-6.1.y'
+    variants: *stable_variants
+    reference:
+      tree: stable
+      branch: 'linux-6.1.y'
+
   stable-rc_queue-4.4:
     tree: stable-rc
     branch: 'queue/4.4'
@@ -380,3 +393,11 @@ build_configs:
     reference:
       tree: stable
       branch: 'linux-5.19.y'
+
+  stable-rc_queue-6.1:
+    tree: stable-rc
+    branch: 'queue/6.1'
+    variants: *stable_variants
+    reference:
+      tree: stable
+      branch: 'linux-6.1.y'


### PR DESCRIPTION
As Linux 6.1 declared as LTS, we need to add testing for stable trees, rc-queues and such, similar to other LTS kernels.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>