### PR TITLE
Add and use bookworm rootfs for kselftest-alsa

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -1,4 +1,44 @@
 rootfs_configs:
+  bookworm-kselftest:
+    rootfs_type: debos
+    debian_release: bookworm
+    arch_list:
+      - amd64
+      - arm64
+      - armhf
+    extra_packages:
+      - alsa-ucm-conf
+      - alsa-utils
+      - bc
+      - ca-certificates
+      - iproute2
+      - jdim
+      - libasound2
+      - libatm1
+      - libcap2-bin
+      - libelf1
+      - libgdbm-compat4
+      - libgdbm6
+      - libhugetlbfs0
+      - libmnl0
+      - libnuma1
+      - libpam-cap
+      - libpcre2-8-0
+      - libperl5.36
+      - libpsl5
+      - libxtables12
+      - netbase
+      - openssl
+      - perl
+      - perl-modules-5.36
+      - procps
+      - publicsuffix
+      - python3-minimal
+      - python3-unittest2
+      - tpm2-tools
+      - wget
+      - xz-utils
+
   buildroot-baseline:
     rootfs_type: buildroot
     git_url: https://github.com/kernelci/buildroot

--- a/config/core/rootfs-images.yaml
+++ b/config/core/rootfs-images.yaml
@@ -7,6 +7,23 @@ file_systems:
     ramdisk: buildroot-baseline/20230211.0/{arch}/rootfs.cpio.gz
     root_type: ramdisk
     type: buildroot
+  debian_bookworm-kselftest_nfs:
+    boot_protocol: tftp
+    nfs: bookworm-kselftest/20230211.0/{arch}/full.rootfs.tar.xz
+    params:
+      os_config: debian
+    prompt: '/ #'
+    ramdisk: bookworm-kselftest/20230211.0/{arch}/initrd.cpio.gz
+    root_type: nfs
+    type: debian
+  debian_bookworm-kselftest_ramdisk:
+    boot_protocol: ramdisk
+    params:
+      os_config: debian
+    prompt: '/ #'
+    ramdisk: bookworm-kselftest/20230211.0/{arch}/rootfs.cpio.gz
+    root_type: ramdisk
+    type: debian
   debian_bullseye-cros-ec_ramdisk:
     boot_protocol: tftp
     params: {}

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -238,6 +238,7 @@ test_plans:
 
   kselftest-alsa:
     <<: *kselftest
+    rootfs: debian_bookworm-kselftest_nfs
     params:
       job_timeout: '10'
       kselftest_collections: "alsa"


### PR DESCRIPTION
Add a rootfs to run kselftest on Debian bookworm, and update the kselftest-alsa test plan to use it instead. Bookworm is needed since it includes more recent versions of the alsa-ucm-conf, libasound2 and alsa-utils packages than the ones available in bullseye, allowing us to access UCM files for more recent platforms. In the end this allows more thorough testing of audio on these machines and better scores.

I created [a bug report](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1029272) on libasound2 to see if a backport to stable was possible, but since I haven't heard back from the maintainer in a while, let's get this going with debian testing. If the packages are ever backported we can switch to those then.