### PR TITLE
Consolidate YAML config file arguments

### DIFF
--- a/kci_bisect
+++ b/kci_bisect
@@ -62,6 +62,6 @@ class cmd_get_mbox(Command):
 
 if __name__ == '__main__':
     opts = parse_opts("kci_bisect", globals())
-    configs = kernelci.config.load_all(opts.get_yaml_configs())
+    configs = kernelci.config.load(opts.get_yaml_configs())
     status = opts.command(configs, opts)
     sys.exit(0 if status is True else 1)

--- a/kci_build
+++ b/kci_build
@@ -476,6 +476,6 @@ class cmd_push_tarball(Command):
 
 if __name__ == '__main__':
     opts = parse_opts("kci_build", globals())
-    configs = kernelci.config.load_all(opts.get_yaml_configs())
+    configs = kernelci.config.load(opts.get_yaml_configs())
     status = opts.command(configs, opts)
     sys.exit(0 if status is True else 1)

--- a/kci_data
+++ b/kci_data
@@ -115,6 +115,6 @@ class cmd_create_user(Command):
 
 if __name__ == '__main__':
     opts = parse_opts("kci_data", globals())
-    configs = kernelci.config.load_all(opts.get_yaml_configs())
+    configs = kernelci.config.load(opts.get_yaml_configs())
     status = opts.command(configs, opts)
     sys.exit(0 if status is True else 1)

--- a/kci_rootfs
+++ b/kci_rootfs
@@ -145,6 +145,6 @@ class cmd_upload(Command):
 
 if __name__ == '__main__':
     opts = parse_opts("kci_rootfs", globals())
-    configs = kernelci.config.load_all(opts.get_yaml_configs())
+    configs = kernelci.config.load(opts.get_yaml_configs())
     status = opts.command(configs, opts)
     sys.exit(0 if status is True else 1)

--- a/kci_test
+++ b/kci_test
@@ -395,6 +395,6 @@ class cmd_submit(Command):
 
 if __name__ == '__main__':
     opts = parse_opts("kci_test", globals())
-    configs = kernelci.config.load_all(opts.get_yaml_configs())
+    configs = kernelci.config.load(opts.get_yaml_configs())
     status = opts.command(configs, opts)
     sys.exit(0 if status is True else 1)

--- a/kernelci/config/__init__.py
+++ b/kernelci/config/__init__.py
@@ -72,7 +72,7 @@ def validate_yaml(config_paths, entries):
     return None
 
 
-def load_single_yaml(config_path, validate_entries=None):
+def load_single_yaml(config_path):
     """Load the YAML configuration from a single directory or file
 
     Load all the YAML files found in a configuration directory or single file
@@ -81,8 +81,6 @@ def load_single_yaml(config_path, validate_entries=None):
 
     *config_path* is the path to the YAML config directory, or alternative a
                   single YAML file.
-
-    *validate_entries* is not used
     """
     config = dict()
     for yaml_path, data in _iterate_yaml_files(config_path):
@@ -133,7 +131,7 @@ def _merge_trees(old, update):
         return update
 
 
-def load_yaml(config_paths, validate_entries=None):
+def load_yaml(config_paths):
     """Load the YAML configuration
 
     Load all the YAML files in all the specific configuration directories or
@@ -144,14 +142,12 @@ def load_yaml(config_paths, validate_entries=None):
     *config_paths* is a single string or an ordered list of YAML configuration
                    directories or YAML files, with later entries having higher
                    priority.
-
-    *validate_entries* is not used
     """
     if not isinstance(config_paths, list):
         config_paths = [config_paths]
     config = dict()
     for path in config_paths:
-        data = load_single_yaml(path, validate_entries)
+        data = load_single_yaml(path)
         config = _merge_trees(config, data)
     return config
 

--- a/kernelci/config/__init__.py
+++ b/kernelci/config/__init__.py
@@ -152,7 +152,7 @@ def load_yaml(config_paths):
     return config
 
 
-def from_data(data):
+def load_data(data):
     """Create configuration objects from the YAML data
 
     Create a top-level dictionary with all the configuration objects using the
@@ -186,4 +186,4 @@ def load(config_paths):
     if not config_paths:
         return {}
     data = load_yaml(config_paths)
-    return from_data(data)
+    return load_data(data)


### PR DESCRIPTION
Allow `yaml_config` and `extra_configs` to be defined in the settings file and consolidate the code to have only one path for loading the configuration.