### PR TITLE
test-configs.yaml: Tune down the number of tests run on Pine64+

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -3217,17 +3217,9 @@ test_configs:
       - igt-gpu-lima
       - kselftest-arm64
       - kselftest-cpufreq
-      - kselftest-filesystems
-      - kselftest-futex
-      - kselftest-lib
       - kselftest-rtc
-      - kselftest-seccomp
       - ltp-crypto
-      - ltp-fcntl-locktests
-      - ltp-ima
-      - ltp-ipc
       # ltp-mm - runs system out of memory
-      - smc
 
   - device_type: sun50i-h5-libretech-all-h3-cc
     test_plans:


### PR DESCRIPTION
With the increased number of trees and increased activity in some of those trees we aren't getting anywhere near being able to run the tests we currently schedule on Pine64+ in the labs we have.  Tune down the number of tests to help us get through the tests reliably and promptly.

Signed-off-by: Mark Brown <broonie@kernel.org>