### PR TITLE
Add `kci job` command

### DIFF
--- a/kernelci/cli/__init__.py
+++ b/kernelci/cli/__init__.py
@@ -9,12 +9,14 @@ import sys
 
 from .base import Args, Command, parse_opts, sub_main
 from . import (
+    job,
     node,
     user,
     validate,
 )
 
 _COMMANDS = {
+    'job': job.main,
     'node': node.main,
     'user': user.main,
     'validate': validate.main,

--- a/kernelci/cli/base.py
+++ b/kernelci/cli/base.py
@@ -377,8 +377,8 @@ class Command(abc.ABC):
     """
 
     help = None
-    args = None
-    opt_args = None
+    args = []
+    opt_args = []
 
     def __init__(self, sub_parser, name):
         """This class is to facilitate creating command line utilities
@@ -445,10 +445,9 @@ class Command(abc.ABC):
 
 class APICommand(Command):  # pylint: disable=too-few-public-methods
     """Base command class for interacting with the KernelCI API"""
-    args = [
+    args = Command.args + [
         Args.api_config, Args.api_token,
     ]
-    opt_args = []
 
     @classmethod
     def _get_api(cls, configs, args):

--- a/kernelci/cli/base.py
+++ b/kernelci/cli/base.py
@@ -459,6 +459,11 @@ class APICommand(Command):  # pylint: disable=too-few-public-methods
         n_indent = 0 if indent is None else int(indent)
         print(json.dumps(data, indent=n_indent))
 
+    @classmethod
+    def _load_json(cls, json_path, encoding='utf-8'):
+        with open(json_path, encoding=encoding) as json_file:
+            return json.load(json_file)
+
 
 class Options:
     """Options based on user settings with CLI override."""

--- a/kernelci/cli/job.py
+++ b/kernelci/cli/job.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2022-2023 Collabora Limited
+# Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+
+"""Tool to generate and run KernelCI jobs"""
+
+from .base import sub_main
+
+
+def main(args=None):
+    """Entry point for the command line tool"""
+    sub_main("job", globals(), args)

--- a/kernelci/cli/job.py
+++ b/kernelci/cli/job.py
@@ -8,7 +8,7 @@
 import yaml
 
 import kernelci.runtime
-from .base import APICommand, Args, sub_main
+from .base import APICommand, Args, Command, sub_main
 
 
 class cmd_register(APICommand):  # pylint: disable=invalid-name
@@ -125,6 +125,25 @@ Invalid arguments.  Either --node-id or --node-json is required.")
             print(job)
 
         return True
+
+
+class cmd_submit(Command):  # pylint: disable=invalid-name
+    """Submit a job definition from a file"""
+    args = Command.args + [
+        {
+            'name': '--runtime-config',
+            'help': "Name of the runtime config",
+        },
+        {
+            'name': 'job_path',
+            'help': "Path of the job file to submit",
+        },
+    ]
+
+    def __call__(self, configs, args):
+        runtime_config = configs['runtimes'][args.runtime_config]
+        runtime = kernelci.runtime.get_runtime(runtime_config)
+        runtime.submit(args.job_path)
 
 
 def main(args=None):

--- a/kernelci/cli/job.py
+++ b/kernelci/cli/job.py
@@ -5,7 +5,60 @@
 
 """Tool to generate and run KernelCI jobs"""
 
-from .base import sub_main
+from .base import APICommand, Args, sub_main
+
+
+class cmd_register(APICommand):  # pylint: disable=invalid-name
+    """Create a new node before running a job"""
+    args = APICommand.args + [Args.plan]
+
+    opt_args = APICommand.opt_args + [
+        Args.indent,
+        {
+            'name': '--input-node-id',
+            'help': "ID of the input node",
+        },
+        {
+            'name': '--input-node-json',
+            'help': "Alternatively, path to the input node JSON file",
+        },
+        {
+            'name': '--id-only',
+            'action': 'store_true',
+            'help': "Only print the node ID rather than the full node data",
+        },
+    ]
+
+    # This should in fact be using a generic method in the API class
+    # pylint: disable=no-self-use
+    def _create_node(self, api, input_node, plan_config):
+        job_node = {
+            'parent': input_node['_id'],
+            'name': plan_config.name,
+            'path': input_node['path'] + [plan_config.name],
+            'group': plan_config.name,
+            'artifacts': input_node['artifacts'],
+            'revision': input_node['revision'],
+        }
+        return api.submit({'node': job_node})[0]
+
+    def __call__(self, configs, args):
+        api = self._get_api(configs, args)
+        if args.input_node_id:
+            input_node = api.get_node(args.input_node_id)
+        elif args.input_node_json:
+            input_node = self._load_json(args.input_node_json)
+        else:
+            print("\
+Invalid arguments.  Either --input-node-id or --input-node-json is required.")
+            return False
+        plan_config = configs['test_plans'][args.plan]
+        node = self._create_node(api, input_node, plan_config)
+        if args.id_only:
+            print(node['_id'])
+        else:
+            self._print_json(node, args.indent)
+        return True
 
 
 def main(args=None):


### PR DESCRIPTION
Add a `kci job` command to run jobs with the new API.  Sample commands:

```
kci job register --input-node-id=<checkout node id> --plan=kver --id-only
kci job generate --runtime-config=shell --platform-config=shell --node-id=<job node id>
kci job submit --runtime-config=shell job/kver
```

Fixes #1728 
Depends on #1773