### PR TITLE
CHROMEOS build_board.sh: Extract and move CR50 firmware during build

### DIFF
--- a/config/rootfs/chromiumos/scripts/build_board.sh
+++ b/config/rootfs/chromiumos/scripts/build_board.sh
@@ -128,6 +128,8 @@ echo "Extracting additional artifacts"
 sudo tar -cJf "${DATA_DIR}/${BOARD}/modules.tar.xz" -C ./chroot/build/${BOARD} lib/modules
 sudo cp "./chroot/build/${BOARD}/boot/vmlinuz" "${DATA_DIR}/${BOARD}/bzImage"
 sudo cp ./chroot/build/${BOARD}/boot/config* "${DATA_DIR}/${BOARD}/kernel.config"
+# Extract CR50 firmware, but dont crash in case it is missing
+sudo mv ./chroot/build/${BOARD}/opt/google/cr50/firmware/* "${DATA_DIR}/${BOARD}/" || true
 
 echo "Extracting ${BOARD} specific artifacts"
 case ${BOARD} in


### PR DESCRIPTION
This commit introduces a patch that allows for the extraction of CR50 firmware, enabling it to be flashed separately. Prior to this patch, ChromeOS would attempt to reflash the CR50 during rootfs installation, which required manual intervention to powercycle the device. By extracting the firmware and making it a separate step, we can now plan for proper testing by Labs personnel.