### PR TITLE
test-configs.yaml: Raise memory allocation for arm64 qemu

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1655,6 +1655,7 @@ device_types:
       cpu: 'max,pauth-impdef=on'
       guestfs_interface: 'virtio'
       machine: 'virt,gic-version=2,mte=on,accel=tcg'
+      memory: 1g
     filters:
       - regex: { defconfig: 'defconfig' }
 
@@ -1673,6 +1674,7 @@ device_types:
       cpu: 'max,pauth-impdef=on'
       guestfs_interface: 'virtio'
       machine: 'virt,gic-version=3,mte=on,accel=tcg'
+      memory: 1g
     filters:
       - passlist: {defconfig: ['defconfig']}
 


### PR DESCRIPTION
arm64 debug configurations are starting to get rather large and run into
problems booting with the default memory allocation of 512m, especially in
UEFI configurations. Increase the amount of memory guests are given to a
gigabyte to avoid these issues.

Signed-off-by: Mark Brown <broonie@kernel.org>
