### PR TITLE
test-configs.yaml: Expand coverage for QDF2400

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2931,6 +2931,8 @@ test_configs:
   - device_type: qcom-qdf2400
     test_plans:
       - baseline
+      - baseline-nfs
+      - kselftest-arm64
       - kselftest-filesystems
       - kselftest-futex
       - kselftest-kvm


### PR DESCRIPTION
Now we have curtailed the set of trees we cover with the QDF2400 we are getting through all the currently scheduled tests with room to spare, expand the coverage a bit and also cover the arm64 selftests (this is a unique microarchitecture so it's good to cover them) and since we're relying on it for all the other tests include baseline-nfs too.