### PR TITLE
Add and run igt-kms-mediatek on MediaTek Chromebooks

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -204,6 +204,12 @@ test_plans:
       <<: *igt-kms-test-list
       drm_driver: "exynos"
 
+  igt-kms-mediatek:
+    <<: *igt-kms
+    params:
+      <<: *igt-kms-test-list
+      drm_driver: "mediatek"
+
   igt-kms-msm:
     <<: *igt-kms
     params:

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2843,6 +2843,7 @@ test_configs:
       - baseline
       - baseline-nfs
       - cros-ec
+      - igt-kms-mediatek
       - kselftest-arm64
       - kselftest-cpufreq
       - kselftest-filesystems
@@ -2870,6 +2871,7 @@ test_configs:
       - baseline-nfs
       - cros-ec
       - igt-gpu-panfrost
+      - igt-kms-mediatek
       - kselftest-alsa
       - kselftest-arm64
       - kselftest-cpufreq
@@ -2888,6 +2890,7 @@ test_configs:
       - baseline-nfs
       - cros-ec
       - igt-gpu-panfrost
+      - igt-kms-mediatek
       - kselftest-alsa
       - kselftest-arm64
       - kselftest-cpufreq


### PR DESCRIPTION
Add IGT KMS test plan for MediaTek and enable on MediaTek Chromebooks: Hana, Juniper and Spherion. Even though all three use the same DRM driver (mediatek), each one has a different display pipeline, so it's worth testing on all of them.

Hana (MT8173 Elm based) uses a PS8640 DSI-eDP bridge. Spherion (MT8192 Asurada based) and Juniper (MT8183 Kukui Jacuzzi based) both use the ANX7625 DSI-DP bridge, but they use different eDP panels: Spherion has IVO 0x075d; Juniper has AUO 0x145c.