### PR TITLE
CHROMEOS rootfs-configs-chromeos.yaml: Add bullseye-cros-flash.sh to bullseye-cros-flash

### DIFF
--- a/config/core/rootfs-configs-chromeos.yaml
+++ b/config/core/rootfs-configs-chromeos.yaml
@@ -13,6 +13,7 @@ rootfs_configs:
       - wget
       - xz-utils
     test_overlay: "overlays/cros-flash"
+    script: "scripts/bullseye-cros-flash.sh"
 
   chromiumos-amd64-generic:
     rootfs_type: chromiumos

--- a/config/rootfs/debos/scripts/bullseye-cros-flash.sh
+++ b/config/rootfs/debos/scripts/bullseye-cros-flash.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Important: This script is run under QEMU
+
+set -e
+
+# Build-depends needed to build the test suites, they'll be removed later
+BUILD_DEPS="\
+    build-essential \
+    ca-certificates \
+    git \
+    wget \
+    pkg-config \
+    libssl-dev \
+    libusb-1.0-0-dev
+"
+
+apt-get install --no-install-recommends -y  ${BUILD_DEPS}
+
+mkdir -p /tmp/tests
+cd /tmp/tests
+wget --no-verbose --inet4-only --no-clobber --tries 5 \
+    https://chromium.googlesource.com/chromiumos/platform/ec/+archive/refs/heads/cr50_stab.tar.gz
+
+tar -xzf cr50_stab.tar.gz
+cd extra/usb_updater
+make
+cp gsctool /usr/bin
+
+########################################################################
+# Cleanup: remove files and packages we don't want in the images       #
+########################################################################
+cd /tmp
+rm -rf /tmp/tests
+
+apt-get remove --purge -y ${BUILD_DEPS}
+apt-get autoremove --purge -y
+apt-get clean
+
+# re-add some stuff that is removed by accident
+apt-get install -y initramfs-tools


### PR DESCRIPTION
Add gsctool build script to enable CR50 flashing over TPM device.