### PR TITLE
Rename kernelci.lab as kernelci.runtime

### DIFF
--- a/kci_test
+++ b/kci_test
@@ -30,7 +30,7 @@ from kernelci.cli import Args, Command, parse_opts
 import kernelci
 import kernelci.config.test
 import kernelci.build
-import kernelci.lab
+import kernelci.runtime
 import kernelci.legacy
 import kernelci.test
 
@@ -208,14 +208,14 @@ class cmd_list_jobs(Command):
             return True
 
         runtime_config = configs['runtimes'][args.runtime_config]
-        lab_api = kernelci.lab.get_runtime(
-            runtime_config, args.user, args.runtime_token, args.runtime_json)
-
+        runtime = kernelci.runtime.get_runtime(
+            runtime_config, args.user, args.runtime_token, args.runtime_json
+        )
         configs = kernelci.test.match_configs(
             configs['test_configs'], meta, runtime_config)
         jobs = list()
         for device_type, plan in configs:
-            if not lab_api.device_type_online(device_type):
+            if not runtime.device_type_online(device_type):
                 continue
             jobs.append((device_type.name, plan.name))
 
@@ -251,13 +251,15 @@ class cmd_get_lab_info(Command):
     opt_args = [Args.user, Args.runtime_token]
 
     def __call__(self, configs, args):
-        lab = configs['runtimes'][args.runtime_config]
-        lab_api = kernelci.lab.get_runtime(lab, args.user, args.runtime_token)
+        runtime_config = configs['runtimes'][args.runtime_config]
+        runtime = kernelci.runtime.get_runtime(
+            runtime_config, args.user, args.runtime_token
+        )
         data = {
-            'lab': lab.name,
-            'lab_type': lab.lab_type,
-            'url': lab.url,
-            'devices': lab_api.devices,
+            'lab': runtime_config.name,
+            'lab_type': runtime_config.lab_type,
+            'url': runtime_config.url,
+            'devices': runtime.devices,
         }
         dir = os.path.dirname(args.runtime_json)
         if dir and not os.path.exists(dir):
@@ -297,9 +299,9 @@ class cmd_generate(Command):
             return True
 
         runtime_config = configs['runtimes'][args.runtime_config]
-        lab_api = kernelci.lab.get_runtime(
-            runtime_config, args.user, args.runtime_token, args.runtime_json)
-
+        runtime = kernelci.runtime.get_runtime(
+            runtime_config, args.user, args.runtime_token, args.runtime_json
+        )
         if args.target and args.plan:
             device_config = configs['device_types'][args.target]
             plan_config = configs['test_plans'][args.plan]
@@ -309,7 +311,7 @@ class cmd_generate(Command):
             test_configs = kernelci.test.match_configs(
                 configs['test_configs'], meta, runtime_config)
             for device_config, plan_config in test_configs:
-                if not lab_api.device_type_online(device_config):
+                if not runtime.device_type_online(device_config):
                     continue
                 if args.target and device_config.name != args.target:
                     continue
@@ -334,13 +336,14 @@ class cmd_generate(Command):
             params = kernelci.test.get_params(
                 meta, device_config, plan_config, args.storage,
                 args.device_id)
-            job = lab_api.generate(params, device_config, plan_config,
-                                   callback_opts)
+            job = runtime.generate(
+                params, device_config, plan_config, callback_opts
+            )
             if job is None:
                 print("Failed to generate the job definition")
                 return False
             if args.output:
-                output_file = lab_api.save_file(job, args.output, params)
+                output_file = runtime.save_file(job, args.output, params)
                 print(output_file)
             else:
                 print("# Job: {}".format(params['name']))
@@ -349,19 +352,21 @@ class cmd_generate(Command):
 
 
 class cmd_submit(Command):
-    help = "Submit job definitions to a lab"
+    help = "Submit job definitions to a runtime environment"
     args = [Args.runtime_config, Args.user, Args.runtime_token, Args.jobs]
 
     def __call__(self, configs, args):
-        lab = configs['runtimes'][args.runtime_config]
-        lab_api = kernelci.lab.get_runtime(lab, args.user, args.runtime_token)
+        runtime_config = configs['runtimes'][args.runtime_config]
+        runtime = kernelci.runtime.get_runtime(
+            runtime_config, args.user, args.runtime_token
+        )
         job_paths = glob.glob(args.jobs)
         res = True
         for path in job_paths:
             if not os.path.isfile(path):
                 continue
             try:
-                job_id = lab_api.submit(path)
+                job_id = runtime.submit(path)
                 print("{} {}".format(job_id, path))
             except requests.exceptions.HTTPError as e:
                 print(f'HTTPError: {e}')

--- a/kernelci/runtime/__init__.py
+++ b/kernelci/runtime/__init__.py
@@ -121,7 +121,7 @@ def get_runtime(config, user=None, token=None, runtime_json=None):
     *token* is the associated token to connect to the runtime
     *runtime_json* is the path to a JSON file with cached runtime information
     """
-    module_name = '.'.join(['kernelci', 'lab', config.lab_type])
+    module_name = '.'.join(['kernelci', 'runtime', config.lab_type])
     runtime_module = importlib.import_module(module_name)
     runtime = runtime_module.get_runtime(config, user=user, token=token)
     if runtime_json:

--- a/kernelci/runtime/kubernetes.py
+++ b/kernelci/runtime/kubernetes.py
@@ -8,7 +8,7 @@ import random
 import re
 import string
 from jinja2 import Environment, FileSystemLoader
-from kernelci.lab import Runtime
+from kernelci.runtime import Runtime
 
 
 class Kubernetes(Runtime):

--- a/kernelci/runtime/lava/__init__.py
+++ b/kernelci/runtime/lava/__init__.py
@@ -9,7 +9,7 @@
 
 from jinja2 import Environment, FileSystemLoader
 import os
-from kernelci.lab import add_kci_raise, Runtime
+from kernelci.runtime import add_kci_raise, Runtime
 
 
 class LavaRuntime(Runtime):

--- a/kernelci/runtime/lava/lava_rest.py
+++ b/kernelci/runtime/lava/lava_rest.py
@@ -9,7 +9,7 @@ import json
 import requests
 from urllib.parse import urljoin
 import yaml
-from kernelci.lab.lava import LavaRuntime
+from kernelci.runtime.lava import LavaRuntime
 
 RestAPIServer = namedtuple('RestAPIServer', ['url', 'session'])
 
@@ -17,7 +17,7 @@ RestAPIServer = namedtuple('RestAPIServer', ['url', 'session'])
 class LavaRest(LavaRuntime):
     """Interface to a LAVA lab
 
-    This implementation of kernelci.lab.LabAPI is to communicate with LAVA
+    This implementation of kernelci.runtime.LabAPI is to communicate with LAVA
     labs.  It can retrieve some information such as the list of devices and
     their online status, generate and submit jobs with callback parameters.
     One special thing it can deal with is job priorities, which is only

--- a/kernelci/runtime/lava/lava_xmlrpc.py
+++ b/kernelci/runtime/lava/lava_xmlrpc.py
@@ -9,7 +9,8 @@
 
 import xmlrpc.client
 import urllib.parse
-from kernelci.lab.lava import LavaRuntime
+
+from kernelci.runtime.lava import LavaRuntime
 
 DEVICE_ONLINE_STATUS = ['idle', 'running', 'reserved']
 
@@ -17,7 +18,7 @@ DEVICE_ONLINE_STATUS = ['idle', 'running', 'reserved']
 class LAVA(LavaRuntime):
     """Interface to a LAVA lab
 
-    This implementation of kernelci.lab.LabAPI is to communicate with LAVA
+    This implementation of kernelci.runtime.LabAPI is to communicate with LAVA
     labs.  It can retrieve some information such as the list of devices and
     their online status, generate and submit jobs with callback parameters.
     One special thing it can deal with is job priorities, which is only

--- a/kernelci/runtime/shell.py
+++ b/kernelci/runtime/shell.py
@@ -6,7 +6,7 @@
 import os
 import subprocess
 from jinja2 import Environment, FileSystemLoader
-from kernelci.lab import Runtime
+from kernelci.runtime import Runtime
 
 
 class Shell(Runtime):

--- a/setup.py
+++ b/setup.py
@@ -43,9 +43,9 @@ setuptools.setup(
         "kernelci",
         "kernelci.cli",
         "kernelci.config",
-        "kernelci.lab",
-        "kernelci.lab.lava",
         "kernelci.db",
+        "kernelci.runtime",
+        "kernelci.runtime.lava",
         "kernelci.storage",
     ],
     scripts=[

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -13,7 +13,7 @@
 # pylint: disable=protected-access
 
 import kernelci.config
-import kernelci.lab
+import kernelci.runtime
 
 
 def test_runtimes_init():
@@ -22,7 +22,7 @@ def test_runtimes_init():
     runtimes = config['runtimes']
     for runtime_name, runtime_config in runtimes.items():
         print(f"Runtime name: {runtime_name}")
-        kernelci.lab.get_runtime(runtime_config)
+        kernelci.runtime.get_runtime(runtime_config)
 
 
 def test_lava_priority_scale():
@@ -58,7 +58,7 @@ def test_lava_priority_scale():
             runtime_config.priority_max,
         ])
         print(f"{runtime_name}: {priorities}")
-        lab = kernelci.lab.get_runtime(
+        lab = kernelci.runtime.get_runtime(
             runtime_config, runtime_json=f'tests/configs/{runtime_name}.json'
         )
         for plan_name, priority in specs.items():


### PR DESCRIPTION
Rename the `kernelci.lab` package as `kernelci.runtime` and update all areas of the code accordingly.  Add an extra unit test to check all the runtime types can be initialised.