### PR TITLE
workflows: run pycodestyle on standalone scripts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Get changed python files between base and head
         run: >
-          echo CHANGED_FILES=$(echo $(git diff --name-only ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} -- | grep '\.py\|kci$')) >> $GITHUB_ENV
+          echo CHANGED_FILES=$(echo $(git diff --name-only ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} -- | grep '\.py\|^kci$')) >> $GITHUB_ENV
 
       - if: env.CHANGED_FILES
         uses: marian-code/python-lint-annotate@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,3 +82,20 @@ jobs:
           use-mypy: false
           use-pydocstyle: false
           use-vulture: false
+
+      - name: Get changed kci scripts between base and head
+        run: >
+          echo CHANGED_KCI_FILES=$(echo $(git diff --name-only ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} -- | grep -v '.*\.md' | grep '^kci_\|^scripts/kci-')) >> $GITHUB_ENV
+
+      - if: env.CHANGED_KCI_FILES
+        uses: marian-code/python-lint-annotate@v3
+        name: Run pycodestyle annotations on kci scripts
+        with:
+          python-root-list: ${{ env.CHANGED_KCI_FILES }}
+          use-black: false
+          use-flake8: false
+          use-isort: false
+          use-mypy: false
+          use-pydocstyle: false
+          use-pylint: false
+          use-vulture: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,20 +62,27 @@ jobs:
         with:
           fetch-depth: 32  # This is necessary to get the commits
 
-      - name: Set up Python environment
-        uses: actions/setup-python@v3
-        with:
-          python-version: "3.10"
-
       - name: Get changed python files between base and head
         run: >
           echo CHANGED_FILES=$(echo $(git diff --name-only ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} -- | grep '\.py\|^kci$')) >> $GITHUB_ENV
+
+      - if: env.CHANGED_FILES
+        name: Set up Python
+        uses: actions/setup-python@master
+        with:
+          python-version: "3.10"
+
+      - if: env.CHANGED_FILES
+        name: Install Python packages
+        run: |
+          pip install -r requirements.txt
 
       - if: env.CHANGED_FILES
         uses: marian-code/python-lint-annotate@v3
         name: Run linter annotations
         with:
           python-root-list: ${{ env.CHANGED_FILES }}
+          python-version: "3.10"
           use-black: false
           use-flake8: false
           use-isort: false
@@ -92,6 +99,7 @@ jobs:
         name: Run pycodestyle annotations on kci scripts
         with:
           python-root-list: ${{ env.CHANGED_KCI_FILES }}
+          python-version: "3.10"
           use-black: false
           use-flake8: false
           use-isort: false


### PR DESCRIPTION
Tweak how linter annotations are run to only cover with pylint the *.py files and kci, and only add pycodestyle annotations to the kci_* and scripts/kci-* tools.

Tested with #1749 