### PR TITLE
Add decorator to catch HTTP errors in command line tools

### DIFF
--- a/kernelci/cli/api.py
+++ b/kernelci/cli/api.py
@@ -13,8 +13,7 @@ class cmd_hello(APICommand):  # pylint: disable=invalid-name
 
     opt_args = APICommand.opt_args + [Args.indent]
 
-    def __call__(self, configs, args):
-        api = self._get_api(configs, args)
+    def _api_call(self, api, configs, args):
         hello = api.hello()
         self._print_json(hello, args.indent)
         return True
@@ -23,8 +22,7 @@ class cmd_hello(APICommand):  # pylint: disable=invalid-name
 class cmd_version(APICommand):  # pylint: disable=invalid-name
     """Get the API version"""
 
-    def __call__(self, configs, args):
-        api = self._get_api(configs, args)
+    def _api_call(self, api, configs, args):  # pylint: disable=no-self-use
         print(api.version)
         return True
 

--- a/kernelci/cli/job.py
+++ b/kernelci/cli/job.py
@@ -43,7 +43,7 @@ class cmd_register(APICommand):  # pylint: disable=invalid-name
         }
         return api.submit({'node': job_node})[0]
 
-    def __call__(self, configs, args):
+    def _api_call(self, api, configs, args):
         api = self._get_api(configs, args)
         if args.input_node_id:
             input_node = api.get_node(args.input_node_id)
@@ -89,7 +89,7 @@ class cmd_generate(APICommand):  # pylint: disable=invalid-name
         },
     ]
 
-    def __call__(self, configs, args):
+    def _api_call(self, api, configs, args):
         api = self._get_api(configs, args)
         if args.node_id:
             job_node = api.get_node(args.node_id)

--- a/kernelci/cli/node.py
+++ b/kernelci/cli/node.py
@@ -39,8 +39,7 @@ class cmd_get(NodeCommand):  # pylint: disable=invalid-name
         },
     ]
 
-    def __call__(self, configs, args):
-        api = self._get_api(configs, args)
+    def _api_call(self, api, configs, args):
         node = api.get_node(args.id)
         self._print_json(node, args.indent)
         return True
@@ -65,8 +64,7 @@ the matching nodes are retrieved.\
         },
     ]
 
-    def __call__(self, configs, args):
-        api = self._get_api(configs, args)
+    def _api_call(self, api, configs, args):
         attributes = self._split_attributes(args.attributes)
         nodes = api.get_nodes(attributes, args.offset, args.limit)
         self._print_json(nodes, args.indent)
@@ -77,8 +75,7 @@ class cmd_count(NodeAttributesCommand):  # pylint: disable=invalid-name
     """Count nodes with arbitrary attributes"""
     opt_args = None
 
-    def __call__(self, configs, args):
-        api = self._get_api(configs, args)
+    def _api_call(self, api, configs, args):
         attributes = self._split_attributes(args.attributes)
         count = api.count_nodes(attributes)
         print(count)

--- a/kernelci/cli/user.py
+++ b/kernelci/cli/user.py
@@ -15,8 +15,7 @@ class cmd_whoami(APICommand):  # pylint: disable=invalid-name
     args = APICommand.args + [Args.api_token]
     opt_args = APICommand.opt_args + [Args.indent]
 
-    def __call__(self, configs, args):
-        api = self._get_api(configs, args)
+    def _api_call(self, api, configs, args):
         data = api.whoami()
         self._print_json(data, args.indent)
         return True
@@ -33,9 +32,8 @@ class cmd_get_token(APICommand):  # pylint: disable=invalid-name
         },
     ]
 
-    def __call__(self, configs, args):
+    def _api_call(self, api, configs, args):
         password = getpass.getpass()
-        api = self._get_api(configs, args)
         token = api.create_token(args.username, password, args.scopes)
         self._print_json(token, args.indent)
         return True
@@ -44,9 +42,8 @@ class cmd_get_token(APICommand):  # pylint: disable=invalid-name
 class cmd_password_hash(APICommand):  # pylint: disable=invalid-name
     """Get an encryption hash for an arbitrary password"""
 
-    def __call__(self, configs, args):
+    def _api_call(self, api, configs, args):
         password = getpass.getpass()
-        api = self._get_api(configs, args)
         print(api.password_hash(password))
         return True
 


### PR DESCRIPTION
Add a `catch_http_error` decorator and use it in a new method `APICommand._api_call()`.  Update all the command line tools that use the API to use this and improve error reporting.