### PR TITLE
Refine GStreamer config and job definition args for V4L2 decoder tests

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -628,6 +628,7 @@ test_plans:
     params:
       job_timeout: '30'
       testsuite: 'AV1-TEST-VECTORS'
+      decoder: 'GStreamer-AV1-V4L2SL-Gst1.0'
       videodec_parallel_jobs: '1'
     filters:
       - regex: {'tree': '(next|mainline|media)'}
@@ -638,6 +639,7 @@ test_plans:
     params:
       job_timeout: '30'
       testsuite: 'JVT-AVC_V1'
+      decoder: 'GStreamer-H.264-V4L2SL-Gst1.0'
       videodec_parallel_jobs: '1'
     filters:
       - regex: {'tree': '(next|mainline|media)'}
@@ -648,6 +650,7 @@ test_plans:
     params:
       job_timeout: '30'
       testsuite: 'JCT-VC-HEVC-V1'
+      decoder: 'GStreamer-H.265-V4L2SL-Gst1.0'
       videodec_parallel_jobs: '1'
     filters:
       - regex: {'tree': '(next|mainline|media)'}
@@ -658,6 +661,7 @@ test_plans:
     params:
       job_timeout: '30'
       testsuite: 'VP8-TEST-VECTORS'
+      decoder: 'GStreamer-VP8-V4L2SL-Gst1.0'
       videodec_parallel_jobs: '1'
     filters:
       - regex: {'tree': '(next|mainline|media)'}
@@ -668,6 +672,7 @@ test_plans:
     params:
       job_timeout: '30'
       testsuite: 'VP9-TEST-VECTORS'
+      decoder: 'GStreamer-VP9-V4L2SL-Gst1.0'
       videodec_parallel_jobs: '1'
     filters:
       - regex: {'tree': '(next|mainline|media)'}

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -628,6 +628,7 @@ test_plans:
     params:
       job_timeout: '30'
       testsuite: 'AV1-TEST-VECTORS'
+      videodec_parallel_jobs: '1'
     filters:
       - regex: {'tree': '(next|mainline|media)'}
 
@@ -637,6 +638,7 @@ test_plans:
     params:
       job_timeout: '30'
       testsuite: 'JVT-AVC_V1'
+      videodec_parallel_jobs: '1'
     filters:
       - regex: {'tree': '(next|mainline|media)'}
 
@@ -646,6 +648,7 @@ test_plans:
     params:
       job_timeout: '30'
       testsuite: 'JCT-VC-HEVC-V1'
+      videodec_parallel_jobs: '1'
     filters:
       - regex: {'tree': '(next|mainline|media)'}
 
@@ -655,6 +658,7 @@ test_plans:
     params:
       job_timeout: '30'
       testsuite: 'VP8-TEST-VECTORS'
+      videodec_parallel_jobs: '1'
     filters:
       - regex: {'tree': '(next|mainline|media)'}
 
@@ -664,6 +668,7 @@ test_plans:
     params:
       job_timeout: '30'
       testsuite: 'VP9-TEST-VECTORS'
+      videodec_parallel_jobs: '1'
     filters:
       - regex: {'tree': '(next|mainline|media)'}
 

--- a/config/lava/v4l2-decoder-conformance/v4l2-decoder-conformance.jinja2
+++ b/config/lava/v4l2-decoder-conformance/v4l2-decoder-conformance.jinja2
@@ -1,3 +1,9 @@
+{%- if testsuite -%}
+    {% set testsuite_arg = "-ts " + testsuite %}
+{%- endif -%}
+{%- if videodec_timeout -%}
+    {% set videodec_timeout_arg = "-t " + videodec_timeout|string %}
+{%- endif -%}
 - test:
     timeout:
       minutes: {{ job_timeout }}
@@ -13,7 +19,7 @@
           - functional
         run:
           steps:
-          - python3 /usr/bin/fluster_parser.py -ts {{ testsuite }} -t {{ videodec_timeout|default('30') }}
+          - python3 /usr/bin/fluster_parser.py {{ testsuite_arg }} {{ videodec_timeout_arg }}
       from: inline
       name: {{ plan }}
       path: inline/{{ plan }}.yaml

--- a/config/lava/v4l2-decoder-conformance/v4l2-decoder-conformance.jinja2
+++ b/config/lava/v4l2-decoder-conformance/v4l2-decoder-conformance.jinja2
@@ -4,6 +4,9 @@
 {%- if videodec_timeout -%}
     {% set videodec_timeout_arg = "-t " + videodec_timeout|string %}
 {%- endif -%}
+{%- if videodec_parallel_jobs -%}
+    {% set videodec_parallel_jobs_arg = "-j " + videodec_parallel_jobs|string %}
+{%- endif -%}
 - test:
     timeout:
       minutes: {{ job_timeout }}
@@ -19,7 +22,7 @@
           - functional
         run:
           steps:
-          - python3 /usr/bin/fluster_parser.py {{ testsuite_arg }} {{ videodec_timeout_arg }}
+          - python3 /usr/bin/fluster_parser.py {{ testsuite_arg }} {{ videodec_timeout_arg }} {{ videodec_parallel_jobs_arg }}
       from: inline
       name: {{ plan }}
       path: inline/{{ plan }}.yaml

--- a/config/lava/v4l2-decoder-conformance/v4l2-decoder-conformance.jinja2
+++ b/config/lava/v4l2-decoder-conformance/v4l2-decoder-conformance.jinja2
@@ -1,6 +1,9 @@
 {%- if testsuite -%}
     {% set testsuite_arg = "-ts " + testsuite %}
 {%- endif -%}
+{%- if decoder -%}
+    {% set decoder_arg = "-d " + decoder|string %}
+{%- endif -%}
 {%- if videodec_timeout -%}
     {% set videodec_timeout_arg = "-t " + videodec_timeout|string %}
 {%- endif -%}
@@ -22,7 +25,7 @@
           - functional
         run:
           steps:
-          - python3 /usr/bin/fluster_parser.py {{ testsuite_arg }} {{ videodec_timeout_arg }} {{ videodec_parallel_jobs_arg }}
+          - python3 /usr/bin/fluster_parser.py {{ testsuite_arg }} {{ decoder_arg }} {{ videodec_timeout_arg }} {{ videodec_parallel_jobs_arg }}
       from: inline
       name: {{ plan }}
       path: inline/{{ plan }}.yaml

--- a/config/rootfs/debos/overlays/fluster/usr/bin/fluster_parser.py
+++ b/config/rootfs/debos/overlays/fluster/usr/bin/fluster_parser.py
@@ -67,14 +67,16 @@ def _load_results_file(filename):
     return ret
 
 
-def _run_fluster(test_suite=None, timeout=None):
+def _run_fluster(test_suite=None, timeout=None, jobs=None):
     cmd = ['python3', 'fluster.py', '-ne', 'run',
-           '-j1', '-f', 'junitxml', '-so', RESULTS_FILE]
+           '-f', 'junitxml', '-so', RESULTS_FILE]
 
     if test_suite:
         cmd.extend(['-ts', test_suite])
     if timeout:
         cmd.extend(['-t', timeout])
+    if jobs:
+        cmd.extend(['-j', jobs])
 
     subprocess.run(cmd, cwd=FLUSTER_PATH, check=False)
 
@@ -89,7 +91,7 @@ def main(args):
         cmd = cmd.fromkeys(cmd, 'echo')
 
     # run fluster tests
-    _run_fluster(args.test_suite, args.timeout)
+    _run_fluster(args.test_suite, args.timeout, args.jobs)
 
     # load test results
     junitxml = _load_results_file(f'{FLUSTER_PATH}/{RESULTS_FILE}')
@@ -122,5 +124,6 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('-ts', '--test-suite')
     parser.add_argument('-t', '--timeout')
+    parser.add_argument('-j', '--jobs')
     args = parser.parse_args()
     sys.exit(main(args))

--- a/config/rootfs/debos/overlays/fluster/usr/bin/fluster_parser.py
+++ b/config/rootfs/debos/overlays/fluster/usr/bin/fluster_parser.py
@@ -67,7 +67,7 @@ def _load_results_file(filename):
     return ret
 
 
-def _run_fluster(test_suite=None, timeout=None, jobs=None):
+def _run_fluster(test_suite=None, timeout=None, jobs=None, decoders=None):
     cmd = ['python3', 'fluster.py', '-ne', 'run',
            '-f', 'junitxml', '-so', RESULTS_FILE]
 
@@ -77,6 +77,8 @@ def _run_fluster(test_suite=None, timeout=None, jobs=None):
         cmd.extend(['-t', timeout])
     if jobs:
         cmd.extend(['-j', jobs])
+    if decoders:
+        cmd.extend(['-d', decoders])
 
     subprocess.run(cmd, cwd=FLUSTER_PATH, check=False)
 
@@ -91,7 +93,7 @@ def main(args):
         cmd = cmd.fromkeys(cmd, 'echo')
 
     # run fluster tests
-    _run_fluster(args.test_suite, args.timeout, args.jobs)
+    _run_fluster(args.test_suite, args.timeout, args.jobs, args.decoders)
 
     # load test results
     junitxml = _load_results_file(f'{FLUSTER_PATH}/{RESULTS_FILE}')
@@ -125,5 +127,6 @@ if __name__ == '__main__':
     parser.add_argument('-ts', '--test-suite')
     parser.add_argument('-t', '--timeout')
     parser.add_argument('-j', '--jobs')
+    parser.add_argument('-d', '--decoders')
     args = parser.parse_args()
     sys.exit(main(args))

--- a/config/rootfs/debos/scripts/bullseye-gst-fluster.sh
+++ b/config/rootfs/debos/scripts/bullseye-gst-fluster.sh
@@ -53,7 +53,9 @@ meson setup build \
 	-Dbad=enabled \
 	-Dbase=enabled \
 	-Dgood=enabled \
+	-Dugly=disabled \
 	-Dgst-plugins-bad:ivfparse=enabled \
+	-Dgst-plugins-bad:debugutils=enabled \
 	-Dgst-plugins-bad:v4l2codecs=enabled \
 	-Dgst-plugins-bad:videoparsers=enabled \
 	-Dgst-plugins-base:app=enabled \
@@ -62,7 +64,11 @@ meson setup build \
 	-Dgst-plugins-base:typefind=enabled \
 	-Dgst-plugins-base:videoconvertscale=enabled \
 	-Dgst-plugins-good:matroska=enabled \
-	-Dtools=enabled
+	-Dtools=enabled \
+	-Ddevtools=disabled \
+	-Dges=disabled \
+	-Dlibav=disabled \
+	-Drtsp_server=disabled
 
 ninja -C build
 ninja -C build install

--- a/config/rootfs/debos/scripts/bullseye-gst-fluster.sh
+++ b/config/rootfs/debos/scripts/bullseye-gst-fluster.sh
@@ -47,7 +47,7 @@ mkdir -p /var/tests/gstreamer && cd /var/tests/gstreamer
 
 git clone --depth 1 $GSTREAMER_URL .
 
-meson build \
+meson setup build \
 	--wrap-mode=nofallback \
 	-Dauto_features=disabled \
 	-Dbad=enabled \


### PR DESCRIPTION
Reduce the size of the GStreamer build in the `bullseye-gst-fluster` rootfs, by disabling non essential components for V4L2 decoder tests. Enable also the `videocodectestsink` element through the additional `debugutils` plugin, which improves the performance of fluster tests.

With this GStreamer configuration, the score for VP9 tests on `rk3399-gru-kevin` improves from 169/305 to 228/305.

Add extra arguments in the decoder test job definition to specify the number of decoding parallel jobs and the decoder to be ran.