### PR TITLE
kselftest alsa bookworm bodge

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -1,4 +1,44 @@
 rootfs_configs:
+  bookworm-kselftest:
+    rootfs_type: debos
+    debian_release: bookworm
+    arch_list:
+      - amd64
+      - arm64
+      - armhf
+    extra_packages:
+      - alsa-ucm-conf
+      - alsa-utils
+      - bc
+      - ca-certificates
+      - iproute2
+      - jdim
+      - libasound2
+      - libatm1
+      - libcap2-bin
+      - libelf1
+      - libgdbm-compat4
+      - libgdbm6
+      - libhugetlbfs0
+      - libmnl0
+      - libnuma1
+      - libpam-cap
+      - libpcre2-8-0
+      - libperl5.36
+      - libpsl5
+      - libxtables12
+      - netbase
+      - openssl
+      - perl
+      - perl-modules-5.36
+      - procps
+      - publicsuffix
+      - python3-minimal
+      - python3-unittest2
+      - tpm2-tools
+      - wget
+      - xz-utils
+
   buildroot-baseline:
     rootfs_type: buildroot
     git_url: https://github.com/kernelci/buildroot

--- a/config/core/rootfs-images.yaml
+++ b/config/core/rootfs-images.yaml
@@ -7,6 +7,23 @@ file_systems:
     ramdisk: buildroot-baseline/20230211.0/{arch}/rootfs.cpio.gz
     root_type: ramdisk
     type: buildroot
+  debian_bookworm-kselftest_nfs:
+    boot_protocol: tftp
+    nfs: bookworm-kselftest/20230211.0/{arch}/full.rootfs.tar.xz
+    params:
+      os_config: debian
+    prompt: '/ #'
+    ramdisk: bookworm-kselftest/20230211.0/{arch}/initrd.cpio.gz
+    root_type: nfs
+    type: debian
+  debian_bookworm-kselftest_ramdisk:
+    boot_protocol: ramdisk
+    params:
+      os_config: debian
+    prompt: '/ #'
+    ramdisk: bookworm-kselftest/20230211.0/{arch}/rootfs.cpio.gz
+    root_type: ramdisk
+    type: debian
   debian_bullseye-cros-ec_ramdisk:
     boot_protocol: tftp
     params: {}

--- a/config/core/rootfs-images.yaml
+++ b/config/core/rootfs-images.yaml
@@ -9,21 +9,21 @@ file_systems:
     type: buildroot
   debian_bookworm-kselftest_nfs:
     boot_protocol: tftp
-    nfs: bookworm-kselftest/20230211.0/{arch}/full.rootfs.tar.xz
+    nfs: bookworm-kselftest/20230224.0/{arch}/full.rootfs.tar.xz
     params:
       os_config: debian
     prompt: '/ #'
-    ramdisk: bookworm-kselftest/20230211.0/{arch}/initrd.cpio.gz
+    ramdisk: bookworm-kselftest/20230224.0/{arch}/initrd.cpio.gz
     root_type: nfs
-    type: debian
+    type: debian-staging
   debian_bookworm-kselftest_ramdisk:
     boot_protocol: ramdisk
     params:
       os_config: debian
     prompt: '/ #'
-    ramdisk: bookworm-kselftest/20230211.0/{arch}/rootfs.cpio.gz
+    ramdisk: bookworm-kselftest/20230224.0/{arch}/rootfs.cpio.gz
     root_type: ramdisk
-    type: debian
+    type: debian-staging
   debian_bullseye-cros-ec_ramdisk:
     boot_protocol: tftp
     params: {}

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -238,6 +238,7 @@ test_plans:
 
   kselftest-alsa:
     <<: *kselftest
+    rootfs: debian_bookworm-kselftest_nfs
     params:
       job_timeout: '10'
       kselftest_collections: "alsa"


### PR DESCRIPTION
- rootfs-configs.yaml: Add bookworm-kselftest
- test-configs.yaml: Use bookworm rootfs for kselftest-alsa
- BODGE: Use staging builds of the new bookworm-kselftest images
