### PR TITLE
test-configs.yaml: Only run ALSA selftests where they exist

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -255,6 +255,7 @@ test_plans:
     filters:
       - passlist: {defconfig: ['kselftest']}
 
+  # Supported from v5.17 on but the latest v5.x stable is v5.15
   kselftest-alsa:
     <<: *kselftest
     rootfs: debian_bookworm-kselftest_nfs
@@ -263,6 +264,7 @@ test_plans:
       kselftest_collections: "alsa"
     filters: &kselftest_no_fragment
       - combination: *arch_defconfig_filter
+      - blocklist: {kernel: ['v3.', 'v4.', 'v5.']}
 
   kselftest-arm64:
     <<: *kselftest


### PR DESCRIPTION
The ALSA selftests were merged in v5.17 so there is no point in running them on older kernels, add a filter. We block all v5.x since there are no longer any active v5.x kernels based on anything newer than v5.15 so it's not worth the effort of writing the filter.

Signed-off-by: Mark Brown <broonie@kernel.org>