### PR TITLE
Upgrade to Cloudevents 1.9.0 and Python 3.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cloudevents==1.2.0
+cloudevents==1.9.0
 jinja2==3.1.1
 kubernetes==23.3.0
 pyelftools==0.28

--- a/setup.py
+++ b/setup.py
@@ -66,11 +66,11 @@ setuptools.setup(
         'Operating System :: POSIX :: Linux',
         'Programming Language :: C',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Software Development :: Build Tools',
         'Topic :: Software Development :: Testing',
     ],
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     install_requires=[
         "cloudevents",
         "jinja2",


### PR DESCRIPTION
Upgrade Cloudevents to 1.9.0 in order to pass `mypy` checks.  Also upgrade the minimum Python version from 3.6 to 3.7 as 3.6 is end-of-life and not supported by recent packages such as Cloudevents.