### PR TITLE
test-configs.yaml: Don't run v4.x stables on Le Potato

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1409,6 +1409,8 @@ device_types:
     class: arm64-dtb
     boot_method: uboot
     flags: ['big_endian']
+    filters:
+      - blocklist: {kernel: ['v4.']}
 
   meson-gxm-khadas-vim2:
     mach: amlogic


### PR DESCRIPTION
Though looking at the code it was supported at time of release the stable kernels have been failing to boot on these boards for quite some time (since April 2022 for v4.14 in my lab for example), and testing with the initial releases from Linus and a GCC 8 toolchain I'm getting no output on boot so there's no obvious prospect of bisecting.

Given the length of time that things have been failing just stop scheduling tests, we can reenable if someone goes and fixes things but probably there are no users of these kernels on these boards who are keeping up to date with fixes any more.

Signed-off-by: Mark Brown <broonie@kernel.org>