### PR TITLE
test-configs.yaml: arm64 ftrace selftsts coverage

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -333,6 +333,12 @@ test_plans:
       kselftest_collections: "filesystems"
     filters: *kselftest_no_fragment
 
+  kselftest-ftrace:
+    <<: *kselftest
+    params:
+      job_timeout: '20'
+      kselftest_collections: "ftrace"
+
   kselftest-futex:
     <<: *kselftest
     params:

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2931,6 +2931,7 @@ test_configs:
       - baseline-nfs
       - kselftest-cpufreq
       - kselftest-dt
+      - kselftest-ftrace
       - ltp-crypto
       # ltp-mm - runs system out of memory
       - smc


### PR DESCRIPTION
The ftrace kselftests are very useful but currently we don't try to run
it, add the config fragment and enable it on Juno.  Since a config
fragment is required this will be a lot easier to deploy with the
kselftest-slim PR (https://github.com/kernelci/kernelci-core/pull/1759)
merged.

We will also need https://github.com/Linaro/test-definitions/pull/431
for this to be useful, at the minute the test is unconditionally skipped
everywhere by the Linaro skipfile due to what appear to be no longer
relevant reasons.
