### PR TITLE
Initial kernelci.api.API base abstract class

### DIFF
--- a/kernelci/api/__init__.py
+++ b/kernelci/api/__init__.py
@@ -60,6 +60,10 @@ class API(abc.ABC):
         """Get information about the current user"""
 
     @abc.abstractmethod
+    def password_hash(self, password: str) -> dict:
+        """Get an encryption hash for a given password"""
+
+    @abc.abstractmethod
     def create_token(self, username: str, password: str,
                      scopes: Optional[Sequence[str]] = None) -> str:
         """Create a new API token for the current user

--- a/kernelci/api/__init__.py
+++ b/kernelci/api/__init__.py
@@ -5,11 +5,86 @@
 
 """KernelCI API"""
 
+import abc
+import enum
 import importlib
+import json
+import urllib
+
+import requests
+
+import kernelci.config.api
+
+
+class API(abc.ABC):
+    """Base class for the KernelCI API Python bindings"""
+
+    def __init__(self, config: kernelci.config.api.API, token: str):
+        self._config = config
+        self._token = token
+        self._headers = {'Content-Type': 'application/json'}
+        if self._token:
+            self._headers['Authorization'] = f'Bearer {self._token}'
+
+    @property
+    def config(self) -> kernelci.config.api.API:
+        """API configuration data"""
+        return self._config
+
+    # -------------------------------------------------------------------------
+    # Abstract interface to be implemented
+    #
+
+    @property
+    @abc.abstractmethod
+    def version(self) -> str:
+        """API version"""
+
+    @property
+    @abc.abstractmethod
+    def node_states(self):
+        """An enum with all the valid node state names"""
+
+    @abc.abstractmethod
+    def hello(self) -> dict:
+        """Get the hello message"""
+
+    @abc.abstractmethod
+    def whoami(self) -> dict:
+        """Get information about the current user"""
+
+    # -------------------------------------------------------------------------
+    # Private methods
+    #
+
+    def _make_url(self, path):
+        version_path = '/'.join((self.config.version, path))
+        return urllib.parse.urljoin(self.config.url, version_path)
+
+    def _get(self, path, params=None):
+        url = self._make_url(path)
+        resp = requests.get(url, params, headers=self._headers)
+        resp.raise_for_status()
+        return resp
+
+    def _post(self, path, data=None, params=None):
+        url = self._make_url(path)
+        jdata = json.dumps(data)
+        resp = requests.post(url, jdata, headers=self._headers, params=params)
+        resp.raise_for_status()
+        return resp
+
+    def _put(self, path, data=None, params=None):
+        url = self._make_url(path)
+        jdata = json.dumps(data)
+        resp = requests.put(url, jdata, headers=self._headers, params=params)
+        resp.raise_for_status()
+        return resp
 
 
 def get_api(config, token=None):
     """Get a KernelCI API object matching the provided configuration"""
-    mod = importlib.import_module('.'.join(['kernelci', 'db', 'kernelci_api']))
-    api = mod.get_db(config, token)
+    version = config.version
+    mod = importlib.import_module('.'.join(['kernelci', 'api', version]))
+    api = mod.get_api(config, token)
     return api

--- a/kernelci/api/__init__.py
+++ b/kernelci/api/__init__.py
@@ -10,6 +10,7 @@ import enum
 import importlib
 import json
 import urllib
+from typing import Optional, Sequence
 
 import requests
 
@@ -45,6 +46,11 @@ class API(abc.ABC):
     def node_states(self):
         """An enum with all the valid node state names"""
 
+    @property
+    @abc.abstractmethod
+    def security_scopes(self) -> Sequence[str]:
+        """All the user token security scope names"""
+
     @abc.abstractmethod
     def hello(self) -> dict:
         """Get the hello message"""
@@ -52,6 +58,17 @@ class API(abc.ABC):
     @abc.abstractmethod
     def whoami(self) -> dict:
         """Get information about the current user"""
+
+    @abc.abstractmethod
+    def create_token(self, username: str, password: str,
+                     scopes: Optional[Sequence[str]] = None) -> str:
+        """Create a new API token for the current user
+
+        `scopes` contains optional security scope names which needs to be part
+        of API.security_scopes.  Please note that user permissions can limit
+        the available scopes, for example only admin users can create admin
+        tokens.
+        """
 
     # -------------------------------------------------------------------------
     # Private methods

--- a/kernelci/api/latest.py
+++ b/kernelci/api/latest.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2023 Collabora Limited
+# Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+
+"""KernelCI API bindings for the latest version"""
+
+import enum
+
+from . import API
+
+
+class NodeStates(enum.Enum):
+    """Node states names"""
+    RUNNING = 'running'
+    AVAILABLE = 'available'
+    CLOSING = 'closing'
+    DONE = 'done'
+
+
+class LatestAPI(API):
+    """Latest API version
+
+    The 'latest' version is used to refer to the current development version,
+    so it's not pinned down.  It's a moving target and shouldn't be used in
+    production environments.
+    """
+
+    @property
+    def version(self) -> str:
+        return self.config.version
+
+    @property
+    def node_states(self):
+        return NodeStates
+
+    def hello(self) -> dict:
+        return self._get('/').json()
+
+    def whoami(self) -> dict:
+        return self._get('/whoami').json()
+
+
+def get_api(config, token):
+    """Get an API object for the latest version"""
+    return LatestAPI(config, token)

--- a/kernelci/api/latest.py
+++ b/kernelci/api/latest.py
@@ -47,6 +47,9 @@ class LatestAPI(API):
     def whoami(self) -> dict:
         return self._get('/whoami').json()
 
+    def password_hash(self, password: str) -> dict:
+        return self._post('/hash', {'password': password}).json()
+
     def create_token(self, username: str, password: str,
                      scopes: Optional[Sequence[str]] = None) -> str:
         data = {

--- a/kernelci/cli/__init__.py
+++ b/kernelci/cli/__init__.py
@@ -9,6 +9,7 @@ import sys
 
 from .base import Args, Command, parse_opts, sub_main
 from . import (
+    api,
     job,
     node,
     user,
@@ -16,6 +17,7 @@ from . import (
 )
 
 _COMMANDS = {
+    'api': api.main,
     'job': job.main,
     'node': node.main,
     'user': user.main,

--- a/kernelci/cli/api.py
+++ b/kernelci/cli/api.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2023 Collabora Limited
+# Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+
+"""Tool to interact with the KernelCI API"""
+
+from .base import APICommand, Args, sub_main
+
+
+class cmd_hello(APICommand):  # pylint: disable=invalid-name
+    """Get the hello message"""
+
+    opt_args = APICommand.opt_args + [Args.indent]
+
+    def __call__(self, configs, args):
+        api = self._get_api(configs, args)
+        hello = api.hello()
+        self._print_json(hello, args.indent)
+        return True
+
+
+class cmd_version(APICommand):  # pylint: disable=invalid-name
+    """Get the API version"""
+
+    def __call__(self, configs, args):
+        api = self._get_api(configs, args)
+        print(api.version)
+        return True
+
+
+def main(args=None):
+    """Entry point for the command line tool"""
+    sub_main("api", globals(), args)

--- a/kernelci/cli/base.py
+++ b/kernelci/cli/base.py
@@ -444,10 +444,12 @@ class Command(abc.ABC):
 
 
 class APICommand(Command):  # pylint: disable=too-few-public-methods
-    """Base command class for interacting with the KernelCI API"""
-    args = Command.args + [
-        Args.api_config, Args.api_token,
-    ]
+    """Base command class for interacting with the KernelCI API
+
+    The Args.api_token argument needs to be added for commands that require
+    authentication with the API.
+    """
+    args = Command.args + [Args.api_config]
 
     @classmethod
     def _get_api(cls, configs, args):

--- a/kernelci/cli/job.py
+++ b/kernelci/cli/job.py
@@ -11,7 +11,7 @@ from .base import APICommand, Args, Command, sub_main
 
 class cmd_register(APICommand):  # pylint: disable=invalid-name
     """Create a new node before running a job"""
-    args = APICommand.args + [Args.plan]
+    args = APICommand.args + [Args.api_token, Args.plan]
 
     opt_args = APICommand.opt_args + [
         Args.indent,
@@ -119,6 +119,7 @@ Invalid arguments.  Either --node-id or --node-json is required.")
 class cmd_submit(Command):  # pylint: disable=invalid-name
     """Submit a job definition from a file"""
     args = Command.args + [
+        Args.api_token,
         {
             'name': '--runtime-config',
             'help': "Name of the runtime config",

--- a/kernelci/cli/user.py
+++ b/kernelci/cli/user.py
@@ -41,6 +41,16 @@ class cmd_get_token(APICommand):  # pylint: disable=invalid-name
         return True
 
 
+class cmd_password_hash(APICommand):  # pylint: disable=invalid-name
+    """Get an encryption hash for an arbitrary password"""
+
+    def __call__(self, configs, args):
+        password = getpass.getpass()
+        api = self._get_api(configs, args)
+        print(api.password_hash(password))
+        return True
+
+
 def main(args=None):
     """Entry point for the command line tool"""
     sub_main("user", globals(), args)

--- a/kernelci/cli/user.py
+++ b/kernelci/cli/user.py
@@ -10,6 +10,7 @@ from .base import Args, APICommand, sub_main
 
 class cmd_whoami(APICommand):  # pylint: disable=invalid-name
     """Use the /whoami entry point to get the current user's data"""
+    args = APICommand.args + [Args.api_token]
     opt_args = APICommand.opt_args + [Args.indent]
 
     def __call__(self, configs, args):

--- a/kernelci/cli/user.py
+++ b/kernelci/cli/user.py
@@ -5,6 +5,8 @@
 
 """Tool to manage KernelCI API users"""
 
+import getpass
+
 from .base import Args, APICommand, sub_main
 
 
@@ -17,6 +19,25 @@ class cmd_whoami(APICommand):  # pylint: disable=invalid-name
         api = self._get_api(configs, args)
         data = api.whoami()
         self._print_json(data, args.indent)
+        return True
+
+
+class cmd_get_token(APICommand):  # pylint: disable=invalid-name
+    """Create a new API token for the current user"""
+    args = APICommand.args + [Args.username]
+    opt_args = APICommand.opt_args + [
+        {
+            'name': '--scopes',
+            'action': 'append',
+            'help': "Security scopes",
+        },
+    ]
+
+    def __call__(self, configs, args):
+        password = getpass.getpass()
+        api = self._get_api(configs, args)
+        token = api.create_token(args.username, password, args.scopes)
+        self._print_json(token, args.indent)
         return True
 
 

--- a/kernelci/cli/user.py
+++ b/kernelci/cli/user.py
@@ -8,13 +8,13 @@
 from .base import Args, APICommand, sub_main
 
 
-class cmd_me(APICommand):  # pylint: disable=invalid-name
-    """Use the /me entry point to get the current user's data"""
+class cmd_whoami(APICommand):  # pylint: disable=invalid-name
+    """Use the /whoami entry point to get the current user's data"""
     opt_args = APICommand.opt_args + [Args.indent]
 
     def __call__(self, configs, args):
         api = self._get_api(configs, args)
-        data = api.me()
+        data = api.whoami()
         self._print_json(data, args.indent)
         return True
 


### PR DESCRIPTION
Add an initial `kernelci.api.API` base abstract class with an implementation for the `latest` version.  Also update some `kci` command line tools to use the API by hand.

Depends on https://github.com/kernelci/kernelci-api/pull/224