### PR TITLE
Makefile cleanup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Run unit tests
         run: |
-          make test
+          make unit-tests
 
       - name: Run pycodestyle
         run: |

--- a/Makefile
+++ b/Makefile
@@ -6,12 +6,6 @@
 # Copyright (C) 2019, 2020, 2023 Collabora Limited
 # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
 
-checks: \
-	pylint \
-	pycodestyle \
-	test \
-	validate-yaml
-
 pylint:
 	pylint --reports=y \
 		kci \

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,12 @@
 # Copyright (C) 2019, 2020, 2023 Collabora Limited
 # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
 
+test: \
+	pylint \
+	pycodestyle \
+	unit-tests \
+	validate-yaml
+
 pylint:
 	pylint --reports=y \
 		kci \
@@ -21,7 +27,7 @@ pycodestyle:
 	pycodestyle scripts/*
 	pycodestyle tests/*
 
-test:
+unit-tests:
 	python3 -m pytest tests
 
 validate-yaml:


### PR DESCRIPTION
Clean up the Makefile and move checks from the GitHub workflow `main.yaml` config to the Makefile to make it easier to run them by hand and in a reproducible way.