### PR TITLE
test-configs.yaml: Tune down number of tests run on Juno

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2663,14 +2663,7 @@ test_configs:
       - baseline
       - baseline-nfs
       - kselftest-cpufreq
-      - kselftest-futex
-      - kselftest-lib
-      - kselftest-lkdtm
-      - kselftest-rtc
-      - kselftest-seccomp
       - ltp-crypto
-      - ltp-fcntl-locktests
-      - ltp-ipc
       # ltp-mm - runs system out of memory
       - smc
 


### PR DESCRIPTION
Due to increased numbers of trees and activity in some of those trees we are not managing to get through the tests we currently schedule on Juno. Tune down the number of tests to try to ensure we get through things promptly and reliably.

Signed-off-by: Mark Brown <broonie@kernel.org>