### PR TITLE
workflows use checkout v3 for older checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
 
       - name: Check out source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python
         uses: actions/setup-python@master


### PR DESCRIPTION
Update the checkout action to v3 to fix this warning:

  Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>