### PR TITLE
rootfs/debos/scripts: update cros-ec-tests upstream repo

### DIFF
--- a/config/rootfs/debos/scripts/bullseye-cros-ec-tests.sh
+++ b/config/rootfs/debos/scripts/bullseye-cros-ec-tests.sh
@@ -26,7 +26,7 @@ echo '{  "tests_suites": [' >> $BUILDFILE
 # Build and install tests                                              #
 ########################################################################
 
-CROS_URL="https://github.com/hardboprobot/cros-ec-tests.git"
+CROS_URL="https://github.com/kernelci/cros-ec-tests.git"
 CROS_SHA=$(git ls-remote ${CROS_URL} | head -n 1 | cut -f 1)
 
 pip3 install git+${CROS_URL}@${CROS_SHA}


### PR DESCRIPTION
This repo has been moved to the KernelCI github project.

Signed-off-by: Ricardo Cañuelo <ricardo.canuelo@collabora.com>