### PR TITLE
Add `kernelci.api` to load the existing API module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ test: \
 pylint:
 	pylint --reports=y \
 		kci \
+		kernelci.api \
 		kernelci.cli \
 		kernelci.config.api \
 		kernelci.config.runtime \

--- a/kernelci/api/__init__.py
+++ b/kernelci/api/__init__.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2023 Collabora Limited
+# Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+
+"""KernelCI API"""
+
+import importlib
+
+
+def get_api(config, token=None):
+    """Get a KernelCI API object matching the provided configuration"""
+    mod = importlib.import_module('.'.join(['kernelci', 'db', 'kernelci_api']))
+    api = mod.get_db(config, token)
+    return api

--- a/kernelci/cli/base.py
+++ b/kernelci/cli/base.py
@@ -16,8 +16,8 @@ import configparser
 import os.path
 import sys
 
+import kernelci.api
 import kernelci.config
-from kernelci.db import kernelci_api
 
 
 # -----------------------------------------------------------------------------
@@ -451,7 +451,7 @@ class APICommand(Command):  # pylint: disable=too-few-public-methods
     @classmethod
     def _get_api(cls, configs, args):
         config = configs['api_configs'][args.api_config]
-        return kernelci_api.KernelCI_API(config, args.api_token)
+        return kernelci.api.get_api(config, args.api_token)
 
 
 class Options:

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setuptools.setup(
     url="https://github.com/kernelci/kernelci-core",
     packages=[
         "kernelci",
+        "kernelci.api",
         "kernelci.cli",
         "kernelci.config",
         "kernelci.db",


### PR DESCRIPTION
As an intermediate step before having a new `API` class with API bindings, add the `kernelci.api` package with a loader to dynamically import the matching module.  Right now the module is hard-coded but it will become useful when supporting different API versions.

This also decouples the Python dependencies needed for the API with the command line tools e.g. `cloudevents` is now only imported when an API object is needed (this particular Python package is not in Debian so it's particularly inconvenient).