### PR TITLE
Mitigate size issues with kselftest kernels

### DIFF
--- a/config/core/build-configs-cip.yaml
+++ b/config/core/build-configs-cip.yaml
@@ -59,19 +59,21 @@ cip_variants_kselftest: &cip_variants_kselftest
       <<: *cip_architectures
       arm:
         base_defconfig: 'multi_v7_defconfig'
-        fragments: [kselftest]
+        fragments: [kselftest, kselftest-slim]
         extra_configs: ['allnoconfig']
       arm64:
         fragments: [kselftest, arm64-chromebook]
         extra_configs:
           - 'allnoconfig'
           - 'defconfig+arm64-chromebook+kselftest'
+          - 'defconfig+arm64-chromebook+kselftest-slim'
       x86_64:
         base_defconfig: 'x86_64_defconfig'
         fragments: [kselftest, x86-chromebook]
         extra_configs:
           - 'allnoconfig'
           - 'x86_64_defconfig+x86-chromebook+kselftest'
+          - 'x86_64_defconfig+x86-chromebook+kselftest-slim'
 
 
 cip_variants_preempt_rt: &cip_variants_preempt_rt

--- a/config/core/build-configs-stable.yaml
+++ b/config/core/build-configs-stable.yaml
@@ -70,18 +70,20 @@ stable_variants_kselftest: &stable_variants_kselftest
       arm:
         base_defconfig: 'multi_v7_defconfig'
         extra_configs: ['allnoconfig']
-        fragments: [kselftest]
+        fragments: [kselftest, kselftest-slim]
       arm64:
         extra_configs:
           - 'allnoconfig'
           - 'defconfig+arm64-chromebook+kselftest'
+          - 'defconfig+arm64-chromebook+kselftest-slim'
         fragments: [arm64-chromebook, kselftest]
       x86_64:
         base_defconfig: 'x86_64_defconfig'
         extra_configs:
           - 'allnoconfig'
           - 'x86_64_defconfig+x86-chromebook+kselftest'
-        fragments: [x86-chromebook, kselftest]
+          - 'x86_64_defconfig+x86-chromebook+kselftest-slim'
+        fragments: [x86-chromebook, kselftest, kselftest-slim]
 
 
 build_configs:

--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -418,7 +418,7 @@ fragments:
       - 'CONFIG_IMA=y'
       - 'CONFIG_IMA_READ_POLICY=y'
 
-  kselftest:
+  kselftest: &kselftest-fragment
     path: "kernel/configs/kselftest.config"
     configs:
       - '# CONFIG_DUMMY is not set'
@@ -426,11 +426,8 @@ fragments:
       - 'CONFIG_NET_IPGRE_DEMUX=m'
 
   kselftest-slim:
+    <<: *kselftest-fragment
     path: "kernel/configs/kselftest-slim.config"
-    configs:
-      - '# CONFIG_DUMMY is not set'
-      - 'CONFIG_NET_IPGRE=m'
-      - 'CONFIG_NET_IPGRE_DEMUX=m'
 
   preempt_rt:
     path: "kernel/configs/preempt_rt.config"
@@ -723,7 +720,6 @@ build_configs_defaults:
 
       fragments: &default_fragments
         - 'debug'
-        - 'kselftest'
         - 'kselftest-slim'
         - 'tinyconfig'
 
@@ -761,7 +757,6 @@ build_configs_defaults:
             - 'allnoconfig'
             - 'defconfig+CONFIG_CPU_BIG_ENDIAN=y'
             - 'defconfig+CONFIG_RANDOMIZE_BASE=y'
-            - 'defconfig+arm64-chromebook+kselftest'
             - 'defconfig+arm64-chromebook+kselftest-slim'
             - 'defconfig+arm64-chromebook+videodec'
           fragments: [arm64-chromebook, crypto, ima, videodec]
@@ -791,7 +786,6 @@ build_configs_defaults:
           extra_configs:
             - 'allmodconfig'
             - 'allnoconfig'
-            - 'x86_64_defconfig+x86-chromebook+kselftest'
             - 'x86_64_defconfig+x86-chromebook+kselftest-slim'
             - 'x86_64_defconfig+x86-chromebook+amdgpu'
           fragments: [amdgpu, crypto, ima, x86_kvm_guest, x86-chromebook]
@@ -1116,15 +1110,46 @@ build_configs:
     tree: mainline
     branch: 'master'
     variants:
-      gcc-10: *default_gcc-10
+      gcc-10:
+        <<: *default_gcc-10
+        fragments: &fragments-kselftest
+          - 'debug'
+          - 'kselftest'
+          - 'kselftest-slim'
+          - 'tinyconfig'
+
+        architectures:
+          <<: *default_architectures
+          arm64: &arm64_arch-kselftest
+            <<: *arm64_arch
+            extra_configs:
+              - 'allmodconfig'
+              - 'allnoconfig'
+              - 'defconfig+CONFIG_CPU_BIG_ENDIAN=y'
+              - 'defconfig+CONFIG_RANDOMIZE_BASE=y'
+              - 'defconfig+arm64-chromebook+kselftest'
+              - 'defconfig+arm64-chromebook+kselftest-slim'
+              - 'defconfig+arm64-chromebook+videodec'
+
+          x86_64: &x86_64_arch-kselftest
+            <<: *x86_64_arch
+            extra_configs:
+              - 'allmodconfig'
+              - 'allnoconfig'
+              - 'x86_64_defconfig+x86-chromebook+kselftest'
+              - 'x86_64_defconfig+x86-chromebook+kselftest-slim'
+              - 'x86_64_defconfig+x86-chromebook+amdgpu'
+
       # Minimum version
       clang-11:
         build_environment: clang-11
         architectures: *arch_clang_configs
+
       # Latest stable release
       clang-16:
         build_environment: clang-16
         architectures: *arch_clang_configs
+
       rustc-1.62:
         build_environment: rustc-1.62
         fragments: [rust, rust-samples, kselftest, kselftest-slim]
@@ -1169,14 +1194,14 @@ build_configs:
     variants:
       gcc-10:
         build_environment: gcc-10
-        fragments: *default_fragments
+        fragments: *fragments-kselftest
         architectures:
           i386: *i386_arch
-          x86_64: *x86_64_arch
+          x86_64: *x86_64_arch-kselftest
           mips: *mips_arch
           riscv: *riscv_arch
           sparc: *sparc_arch
-          arc: *arc_arch
+          arc:: *arc_arch
           arm64:
             <<: *arm64_arch
             extra_configs:
@@ -1188,6 +1213,8 @@ build_configs:
               - 'defconfig+CONFIG_RANDOMIZE_BASE=y'
               - 'defconfig+arm64-chromebook+kselftest'
               - 'defconfig+arm64-chromebook+kselftest-slim'
+              - 'kselftest'
+              - 'kselftest-slim'
           arm:
             base_defconfig: 'multi_v7_defconfig'
             extra_configs:
@@ -1197,6 +1224,8 @@ build_configs:
               - 'multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y'
               - 'allnoconfig'
               - 'allmodconfig'
+              - 'kselftest'
+              - 'kselftest-slim'
 
       # Current development clang release
       clang-17:

--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -425,6 +425,13 @@ fragments:
       - 'CONFIG_NET_IPGRE=m'
       - 'CONFIG_NET_IPGRE_DEMUX=m'
 
+  kselftest-slim:
+    path: "kernel/configs/kselftest-slim.config"
+    configs:
+      - '# CONFIG_DUMMY is not set'
+      - 'CONFIG_NET_IPGRE=m'
+      - 'CONFIG_NET_IPGRE_DEMUX=m'
+
   preempt_rt:
     path: "kernel/configs/preempt_rt.config"
     configs:
@@ -717,6 +724,7 @@ build_configs_defaults:
       fragments: &default_fragments
         - 'debug'
         - 'kselftest'
+        - 'kselftest-slim'
         - 'tinyconfig'
 
       architectures: &default_architectures
@@ -754,6 +762,7 @@ build_configs_defaults:
             - 'defconfig+CONFIG_CPU_BIG_ENDIAN=y'
             - 'defconfig+CONFIG_RANDOMIZE_BASE=y'
             - 'defconfig+arm64-chromebook+kselftest'
+            - 'defconfig+arm64-chromebook+kselftest-slim'
             - 'defconfig+arm64-chromebook+videodec'
           fragments: [arm64-chromebook, crypto, ima, videodec]
 
@@ -783,6 +792,7 @@ build_configs_defaults:
             - 'allmodconfig'
             - 'allnoconfig'
             - 'x86_64_defconfig+x86-chromebook+kselftest'
+            - 'x86_64_defconfig+x86-chromebook+kselftest-slim'
             - 'x86_64_defconfig+x86-chromebook+amdgpu'
           fragments: [amdgpu, crypto, ima, x86_kvm_guest, x86-chromebook]
 
@@ -1052,7 +1062,9 @@ build_configs:
           arm64: &arm64-kselftest
             <<: *arm64_defconfig
             fragments: [arm64-chromebook]
-            extra_configs: ['defconfig+kselftest+arm64-chromebook']
+            extra_configs: [
+                    'defconfig+kselftest+arm64-chromebook',
+                    'defconfig+kselftest-slim+arm64-chromebook']
             filters: *kselftest-only
           i386:
             <<: *i386_defconfig
@@ -1060,7 +1072,9 @@ build_configs:
           x86_64: &x86_64-kselftest
             <<: *x86_64_defconfig
             fragments: [x86-chromebook]
-            extra_configs: ['x86_64+defconfig+kselftest+x86-chromebook']
+            extra_configs: [
+                    'x86_64+defconfig+kselftest+x86-chromebook',
+                    'x86_64+defconfig+kselftest-slim+x86-chromebook']
             filters: *kselftest-only
       clang-16:
         build_environment: clang-16
@@ -1113,7 +1127,7 @@ build_configs:
         architectures: *arch_clang_configs
       rustc-1.62:
         build_environment: rustc-1.62
-        fragments: [rust, rust-samples, kselftest]
+        fragments: [rust, rust-samples, kselftest, kselftest-slim]
         architectures:
           x86_64:
             base_defconfig: 'x86_64_defconfig'
@@ -1173,6 +1187,7 @@ build_configs:
               - 'defconfig+CONFIG_CPU_BIG_ENDIAN=y'
               - 'defconfig+CONFIG_RANDOMIZE_BASE=y'
               - 'defconfig+arm64-chromebook+kselftest'
+              - 'defconfig+arm64-chromebook+kselftest-slim'
           arm:
             base_defconfig: 'multi_v7_defconfig'
             extra_configs:
@@ -1341,7 +1356,7 @@ build_configs:
     variants:
       rustc-1.66:
         build_environment: rustc-1.66
-        fragments: [rust, rust-for-linux-samples, kselftest]
+        fragments: [rust, rust-for-linux-samples, kselftest, kselftest-slim]
         architectures:
           x86_64:
             base_defconfig: 'x86_64_defconfig'
@@ -1352,7 +1367,7 @@ build_configs:
     variants:
       rustc-1.68:
         build_environment: rustc-1.68
-        fragments: [rust, rust-samples, kselftest]
+        fragments: [rust, rust-samples, kselftest, kselftest-slim]
         architectures:
           x86_64:
             base_defconfig: 'x86_64_defconfig'

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -51,7 +51,7 @@ default_filters:
           - ['x86_64', 'x86_64_defconfig+x86-chromebook']
 
     - blocklist: &kselftest_defconfig_filter
-        defconfig: ['kselftest']
+        defconfig: ['kselftest', 'kselftest-slim']
 
   device_types:
 
@@ -233,7 +233,7 @@ test_plans:
     rootfs: debian_bullseye-kselftest_nfs
     pattern: 'kselftest/{category}-{method}-{protocol}-{rootfs}-kselftest-template.jinja2'
     filters:
-      - passlist: {defconfig: ['kselftest']}
+      - passlist: {defconfig: ['kselftest-slim']}
 
   # Add _a_ into the name so we can keep this before the individual
   # definitions
@@ -241,7 +241,7 @@ test_plans:
     rootfs: debian_bullseye-kselftest_ramdisk
     pattern: 'kselftest/{category}-{method}-{rootfs}-kselftest-template.jinja2'
     filters:
-      - passlist: {defconfig: ['kselftest']}
+      - passlist: {defconfig: ['kselftest-slim']}
 
   kselftest-alsa:
     <<: *kselftest
@@ -292,6 +292,9 @@ test_plans:
     params:
       job_timeout: '10'
       kselftest_collections: "cpufreq"
+    filters: &kselftest_full_fragment
+      - passlist: {defconfig: ['kselftest']}
+      - blocklist: {defconfig: ['kselftest-slim']}
 
   kselftest-exec:
     <<: *kselftest
@@ -351,6 +354,7 @@ test_plans:
     params:
       job_timeout: '10'
       kselftest_collections: "lkdtm"
+    filters: *kselftest_full_fragment
 
   kselftest-membarrier:
     <<: *kselftest

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -241,11 +241,12 @@ def make_tarball(kdir, tarball_name):
     os.chdir(cwd)
 
 
-def generate_kselftest_fragment(frag, kdir):
+def generate_kselftest_fragment(frag, kdir, skip=[]):
     """Create a config fragment file for kselftest
 
     *frag* is a Fragment object
     *kdir* is the path to a kernel source directory
+    *skip* is a list of kselftests to skip
     """
     shell_cmd(r"""
 set -e
@@ -259,6 +260,8 @@ find \
 """.format(kdir=kdir, frag_path=frag.path))
     with open(os.path.join(kdir, frag.path), 'a') as f:
         for kernel_config in frag.configs:
+            if kernel_config in enumerate(skip):
+                continue
             f.write(kernel_config + '\n')
 
 
@@ -271,6 +274,12 @@ def generate_config_fragment(frag, kdir):
     with open(os.path.join(kdir, frag.path), 'w') as f:
         for kernel_config in frag.configs:
             f.write(kernel_config + '\n')
+
+
+slim_skip_frags = [
+    "tools/testing/selftests/lkdtm/config",
+    "tools/testing/selftests/cpufreq/config"
+]
 
 
 def generate_fragments(config, kdir):
@@ -288,6 +297,8 @@ def generate_fragments(config, kdir):
         print(frag.path)
         if frag.name == 'kselftest':
             generate_kselftest_fragment(frag, kdir)
+        elif frag.name == 'kselftest-slim':
+            generate_kselftest_fragment(frag, kdir, skip=slim_skip_frags)
         elif frag.configs:
             generate_config_fragment(frag, kdir)
 


### PR DESCRIPTION
We struggle to run kselftest on a lot of u-boot platforms since the kselftest builds produce a kernel which is much larger than usual, and some of the emulated platforms can struggle at runtime since they are also slower than usual. The increase in size is mostly due to only two of the config fragments, those for cpufreq and LKDTM. These add options that instrument the entire kernel, inflating the size of the resulting image substantially.

While we can address the configuration of individual boards this is a constant burden and we still have the overhead of downloading the larger images and slower execution caused by the instrumentation to deal with. Instead let's define a second kselftest fragment which excludes the problematic fragments and use that unless we need the extra fragments.

This does mean we end up doing an extra build whenever we build kselftest but the improved test coverage and runtime performance seems worth it.