### PR TITLE
ltp syscalls bodge

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2350,6 +2350,7 @@ test_configs:
       - ltp-io
       - ltp-ipc
       - ltp-smoketest
+      - ltp-syscalls
       - preempt-rt
       - vdso
 

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -547,8 +547,10 @@ test_plans:
     params:
       <<: *ltp-params
       tst_cmdfiles: "syscalls"
-      job_timeout: '120'
+      job_timeout: '150'
       priority: 0
+    filters:
+      - regex: {'tree': '(next|mainline)'}
 
   ltp-timers:
     <<: *ltp

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -549,8 +549,6 @@ test_plans:
       tst_cmdfiles: "syscalls"
       job_timeout: '150'
       priority: 0
-    filters:
-      - regex: {'tree': '(next|mainline)'}
 
   ltp-timers:
     <<: *ltp


### PR DESCRIPTION
- test-configs.yaml: Only run ltp-syscalls on mainline and next
- test-configs.yaml: Enable LTP syscalls tests on BeagleBone Black
- test-configs.yaml: Remove the filter from ltp-syscalls
