### PR TITLE
Enable `mypy` to run on `kernelci.api` modules

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,10 @@ jobs:
         run: |
           make pylint
 
+      - name: Run mypy
+        run: |
+          make mypy
+
       - name: Run YAML config validation
         run: |
           make validate-yaml
@@ -86,7 +90,6 @@ jobs:
           use-black: false
           use-flake8: false
           use-isort: false
-          use-mypy: false
           use-pydocstyle: false
           use-vulture: false
 

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,11 @@ test: \
 	unit-tests \
 	validate-yaml
 
+mypy:
+	mypy \
+		-m kernelci.api \
+		-m kernelci.api.latest
+
 pylint:
 	pylint --reports=y \
 		kci \

--- a/kernelci/config/base.py
+++ b/kernelci/config/base.py
@@ -15,6 +15,8 @@
 # along with this library; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+# mypy: ignore-errors
+
 import re
 import yaml
 import copy

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,7 @@
 -r requirements.txt
+mypy==1.1.1
 pycodestyle==2.8.0
 pylint==2.12.2
+types-PyYAML==6.0.12.8
+types-requests==2.28.11.15
+types-urllib3==1.26.25.8


### PR DESCRIPTION
Add a check to run `mypy` on the `kernelci.api` modules and enable GitHub annotations on all `.py` files.