### PR TITLE
CHROMEOS rootfs-configs-chromeos.yaml: Add arm64 to bullseye-cros-flash

### DIFF
--- a/config/core/rootfs-configs-chromeos.yaml
+++ b/config/core/rootfs-configs-chromeos.yaml
@@ -5,6 +5,7 @@ rootfs_configs:
     debian_release: bullseye
     arch_list:
       - amd64
+      - arm64
     extra_packages:
       - bzip2
       - ca-certificates


### PR DESCRIPTION
As we have ChromiumOS ARM64 Chromebooks, we need "flasher" image for them too.