### PR TITLE
Enable kselftest-alsa (bookworm) on mt8173-elm-hana

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2846,6 +2846,7 @@ test_configs:
       - baseline-nfs
       - cros-ec
       - igt-kms-mediatek
+      - kselftest-alsa
       - kselftest-arm64
       - kselftest-cpufreq
       - kselftest-filesystems


### PR DESCRIPTION
Based on #1740.

Add and enable the kselftest-alsa-bookworm test plan on mt8173-elm-hana. The UCM
files for mt8173-elm-hana are under ucm2/MediaTek/mtk-rt5650, which is
only present starting with v1.2.6.3 of alsa-ucm-conf. Bullseye provides
alsa-ucm-conf v1.2.4, and therefore the bookworm rootfs is needed to
completely initialize audio on this machine.

Without the UCM, errors like the following show up during the pcm-test
in alsa-kselftest:

```
rt5650 Playback: ASoC: no backend DAIs enabled for rt5650 Playback
rt5650 Playback: ASoC: error at dpcm_fe_dai_prepare on rt5650 Playback: -22
```

And with the UCM applied, results from pcm-test go from

```
Totals: pass:2 fail:2 xfail:0 xpass:0 skip:17 error:0
```

to

```
Totals: pass:12 fail:1 xfail:0 xpass:0 skip:8 error:0
```

The default selftest timeout is too short to run pcm-test on this machine, so I had to apply [[PATCH v2] kselftest/alsa: Increase kselftest timeout](https://lore.kernel.org/all/20221214130353.1989075-1-nfraprado@collabora.com/#r) to be able to run the test through the end. But it wasn't accepted upstream, so a different approach might be needed (or more data to show that the current timeout isn't enough). Related to this, there has also been `69218b59be20 kselftest/alsa: Run PCM tests for multiple cards in parallel` merged recently, but that doesn't help here, since this machine has a single sound card.