### PR TITLE
test-configs.yaml: Tune down number of tests run on i.MX UDOO boards

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2546,11 +2546,6 @@ test_configs:
       - baseline-nfs
       - igt-gpu-etnaviv
       - kselftest-alsa
-      - kselftest-capabilities
-      - kselftest-cgroup
-      - kselftest-exec
-      - kselftest-futex
-      - kselftest-kcmp
       - ltp-crypto
 
   - device_type: imx6q-nitrogen6x
@@ -2584,11 +2579,6 @@ test_configs:
       - baseline-nfs
       - igt-gpu-etnaviv
       - kselftest-alsa
-      - kselftest-capabilities
-      - kselftest-cgroup
-      - kselftest-exec
-      - kselftest-futex
-      - kselftest-kcmp
       - ltp-crypto
 
   - device_type: imx6q-var-dt6customboard


### PR DESCRIPTION
Due to an increase in the number of commits tested, due to increasing numbers of trees and activity in some of the larger ones like stable, we are not managing to get through all the scheduled jobs on the UDOO boards.  Trim the list of tests scheduled on these boards to just those that exercise hardware and features specific to them.

Signed-off-by: Mark Brown <broonie@kernel.org>