### PR TITLE
Initial `kci user` tool and `APICommand` base class

### DIFF
--- a/kernelci/cli/__init__.py
+++ b/kernelci/cli/__init__.py
@@ -10,11 +10,13 @@ import sys
 from .base import Args, Command, parse_opts, sub_main
 from . import (
     node,
+    user,
     validate,
 )
 
 _COMMANDS = {
     'node': node.main,
+    'user': user.main,
     'validate': validate.main,
 }
 

--- a/kernelci/cli/base.py
+++ b/kernelci/cli/base.py
@@ -17,6 +17,7 @@ import os.path
 import sys
 
 import kernelci.config
+from kernelci.db import kernelci_api
 
 
 # -----------------------------------------------------------------------------
@@ -433,6 +434,19 @@ class Command(abc.ABC):
         namespace.  For example, `--db-token` gets convereted to `db_token`.
         """
         return arg_name.strip('-').replace('-', '_')
+
+
+class APICommand(Command):  # pylint: disable=too-few-public-methods
+    """Base command class for interacting with the KernelCI API"""
+    args = [
+        Args.api_config, Args.api_token,
+    ]
+    opt_args = []
+
+    @classmethod
+    def _get_api(cls, configs, args):
+        config = configs['api_configs'][args.api_config]
+        return kernelci_api.KernelCI_API(config, args.api_token)
 
 
 class Options:

--- a/kernelci/cli/base.py
+++ b/kernelci/cli/base.py
@@ -171,6 +171,11 @@ class Args:  # pylint: disable=too-few-public-methods
         'help': "Path to the dtbs.json file",
     }
 
+    indent = {
+        'name': '--indent',
+        'help': "Indentation string in JSON output",
+    }
+
     install = {
         'name': '--install',
         'action': 'store_true',

--- a/kernelci/cli/node.py
+++ b/kernelci/cli/node.py
@@ -7,17 +7,12 @@
 
 import json
 
-from .base import APICommand, sub_main
+from .base import APICommand, Args, sub_main
 
 
 class NodeCommand(APICommand):  # pylint: disable=too-few-public-methods
     """Base command class for interacting with the KernelCI API"""
-    opt_args = [
-        {
-            'name': '--indent',
-            'help': "Indentation string in JSON output",
-        },
-    ]
+    opt_args = APICommand.opt_args + [Args.indent]
 
 
 class NodeAttributesCommand(NodeCommand):

--- a/kernelci/cli/node.py
+++ b/kernelci/cli/node.py
@@ -7,26 +7,17 @@
 
 import json
 
-from kernelci.db import kernelci_api
-from .base import Args, Command, sub_main
+from .base import APICommand, sub_main
 
 
-class NodeCommand(Command):  # pylint: disable=too-few-public-methods
+class NodeCommand(APICommand):  # pylint: disable=too-few-public-methods
     """Base command class for interacting with the KernelCI API"""
-    args = [
-        Args.api_config, Args.api_token,
-    ]
     opt_args = [
         {
             'name': '--indent',
             'help': "Indentation string in JSON output",
         },
     ]
-
-    @classmethod
-    def _get_api(cls, configs, args):
-        config = configs['api_configs'][args.api_config]
-        return kernelci_api.KernelCI_API(config, args.api_token)
 
 
 class NodeAttributesCommand(NodeCommand):

--- a/kernelci/cli/user.py
+++ b/kernelci/cli/user.py
@@ -7,17 +7,12 @@
 
 import json
 
-from .base import APICommand, sub_main
+from .base import Args, APICommand, sub_main
 
 
 class cmd_me(APICommand):  # pylint: disable=invalid-name
     """Use the /me entry point to get the current user's data"""
-    opt_args = [
-        {
-            'name': '--indent',
-            'help': "Indentation string in JSON output",
-        },
-    ]
+    opt_args = APICommand.opt_args + [Args.indent]
 
     def __call__(self, configs, args):
         api = self._get_api(configs, args)

--- a/kernelci/cli/user.py
+++ b/kernelci/cli/user.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2023 Collabora Limited
+# Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+
+"""Tool to manage KernelCI API users"""
+
+import json
+
+from kernelci.db import kernelci_api
+from .base import Args, Command, sub_main
+
+
+class cmd_me(Command):  # pylint: disable=invalid-name
+    """Use the /me entry point to get the current user's data"""
+    args = [
+        Args.api_config, Args.api_token,
+    ]
+    opt_args = [
+        {
+            'name': '--indent',
+            'help': "Indentation string in JSON output",
+        },
+    ]
+
+    @classmethod
+    def _get_api(cls, configs, args):
+        config = configs['api_configs'][args.api_config]
+        return kernelci_api.KernelCI_API(config, args.api_token)
+
+    def __call__(self, configs, args):
+        api = self._get_api(configs, args)
+        data = api.me()
+        print(json.dumps(data, indent=args.indent))
+        return True
+
+
+def main(args=None):
+    """Entry point for the command line tool"""
+    sub_main("user", globals(), args)

--- a/kernelci/cli/user.py
+++ b/kernelci/cli/user.py
@@ -7,26 +7,17 @@
 
 import json
 
-from kernelci.db import kernelci_api
-from .base import Args, Command, sub_main
+from .base import APICommand, sub_main
 
 
-class cmd_me(Command):  # pylint: disable=invalid-name
+class cmd_me(APICommand):  # pylint: disable=invalid-name
     """Use the /me entry point to get the current user's data"""
-    args = [
-        Args.api_config, Args.api_token,
-    ]
     opt_args = [
         {
             'name': '--indent',
             'help': "Indentation string in JSON output",
         },
     ]
-
-    @classmethod
-    def _get_api(cls, configs, args):
-        config = configs['api_configs'][args.api_config]
-        return kernelci_api.KernelCI_API(config, args.api_token)
 
     def __call__(self, configs, args):
         api = self._get_api(configs, args)

--- a/kernelci/db/kernelci_api.py
+++ b/kernelci/db/kernelci_api.py
@@ -96,6 +96,11 @@ class KernelCI_API(Database):
             raise(ex)
         return resp.json()
 
+    def me(self):
+        path = '/'.join(['me'])
+        resp = self._get(path)
+        return resp.json()
+
     def subscribe(self, channel):
         resp = self._post(f'subscribe/{channel}')
         return json.loads(resp.text)['id']


### PR DESCRIPTION
Add an initial implementation of the `kci user` tool with a command to get the current user's data.  For example:

```
kernelci@e4625cc550a0:~/core$ ./kci user me --indent='  ' --api-config=docker-host
{
  "_id": "62d91818f79fc24661556e46",
  "username": "admin",
  "hashed_password": "$2b$12$MZnf5VmvFKikPbpJ9ePTO.AJUh9DbLg/ypr.k6eWslK14.e8r55sq",
  "active": true,
  "is_admin": true
}
```

Also introduce a new base class `APICommand` for running commands that interact with the API.