### PR TITLE
test-configs.yaml: Enable NFS baseline tests on bcm2385-rpi-b-rev2

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2303,6 +2303,7 @@ test_configs:
   - device_type: bcm2835-rpi-b-rev2
     test_plans:
       - baseline
+      - baseline-nfs
 
   - device_type: bcm2836-rpi-2-b
     test_plans:


### PR DESCRIPTION
These boards have everything needed for NFS boot so let's cover it.