### PR TITLE
Support arm64 virtconfig

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -794,6 +794,7 @@ arch_clang_configs: &arch_clang_configs
       - 'allmodconfig'
       - 'allnoconfig'
       - 'defconfig+CONFIG_ARM64_64K_PAGES=y'
+      - 'virtconfig'
   arm:
     base_defconfig: 'multi_v7_defconfig'
     filters:

--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -746,6 +746,7 @@ build_configs_defaults:
           extra_configs:
             - 'allmodconfig'
             - 'allnoconfig'
+            - 'virtconfig'
             - 'defconfig+CONFIG_CPU_BIG_ENDIAN=y'
             - 'defconfig+CONFIG_RANDOMIZE_BASE=y'
             - 'defconfig+arm64-chromebook+kselftest'
@@ -1163,6 +1164,7 @@ build_configs:
             extra_configs:
               - 'allmodconfig'
               - 'allnoconfig'
+              - 'virtconfig'
               - 'defconfig+CONFIG_ARM64_16K_PAGES=y'
               - 'defconfig+CONFIG_ARM64_64K_PAGES=y'
               - 'defconfig+CONFIG_CPU_BIG_ENDIAN=y'

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1696,7 +1696,7 @@ device_types:
       machine: 'virt,gic-version=2,mte=on,accel=tcg'
       memory: 1g
     filters:
-      - regex: { defconfig: 'defconfig' }
+      - regex: { defconfig: '(def|virt)config' }
 
   qemu_arm64-virt-gicv2-uefi:
     <<: *qemu_arm64-virt-gicv2
@@ -1715,7 +1715,7 @@ device_types:
       machine: 'virt,gic-version=3,mte=on,accel=tcg'
       memory: 1g
     filters:
-      - passlist: {defconfig: ['defconfig']}
+      - passlist: {defconfig: ['defconfig', 'virtconfig']}
 
   qemu_arm64-virt-gicv3-uefi:
     <<: *qemu_arm64-virt-gicv3


### PR DESCRIPTION
Upstream has just introduced a new configuration virtconfig for arm64, intended to build more quickly but test mach-virt only. Since it's implemented with a fragment we need to manually trigger builds.