### PR TITLE
Move chromeos rootfs related commits from chromeos branch to main

### DIFF
--- a/config/core/rootfs-configs-chromeos.yaml
+++ b/config/core/rootfs-configs-chromeos.yaml
@@ -30,6 +30,14 @@ rootfs_configs:
     arch_list:
       - amd64
 
+  chromiumos-dedede:
+    rootfs_type: chromiumos
+    board: dedede
+    branch: release-R106-15054.B
+    serial: ttyS0
+    arch_list:
+      - amd64
+
   chromiumos-grunt:
     rootfs_type: chromiumos
     board: grunt
@@ -46,10 +54,50 @@ rootfs_configs:
     arch_list:
       - amd64
 
+  chromiumos-nami:
+    rootfs_type: chromiumos
+    board: nami
+    branch: release-R106-15054.B
+    serial: ttyS0
+    arch_list:
+      - amd64
+
   chromiumos-octopus:
     rootfs_type: chromiumos
     board: octopus
     branch: release-R106-15054.B
     serial: ttyS1
+    arch_list:
+      - amd64
+
+  chromiumos-rammus:
+    rootfs_type: chromiumos
+    board: rammus
+    branch: release-R106-15054.B
+    serial: ttyS0
+    arch_list:
+      - amd64
+
+  chromiumos-sarien:
+    rootfs_type: chromiumos
+    board: sarien
+    branch: release-R106-15054.B
+    serial: ttyS0
+    arch_list:
+      - amd64
+
+  chromiumos-volteer:
+    rootfs_type: chromiumos
+    board: volteer
+    branch: release-R106-15054.B
+    serial: ttyS0
+    arch_list:
+      - amd64
+
+  chromiumos-zork:
+    rootfs_type: chromiumos
+    board: zork
+    branch: release-R106-15054.B
+    serial: ttyS0
     arch_list:
       - amd64

--- a/config/core/rootfs-configs-chromeos.yaml
+++ b/config/core/rootfs-configs-chromeos.yaml
@@ -8,6 +8,7 @@ rootfs_configs:
     extra_packages:
       - bzip2
       - ca-certificates
+      - gdisk
       - parted
       - wget
       - xz-utils

--- a/config/core/rootfs-configs-chromeos.yaml
+++ b/config/core/rootfs-configs-chromeos.yaml
@@ -86,6 +86,14 @@ rootfs_configs:
     arch_list:
       - amd64
 
+  chromiumos-trogdor:
+    rootfs_type: chromiumos
+    board: trogdor
+    branch: release-R106-15054.B
+    serial: ttyMSM0
+    arch_list:
+      - arm64
+
   chromiumos-volteer:
     rootfs_type: chromiumos
     board: volteer

--- a/config/core/rootfs-configs-chromeos.yaml
+++ b/config/core/rootfs-configs-chromeos.yaml
@@ -22,6 +22,14 @@ rootfs_configs:
     arch_list:
       - amd64
 
+  chromiumos-coral:
+    rootfs_type: chromiumos
+    board: coral
+    branch: release-R100-14526.B
+    serial: ttyS2
+    arch_list:
+      - amd64
+
   chromiumos-grunt:
     rootfs_type: chromiumos
     board: grunt

--- a/config/core/rootfs-configs-chromeos.yaml
+++ b/config/core/rootfs-configs-chromeos.yaml
@@ -16,14 +16,14 @@ rootfs_configs:
   chromiumos-amd64-generic:
     rootfs_type: chromiumos
     board: amd64-generic
-    branch: release-R100-14526.B
+    branch: release-R102-14695.B
     arch_list:
       - amd64
 
   chromiumos-grunt:
     rootfs_type: chromiumos
     board: grunt
-    branch: release-R100-14526.B
+    branch: release-R102-14695.B
     serial: ttyS0
     arch_list:
       - amd64
@@ -31,7 +31,7 @@ rootfs_configs:
   chromiumos-hatch:
     rootfs_type: chromiumos
     board: hatch
-    branch: release-R100-14526.B
+    branch: release-R102-14695.B
     serial: ttyS0
     arch_list:
       - amd64
@@ -39,7 +39,7 @@ rootfs_configs:
   chromiumos-octopus:
     rootfs_type: chromiumos
     board: octopus
-    branch: release-R100-14526.B
+    branch: release-R102-14695.B
     serial: ttyS1
     arch_list:
       - amd64

--- a/config/core/rootfs-configs-chromeos.yaml
+++ b/config/core/rootfs-configs-chromeos.yaml
@@ -22,6 +22,22 @@ rootfs_configs:
     arch_list:
       - amd64
 
+  chromiumos-asurada:
+    rootfs_type: chromiumos
+    board: asurada
+    branch: release-R106-15054.B
+    serial: ttyS0
+    arch_list:
+      - arm64
+
+  chromiumos-cherry:
+    rootfs_type: chromiumos
+    board: cherry
+    branch: release-R106-15054.B
+    serial: ttyS0
+    arch_list:
+      - arm64
+
   chromiumos-coral:
     rootfs_type: chromiumos
     board: coral
@@ -38,6 +54,14 @@ rootfs_configs:
     arch_list:
       - amd64
 
+  chromiumos-geralt:
+    rootfs_type: chromiumos
+    board: geralt
+    branch: release-R106-15054.B
+    serial: ttyS0
+    arch_list:
+      - arm64
+
   chromiumos-grunt:
     rootfs_type: chromiumos
     board: grunt
@@ -53,6 +77,14 @@ rootfs_configs:
     serial: ttyS0
     arch_list:
       - amd64
+
+  chromiumos-jacuzzi:
+    rootfs_type: chromiumos
+    board: jacuzzi
+    branch: release-R106-15054.B
+    serial: ttyS0
+    arch_list:
+      - arm64
 
   chromiumos-nami:
     rootfs_type: chromiumos

--- a/config/core/rootfs-configs-chromeos.yaml
+++ b/config/core/rootfs-configs-chromeos.yaml
@@ -17,7 +17,7 @@ rootfs_configs:
   chromiumos-amd64-generic:
     rootfs_type: chromiumos
     board: amd64-generic
-    branch: release-R102-14695.B
+    branch: release-R106-15054.B
     serial: ttyS0
     arch_list:
       - amd64
@@ -25,7 +25,7 @@ rootfs_configs:
   chromiumos-coral:
     rootfs_type: chromiumos
     board: coral
-    branch: release-R100-14526.B
+    branch: release-R106-15054.B
     serial: ttyS2
     arch_list:
       - amd64
@@ -33,7 +33,7 @@ rootfs_configs:
   chromiumos-grunt:
     rootfs_type: chromiumos
     board: grunt
-    branch: release-R102-14695.B
+    branch: release-R106-15054.B
     serial: ttyS0
     arch_list:
       - amd64
@@ -41,7 +41,7 @@ rootfs_configs:
   chromiumos-hatch:
     rootfs_type: chromiumos
     board: hatch
-    branch: release-R102-14695.B
+    branch: release-R106-15054.B
     serial: ttyS0
     arch_list:
       - amd64
@@ -49,7 +49,7 @@ rootfs_configs:
   chromiumos-octopus:
     rootfs_type: chromiumos
     board: octopus
-    branch: release-R102-14695.B
+    branch: release-R106-15054.B
     serial: ttyS1
     arch_list:
       - amd64

--- a/config/core/rootfs-configs-chromeos.yaml
+++ b/config/core/rootfs-configs-chromeos.yaml
@@ -18,6 +18,7 @@ rootfs_configs:
     rootfs_type: chromiumos
     board: amd64-generic
     branch: release-R102-14695.B
+    serial: ttyS0
     arch_list:
       - amd64
 

--- a/config/core/rootfs-configs-chromeos.yaml
+++ b/config/core/rootfs-configs-chromeos.yaml
@@ -13,6 +13,7 @@ rootfs_configs:
       - wget
       - xz-utils
     test_overlay: "overlays/cros-flash"
+    script: "scripts/bullseye-cros-flash.sh"
 
   chromiumos-amd64-generic:
     rootfs_type: chromiumos

--- a/config/rootfs/chromiumos/cros-snapshot-release-R100-14526.B.xml
+++ b/config/rootfs/chromiumos/cros-snapshot-release-R100-14526.B.xml
@@ -1,0 +1,276 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <remote name="aosp" fetch="https://android.googlesource.com" review="https://android-review.googlesource.com">
+    <annotation name="public" value="true"/>
+  </remote>
+  <remote name="chromium" fetch="https://chromium.googlesource.com/" alias="cros">
+    <annotation name="public" value="true"/>
+  </remote>
+  <remote name="cros" fetch="https://chromium.googlesource.com" review="https://chromium-review.googlesource.com">
+    <annotation name="public" value="true"/>
+  </remote>
+  <remote name="pigweed" fetch="https://pigweed.googlesource.com" review="https://pigweed-review.googlesource.com">
+    <annotation name="public" value="true"/>
+  </remote>
+  
+  <default remote="cros" sync-j="8"/>
+  
+  <project name="aosp/platform/external/libchrome" path="src/aosp/external/libchrome" revision="913f66c91436f2cb1a86dc27184897c2e0ab522a" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="aosp/platform/external/libutf" path="src/aosp/external/libutf" revision="c17bb435be940edf1aff81469215bb6a071f3c38" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="aosp/platform/external/modp_b64" path="src/third_party/modp_b64" revision="269b6fb8401617b85e2dff7ae8a7b0f97613e2cd" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="aosp/platform/frameworks/ml" path="src/aosp/frameworks/ml" revision="4765642ab012f974fdd85d2e11fbf1d81096f20a" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="aosp/platform/frameworks/native" path="src/aosp/frameworks/native" revision="8300206169b81cf8f6600886bc1f5a86e62ace98" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="aosp/platform/hardware/interfaces/neuralnetworks" path="src/aosp/hardware/interfaces/neuralnetworks" revision="eee167fa829d108a5678624050425899b348a252" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="aosp/platform/system/core/base" path="src/aosp/system/core/base" revision="8cf6479cfd925657da51da04902a68dfe7e84632" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="aosp/platform/system/core/libbacktrace" path="src/aosp/system/core/libbacktrace" revision="d67ee5af5ee2790631aa4f7ca125d12c09840436" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="aosp/platform/system/core/libcutils" path="src/aosp/system/core/libcutils" revision="e50a8af67660544144c9e572d563c0c6ae8a8ddf" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="aosp/platform/system/core/liblog" path="src/aosp/system/core/liblog" revision="9cca7081cb7d158034bffec841f227af52cca401" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="aosp/platform/system/core/libsync" path="src/aosp/system/libsync" revision="2069472e9e66b3b7d6fa7800a1f91c0e9290b4c2" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="aosp/platform/system/core/libutils" path="src/aosp/system/core/libutils" revision="02110e5625e05439f6008a01ba40e812cf1c03df" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="aosp/platform/system/libbase" path="src/aosp/system/libbase" revision="2cba90a13babf861385364d191710eadab30a50d" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="aosp/platform/system/libfmq" path="src/aosp/system/libfmq" revision="88e224a8203eea9ed9fa38a0e4c0260ecd9b69e7" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="aosp/platform/system/libhidl" path="src/aosp/system/libhidl" revision="471609b486435ebb3b1136dfe24fca24a48c74ff" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="aosp/platform/system/logging" path="src/aosp/system/logging" revision="47a22f5a8ab194749f2e4faedff997dab344534f" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="aosp/platform/system/update_engine" path="src/aosp/system/update_engine" revision="aed89a07253db50c9d3aa0362d30f53be2b5dcee" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="apps/libapps" path="src/third_party/libapps" revision="22be6d354da6e20bb469eb88d99d6e1f68814772">
+    <annotation name="branch-mode" value="pin"/>
+  </project>
+  <project name="breakpad/breakpad" path="src/third_party/breakpad" revision="bc7ddae23425cee8999e4e8ed61f77a62f058cbf"/>
+  <project name="chromium/llvm-project/cfe/tools/clang-format" path="src/chromium/src/buildtools/clang_format/script" remote="chromium" revision="bb994c6f067340c1135eb43eed84f4b33cfa7397" groups="minilayout,buildtools,labtools"/>
+  <project name="chromium/src/buildtools" path="src/chromium/src/buildtools" remote="chromium" revision="5a8d487fffcb652600f34e7b562f715523d27fd4" groups="minilayout,buildtools,labtools"/>
+  <project name="chromium/src/components/policy" path="src/chromium/src/components/policy" remote="chromium" revision="f5d29089f7d094e30a86030f198f40357c97e195"/>
+  <project name="chromium/src/media/midi" path="src/chromium/src/media/midi" remote="chromium" revision="06a8cf268baf9530267c9581801b8f8749ec9312"/>
+  <project name="chromium/src/net/tools/testserver" path="src/chromium/src/net/tools/testserver" remote="chromium" revision="8599944a086c503a4e31a95e226e967f5db560f7"/>
+  <project name="chromium/src/third_party/Python-Markdown" path="src/chromium/src/third_party/Python-Markdown" remote="chromium" revision="872ba9e68a6c698ede103b32265c265c026b8fee"/>
+  <project name="chromium/src/third_party/private_membership" path="src/chromium/src/third_party/private_membership" remote="chromium" revision="7a4824c2eae90e729c8b24ab01d4a1a6e26cde98"/>
+  <project name="chromium/src/third_party/shell-encryption" path="src/chromium/src/third_party/shell-encryption" remote="chromium" revision="04a46b48f70713db831b32da1581437d587f4081"/>
+  <project name="chromium/src/third_party/tlslite" path="src/chromium/src/third_party/tlslite" remote="chromium" revision="05d9f22315757117685ad2f5265148f900f18034"/>
+  <project name="chromium/src/tools/md_browser" path="src/chromium/src/tools/md_browser" remote="chromium" revision="ac44704f23348283ef7ae6ddbfe95420b37c34dc"/>
+  <project name="chromium/tools/depot_tools" path="src/chromium/depot_tools" remote="chromium" revision="c49a7334d30256abc1fc1e56d79615a220028998" groups="minilayout,firmware,buildtools,labtools"/>
+  <project name="chromiumos/chromite" path="chromite" revision="ac12ce1bf057995af3217489177fe5284ce18bfe" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B" groups="minilayout,firmware,buildtools,chromeos-admin,labtools,sysmon,devserver,crosvm">
+    <copyfile src="AUTHORS" dest="AUTHORS"/>
+    <copyfile src="LICENSE" dest="LICENSE"/>
+  </project>
+  <project name="chromiumos/chromite" path="infra/chromite-HEAD" revision="09e95269498e195e7dc77e55d570d52a89a40416" upstream="refs/heads/main" dest-branch="refs/heads/main" groups="buildtools">
+    <annotation name="branch-mode" value="tot"/>
+  </project>
+  <project name="chromiumos/config" path="src/config" revision="fb0da5024ec0be028ec51724bf1158f0de2ac030" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B" groups="config,partner-config"/>
+  <project name="chromiumos/containers/cros-container-guest-tools" path="src/platform/container-guest-tools" revision="d51fa758a056ace683c4f717f45ad16ccc5cf1cd" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/docs" path="docs" revision="8ec863724eb251cea8cc7d222560f33ff6b0c9fc" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B" groups="crosvm"/>
+  <project name="chromiumos/graphyte" path="src/platform/graphyte" revision="f661990d0379f1030bdaa93c573ef4a50e9c6e66" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/infra/build/empty-project" path="src/platform/empty-project" revision="e8d0ce9c4326f0e57235f1acead1fcbc1ba2d0b9" groups="minilayout,firmware">
+    <annotation name="branch-mode" value="pin"/>
+  </project>
+  <project name="chromiumos/infra/go" path="infra/go" revision="6eadc22e734e94376e053926fb56729094b36adc" upstream="refs/heads/main" dest-branch="refs/heads/main" groups="chromeos-admin">
+    <annotation name="branch-mode" value="tot"/>
+  </project>
+  <project name="chromiumos/infra/lucifer" path="infra/lucifer" revision="12e9e6bde527c0bf97ff68c1d5f70385e15d1e58" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/infra/proto" path="chromite/infra/proto" revision="cb162db5357eabc34db12ba717a816928e376bbc" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/infra/proto" path="infra/proto" revision="d82dd2260ea7c39b4fb054f2e4246e4bdb4f1099" upstream="refs/heads/main" dest-branch="refs/heads/main">
+    <annotation name="branch-mode" value="tot"/>
+  </project>
+  <project name="chromiumos/infra/test_analyzer" path="infra/test_analyzer" revision="14119cc21c146544791fe387f64a4b809c4ea789" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/infra_virtualenv" path="infra_virtualenv" revision="cab8a95f2961561eb56a95d6f2bfc685686db75a" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B" groups="minilayout,firmware,buildtools,chromeos-admin,labtools,sysmon,devserver"/>
+  <project name="chromiumos/manifest" path="manifest" revision="bb6cc6b2c49bf1dd2b6fa555dd7c3ceeae5f3e9a" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/overlays/board-overlays" path="src/overlays" revision="d453b2c023dfdef014939b8ef1c5e1b3e6e14581" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B" groups="minilayout,firmware"/>
+  <project name="chromiumos/overlays/chromiumos-overlay" path="src/third_party/chromiumos-overlay" revision="0441831c7a9f6f7691ea52390f687b8628a7b3e1" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B" groups="minilayout,firmware,labtools" sync-c="true"/>
+  <project name="chromiumos/overlays/eclass-overlay" path="src/third_party/eclass-overlay" revision="84a12972136e7b2c1af4769c1443588fb65e1ded" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B" groups="minilayout,firmware,labtools"/>
+  <project name="chromiumos/overlays/portage-stable" path="src/third_party/portage-stable" revision="d72661e8338a7d166418df5156686639bed289cd" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B" groups="minilayout,firmware,labtools"/>
+  <project name="chromiumos/platform/assets" path="src/platform/assets" revision="8a2276f22f0678bee89b8ac6c46d9dd597c6d549" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/platform/audiotest" path="src/platform/audiotest" revision="a0a7ca5a07712549d445e0cb76070ea2cc3f47d6" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/platform/bisect-kit" path="src/platform/bisect-kit" revision="88f57ee8f4dfa029b02468f6dca6ba61880410aa" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/platform/bmpblk" path="src/platform/bmpblk" revision="31a5652b41878a805b35e7ded9734a20d3756743" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/platform/btsocket" path="src/platform/btsocket" revision="d68b83ccc4a645edeeeeaba39e8fe4e079a01aa2" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/platform/camera" path="src/platform/camera" revision="4417045de917bf984a3d4c518d22f4134883242c" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/platform/cbor" path="src/platform/cbor" revision="b88c63453b18ef3b6058377aee2cbb5152dda39b" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/platform/cfm-device-monitor" path="src/platform/cfm-device-monitor" revision="6753ddd2022996f1d131a8c45749db3c5f741a28" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/platform/chameleon" path="src/platform/chameleon" revision="eaca0ac2ee8ba008b2f32bd3b5528bda786ec4fa" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/platform/chromiumos-assets" path="src/platform/chromiumos-assets" revision="de6c118f21ef7130feb30d4b7f703cfe2ba2748f" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/platform/cobble" path="src/platform/cobble" revision="4ab43f1f86b7099b8ad75cf9615ea1fa155bbd7d" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/platform/croscomp" path="src/platform/croscomp" revision="dff13bf8763642be89bf67245a81224faf561543" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/platform/crostestutils" path="src/platform/crostestutils" revision="8e541e8b3e4c605cd0d33c346944dd6b84c619f7" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B" groups="minilayout,firmware,buildtools"/>
+  <project name="chromiumos/platform/crosutils" path="src/scripts" revision="74e9c40270a6e273353a0d6f89692f9687d67ed3" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B" groups="minilayout,firmware,buildtools,labtools"/>
+  <project name="chromiumos/platform/crosvm" path="src/platform/crosvm" revision="463ed0d101903b09d0325ed79c1382e21277b86a" upstream="refs/heads/release-R100-14526.B-chromeos" dest-branch="main" groups="crosvm"/>
+  <project name="chromiumos/platform/crosvm" path="src/platform/crosvm-upstream" revision="05bd01793d82c740f5c4bd0c19eb69423382cb56" upstream="refs/heads/release-R100-14526.B-main" dest-branch="refs/heads/release-R100-14526.B-main" groups="crosvm"/>
+  <project name="chromiumos/platform/depthcharge" path="src/platform/depthcharge" revision="9f382579b0c99be68c9831e78ed0eeab66f99c7d" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B" groups="firmware"/>
+  <project name="chromiumos/platform/dev-util" path="src/platform/dev" revision="cff0438366e871b3dde85af28a1ebeb769c40e66" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B" groups="minilayout,firmware,buildtools,devserver"/>
+  <project name="chromiumos/platform/drm-tests" path="src/platform/drm-tests" revision="f26e60d116f85eaa69313cbcb5c49e958179bb14" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/platform/ec" path="src/platform/cr50" revision="43fa560eb5c519f1a5afabe1fb2374943fe88013" upstream="refs/heads/release-R100-14526.B-cr50_stab" dest-branch="refs/heads/release-R100-14526.B-cr50_stab" groups="firmware"/>
+  <project name="chromiumos/platform/ec" path="src/platform/ec" revision="55680f70d2a1e61c193fc78ff1d51c7437803683" upstream="refs/heads/release-R100-14526.B-main" dest-branch="refs/heads/release-R100-14526.B-main" groups="firmware"/>
+  <project name="chromiumos/platform/ec" path="src/platform/ish" revision="252457d4b21f46889eebad61d4c0a65331919cec" upstream="refs/heads/release-R100-14526.B-ish" dest-branch="refs/heads/release-R100-14526.B-ish" groups="firmware"/>
+  <project name="chromiumos/platform/ec" path="src/platform/release-firmware/fpmcu-bloonchipper" revision="bc24e6634a3859fd9ce12b640535a7d584c06862" groups="firmware">
+    <annotation name="branch-mode" value="pin"/>
+  </project>
+  <project name="chromiumos/platform/ec" path="src/platform/release-firmware/fpmcu-dartmonkey" revision="aedc4fc907139dc5689f424c80cc37d6750b7404" groups="firmware">
+    <annotation name="branch-mode" value="pin"/>
+  </project>
+  <project name="chromiumos/platform/ec" path="src/platform/release-firmware/fpmcu-nami" revision="aedc4fc907139dc5689f424c80cc37d6750b7404" groups="firmware">
+    <annotation name="branch-mode" value="pin"/>
+  </project>
+  <project name="chromiumos/platform/ec" path="src/platform/release-firmware/fpmcu-nocturne" revision="aedc4fc907139dc5689f424c80cc37d6750b7404" groups="firmware">
+    <annotation name="branch-mode" value="pin"/>
+  </project>
+  <project name="chromiumos/platform/experimental" path="src/platform/experimental" revision="2927fce20adf74b0c9a32a61e3edff894221f283" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/platform/factory" path="src/platform/factory" revision="c63d64d130a170d5eb7dccaf3c3ca91d705d2703" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/platform/factory_installer" path="src/platform/factory_installer" revision="8f054aa54129ee964639798e76550cbc7b9d9ecf" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/platform/firmware" path="src/platform/firmware" revision="c4442ed129f3324dd53e11980b1c6e32ea44a849" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B" groups="firmware"/>
+  <project name="chromiumos/platform/frecon" path="src/platform/frecon" revision="96a42bb1f2f3601ac80dddb87c1d4357f4424fb0" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/platform/fw-testing-configs" path="src/platform/tast-tests/src/chromiumos/tast/remote/firmware/data/fw-testing-configs" revision="7a01213d5fdc415d99fe5060a0f06fccdcee018a" upstream="refs/heads/release-R100-14526.B-main" dest-branch="refs/heads/release-R100-14526.B-main" groups="buildtools,labtools,devserver,firmware"/>
+  <project name="chromiumos/platform/fw-testing-configs" path="src/third_party/autotest/files/server/cros/faft/fw-testing-configs" revision="7a01213d5fdc415d99fe5060a0f06fccdcee018a" upstream="refs/heads/release-R100-14526.B-main" dest-branch="refs/heads/release-R100-14526.B-main" groups="buildtools,labtools,devserver,firmware"/>
+  <project name="chromiumos/platform/gestures" path="src/platform/gestures" revision="c17140b9409584958b4916aa11d0ea396c731f25" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/platform/glbench" path="src/platform/glbench" revision="b80527734ad996fdf369af9fc3b171fe997f3858" upstream="refs/heads/release-R100-14526.B-main" dest-branch="refs/heads/release-R100-14526.B-main"/>
+  <project name="chromiumos/platform/go-seccomp" path="src/platform/go-seccomp" revision="9d14f8b297985ec80f05d14afd6378e3350e2c41" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/platform/graphics" path="src/platform/graphics" revision="ae720d277b95260ae39db81827af959115c74494" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/platform/hps-firmware" path="src/platform/hps-firmware2" revision="7b9fa0f4e85fe6eb4afd7d32508ea5a7508b39f9" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/platform/hps-firmware-images" path="src/platform/hps-firmware-images" revision="767ddd2e417ec3c9ea3f4820dfbd162c8eb363f9" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/platform/initramfs" path="src/platform/initramfs" revision="63f490c260245bb4a966d6a0797b67419c45737c" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/platform/inputcontrol" path="src/platform/inputcontrol" revision="6c9fd34b4a6231efc189c530e2f05d908b55185e" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/platform/jabra_vold" path="src/platform/jabra_vold" revision="233d517d2904912b207d273794b0ec5343e48010" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/platform/libevdev" path="src/platform/libevdev" revision="8d00f789df9bd4efce783a46f30d75d742d3e8d4" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/platform/libva-fake-driver" path="src/platform/libva-fake-driver" revision="7754dd6e00355bb0d7bb5f597b482b6d5ff5cab5" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/platform/lithium" path="src/platform/lithium" revision="1b54b0fa69bb183ed19945a79b72bc17145eafe4" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B" groups="firmware"/>
+  <project name="chromiumos/platform/microbenchmarks" path="src/platform/microbenchmarks" revision="beefcc767427751cf1343c1a944c5dbce7aabfa2" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/platform/minigbm" path="src/platform/minigbm" revision="0af104ca932cb1bdcad3e8d3805e1ed64472a362" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B" groups="crosvm"/>
+  <project name="chromiumos/platform/mosys" path="src/platform/mosys" revision="cc21161ca1dc8dd5cd8f729cff978e7a31f71aba" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/platform/mttools" path="src/platform/mttools" revision="957a434f10b7663bbafc85fb19afe1a3318c0a10" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/platform/pinweaver" path="src/platform/pinweaver" revision="fc39c8b509da8a45869d7c0e44b263dd631c6fb4" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/platform/rules_cros" path="src/platform/rules_cros" revision="5a39f17111e32c688c5149df8adc6ee75e249976" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/platform/tast" path="src/platform/tast" revision="f8752d432a9a0ad97c88abb8179680cc800c06f8" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/platform/tast-tests" path="src/platform/tast-tests" revision="801ace3c27ba96b1b2e5d4152fca4ba51d8e0df7" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/platform/tauto" path="src/platform/tauto" revision="2c088e3efa0b85bf21457b4df3f3b68d682d7a15" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/platform/touch_firmware_test" path="src/platform/touch_firmware_test" revision="2385881e6a19a904687ced52f27541b716e8168c" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B" groups="firmware"/>
+  <project name="chromiumos/platform/touch_updater" path="src/platform/touch_updater" revision="272b5a1465611b1b6029b9e4a729c1ca2756ba9f" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/platform/touchpad-tests" path="src/platform/touchpad-tests" revision="4c32bef9592024fe76fb0b8c913add3b1421e2d6" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/platform/tpm" path="src/third_party/tpm" revision="421593a8cea1083288d5d047b0c43f85c92fe069" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B" groups="firmware"/>
+  <project name="chromiumos/platform/tpm_lite" path="src/platform/tpm_lite" revision="dd6ae9f3a223c0a8a89a2e4c10600f7700354a53" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/platform/tremplin" path="src/platform/tremplin" revision="df7c7ad42fa9ed6506d441e3a2c941523496ef44" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/platform/usi-test" path="src/platform/usi-test" revision="ca7b4b66c18c97e1d7e21b36a9c76239ea0530ef" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/platform/vboot_reference" path="src/platform/vboot_reference" revision="e35fb64df248c030d4aea1768a7aec68766b3e0c" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B" groups="firmware,buildtools"/>
+  <project name="chromiumos/platform/vkbench" path="src/platform/vkbench" revision="96811b97cb9e532d6149f2c0bd5c18987cef3eef" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/platform/vpd" path="src/platform/vpd" revision="21ac829a3c671e9728ef6b68a049ad180aa9a898" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/platform/xorg-conf" path="src/platform/xorg-conf" revision="faafb4710d233447fd90f1f31f92da227bb511c0" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/platform2" path="src/platform2" revision="36427938c8f3657840329b3bdd1e26ab82a0042a" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B" groups="crosvm"/>
+  <project name="chromiumos/project" path="src/project_public" revision="5f93f0b583e5cc6e36c9aa14b882ba0d3605679c" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B" groups="partner-config"/>
+  <project name="chromiumos/repohooks" path="src/repohooks" revision="bf40beef846e8af5f2df37c66438e4cc46bca12b" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B" groups="minilayout,firmware,buildtools,labtools,crosvm"/>
+  <project name="chromiumos/third_party/Wi-FiTestSuite-Linux-DUT" path="src/third_party/Wi-FiTestSuite-Linux-DUT" revision="afe5b18c1b33f03169779851369c8c4ab0bb941d" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/third_party/adhd" path="src/third_party/adhd" revision="ea514445577d029afe2fd4fe06e5ed4a6b4075b5" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B" groups="crosvm"/>
+  <project name="chromiumos/third_party/apitrace" path="src/third_party/apitrace" revision="fb01568634eb35fc21b24ca6a48acaa6b0dd3708" upstream="refs/heads/release-R100-14526.B-master" dest-branch="refs/heads/release-R100-14526.B-master"/>
+  <project name="chromiumos/third_party/arm-trusted-firmware" path="src/third_party/arm-trusted-firmware" revision="0586c41b3f2d52aae847b7212e7b0c7e19197ea2" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/third_party/atrusctl" path="src/third_party/atrusctl" revision="4f1d81ecfa86ae7570f951fe6eaac9ab2c1290d7" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/third_party/autotest" path="src/third_party/autotest/files" revision="f6d8c0cbc34feea65ffa82be20ba459d4f160f8e" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B" groups="buildtools,labtools,devserver"/>
+  <project name="chromiumos/third_party/aver-updater" path="src/third_party/aver-updater" revision="6418ac5d86c720d234f961513021a5ff0a2bf3d8" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/third_party/bluez" path="src/third_party/bluez/current" revision="c1188899c4b2101e10a44304e05d9991a6d84eea" upstream="refs/heads/release-R100-14526.B-chromeos-5.54" dest-branch="refs/heads/release-R100-14526.B-chromeos-5.54"/>
+  <project name="chromiumos/third_party/bluez" path="src/third_party/bluez/next" revision="c1188899c4b2101e10a44304e05d9991a6d84eea" upstream="refs/heads/release-R100-14526.B-chromeos-5.54" dest-branch="refs/heads/release-R100-14526.B-chromeos-5.54"/>
+  <project name="chromiumos/third_party/bluez" path="src/third_party/bluez/upstream" revision="ec8c8f22efb66ccae533fbd55a236570ffcf756c">
+    <annotation name="branch-mode" value="pin"/>
+  </project>
+  <project name="chromiumos/third_party/bootstub" path="src/third_party/bootstub" revision="076cb8e624d2f9d8ab75fc07f614e3c1288e0b2e" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B" groups="firmware"/>
+  <project name="chromiumos/third_party/cbootimage" path="src/third_party/cbootimage" revision="b7d5b2d6a6dd05874d86ee900ff441d261f9034c" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B" groups="firmware"/>
+  <project name="chromiumos/third_party/chre" path="src/third_party/chre" revision="af3cf9f05f773e72987b8e24fb1dcfef64e30c8a" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/third_party/clspv" path="src/third_party/clspv" revision="b8f94af8fd3d95770fdb5b90f387786d8d15c2fb" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/third_party/clvk" path="src/third_party/clvk" revision="865ae225a630bfbdc3e9eae44999cd19bef0f337" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/third_party/coreboot" path="src/third_party/coreboot" revision="382d317702daab8e64e9082ffec7c5cdfbbef896" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B" groups="firmware"/>
+  <project name="chromiumos/third_party/coreboot/amd_blobs" path="src/third_party/coreboot/3rdparty/amd_blobs" revision="b13bd7f3d5a7c91a841fa9766954684849fc6593" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B" groups="firmware"/>
+  <project name="chromiumos/third_party/coreboot/blobs" path="src/third_party/coreboot/3rdparty/blobs" revision="7b5d641c028c3b46be8478ac6eb73e853adc08b7" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B" groups="firmware"/>
+  <project name="chromiumos/third_party/coreboot/intel-microcode" path="src/third_party/coreboot/3rdparty/intel-microcode" revision="ee319ae7bc59e88b60142f40a9ec1b46656de4db" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B" groups="firmware"/>
+  <project name="chromiumos/third_party/coreboot/qc_blobs" path="src/third_party/coreboot/3rdparty/qc_blobs" revision="9ab0f0b71c25aa8414e72040bad6fe12b0ccb3f3" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B" groups="firmware"/>
+  <project name="chromiumos/third_party/cros-adapta" path="src/third_party/cros-adapta" revision="eb6d8c1832b9181926df107faf41a80887fd982c" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/third_party/cryptoc" path="src/third_party/cryptoc" revision="92221d4688ed01cc361f01d650b82bf7e28078b2" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B" groups="firmware"/>
+  <project name="chromiumos/third_party/cups" path="src/third_party/cups" revision="88d6289b3722e507a8504739f67c44919b165410" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/third_party/daisydog" path="src/third_party/daisydog" revision="4b0c966fb6a35eabd6f06633a5c48ecff27ce2a5" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/third_party/edk2" path="src/third_party/amd-firmware/binarypi/picasso-edk2" revision="e2fc5e5879135d2c7e638a83ca066b2a08e134d5" upstream="refs/heads/release-R100-14526.B-pco" dest-branch="refs/heads/release-R100-14526.B-pco" groups="firmware"/>
+  <project name="chromiumos/third_party/edk2" path="src/third_party/edk2" revision="8523e9c995e7204e1067c1660ac04177932d4b1b" upstream="refs/heads/release-R100-14526.B-chromeos-2017.08" dest-branch="refs/heads/release-R100-14526.B-chromeos-2017.08" groups="firmware"/>
+  <project name="chromiumos/third_party/edk2" path="src/third_party/fsp/cml/edk2/branch1" revision="4de539eb3f1bcc304ac2ea88c3a8d4b5cc76a5d6" upstream="refs/heads/release-R100-14526.B-chromeos-cml-branch1" dest-branch="refs/heads/release-R100-14526.B-chromeos-cml-branch1" groups="firmware"/>
+  <project name="chromiumos/third_party/edk2" path="src/third_party/fsp/cnl/edk2" revision="995dede2362e4947c91f631069444552a1d2eeff" upstream="refs/heads/release-R100-14526.B-chromeos-cnl" dest-branch="refs/heads/release-R100-14526.B-chromeos-cnl" groups="firmware"/>
+  <project name="chromiumos/third_party/edk2" path="src/third_party/fsp/glk/edk2" revision="f84e90881271300af73761bbd6a6fa8b8f82c266" upstream="refs/heads/release-R100-14526.B-chromeos-glk" dest-branch="refs/heads/release-R100-14526.B-chromeos-glk" groups="firmware"/>
+  <project name="chromiumos/third_party/em100" path="src/third_party/em100" revision="62df8620590cb363f6c283a84ac8c1cdd80b29ce" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B" groups="firmware"/>
+  <project name="chromiumos/third_party/fastrpc" path="src/third_party/fastrpc" revision="c2d1cdc0fb781ee673077c5d4b243eb239c73bb5" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/third_party/flashmap" path="src/third_party/flashmap" revision="9c71c8331ad52a11d29496ffb10cbdb1a51e2ccb" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B" groups="firmware"/>
+  <project name="chromiumos/third_party/flashrom" path="src/third_party/flashrom" revision="ab818f75712d7c01aa6e74a96a39a1e45930381a" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B" groups="firmware"/>
+  <project name="chromiumos/third_party/fwupd" path="src/third_party/fwupd" revision="6c372a7e7175b091f35446bcd15a94d78f56554e" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/third_party/hdctools" path="src/third_party/hdctools" revision="bdb3bfd437909b040a26aac9c8e22437737b7a56" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B" groups="labtools"/>
+  <project name="chromiumos/third_party/hostap" path="src/third_party/wpa_supplicant" revision="c297db6ffd38d6694fe5f8b04b55aa74e00e9c77" upstream="refs/heads/release-R100-14526.B-master" dest-branch="refs/heads/release-R100-14526.B-master"/>
+  <project name="chromiumos/third_party/hostap" path="src/third_party/wpa_supplicant-cros/current" revision="388d7931d3e5adaf154a52a7df2f15560af065ab" upstream="refs/heads/release-R100-14526.B-wpa_supplicant-2.9.1" dest-branch="refs/heads/release-R100-14526.B-wpa_supplicant-2.9.1"/>
+  <project name="chromiumos/third_party/hostap" path="src/third_party/wpa_supplicant-cros/next" revision="388d7931d3e5adaf154a52a7df2f15560af065ab" upstream="refs/heads/release-R100-14526.B-wpa_supplicant-2.9.1" dest-branch="refs/heads/release-R100-14526.B-wpa_supplicant-2.9.1"/>
+  <project name="chromiumos/third_party/huddly-updater" path="src/third_party/huddly-updater" revision="ef31fc0592da44084f53ccde05b7ec2b14639b27" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/third_party/igt-gpu-tools" path="src/third_party/igt-gpu-tools" revision="ef0df2fbe5847fe5c4426b8a86a0b101588d0586" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/third_party/intel-wifi-fw-dump" path="src/third_party/intel-wifi-fw-dump" revision="c37a35ed64538beeb8240c19db85bce29ef6e534" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/third_party/kernel" path="src/third_party/kernel/v4.4" revision="18510245cdbadb494d55ba6df30ed16221b13c4a" upstream="refs/heads/release-R100-14526.B-chromeos-4.4" dest-branch="refs/heads/release-R100-14526.B-chromeos-4.4"/>
+  <project name="chromiumos/third_party/kernel" path="src/third_party/kernel/v4.14" revision="1d3bb728009a1240a343c5e27757fe6433fe32e8" upstream="refs/heads/release-R100-14526.B-chromeos-4.14" dest-branch="refs/heads/release-R100-14526.B-chromeos-4.14"/>
+  <project name="chromiumos/third_party/kernel" path="src/third_party/kernel/v4.19" revision="f06fecba26857c67cff9ba2268e5c60237c114f5" upstream="refs/heads/release-R100-14526.B-chromeos-4.19" dest-branch="refs/heads/release-R100-14526.B-chromeos-4.19"/>
+  <project name="chromiumos/third_party/kernel" path="src/third_party/kernel/v5.4" revision="44152654f29b96800c7f78e55696c638f779a546" upstream="refs/heads/release-R100-14526.B-chromeos-5.4" dest-branch="refs/heads/release-R100-14526.B-chromeos-5.4"/>
+  <project name="chromiumos/third_party/kernel" path="src/third_party/kernel/v5.4-arcvm" revision="eab5110be12c10dcc78905cc569e26b0847b90b2" upstream="refs/heads/release-R100-14526.B-chromeos-5.4-arcvm" dest-branch="refs/heads/release-R100-14526.B-chromeos-5.4-arcvm"/>
+  <project name="chromiumos/third_party/kernel" path="src/third_party/kernel/v5.4-manatee" revision="b0fcb811fd9c0bee9feadccfda27ff80049a6534" upstream="refs/heads/release-R100-14526.B-chromeos-5.4-manatee" dest-branch="refs/heads/release-R100-14526.B-chromeos-5.4-manatee"/>
+  <project name="chromiumos/third_party/kernel" path="src/third_party/kernel/v5.10" revision="ede4ccb2bf53f43a87b6b0cfb898e6d31469199f" upstream="refs/heads/release-R100-14526.B-chromeos-5.10" dest-branch="refs/heads/release-R100-14526.B-chromeos-5.10"/>
+  <project name="chromiumos/third_party/kernel" path="src/third_party/kernel/v5.10-arcvm" revision="a75aece66dd19d8900b64b041b5053faebe85945" upstream="refs/heads/release-R100-14526.B-chromeos-5.10-arcvm" dest-branch="refs/heads/release-R100-14526.B-chromeos-5.10-arcvm"/>
+  <project name="chromiumos/third_party/kernel" path="src/third_party/kernel/v5.10-manatee" revision="8f4fef06ddf9197f765a17726e759c87a01dd889" upstream="refs/heads/release-R100-14526.B-chromeos-5.10-manatee" dest-branch="refs/heads/release-R100-14526.B-chromeos-5.10-manatee"/>
+  <project name="chromiumos/third_party/kernel" path="src/third_party/kernel/v5.15" revision="5973ab67e1b826d71dfa9cf44e060a410891e18c" upstream="refs/heads/release-R100-14526.B-chromeos-5.15" dest-branch="refs/heads/release-R100-14526.B-chromeos-5.15"/>
+  <project name="chromiumos/third_party/khronos" path="src/third_party/khronos" revision="c9d952582b74f9609bf68e0402856a2fc1e536c0" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/third_party/labpack" path="src/third_party/labpack/files" revision="17091ae74f32731730f95d6800e45900abdd3e39" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B" groups="labtools"/>
+  <project name="chromiumos/third_party/lexmark-fax-pnh" path="src/third_party/lexmark-fax-pnh" revision="f131d8f851366e6a2f8e8fa8f3042285d021d6c6" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/third_party/libcamera" path="src/third_party/libcamera" revision="039a6a02d019d0e06a5b236bfe99c4444e05fe8d" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/third_party/libdrm" path="src/third_party/libdrm" revision="728dfa9dbeeb013e5a26c24f4372a16eace99c5e" upstream="refs/heads/release-R100-14526.B-master" dest-branch="refs/heads/release-R100-14526.B-master"/>
+  <project name="chromiumos/third_party/libiio" path="src/third_party/libiio" revision="213eca340c157b96232242da15539e12efb2d5c9" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/third_party/libmbim" path="src/third_party/libmbim" revision="cabfa3546d5c74a0db6b35b97a14fd2aae80e8ef" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/third_party/libqmi" path="src/third_party/libqmi" revision="5070aa395e69e09fec182f93dffef321dd0379d4" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/third_party/libqrtr" path="src/third_party/libqrtr" revision="ba87335b33afcc0c1e0860ed41d0a98abc804184" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/third_party/libqrtr-glib" path="src/third_party/libqrtr-glib" revision="b19fd9966e5bdc7aaa03c1cc1035104809969186" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/third_party/libsigrok" path="src/third_party/libsigrok" revision="199fe31115c76231746f5953271795d58679561c" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/third_party/libsigrok-cli" path="src/third_party/sigrok-cli" revision="c9edfa218e5a5972531b6f4a3ece8d33a44ae1b5" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/third_party/libsigrokdecode" path="src/third_party/libsigrokdecode" revision="3279c2825684c7009775b731d0a9e37815778282" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/third_party/libtextclassifier" path="src/third_party/libtextclassifier" revision="01652c17e116baa8ebd7083e8cbc3dede513ac9e" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/third_party/libv4lplugins" path="src/third_party/libv4lplugins" revision="e88945fc2b6b02f37cc1dfc77cde2312787cb0fb" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/third_party/linux-firmware" path="src/third_party/linux-firmware" revision="166d98f503d2fa563008e97bee443a443b14d5cf" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/third_party/logitech-updater" path="src/third_party/logitech-updater" revision="dcb7e7f86dce2f535ac87eecfe17c48575ded9f1" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/third_party/marvell" path="src/third_party/marvell" revision="a1da785c038730d7d900415945688f6fb76175f4" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/third_party/mesa" path="src/third_party/mesa" revision="bc6380259641e6f23e4daefb0268c5f2533be24d" upstream="refs/heads/release-R100-14526.B-upstream-main" dest-branch="refs/heads/release-R100-14526.B-upstream-main"/>
+  <project name="chromiumos/third_party/mesa" path="src/third_party/mesa-amd" revision="c12e1cb2a45ae586f4db37ba5963163b6ae48e48" upstream="refs/heads/release-R100-14526.B-chromeos-amd" dest-branch="refs/heads/release-R100-14526.B-chromeos-amd"/>
+  <project name="chromiumos/third_party/mesa" path="src/third_party/mesa-debian" revision="c36b89b82bcd270e1f9ee7d0824c9e265a39e95b" upstream="refs/heads/release-R100-14526.B-debian" dest-branch="refs/heads/release-R100-14526.B-debian"/>
+  <project name="chromiumos/third_party/mesa" path="src/third_party/mesa-freedreno" revision="23ea7fdb767626397486b342994c65325418b47b" upstream="refs/heads/release-R100-14526.B-chromeos-freedreno" dest-branch="refs/heads/release-R100-14526.B-chromeos-freedreno"/>
+  <project name="chromiumos/third_party/mesa" path="src/third_party/mesa-img" revision="2e7833ad916c493969d00871cdf56db4407b80eb" upstream="refs/heads/release-R100-14526.B-mesa-19.0" dest-branch="refs/heads/release-R100-14526.B-mesa-19.0"/>
+  <project name="chromiumos/third_party/mesa" path="src/third_party/mesa-iris" revision="c5c94598aeb8403a098583ccaa5e44bbca65ba84" upstream="refs/heads/release-R100-14526.B-chromeos-iris" dest-branch="refs/heads/release-R100-14526.B-chromeos-iris"/>
+  <project name="chromiumos/third_party/mesa" path="src/third_party/mesa-reven" revision="2bcb6c3b3e6b1efc97c3219fb994b7e164650a46" upstream="refs/heads/release-R100-14526.B-chromeos-reven" dest-branch="refs/heads/release-R100-14526.B-chromeos-reven"/>
+  <project name="chromiumos/third_party/mimo-updater" path="src/third_party/mimo-updater" revision="fb448bbd2986c743f3c37dbc784ae972e24b1a23" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/third_party/mmc-utils" path="src/third_party/mmc-utils" revision="7be960e2b84b5dfcbec44d3b722fb02d16b9eaf1" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/third_party/modemmanager-next" path="src/third_party/modemmanager-next" revision="d3d19613ae118e4980be4125a8d8c4bb7682f09c" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/third_party/novatek-tcon-fw-update-tool" path="src/third_party/novatek-tcon-fw-update-tool" revision="a78b7b0ba128471af835e44dc97698d39fd89bbf" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/third_party/poly-updater" path="src/third_party/poly-updater" revision="87ad2edeea039892515f68c948bc2b8f94999553" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/third_party/portage_tool" path="src/third_party/portage_tool" revision="dd1033474678f08f981e53afb24221654c1f8ff3" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/third_party/pyelftools" path="chromite/third_party/pyelftools" revision="6fec9f599bef566fe8f6f6ca6c2102508b664792" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B" groups="minilayout,firmware,buildtools"/>
+  <project name="chromiumos/third_party/qemu" path="src/third_party/qemu" revision="fdd76fecdde1ad444ff4deb7f1c4f7e4a1ef97d6" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/third_party/rootdev" path="src/third_party/rootdev" revision="b2f37be7c25bc83b76f1b7063a4ef38b824dc4ef" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/third_party/rust-vmm/vhost" path="src/third_party/rust-vmm/vhost" revision="7c95b4a2c1e378f7328d8bc0510bbb6998f54581" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B" groups="crosvm"/>
+  <project name="chromiumos/third_party/seabios" path="src/third_party/seabios" revision="27b56c6e94fe37e9308392fefd25ba641d8be496" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B" groups="firmware"/>
+  <project name="chromiumos/third_party/shellcheck" path="src/third_party/shellcheck" revision="ed8e64b2a311489fe9854e56d2f61fa67b62eee7" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/third_party/sis-updater" path="src/third_party/sis-updater" revision="0e41acf19950b8c60d1e0c46ff7b64a24c51dea1" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/third_party/sound-open-firmware" path="src/third_party/sound-open-firmware" revision="35691bd4813b901c78ab938a4ec8bcc7fcb7f35f" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/third_party/svunit" path="src/third_party/svunit" revision="76ffd92958212a8e427a8eb6d24956df6ec19dbe" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/third_party/sysbios" path="src/third_party/sysbios" revision="33e1db34b8162de72a5e9bbbc44e6bce38978396" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B" groups="firmware"/>
+  <project name="chromiumos/third_party/systemd" path="src/third_party/systemd" revision="6b08fdfc2c5ca9adb0e443e19b40a910c777de64" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/third_party/tlsdate" path="src/third_party/tlsdate" revision="677864213888d39b3326ad4c6a3dcb9560c44ca4" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/third_party/toolchain-utils" path="src/third_party/toolchain-utils" revision="ca96e26e10db5611214a0c621feddeb9d5872456" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B" groups="minilayout"/>
+  <project name="chromiumos/third_party/tpm2" path="src/third_party/tpm2" revision="a77bf0779e1005c9fd840955193ac7257d67bc05" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B" groups="firmware,crosvm"/>
+  <project name="chromiumos/third_party/trousers" path="src/third_party/trousers" revision="989e2337c1cd9de5b72c84cb06025661881b86f6" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/third_party/u-boot" path="src/third_party/u-boot/files" revision="39ce6d27ad29fd324793a8d0c7db8ae712cc027c" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/third_party/upstart" path="src/third_party/upstart" revision="d053bcfed2a3e98d6f74f51e9f1f847f8ba5b79d" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/third_party/virglrenderer" path="src/third_party/virglrenderer" revision="faa194f8f64d386d47e4c01957130f11a8fae58c" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B" groups="crosvm"/>
+  <project name="chromiumos/third_party/virtual-usb-printer" path="src/third_party/virtual-usb-printer" revision="697fd1a26dca19ca7180b3ce20a25cd58f3fdabf" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/third_party/webrtc-apm" path="src/third_party/webrtc-apm" revision="01ea9cb620e89c5858c3f05501b2bd55061bfcee" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B"/>
+  <project name="chromiumos/third_party/zephyr" path="src/third_party/zephyr/main" revision="a53bff96f96fff0dc9e1ea9b630ed5b86b78d73f" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B" groups="firmware,zephyr"/>
+  <project name="chromiumos/third_party/zephyr/cmsis" path="src/third_party/zephyr/cmsis" revision="0eef4c5574a033a5584a0711d332b41e01ab50c2" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B" groups="firmware,zephyr"/>
+  <project name="chromiumos/third_party/zephyr/hal_stm32" path="src/third_party/zephyr/hal_stm32" revision="bfa3b34f638375b505004095ea3e7a60b3cc7788" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B" groups="firmware,zephyr"/>
+  <project name="chromiumos/third_party/zephyr/nanopb" path="src/third_party/zephyr/nanopb" revision="8eb6edf6e05c2328605ad351da806fa37cefc068" upstream="refs/heads/release-R100-14526.B" dest-branch="refs/heads/release-R100-14526.B" groups="firmware,zephyr"/>
+  <project name="external/git.kernel.org/fs/xfs/xfstests-dev" path="src/third_party/xfstests" revision="b91862aa4c950e0157f241136207e3827cee407e"/>
+  <project name="infra/luci/client-py" path="chromite/third_party/swarming.client" remote="chromium" revision="34b20305c7a69eb89e1abd5e2a94708db999f0a9" groups="buildtools,chromeos-admin,firmware,labtools,minilayout"/>
+  <project name="linux-syscall-support" path="src/third_party/breakpad/src/third_party/lss" revision="e1e7b0ad8ee99a875b272c8e33e308472e897660"/>
+  <project name="pigweed/pigweed" path="src/third_party/pigweed" remote="pigweed" revision="04f7e41b69b55a7a5c887a0204ac7e28f77c3308"/>
+  <project name="platform/external/bsdiff" path="src/aosp/external/bsdiff" remote="aosp" revision="eeb219b8d2f9f10ce00149f4e9ee0fb34c41bcd7"/>
+  <project name="platform/external/marisa-trie" path="src/aosp/external/marisa-trie" remote="aosp" revision="0ba11cd54d07ed323855b76403cd843b3bf90089">
+    <annotation name="branch-mode" value="pin"/>
+  </project>
+  <project name="platform/external/minijail" path="src/aosp/external/minijail" remote="aosp" revision="138761fdcc8c2c074bef7700e39b47b44cc5bcc0" groups="crosvm"/>
+  <project name="platform/external/puffin" path="src/aosp/external/puffin" remote="aosp" revision="7b3e4b308362b1c9364e549be8e109c35f028904"/>
+  <project name="platform/system/keymaster" path="src/aosp/system/keymaster" remote="aosp" revision="49dfc58d6c4c66f5d0b0d06f0161da4e602a1293"/>
+  
+  <repo-hooks in-project="chromiumos/repohooks" enabled-list="pre-upload"/>
+</manifest>

--- a/config/rootfs/chromiumos/cros-snapshot-release-R102-14695.B.xml
+++ b/config/rootfs/chromiumos/cros-snapshot-release-R102-14695.B.xml
@@ -1,0 +1,278 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <remote name="aosp" fetch="https://android.googlesource.com" review="https://android-review.googlesource.com">
+    <annotation name="public" value="true"/>
+  </remote>
+  <remote name="chromium" fetch="https://chromium.googlesource.com/" alias="cros">
+    <annotation name="public" value="true"/>
+  </remote>
+  <remote name="cros" fetch="https://chromium.googlesource.com" review="https://chromium-review.googlesource.com">
+    <annotation name="public" value="true"/>
+  </remote>
+  
+  <default remote="cros" sync-j="8"/>
+  
+  <project name="aosp/platform/external/libchrome" path="src/aosp/external/libchrome" revision="8d8ed5f6840751f2d798060a0b981e1c8f7cc174" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="aosp/platform/external/libutf" path="src/aosp/external/libutf" revision="c17bb435be940edf1aff81469215bb6a071f3c38" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="aosp/platform/external/modp_b64" path="src/third_party/modp_b64" revision="269b6fb8401617b85e2dff7ae8a7b0f97613e2cd" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="aosp/platform/frameworks/ml" path="src/aosp/frameworks/ml" revision="bb3dbed95e2471d1838a8ded41b33e3cf13179e9" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="aosp/platform/frameworks/native" path="src/aosp/frameworks/native" revision="5e9a89d06c41edf5cf43da8acf5f26ed104887e6" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="aosp/platform/hardware/interfaces/neuralnetworks" path="src/aosp/hardware/interfaces/neuralnetworks" revision="ffe5b791c0404184b88a5f8ae86007c106a62fb1" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="aosp/platform/system/core/base" path="src/aosp/system/core/base" revision="8cf6479cfd925657da51da04902a68dfe7e84632" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="aosp/platform/system/core/libbacktrace" path="src/aosp/system/core/libbacktrace" revision="d67ee5af5ee2790631aa4f7ca125d12c09840436" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="aosp/platform/system/core/libcutils" path="src/aosp/system/core/libcutils" revision="dcc518ef32993d0171d0849bd3677c9d0948f8bb" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="aosp/platform/system/core/liblog" path="src/aosp/system/core/liblog" revision="9cca7081cb7d158034bffec841f227af52cca401" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="aosp/platform/system/core/libsync" path="src/aosp/system/libsync" revision="074e053f159602aa7558cfb2ae2f3c67878d90e0" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="aosp/platform/system/core/libutils" path="src/aosp/system/core/libutils" revision="6518555263253e9fdf7e37d26866cbe75bc11e97" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="aosp/platform/system/libbase" path="src/aosp/system/libbase" revision="9537e373c71c26c5495be60d267dff5eb88b180f" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="aosp/platform/system/libfmq" path="src/aosp/system/libfmq" revision="1d72513a44e4cb856c1cc70f95f9b1e88b1b4a78" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="aosp/platform/system/libhidl" path="src/aosp/system/libhidl" revision="49005468bfa1d0c3ed69d8a61b8d0fbaafd1e836" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="aosp/platform/system/logging" path="src/aosp/system/logging" revision="2e909ccdf779939e5caa5ab52851f38f22037ae9" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="aosp/platform/system/update_engine" path="src/aosp/system/update_engine" revision="12ae96dac56e23c438a8bb057e87429baa8b0782" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="apps/libapps" path="src/third_party/libapps" revision="e79a5fa3aa3f6be8a28b4db7b7e9bd3415020d23">
+    <annotation name="branch-mode" value="pin"/>
+  </project>
+  <project name="breakpad/breakpad" path="src/third_party/breakpad" revision="bc7ddae23425cee8999e4e8ed61f77a62f058cbf"/>
+  <project name="chromium/llvm-project/cfe/tools/clang-format" path="src/chromium/src/buildtools/clang_format/script" remote="chromium" revision="bb994c6f067340c1135eb43eed84f4b33cfa7397" groups="minilayout,buildtools,labtools"/>
+  <project name="chromium/src/buildtools" path="src/chromium/src/buildtools" remote="chromium" revision="c2e4795660817c2776dbabd778b92ed58c074032" groups="minilayout,buildtools,labtools"/>
+  <project name="chromium/src/components/policy" path="src/chromium/src/components/policy" remote="chromium" revision="a39a7a0864a66ffba36e2c3d0fe39211f7531e01"/>
+  <project name="chromium/src/media/midi" path="src/chromium/src/media/midi" remote="chromium" revision="77cc36d72b2a07ce056c6dc57290b2e094db7931"/>
+  <project name="chromium/src/net/tools/testserver" path="src/chromium/src/net/tools/testserver" remote="chromium" revision="69ef0407e96d24900081ca114cabdfc891f40d2d"/>
+  <project name="chromium/src/third_party/Python-Markdown" path="src/chromium/src/third_party/Python-Markdown" remote="chromium" revision="872ba9e68a6c698ede103b32265c265c026b8fee"/>
+  <project name="chromium/src/third_party/private_membership" path="src/chromium/src/third_party/private_membership" remote="chromium" revision="453f9e23d3f3269cba421bb618d14bd8c7e97182"/>
+  <project name="chromium/src/third_party/shell-encryption" path="src/chromium/src/third_party/shell-encryption" remote="chromium" revision="04a46b48f70713db831b32da1581437d587f4081"/>
+  <project name="chromium/src/third_party/tlslite" path="src/chromium/src/third_party/tlslite" remote="chromium" revision="05d9f22315757117685ad2f5265148f900f18034"/>
+  <project name="chromium/src/tools/md_browser" path="src/chromium/src/tools/md_browser" remote="chromium" revision="ac44704f23348283ef7ae6ddbfe95420b37c34dc"/>
+  <project name="chromium/tools/depot_tools" path="src/chromium/depot_tools" remote="chromium" revision="62396c5a83595ec985578fe3e163fde931062615" groups="minilayout,firmware,buildtools,labtools"/>
+  <project name="chromiumos/chromite" path="chromite" revision="15163bfb1b2fe1b15478a6081bcaa646558d00ee" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B" groups="minilayout,firmware,buildtools,chromeos-admin,labtools,sysmon,devserver,crosvm">
+    <copyfile src="AUTHORS" dest="AUTHORS"/>
+    <copyfile src="LICENSE" dest="LICENSE"/>
+  </project>
+  <project name="chromiumos/chromite" path="infra/chromite-HEAD" revision="3c37f6d252e86dba127262873a6c87688b456ad8" upstream="refs/heads/main" dest-branch="refs/heads/main" groups="buildtools">
+    <annotation name="branch-mode" value="tot"/>
+  </project>
+  <project name="chromiumos/config" path="src/config" revision="1e5e7775f593ec188d2a85e7221260fd06c4c122" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B" groups="config,partner-config"/>
+  <project name="chromiumos/containers/cros-container-guest-tools" path="src/platform/container-guest-tools" revision="d071402673fcfdc6a9b4c0eaeb059b515fde2adb" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/docs" path="docs" revision="f27f52678831f0fb2f9f61da324432e67bbc2079" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B" groups="crosvm"/>
+  <project name="chromiumos/graphyte" path="src/platform/graphyte" revision="f661990d0379f1030bdaa93c573ef4a50e9c6e66" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/infra/build/empty-project" path="src/platform/empty-project" revision="e8d0ce9c4326f0e57235f1acead1fcbc1ba2d0b9" groups="minilayout,firmware">
+    <annotation name="branch-mode" value="pin"/>
+  </project>
+  <project name="chromiumos/infra/go" path="infra/go" revision="6eadc22e734e94376e053926fb56729094b36adc" upstream="refs/heads/main" dest-branch="refs/heads/main" groups="chromeos-admin">
+    <annotation name="branch-mode" value="tot"/>
+  </project>
+  <project name="chromiumos/infra/lucifer" path="infra/lucifer" revision="12e9e6bde527c0bf97ff68c1d5f70385e15d1e58" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/infra/proto" path="chromite/infra/proto" revision="58a5de36d55ffe1ee2fded1f715175634b136c93" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/infra/proto" path="infra/proto" revision="84792727a0f41ed51c5593ba31e15b0036b52503" upstream="refs/heads/main" dest-branch="refs/heads/main">
+    <annotation name="branch-mode" value="tot"/>
+  </project>
+  <project name="chromiumos/infra/test_analyzer" path="infra/test_analyzer" revision="14119cc21c146544791fe387f64a4b809c4ea789" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/infra_virtualenv" path="infra_virtualenv" revision="cab8a95f2961561eb56a95d6f2bfc685686db75a" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B" groups="minilayout,firmware,buildtools,chromeos-admin,labtools,sysmon,devserver"/>
+  <project name="chromiumos/manifest" path="manifest" revision="b0ee9ee31ad2ab1c979826539473d0d45a7658ea" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/overlays/board-overlays" path="src/overlays" revision="8beb243231905dcdfadde4523d103334452a020f" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B" groups="minilayout,firmware"/>
+  <project name="chromiumos/overlays/chromiumos-overlay" path="src/third_party/chromiumos-overlay" revision="52a4833c3869c27bd7a95cb9ebaa9abbf1a4ed08" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B" groups="minilayout,firmware,labtools" sync-c="true"/>
+  <project name="chromiumos/overlays/eclass-overlay" path="src/third_party/eclass-overlay" revision="f3163decd13f1a31f8aa9e34a7b0b392ee2b6858" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B" groups="minilayout,firmware,labtools"/>
+  <project name="chromiumos/overlays/portage-stable" path="src/third_party/portage-stable" revision="9ab06075c62df0b6ac28a1def76fc92c61a93a7c" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B" groups="minilayout,firmware,labtools"/>
+  <project name="chromiumos/platform/assets" path="src/platform/assets" revision="8a2276f22f0678bee89b8ac6c46d9dd597c6d549" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/platform/audiotest" path="src/platform/audiotest" revision="c4f3a48a6710ad8630707986f427d1d3b226fda7" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/platform/bisect-kit" path="src/platform/bisect-kit" revision="2953987711ca9a9822516186a89c99e6adf87a67" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/platform/bmpblk" path="src/platform/bmpblk" revision="2c0c4c69acfcd77c43905a181c1e61201b14c15b" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/platform/btsocket" path="src/platform/btsocket" revision="f0c71bd1151cca91ff171e5f9a4582488a3f1dc5" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/platform/camera" path="src/platform/camera" revision="2bd7221fc7f69224b8192e415321d3432004c703" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/platform/cbor" path="src/platform/cbor" revision="9e852aa145930d6ebb990d4e8f84e5907a1321de" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/platform/cfm-device-monitor" path="src/platform/cfm-device-monitor" revision="8cad38cd3abf6ad82947fe3c14a85c207a1959e6" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/platform/chameleon" path="src/platform/chameleon" revision="69caec1c70c7639401d4127dde69de91f8617399" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/platform/chromiumos-assets" path="src/platform/chromiumos-assets" revision="de6c118f21ef7130feb30d4b7f703cfe2ba2748f" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/platform/cobble" path="src/platform/cobble" revision="4ab43f1f86b7099b8ad75cf9615ea1fa155bbd7d" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/platform/croscomp" path="src/platform/croscomp" revision="6a43cc821c34b9ffde89479b4c55f3b56cd14087" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/platform/crostestutils" path="src/platform/crostestutils" revision="33670286e6d4042618f3e756f45b1b6fc9607cae" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B" groups="minilayout,firmware,buildtools"/>
+  <project name="chromiumos/platform/crosutils" path="src/scripts" revision="61438ca275c3fc4c06cf332e81ade709f28d42b5" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B" groups="minilayout,firmware,buildtools,labtools"/>
+  <project name="chromiumos/platform/crosvm" path="src/platform/crosvm" revision="0a60f55c243dad3423730685e8d09ee1eed999df" upstream="refs/heads/release-R102-14695.B-chromeos" dest-branch="main" groups="crosvm"/>
+  <project name="chromiumos/platform/crosvm" path="src/platform/crosvm-upstream" revision="c59db481318d2f6253dbebb8da2998b9597dd608" upstream="refs/heads/release-R102-14695.B-main" dest-branch="refs/heads/release-R102-14695.B-main" groups="crosvm"/>
+  <project name="chromiumos/platform/depthcharge" path="src/platform/depthcharge" revision="46ea10481dcc9e2534ebe0bd8df2c759e5eb1749" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B" groups="firmware"/>
+  <project name="chromiumos/platform/dev-util" path="src/platform/dev" revision="253c149bca719ea8753378691624346002428ad0" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B" groups="minilayout,firmware,buildtools,devserver"/>
+  <project name="chromiumos/platform/drm-tests" path="src/platform/drm-tests" revision="20911b8e08359246b12db9aa6a638fe9c76b3c19" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/platform/ec" path="src/platform/cr50" revision="73c8bc79ba1ac3b2b2b8cda828db913bee99cdba" upstream="refs/heads/release-R102-14695.B-cr50_stab" dest-branch="refs/heads/release-R102-14695.B-cr50_stab" groups="firmware"/>
+  <project name="chromiumos/platform/ec" path="src/platform/ec" revision="b0e0f785f5ea0130da531008d6c801ef4d0c5385" upstream="refs/heads/release-R102-14695.B-main" dest-branch="refs/heads/release-R102-14695.B-main" groups="firmware"/>
+  <project name="chromiumos/platform/ec" path="src/platform/ish" revision="252457d4b21f46889eebad61d4c0a65331919cec" upstream="refs/heads/release-R102-14695.B-ish" dest-branch="refs/heads/release-R102-14695.B-ish" groups="firmware"/>
+  <project name="chromiumos/platform/ec" path="src/platform/release-firmware/fpmcu-bloonchipper" revision="a30940ac8d47cc113cef9e324117d60008486bfb" groups="firmware">
+    <annotation name="branch-mode" value="pin"/>
+  </project>
+  <project name="chromiumos/platform/ec" path="src/platform/release-firmware/fpmcu-dartmonkey" revision="aaf8a96fb96428d951b6176266e7ae6d203f22b2" groups="firmware">
+    <annotation name="branch-mode" value="pin"/>
+  </project>
+  <project name="chromiumos/platform/ec" path="src/platform/release-firmware/fpmcu-nami" revision="aaf8a96fb96428d951b6176266e7ae6d203f22b2" groups="firmware">
+    <annotation name="branch-mode" value="pin"/>
+  </project>
+  <project name="chromiumos/platform/ec" path="src/platform/release-firmware/fpmcu-nocturne" revision="aaf8a96fb96428d951b6176266e7ae6d203f22b2" groups="firmware">
+    <annotation name="branch-mode" value="pin"/>
+  </project>
+  <project name="chromiumos/platform/experimental" path="src/platform/experimental" revision="2927fce20adf74b0c9a32a61e3edff894221f283" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/platform/factory" path="src/platform/factory" revision="bf31a5e5db8b956de3996ef0d41fa0bdeeeb6137" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/platform/factory_installer" path="src/platform/factory_installer" revision="420417d0c27e4b13dd944d3ce97a7069241ced91" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/platform/firmware" path="src/platform/firmware" revision="02fd6f483cd107257dfa505f63cbb92e670c00a2" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B" groups="firmware"/>
+  <project name="chromiumos/platform/frecon" path="src/platform/frecon" revision="47a109a346210d082dbcb0c132d09bb99266c868" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/platform/fw-testing-configs" path="src/platform/tast-tests/src/chromiumos/tast/remote/firmware/data/fw-testing-configs" revision="07771cf74434cac9f6efdc745fa04aee350ad2b4" upstream="refs/heads/release-R102-14695.B-main" dest-branch="refs/heads/release-R102-14695.B-main" groups="buildtools,labtools,devserver,firmware"/>
+  <project name="chromiumos/platform/fw-testing-configs" path="src/third_party/autotest/files/server/cros/faft/fw-testing-configs" revision="07771cf74434cac9f6efdc745fa04aee350ad2b4" upstream="refs/heads/release-R102-14695.B-main" dest-branch="refs/heads/release-R102-14695.B-main" groups="buildtools,labtools,devserver,firmware"/>
+  <project name="chromiumos/platform/gestures" path="src/platform/gestures" revision="02eedde6834bff9d72066339bf9df62911e4df3e" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/platform/glbench" path="src/platform/glbench" revision="67bc8aae5c1f893a07cb6564f84a74f15cc17c2b" upstream="refs/heads/release-R102-14695.B-main" dest-branch="refs/heads/release-R102-14695.B-main"/>
+  <project name="chromiumos/platform/go-seccomp" path="src/platform/go-seccomp" revision="9d14f8b297985ec80f05d14afd6378e3350e2c41" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/platform/graphics" path="src/platform/graphics" revision="eab3108af8375ad7b90b2aa0cf0f9c8ac10387ba" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/platform/hps-firmware" path="src/platform/hps-firmware2" revision="13aebff75cd00dff2e463a78f43d270f278b4b90" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/platform/hps-firmware-images" path="src/platform/hps-firmware-images" revision="b13e60af5a112a886fde6993df5317de3b84405c" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/platform/initramfs" path="src/platform/initramfs" revision="453f08529f407499c2f6614eff042c2d53dcb4b1" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/platform/inputcontrol" path="src/platform/inputcontrol" revision="6c9fd34b4a6231efc189c530e2f05d908b55185e" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/platform/jabra_vold" path="src/platform/jabra_vold" revision="233d517d2904912b207d273794b0ec5343e48010" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/platform/libevdev" path="src/platform/libevdev" revision="8d00f789df9bd4efce783a46f30d75d742d3e8d4" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/platform/libva-fake-driver" path="src/platform/libva-fake-driver" revision="7754dd6e00355bb0d7bb5f597b482b6d5ff5cab5" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/platform/lithium" path="src/platform/lithium" revision="1b54b0fa69bb183ed19945a79b72bc17145eafe4" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B" groups="firmware"/>
+  <project name="chromiumos/platform/microbenchmarks" path="src/platform/microbenchmarks" revision="ec4ae6c0d54618c01a5e1c78d80c44bc80af6ad6" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/platform/minigbm" path="src/platform/minigbm" revision="a5ac45890d256866bac77140da7981e6a8a41c42" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B" groups="crosvm"/>
+  <project name="chromiumos/platform/mosys" path="src/platform/mosys" revision="ee6e44866a95fa50e93e6d993857266073e32f1c" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/platform/mttools" path="src/platform/mttools" revision="957a434f10b7663bbafc85fb19afe1a3318c0a10" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/platform/pinweaver" path="src/platform/pinweaver" revision="fc39c8b509da8a45869d7c0e44b263dd631c6fb4" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/platform/rules_cros" path="src/platform/rules_cros" revision="a2e8126848c451d1edab811fc3ab6bff0858d65d" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/platform/tast" path="src/platform/tast" revision="c0787f49d9d68c4212d7e94540034a6b542bed20" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/platform/tast-tests" path="src/platform/tast-tests" revision="5a9d49f19eeae108aba24a167786153715346525" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/platform/tauto" path="src/platform/tauto" revision="2c088e3efa0b85bf21457b4df3f3b68d682d7a15" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/platform/touch_firmware_test" path="src/platform/touch_firmware_test" revision="2385881e6a19a904687ced52f27541b716e8168c" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B" groups="firmware"/>
+  <project name="chromiumos/platform/touch_updater" path="src/platform/touch_updater" revision="2e9e5d1dda8a198287e49e84c3025b78c435ae16" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/platform/touchpad-tests" path="src/platform/touchpad-tests" revision="4c32bef9592024fe76fb0b8c913add3b1421e2d6" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/platform/tpm" path="src/third_party/tpm" revision="421593a8cea1083288d5d047b0c43f85c92fe069" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B" groups="firmware"/>
+  <project name="chromiumos/platform/tpm_lite" path="src/platform/tpm_lite" revision="dd6ae9f3a223c0a8a89a2e4c10600f7700354a53" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/platform/tremplin" path="src/platform/tremplin" revision="78fb2d7094158cb59435badcd1190187496084b0" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/platform/usi-test" path="src/platform/usi-test" revision="ca7b4b66c18c97e1d7e21b36a9c76239ea0530ef" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/platform/vboot_reference" path="src/platform/vboot_reference" revision="e61f21346777c792868c96aad295aa704a41eae3" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B" groups="firmware,buildtools"/>
+  <project name="chromiumos/platform/vkbench" path="src/platform/vkbench" revision="96811b97cb9e532d6149f2c0bd5c18987cef3eef" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/platform/vpd" path="src/platform/vpd" revision="21ac829a3c671e9728ef6b68a049ad180aa9a898" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/platform/xorg-conf" path="src/platform/xorg-conf" revision="947b0fe90f19bd1e69a0e7692891b7a88e2b71f5" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/platform2" path="src/platform2" revision="2a33488db18786078dbf5bacc85eb3cbb7a9f359" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B" groups="crosvm"/>
+  <project name="chromiumos/project" path="src/project_public" revision="9dac1c8970873936abd9e0e832941ae483cfbe98" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B" groups="partner-config"/>
+  <project name="chromiumos/repohooks" path="src/repohooks" revision="a07c92a6878f22198ee89b5f35c76855ae3252e1" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B" groups="minilayout,firmware,buildtools,labtools,crosvm"/>
+  <project name="chromiumos/third_party/Wi-FiTestSuite-Linux-DUT" path="src/third_party/Wi-FiTestSuite-Linux-DUT" revision="afe5b18c1b33f03169779851369c8c4ab0bb941d" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/third_party/adhd" path="src/third_party/adhd" revision="cf46341faafb78c8b6d3b405215042f757fad0b0" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B" groups="crosvm"/>
+  <project name="chromiumos/third_party/apitrace" path="src/third_party/apitrace" revision="fb01568634eb35fc21b24ca6a48acaa6b0dd3708" upstream="refs/heads/release-R102-14695.B-master" dest-branch="refs/heads/release-R102-14695.B-master"/>
+  <project name="chromiumos/third_party/arm-trusted-firmware" path="src/third_party/arm-trusted-firmware" revision="38dd6b61ae2ae6ba49f425771c0b529f7dbc9b4a" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/third_party/atrusctl" path="src/third_party/atrusctl" revision="4f1d81ecfa86ae7570f951fe6eaac9ab2c1290d7" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/third_party/autotest" path="src/third_party/autotest/files" revision="2d1ba04d82770ec6f1f8a11f6dcaf32db691c5d6" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B" groups="buildtools,labtools,devserver"/>
+  <project name="chromiumos/third_party/aver-updater" path="src/third_party/aver-updater" revision="6418ac5d86c720d234f961513021a5ff0a2bf3d8" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/third_party/bluez" path="src/third_party/bluez/current" revision="80721bb0657280a2a4947f4f725226d4340d4c6c" upstream="refs/heads/release-R102-14695.B-chromeos-5.54" dest-branch="refs/heads/release-R102-14695.B-chromeos-5.54"/>
+  <project name="chromiumos/third_party/bluez" path="src/third_party/bluez/next" revision="80721bb0657280a2a4947f4f725226d4340d4c6c" upstream="refs/heads/release-R102-14695.B-chromeos-5.54" dest-branch="refs/heads/release-R102-14695.B-chromeos-5.54"/>
+  <project name="chromiumos/third_party/bluez" path="src/third_party/bluez/upstream" revision="7903bbe1005bd05f542f64cf6af251f0f648d3ac">
+    <annotation name="branch-mode" value="pin"/>
+  </project>
+  <project name="chromiumos/third_party/bootstub" path="src/third_party/bootstub" revision="076cb8e624d2f9d8ab75fc07f614e3c1288e0b2e" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B" groups="firmware"/>
+  <project name="chromiumos/third_party/cbootimage" path="src/third_party/cbootimage" revision="b7d5b2d6a6dd05874d86ee900ff441d261f9034c" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B" groups="firmware"/>
+  <project name="chromiumos/third_party/chre" path="src/third_party/chre" revision="bb94995ba69f3efebbbeca8a75d1bc9b8426734e" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/third_party/clspv" path="src/third_party/clspv" revision="b8f94af8fd3d95770fdb5b90f387786d8d15c2fb" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/third_party/clvk" path="src/third_party/clvk" revision="865ae225a630bfbdc3e9eae44999cd19bef0f337" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/third_party/coreboot" path="src/third_party/coreboot" revision="efa7d1f14cbf06db6dde0d7950088bbf65b9efa6" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B" groups="firmware"/>
+  <project name="chromiumos/third_party/coreboot/amd_blobs" path="src/third_party/coreboot/3rdparty/amd_blobs" revision="c3aa07acc64a95c46d17799f4062f98acf40989d" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B" groups="firmware"/>
+  <project name="chromiumos/third_party/coreboot/blobs" path="src/third_party/coreboot/3rdparty/blobs" revision="2c67522aae7132c337d994e0ed48ba6d182df08a" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B" groups="firmware"/>
+  <project name="chromiumos/third_party/coreboot/intel-microcode" path="src/third_party/coreboot/3rdparty/intel-microcode" revision="ee319ae7bc59e88b60142f40a9ec1b46656de4db" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B" groups="firmware"/>
+  <project name="chromiumos/third_party/coreboot/libgfxinit" path="src/third_party/coreboot/3rdparty/libgfxinit" revision="f64ccae3ba02210a6f4309264d8e5b8e1af636a8" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B" groups="firmware"/>
+  <project name="chromiumos/third_party/coreboot/libhwbase" path="src/third_party/coreboot/3rdparty/libhwbase" revision="9946827bbae199477cfcb68dcc5ed257aaa9ba7d" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B" groups="firmware"/>
+  <project name="chromiumos/third_party/coreboot/qc_blobs" path="src/third_party/coreboot/3rdparty/qc_blobs" revision="9ab0f0b71c25aa8414e72040bad6fe12b0ccb3f3" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B" groups="firmware"/>
+  <project name="chromiumos/third_party/cros-adapta" path="src/third_party/cros-adapta" revision="46fd2136aa799bb17dfb1002278f98e6397e5806" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/third_party/cryptoc" path="src/third_party/cryptoc" revision="92221d4688ed01cc361f01d650b82bf7e28078b2" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B" groups="firmware"/>
+  <project name="chromiumos/third_party/cups" path="src/third_party/cups" revision="0cdde127524504eb98cf03672597fdc68f8422b0" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/third_party/daisydog" path="src/third_party/daisydog" revision="4b0c966fb6a35eabd6f06633a5c48ecff27ce2a5" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/third_party/edk2" path="src/third_party/amd-firmware/binarypi/picasso-edk2" revision="e2fc5e5879135d2c7e638a83ca066b2a08e134d5" upstream="refs/heads/release-R102-14695.B-pco" dest-branch="refs/heads/release-R102-14695.B-pco" groups="firmware"/>
+  <project name="chromiumos/third_party/edk2" path="src/third_party/edk2" revision="8523e9c995e7204e1067c1660ac04177932d4b1b" upstream="refs/heads/release-R102-14695.B-chromeos-2017.08" dest-branch="refs/heads/release-R102-14695.B-chromeos-2017.08" groups="firmware"/>
+  <project name="chromiumos/third_party/edk2" path="src/third_party/fsp/cml/edk2/branch1" revision="4de539eb3f1bcc304ac2ea88c3a8d4b5cc76a5d6" upstream="refs/heads/release-R102-14695.B-chromeos-cml-branch1" dest-branch="refs/heads/release-R102-14695.B-chromeos-cml-branch1" groups="firmware"/>
+  <project name="chromiumos/third_party/edk2" path="src/third_party/fsp/cnl/edk2" revision="995dede2362e4947c91f631069444552a1d2eeff" upstream="refs/heads/release-R102-14695.B-chromeos-cnl" dest-branch="refs/heads/release-R102-14695.B-chromeos-cnl" groups="firmware"/>
+  <project name="chromiumos/third_party/edk2" path="src/third_party/fsp/glk/edk2" revision="f84e90881271300af73761bbd6a6fa8b8f82c266" upstream="refs/heads/release-R102-14695.B-chromeos-glk" dest-branch="refs/heads/release-R102-14695.B-chromeos-glk" groups="firmware"/>
+  <project name="chromiumos/third_party/em100" path="src/third_party/em100" revision="47a575efc850d88316b3e4349f454e293266ce64" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B" groups="firmware"/>
+  <project name="chromiumos/third_party/fastrpc" path="src/third_party/fastrpc" revision="c2d1cdc0fb781ee673077c5d4b243eb239c73bb5" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/third_party/flashmap" path="src/third_party/flashmap" revision="9c71c8331ad52a11d29496ffb10cbdb1a51e2ccb" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B" groups="firmware"/>
+  <project name="chromiumos/third_party/flashrom" path="src/third_party/flashrom" revision="88cd0a76555db7f66fe3c73f78983cdd2221e8b8" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B" groups="firmware"/>
+  <project name="chromiumos/third_party/fwupd" path="src/third_party/fwupd" revision="e7bb05adfe3c035d27e2c8a0fc1b713751aca692" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/third_party/hdctools" path="src/third_party/hdctools" revision="1a9f69357dc3528ac6ab41365ce79837b1950561" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B" groups="labtools"/>
+  <project name="chromiumos/third_party/hostap" path="src/third_party/wpa_supplicant" revision="c297db6ffd38d6694fe5f8b04b55aa74e00e9c77" upstream="refs/heads/release-R102-14695.B-master" dest-branch="refs/heads/release-R102-14695.B-master"/>
+  <project name="chromiumos/third_party/hostap" path="src/third_party/wpa_supplicant-cros/current" revision="f529a556dfaa87837eddc91c49b9b9f1bbf128d4" upstream="refs/heads/release-R102-14695.B-wpa_supplicant-2.9.1" dest-branch="refs/heads/release-R102-14695.B-wpa_supplicant-2.9.1"/>
+  <project name="chromiumos/third_party/hostap" path="src/third_party/wpa_supplicant-cros/next" revision="f529a556dfaa87837eddc91c49b9b9f1bbf128d4" upstream="refs/heads/release-R102-14695.B-wpa_supplicant-2.9.1" dest-branch="refs/heads/release-R102-14695.B-wpa_supplicant-2.9.1"/>
+  <project name="chromiumos/third_party/huddly-updater" path="src/third_party/huddly-updater" revision="0da35b451529936b6ca8344177dbcfe5b9c5539f" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/third_party/igt-gpu-tools" path="src/third_party/igt-gpu-tools" revision="f3df40281d93d5a63ee98fa30e90852d780673c9" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/third_party/intel-wifi-fw-dump" path="src/third_party/intel-wifi-fw-dump" revision="c37a35ed64538beeb8240c19db85bce29ef6e534" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/third_party/kernel" path="src/third_party/kernel/upstream" revision="2c2bece2c58a36ce22e3b217444996a5f3031cbe">
+    <annotation name="branch-mode" value="pin"/>
+  </project>
+  <project name="chromiumos/third_party/kernel" path="src/third_party/kernel/v4.4" revision="a09c85531b9252fcdc907592fa84303b2a7c5405" upstream="refs/heads/release-R102-14695.B-chromeos-4.4" dest-branch="refs/heads/release-R102-14695.B-chromeos-4.4"/>
+  <project name="chromiumos/third_party/kernel" path="src/third_party/kernel/v4.14" revision="dcb8cde4074b5b5d78ccb0fa12607d50a4217b2b" upstream="refs/heads/release-R102-14695.B-chromeos-4.14" dest-branch="refs/heads/release-R102-14695.B-chromeos-4.14"/>
+  <project name="chromiumos/third_party/kernel" path="src/third_party/kernel/v4.19" revision="559eb53a2183117d54675ca2c80b2d0421f2412d" upstream="refs/heads/release-R102-14695.B-chromeos-4.19" dest-branch="refs/heads/release-R102-14695.B-chromeos-4.19"/>
+  <project name="chromiumos/third_party/kernel" path="src/third_party/kernel/v5.4" revision="ef4ee8342c995e8226458c863387cce5bcba9932" upstream="refs/heads/release-R102-14695.B-chromeos-5.4" dest-branch="refs/heads/release-R102-14695.B-chromeos-5.4"/>
+  <project name="chromiumos/third_party/kernel" path="src/third_party/kernel/v5.4-arcvm" revision="eab5110be12c10dcc78905cc569e26b0847b90b2" upstream="refs/heads/release-R102-14695.B-chromeos-5.4-arcvm" dest-branch="refs/heads/release-R102-14695.B-chromeos-5.4-arcvm"/>
+  <project name="chromiumos/third_party/kernel" path="src/third_party/kernel/v5.4-manatee" revision="b0fcb811fd9c0bee9feadccfda27ff80049a6534" upstream="refs/heads/release-R102-14695.B-chromeos-5.4-manatee" dest-branch="refs/heads/release-R102-14695.B-chromeos-5.4-manatee"/>
+  <project name="chromiumos/third_party/kernel" path="src/third_party/kernel/v5.10" revision="0ed4e7dff8259dfb27f3b9969287c8904e7d3a24" upstream="refs/heads/release-R102-14695.B-chromeos-5.10" dest-branch="refs/heads/release-R102-14695.B-chromeos-5.10"/>
+  <project name="chromiumos/third_party/kernel" path="src/third_party/kernel/v5.10-arcvm" revision="a0d51350ccc391a06d4e97045b57f5bf17b9f75f" upstream="refs/heads/release-R102-14695.B-chromeos-5.10-arcvm" dest-branch="refs/heads/release-R102-14695.B-chromeos-5.10-arcvm"/>
+  <project name="chromiumos/third_party/kernel" path="src/third_party/kernel/v5.10-manatee" revision="7e3e64fa049db23c2e8caca851985fc1e885e47f" upstream="refs/heads/release-R102-14695.B-chromeos-5.10-manatee" dest-branch="refs/heads/release-R102-14695.B-chromeos-5.10-manatee"/>
+  <project name="chromiumos/third_party/kernel" path="src/third_party/kernel/v5.15" revision="f947a39e456f12de32ff98f2af2d3eeeacd4ac60" upstream="refs/heads/release-R102-14695.B-chromeos-5.15" dest-branch="refs/heads/release-R102-14695.B-chromeos-5.15"/>
+  <project name="chromiumos/third_party/khronos" path="src/third_party/khronos" revision="c9d952582b74f9609bf68e0402856a2fc1e536c0" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/third_party/labpack" path="src/third_party/labpack/files" revision="385a9abcc02eea3d7f3169fa35019d00dc501c50" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B" groups="labtools"/>
+  <project name="chromiumos/third_party/lexmark-fax-pnh" path="src/third_party/lexmark-fax-pnh" revision="f131d8f851366e6a2f8e8fa8f3042285d021d6c6" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/third_party/libcamera" path="src/third_party/libcamera" revision="72b6c710d448d5a1ff9407f9f7c7780660ee556a" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/third_party/libdrm" path="src/third_party/libdrm" revision="85393adb12ad6277b21b885f11a3b94ef2d531db" upstream="refs/heads/release-R102-14695.B-upstream-main" dest-branch="refs/heads/release-R102-14695.B-upstream-main"/>
+  <project name="chromiumos/third_party/libiio" path="src/third_party/libiio" revision="213eca340c157b96232242da15539e12efb2d5c9" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/third_party/libmbim" path="src/third_party/libmbim" revision="ec335c53a29f189f9291a97c3826cc6e4b733bb5" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/third_party/libqmi" path="src/third_party/libqmi" revision="31ab1fca029e70f95ef4386a825c5f79f784329e" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/third_party/libqrtr" path="src/third_party/libqrtr" revision="ba87335b33afcc0c1e0860ed41d0a98abc804184" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/third_party/libqrtr-glib" path="src/third_party/libqrtr-glib" revision="b19fd9966e5bdc7aaa03c1cc1035104809969186" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/third_party/libsigrok" path="src/third_party/libsigrok" revision="199fe31115c76231746f5953271795d58679561c" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/third_party/libsigrok-cli" path="src/third_party/sigrok-cli" revision="c9edfa218e5a5972531b6f4a3ece8d33a44ae1b5" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/third_party/libsigrokdecode" path="src/third_party/libsigrokdecode" revision="3279c2825684c7009775b731d0a9e37815778282" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/third_party/libtextclassifier" path="src/third_party/libtextclassifier" revision="01652c17e116baa8ebd7083e8cbc3dede513ac9e" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/third_party/libv4lplugins" path="src/third_party/libv4lplugins" revision="e88945fc2b6b02f37cc1dfc77cde2312787cb0fb" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/third_party/linux-firmware" path="src/third_party/linux-firmware" revision="7387d6dcc7e8380f4f7bfd532904e1463dfee71b" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/third_party/logitech-updater" path="src/third_party/logitech-updater" revision="927b44e38d83c189b2a2f12e6e18b67e32c3bb42" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/third_party/marvell" path="src/third_party/marvell" revision="a1da785c038730d7d900415945688f6fb76175f4" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/third_party/mesa" path="src/third_party/mesa" revision="b7111f89e8213315d4d5f66dee2551bac8af46b1" upstream="refs/heads/release-R102-14695.B-upstream-main" dest-branch="refs/heads/release-R102-14695.B-upstream-main"/>
+  <project name="chromiumos/third_party/mesa" path="src/third_party/mesa-amd" revision="67622a44885c709787e01bd1eef3c5c83ae831ec" upstream="refs/heads/release-R102-14695.B-chromeos-amd" dest-branch="refs/heads/release-R102-14695.B-chromeos-amd"/>
+  <project name="chromiumos/third_party/mesa" path="src/third_party/mesa-arcvm" revision="5d55899da818451844ecee65be11a25c9997de51" upstream="refs/heads/release-R102-14695.B-chromeos-arcvm" dest-branch="refs/heads/release-R102-14695.B-chromeos-arcvm"/>
+  <project name="chromiumos/third_party/mesa" path="src/third_party/mesa-debian" revision="c36b89b82bcd270e1f9ee7d0824c9e265a39e95b" upstream="refs/heads/release-R102-14695.B-debian" dest-branch="refs/heads/release-R102-14695.B-debian"/>
+  <project name="chromiumos/third_party/mesa" path="src/third_party/mesa-freedreno" revision="6d3af095fd9c4f30448c4f52d6534c5d45686130" upstream="refs/heads/release-R102-14695.B-chromeos-freedreno" dest-branch="refs/heads/release-R102-14695.B-chromeos-freedreno"/>
+  <project name="chromiumos/third_party/mesa" path="src/third_party/mesa-img" revision="2e7833ad916c493969d00871cdf56db4407b80eb" upstream="refs/heads/release-R102-14695.B-mesa-19.0" dest-branch="refs/heads/release-R102-14695.B-mesa-19.0"/>
+  <project name="chromiumos/third_party/mesa" path="src/third_party/mesa-iris" revision="f84799e1aeb57465942d959d2b8668c9850b6eba" upstream="refs/heads/release-R102-14695.B-chromeos-iris" dest-branch="refs/heads/release-R102-14695.B-chromeos-iris"/>
+  <project name="chromiumos/third_party/mesa" path="src/third_party/mesa-reven" revision="1fa3f1cbfd990e2f7181da3791b14f3dbfb6953f" upstream="refs/heads/release-R102-14695.B-chromeos-reven" dest-branch="refs/heads/release-R102-14695.B-chromeos-reven"/>
+  <project name="chromiumos/third_party/mimo-updater" path="src/third_party/mimo-updater" revision="fb448bbd2986c743f3c37dbc784ae972e24b1a23" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/third_party/mmc-utils" path="src/third_party/mmc-utils" revision="7be960e2b84b5dfcbec44d3b722fb02d16b9eaf1" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/third_party/modemmanager-next" path="src/third_party/modemmanager-next" revision="a4a93403fe61a7ad431d6afac61800eda67b2875" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/third_party/novatek-tcon-fw-update-tool" path="src/third_party/novatek-tcon-fw-update-tool" revision="a78b7b0ba128471af835e44dc97698d39fd89bbf" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/third_party/poly-updater" path="src/third_party/poly-updater" revision="87ad2edeea039892515f68c948bc2b8f94999553" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/third_party/portage_tool" path="src/third_party/portage_tool" revision="80ed2dac95db81acac8043e6685d0a853a08d268" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/third_party/pyelftools" path="chromite/third_party/pyelftools" revision="6fec9f599bef566fe8f6f6ca6c2102508b664792" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B" groups="minilayout,firmware,buildtools"/>
+  <project name="chromiumos/third_party/qemu" path="src/third_party/qemu" revision="fdd76fecdde1ad444ff4deb7f1c4f7e4a1ef97d6" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/third_party/rootdev" path="src/third_party/rootdev" revision="b2f37be7c25bc83b76f1b7063a4ef38b824dc4ef" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/third_party/rust-vmm/vhost" path="src/third_party/rust-vmm/vhost" revision="7c95b4a2c1e378f7328d8bc0510bbb6998f54581" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B" groups="crosvm"/>
+  <project name="chromiumos/third_party/seabios" path="src/third_party/seabios" revision="27b56c6e94fe37e9308392fefd25ba641d8be496" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B" groups="firmware"/>
+  <project name="chromiumos/third_party/shellcheck" path="src/third_party/shellcheck" revision="bc2c8ab3a6c11721771f04a2c8e3fe16dfc8ca22" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/third_party/sis-updater" path="src/third_party/sis-updater" revision="0e41acf19950b8c60d1e0c46ff7b64a24c51dea1" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/third_party/sound-open-firmware" path="src/third_party/sound-open-firmware" revision="35691bd4813b901c78ab938a4ec8bcc7fcb7f35f" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/third_party/svunit" path="src/third_party/svunit" revision="76ffd92958212a8e427a8eb6d24956df6ec19dbe" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/third_party/sysbios" path="src/third_party/sysbios" revision="33e1db34b8162de72a5e9bbbc44e6bce38978396" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B" groups="firmware"/>
+  <project name="chromiumos/third_party/systemd" path="src/third_party/systemd" revision="58d3fbc2d946d741887b2300d4c70dbe9cddcc7c" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/third_party/tlsdate" path="src/third_party/tlsdate" revision="87f033588885e445abedd3c4ab23afd0e7259aed" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/third_party/toolchain-utils" path="src/third_party/toolchain-utils" revision="4bf7141a31552bb16ea51480acb8401217138272" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B" groups="minilayout"/>
+  <project name="chromiumos/third_party/tpm2" path="src/third_party/tpm2" revision="a77bf0779e1005c9fd840955193ac7257d67bc05" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B" groups="firmware,crosvm"/>
+  <project name="chromiumos/third_party/trousers" path="src/third_party/trousers" revision="989e2337c1cd9de5b72c84cb06025661881b86f6" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/third_party/u-boot" path="src/third_party/u-boot/files" revision="d637294e264adfeb29f390dfc393106fd4d41b17" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/third_party/upstart" path="src/third_party/upstart" revision="060d99cb2854cb2ac42fea7177347cb188138f60" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/third_party/virglrenderer" path="src/third_party/virglrenderer" revision="f77dd9aefb83cf90208b46c0a03804f1e62f0033" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B" groups="crosvm"/>
+  <project name="chromiumos/third_party/virtual-usb-printer" path="src/third_party/virtual-usb-printer" revision="f6958c3ca5c29ba9aaf674b9843dea0cd555c2a5" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/third_party/webrtc-apm" path="src/third_party/webrtc-apm" revision="9218a1d3e20a2f402443a89e21d3533f202b122f" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B"/>
+  <project name="chromiumos/third_party/zephyr" path="src/third_party/zephyr/main" revision="874f953038dac5afec6f8d8565722af0224201ad" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B" groups="firmware,zephyr"/>
+  <project name="chromiumos/third_party/zephyr/cmsis" path="src/third_party/zephyr/cmsis" revision="0eef4c5574a033a5584a0711d332b41e01ab50c2" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B" groups="firmware,zephyr"/>
+  <project name="chromiumos/third_party/zephyr/hal_stm32" path="src/third_party/zephyr/hal_stm32" revision="d16e7a96f91b3946b45b7572bf52f3b240d1f051" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B" groups="firmware,zephyr"/>
+  <project name="chromiumos/third_party/zephyr/nanopb" path="src/third_party/zephyr/nanopb" revision="8eb6edf6e05c2328605ad351da806fa37cefc068" upstream="refs/heads/release-R102-14695.B" dest-branch="refs/heads/release-R102-14695.B" groups="firmware,zephyr"/>
+  <project name="external/git.kernel.org/fs/xfs/xfstests-dev" path="src/third_party/xfstests" revision="4a7b35d7a76cd993ad7a62fd180e00589c73ac4b"/>
+  <project name="infra/luci/client-py" path="chromite/third_party/swarming.client" remote="chromium" revision="34b20305c7a69eb89e1abd5e2a94708db999f0a9" groups="buildtools,chromeos-admin,firmware,labtools,minilayout"/>
+  <project name="linux-syscall-support" path="src/third_party/breakpad/src/third_party/lss" revision="e1e7b0ad8ee99a875b272c8e33e308472e897660"/>
+  <project name="platform/external/bsdiff" path="src/aosp/external/bsdiff" remote="aosp" revision="ed2a90db11ed082ec1969d117587426b645303ac"/>
+  <project name="platform/external/marisa-trie" path="src/aosp/external/marisa-trie" remote="aosp" revision="d743d2b4f6f038eb5654b7fda1478958cf99db78">
+    <annotation name="branch-mode" value="pin"/>
+  </project>
+  <project name="platform/external/minijail" path="src/aosp/external/minijail" remote="aosp" revision="ff062d54f9a419e149f726b69aea8cd509158927" groups="crosvm"/>
+  <project name="platform/external/puffin" path="src/aosp/external/puffin" remote="aosp" revision="80be4157fe6c64bd5c25bc7edbcce1760e4a3758"/>
+  <project name="platform/system/keymaster" path="src/aosp/system/keymaster" remote="aosp" revision="49dfc58d6c4c66f5d0b0d06f0161da4e602a1293"/>
+  
+  <repo-hooks in-project="chromiumos/repohooks" enabled-list="pre-upload"/>
+</manifest>

--- a/config/rootfs/chromiumos/cros-snapshot-release-R106-15054.B.xml
+++ b/config/rootfs/chromiumos/cros-snapshot-release-R106-15054.B.xml
@@ -1,0 +1,280 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <remote name="aosp" fetch="https://android.googlesource.com" review="https://android-review.googlesource.com">
+    <annotation name="public" value="true"/>
+  </remote>
+  <remote name="chromium" fetch="https://chromium.googlesource.com/" alias="cros">
+    <annotation name="public" value="true"/>
+  </remote>
+  <remote name="cros" fetch="https://chromium.googlesource.com" review="https://chromium-review.googlesource.com">
+    <annotation name="public" value="true"/>
+  </remote>
+  
+  <default remote="cros" sync-j="8"/>
+  
+  <project name="aosp/platform/external/libutf" path="src/aosp/external/libutf" revision="c17bb435be940edf1aff81469215bb6a071f3c38" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="aosp/platform/external/modp_b64" path="src/third_party/modp_b64" revision="269b6fb8401617b85e2dff7ae8a7b0f97613e2cd" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="aosp/platform/frameworks/ml" path="src/aosp/frameworks/ml" revision="dfcc377c44234181a2a3625096ba9dd743385ea3" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="aosp/platform/frameworks/native" path="src/aosp/frameworks/native" revision="5e9a89d06c41edf5cf43da8acf5f26ed104887e6" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="aosp/platform/hardware/interfaces/neuralnetworks" path="src/aosp/hardware/interfaces/neuralnetworks" revision="181f7c798017c00372848000f4ba38b04936e5ab" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="aosp/platform/system/core/base" path="src/aosp/system/core/base" revision="8cf6479cfd925657da51da04902a68dfe7e84632" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="aosp/platform/system/core/libbacktrace" path="src/aosp/system/core/libbacktrace" revision="d67ee5af5ee2790631aa4f7ca125d12c09840436" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="aosp/platform/system/core/libcutils" path="src/aosp/system/core/libcutils" revision="dcc518ef32993d0171d0849bd3677c9d0948f8bb" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="aosp/platform/system/core/liblog" path="src/aosp/system/core/liblog" revision="9cca7081cb7d158034bffec841f227af52cca401" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="aosp/platform/system/core/libsync" path="src/aosp/system/libsync" revision="074e053f159602aa7558cfb2ae2f3c67878d90e0" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="aosp/platform/system/core/libutils" path="src/aosp/system/core/libutils" revision="6518555263253e9fdf7e37d26866cbe75bc11e97" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="aosp/platform/system/libbase" path="src/aosp/system/libbase" revision="9537e373c71c26c5495be60d267dff5eb88b180f" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="paygen"/>
+  <project name="aosp/platform/system/libfmq" path="src/aosp/system/libfmq" revision="1d72513a44e4cb856c1cc70f95f9b1e88b1b4a78" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="aosp/platform/system/libhidl" path="src/aosp/system/libhidl" revision="49005468bfa1d0c3ed69d8a61b8d0fbaafd1e836" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="aosp/platform/system/logging" path="src/aosp/system/logging" revision="2e909ccdf779939e5caa5ab52851f38f22037ae9" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="aosp/platform/system/update_engine" path="src/aosp/system/update_engine" revision="13cbe84db16279753fc4f956edda784a6183ae7e" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="paygen"/>
+  <project name="apps/libapps" path="src/third_party/libapps" revision="d5067de5ae5000fa1b19ae7d3119618631dca3f8">
+    <annotation name="branch-mode" value="pin"/>
+  </project>
+  <project name="breakpad/breakpad" path="src/third_party/breakpad" revision="335e61656fa6034fabc3431a91e5800ba6fc3dc9"/>
+  <project name="chromium/llvm-project/cfe/tools/clang-format" path="src/chromium/src/buildtools/clang_format/script" remote="chromium" revision="bb994c6f067340c1135eb43eed84f4b33cfa7397" groups="minilayout,paygen,buildtools,labtools"/>
+  <project name="chromium/src/buildtools" path="src/chromium/src/buildtools" remote="chromium" revision="2c110db04251fd39d54c5f0de824819ab120ca99" groups="minilayout,paygen,buildtools,labtools"/>
+  <project name="chromium/src/components/policy" path="src/chromium/src/components/policy" remote="chromium" revision="60b98b226fe515eac90b51cfd80721d280b5020b"/>
+  <project name="chromium/src/media/midi" path="src/chromium/src/media/midi" remote="chromium" revision="77cc36d72b2a07ce056c6dc57290b2e094db7931"/>
+  <project name="chromium/src/net/tools/testserver" path="src/chromium/src/net/tools/testserver" remote="chromium" revision="69ef0407e96d24900081ca114cabdfc891f40d2d"/>
+  <project name="chromium/src/third_party/Python-Markdown" path="src/chromium/src/third_party/Python-Markdown" remote="chromium" revision="872ba9e68a6c698ede103b32265c265c026b8fee"/>
+  <project name="chromium/src/third_party/private_membership" path="src/chromium/src/third_party/private_membership" remote="chromium" revision="acb07d8034884b0f5e6d3b4379f6032fdb733e44"/>
+  <project name="chromium/src/third_party/shell-encryption" path="src/chromium/src/third_party/shell-encryption" remote="chromium" revision="04a46b48f70713db831b32da1581437d587f4081"/>
+  <project name="chromium/src/third_party/tlslite" path="src/chromium/src/third_party/tlslite" remote="chromium" revision="05d9f22315757117685ad2f5265148f900f18034"/>
+  <project name="chromium/src/tools/md_browser" path="src/chromium/src/tools/md_browser" remote="chromium" revision="ac44704f23348283ef7ae6ddbfe95420b37c34dc"/>
+  <project name="chromium/tools/depot_tools" path="src/chromium/depot_tools" remote="chromium" revision="9997ceb9a1c8680b029e85dc9fe7515dec23cf69" groups="minilayout,paygen,firmware,buildtools,labtools"/>
+  <project name="chromiumos/chromite" path="chromite" revision="84383ce05ff18bd163ebed6bd8d4fc25317cb46f" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="minilayout,paygen,firmware,buildtools,chromeos-admin,labtools,sysmon,devserver,crosvm">
+    <copyfile src="AUTHORS" dest="AUTHORS"/>
+    <copyfile src="LICENSE" dest="LICENSE"/>
+  </project>
+  <project name="chromiumos/chromite" path="infra/chromite-HEAD" revision="610af41d4e9eda9331375a5278c605c570e02044" upstream="refs/heads/main" dest-branch="refs/heads/main" groups="buildtools">
+    <annotation name="branch-mode" value="tot"/>
+  </project>
+  <project name="chromiumos/config" path="src/config" revision="ddca2aa2489d0a3df816648b0772af93a3c0cfc7" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="paygen,config,partner-config"/>
+  <project name="chromiumos/containers/cros-container-guest-tools" path="src/platform/container-guest-tools" revision="cdfb58ba2549626850b9cd17a29b7e1bf617ee77" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/docs" path="docs" revision="c7694254c4a27338e21b79e6992e7a9ec800d294" groups="crosvm">
+    <annotation name="branch-mode" value="pin"/>
+  </project>
+  <project name="chromiumos/graphyte" path="src/platform/graphyte" revision="f661990d0379f1030bdaa93c573ef4a50e9c6e66" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/infra/build/empty-project" path="src/platform/empty-project" revision="e8d0ce9c4326f0e57235f1acead1fcbc1ba2d0b9" groups="minilayout,paygen,firmware">
+    <annotation name="branch-mode" value="pin"/>
+  </project>
+  <project name="chromiumos/infra/go" path="infra/go" revision="6eadc22e734e94376e053926fb56729094b36adc" upstream="refs/heads/main" dest-branch="refs/heads/main" groups="chromeos-admin">
+    <annotation name="branch-mode" value="tot"/>
+  </project>
+  <project name="chromiumos/infra/lucifer" path="infra/lucifer" revision="12e9e6bde527c0bf97ff68c1d5f70385e15d1e58" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/infra/proto" path="chromite/infra/proto" revision="a129aac4875cecd72343e9da724a467133c4414b" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/infra/proto" path="infra/proto" revision="a68d3778d5d453585b7f510525b9dfb8fa879134" upstream="refs/heads/main" dest-branch="refs/heads/main">
+    <annotation name="branch-mode" value="tot"/>
+  </project>
+  <project name="chromiumos/infra/test_analyzer" path="infra/test_analyzer" revision="14119cc21c146544791fe387f64a4b809c4ea789" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/infra_virtualenv" path="infra_virtualenv" revision="cab8a95f2961561eb56a95d6f2bfc685686db75a" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="minilayout,paygen,firmware,buildtools,chromeos-admin,labtools,sysmon,devserver"/>
+  <project name="chromiumos/manifest" path="manifest" revision="9d54e1e24f3ce54baec8e5b483eed2d52dddb5b1" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/overlays/board-overlays" path="src/overlays" revision="2e4cfc31172542c771583fd85dd6d192987f0a1e" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="minilayout,paygen,firmware"/>
+  <project name="chromiumos/overlays/chromiumos-overlay" path="src/third_party/chromiumos-overlay" revision="869a043ba27159b606ca97197718b888d65b3f19" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="minilayout,paygen,firmware,labtools" sync-c="true"/>
+  <project name="chromiumos/overlays/eclass-overlay" path="src/third_party/eclass-overlay" revision="e9e78ef1eaa6a78e05df5af2dd3f9fd7dd8883f0" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="minilayout,paygen,firmware,labtools"/>
+  <project name="chromiumos/overlays/portage-stable" path="src/third_party/portage-stable" revision="5588c0f87d858b5c46f6bb1fc6f5e555959ab0b7" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="minilayout,paygen,firmware,labtools"/>
+  <project name="chromiumos/platform/assets" path="src/platform/assets" revision="8a2276f22f0678bee89b8ac6c46d9dd597c6d549" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/platform/audiotest" path="src/platform/audiotest" revision="c4f3a48a6710ad8630707986f427d1d3b226fda7" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/platform/bisect-kit" path="src/platform/bisect-kit" revision="e355e576dd932e45314090e01010cbdd3d2d7418" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/platform/bmpblk" path="src/platform/bmpblk" revision="fc49054007a161e329c970e9a5267de284f8fd91" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/platform/btsocket" path="src/platform/btsocket" revision="f0c71bd1151cca91ff171e5f9a4582488a3f1dc5" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/platform/camera" path="src/platform/camera" revision="0db089197f74799a6a86522ab568a50a780bcbfb" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/platform/cbor" path="src/platform/cbor" revision="35fe21779fddc0d376da13dab49e31fa3491205f" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/platform/cfm-device-monitor" path="src/platform/cfm-device-monitor" revision="57e2c51983363f743c0ca961638c09418c7bac4c" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/platform/chameleon" path="src/platform/chameleon" revision="93d0135a52909044c8d2ea98b5a8f50169cbb59f" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/platform/chromiumos-assets" path="src/platform/chromiumos-assets" revision="de6c118f21ef7130feb30d4b7f703cfe2ba2748f" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/platform/cobble" path="src/platform/cobble" revision="4ab43f1f86b7099b8ad75cf9615ea1fa155bbd7d" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/platform/croscomp" path="src/platform/croscomp" revision="5846298ea42665c2c0b520d468d79d8fedd4a16f" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/platform/crostestutils" path="src/platform/crostestutils" revision="80bf6266f90f5bab5dd405e3d5f1b974482f2a8a" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="minilayout,paygen,firmware,buildtools"/>
+  <project name="chromiumos/platform/crosutils" path="src/scripts" revision="46719703aba399152fb53ee1f87617487e546d64" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="minilayout,paygen,firmware,buildtools,labtools"/>
+  <project name="chromiumos/platform/crosvm" path="src/platform/crosvm" revision="d58d398581724e81ce57a8dfaeef62c175c06552" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="crosvm"/>
+  <project name="chromiumos/platform/depthcharge" path="src/platform/depthcharge" revision="1a3e4bc36b93dcbcc3370e2160a149118cca9876" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="firmware"/>
+  <project name="chromiumos/platform/dev-util" path="src/platform/dev" revision="b79e19979a59100f19f7de408ffa2eb92277e0a8" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="minilayout,paygen,firmware,buildtools,devserver"/>
+  <project name="chromiumos/platform/drm-tests" path="src/platform/drm-tests" revision="e5c5d569337ad3d1c6e9aea9d509bec818421bb1" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/platform/ec" path="src/platform/cr50" revision="caf0666a392c3601ec79e324d52187e17abbae61" upstream="refs/heads/release-R106-15054.B-cr50_stab" dest-branch="refs/heads/release-R106-15054.B-cr50_stab" groups="paygen,firmware"/>
+  <project name="chromiumos/platform/ec" path="src/platform/ec" revision="96af58d5d8e438628342bca6458d8cd2987df7b6" upstream="refs/heads/release-R106-15054.B-main" dest-branch="refs/heads/release-R106-15054.B-main" groups="paygen,firmware"/>
+  <project name="chromiumos/platform/ec" path="src/platform/ish" revision="f4bb384c7161f6905ddf8a9a3154d58625d1f50a" upstream="refs/heads/release-R106-15054.B-ish" dest-branch="refs/heads/release-R106-15054.B-ish" groups="firmware"/>
+  <project name="chromiumos/platform/ec" path="src/platform/release-firmware/fpmcu-bloonchipper" revision="e5fb0b9ba488614b5684e640530f00821ab7b943" groups="firmware">
+    <annotation name="branch-mode" value="pin"/>
+  </project>
+  <project name="chromiumos/platform/ec" path="src/platform/release-firmware/fpmcu-dartmonkey" revision="6c1587ca70f558b4f96b3f0b18ad8b027d3ba99d" groups="firmware">
+    <annotation name="branch-mode" value="pin"/>
+  </project>
+  <project name="chromiumos/platform/ec" path="src/platform/release-firmware/fpmcu-nami" revision="6c1587ca70f558b4f96b3f0b18ad8b027d3ba99d" groups="firmware">
+    <annotation name="branch-mode" value="pin"/>
+  </project>
+  <project name="chromiumos/platform/ec" path="src/platform/release-firmware/fpmcu-nocturne" revision="6c1587ca70f558b4f96b3f0b18ad8b027d3ba99d" groups="firmware">
+    <annotation name="branch-mode" value="pin"/>
+  </project>
+  <project name="chromiumos/platform/experimental" path="src/platform/experimental" revision="2927fce20adf74b0c9a32a61e3edff894221f283" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/platform/factory" path="src/platform/factory" revision="e711cb5cd04ce07b4901e29db2b4a5cc02d334e9" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/platform/factory_installer" path="src/platform/factory_installer" revision="8f78e5df32594d10f7b3ff0ac381cf36364b07d1" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/platform/firmware" path="src/platform/firmware" revision="fc8caeb7b5c6f623afa3b6d4667c37c8b269807d" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="firmware"/>
+  <project name="chromiumos/platform/frecon" path="src/platform/frecon" revision="e3be588f800b9b46ef4dc788f4179eb39943cccd" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/platform/fw-testing-configs" path="src/platform/tast-tests/src/chromiumos/tast/remote/firmware/data/fw-testing-configs" revision="eedb47dbe3c150de1b19868cb76178b0b0319f65" upstream="refs/heads/release-R106-15054.B-main" dest-branch="refs/heads/release-R106-15054.B-main" groups="paygen,buildtools,labtools,devserver,firmware"/>
+  <project name="chromiumos/platform/fw-testing-configs" path="src/third_party/autotest/files/server/cros/faft/fw-testing-configs" revision="eedb47dbe3c150de1b19868cb76178b0b0319f65" upstream="refs/heads/release-R106-15054.B-main" dest-branch="refs/heads/release-R106-15054.B-main" groups="buildtools,labtools,devserver,firmware"/>
+  <project name="chromiumos/platform/gestures" path="src/platform/gestures" revision="9010b3b6689df0c50dcaf39befef0a0e685ebf86" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/platform/glbench" path="src/platform/glbench" revision="cc945410df567f5da924247d04b87928ca8926a1" upstream="refs/heads/release-R106-15054.B-main" dest-branch="refs/heads/release-R106-15054.B-main"/>
+  <project name="chromiumos/platform/graphics" path="src/platform/graphics" revision="7b7b53d0748d40f4305e2b7e4a67a8bbaf2c0ac1" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/platform/hps-firmware" path="src/platform/hps-firmware2" revision="a6999878c101d15bab83dd04be4c70252ab64deb" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/platform/hps-firmware-images" path="src/platform/hps-firmware-images" revision="4ee72fddab81ee0f22df360c86fd7c3c13e833d8" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/platform/initramfs" path="src/platform/initramfs" revision="7a5d371ba3254b77bd073c5d32cc39f633606b03" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/platform/inputcontrol" path="src/platform/inputcontrol" revision="6c9fd34b4a6231efc189c530e2f05d908b55185e" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/platform/jabra_vold" path="src/platform/jabra_vold" revision="233d517d2904912b207d273794b0ec5343e48010" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/platform/libchrome" path="src/platform/libchrome" revision="90cca6668e529846cd3aaabac5473fff22e9c1c5" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/platform/libevdev" path="src/platform/libevdev" revision="8d00f789df9bd4efce783a46f30d75d742d3e8d4" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/platform/libva-fake-driver" path="src/platform/libva-fake-driver" revision="7754dd6e00355bb0d7bb5f597b482b6d5ff5cab5" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/platform/lithium" path="src/platform/lithium" revision="1b54b0fa69bb183ed19945a79b72bc17145eafe4" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="firmware"/>
+  <project name="chromiumos/platform/microbenchmarks" path="src/platform/microbenchmarks" revision="ec4ae6c0d54618c01a5e1c78d80c44bc80af6ad6" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/platform/minigbm" path="src/platform/minigbm" revision="64de5175a02f9a36a4b0aa6fa54e0dd1d64985bf" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="crosvm"/>
+  <project name="chromiumos/platform/minijail" path="src/platform/minijail" revision="485c8a098c5b1a63f079461826ed45571f2a0032" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="crosvm"/>
+  <project name="chromiumos/platform/mosys" path="src/platform/mosys" revision="f5a6d1de0179bc3b1583861befd111b7b74dd876" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/platform/mttools" path="src/platform/mttools" revision="957a434f10b7663bbafc85fb19afe1a3318c0a10" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/platform/pinweaver" path="src/platform/pinweaver" revision="3abfd77090d24ca8d2d7260d6ba6aaec2e4c35ae" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/platform/rules_cros" path="src/platform/rules_cros" revision="c193ad352d1838861dfd481a2aae0456a8f3d18e" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/platform/tast" path="src/platform/tast" revision="0194f52de329296e27419a1f5a1f58e0b61e56ae" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="minilayout,paygen"/>
+  <project name="chromiumos/platform/tast-tests" path="src/platform/tast-tests" revision="bc1e6804983b8ea179c03ace3dfbc30bbd0e39b3" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="minilayout,paygen"/>
+  <project name="chromiumos/platform/tauto" path="src/platform/tauto" revision="2c088e3efa0b85bf21457b4df3f3b68d682d7a15" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/platform/touch_firmware_test" path="src/platform/touch_firmware_test" revision="b8b2c09a7965e530eeeba1e7adac51ef542264ee" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="firmware"/>
+  <project name="chromiumos/platform/touch_updater" path="src/platform/touch_updater" revision="e195fb663d8990eb68dd1dffdddd1c023ea55720" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/platform/touchpad-tests" path="src/platform/touchpad-tests" revision="4c32bef9592024fe76fb0b8c913add3b1421e2d6" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/platform/tpm" path="src/third_party/tpm" revision="421593a8cea1083288d5d047b0c43f85c92fe069" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="firmware"/>
+  <project name="chromiumos/platform/tpm_lite" path="src/platform/tpm_lite" revision="dd6ae9f3a223c0a8a89a2e4c10600f7700354a53" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/platform/tremplin" path="src/platform/tremplin" revision="ffb5466ae2cf8e2e677c3ecb06f9a1bd811a4736" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/platform/usi-test" path="src/platform/usi-test" revision="36e36575ca053ff30cdd29ee9bce01def40b7c5e" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/platform/vboot_reference" path="src/platform/vboot_reference" revision="9b08a3c4806153256e13a0d8e9019d6a387becd5" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="paygen,firmware,buildtools"/>
+  <project name="chromiumos/platform/vkbench" path="src/platform/vkbench" revision="04181fbbee6d5d36a39a6dcc576eef7556c93436" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/platform/vpd" path="src/platform/vpd" revision="20bf6ac7f99f1c83e1b696f575cdfc9d8fe62498" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/platform/xorg-conf" path="src/platform/xorg-conf" revision="892acd523987be87b84b691452f722cea4d28e00" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/platform2" path="src/platform2" revision="132f4f86c8c744d01ba8a54a48abcc7902a02ff0" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="minilayout,paygen,crosvm"/>
+  <project name="chromiumos/project" path="src/project_public" revision="f1387fd5f4effe236dd2a8e6e2b8e665eb2a6cfb" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="partner-config"/>
+  <project name="chromiumos/repohooks" path="src/repohooks" revision="32b1168199c41dc9e6e0b91dfe37b0568dee538d" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="minilayout,paygen,firmware,buildtools,labtools,crosvm"/>
+  <project name="chromiumos/third_party/Wi-FiTestSuite-Linux-DUT" path="src/third_party/Wi-FiTestSuite-Linux-DUT" revision="afe5b18c1b33f03169779851369c8c4ab0bb941d" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/third_party/adhd" path="src/third_party/adhd" revision="d5bd8897460cc902813b0e3f78f63913a8d182ef" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="crosvm"/>
+  <project name="chromiumos/third_party/apitrace" path="src/third_party/apitrace" revision="1090464595110ae95d329f2f7b6220443052c215" upstream="refs/heads/release-R106-15054.B-master" dest-branch="refs/heads/release-R106-15054.B-master"/>
+  <project name="chromiumos/third_party/arm-trusted-firmware" path="src/third_party/arm-trusted-firmware" revision="38dd6b61ae2ae6ba49f425771c0b529f7dbc9b4a" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/third_party/atrusctl" path="src/third_party/atrusctl" revision="4f1d81ecfa86ae7570f951fe6eaac9ab2c1290d7" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/third_party/autotest" path="src/third_party/autotest/files" revision="9b90659ed098a257f5681ad6fef305d18b3c83d2" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="buildtools,labtools,devserver"/>
+  <project name="chromiumos/third_party/aver-updater" path="src/third_party/aver-updater" revision="6418ac5d86c720d234f961513021a5ff0a2bf3d8" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/third_party/bluez" path="src/third_party/bluez/current" revision="222ead55bd4444cd754357d6819caacd8ab095bd" upstream="refs/heads/release-R106-15054.B-chromeos-5.54" dest-branch="refs/heads/release-R106-15054.B-chromeos-5.54"/>
+  <project name="chromiumos/third_party/bluez" path="src/third_party/bluez/next" revision="222ead55bd4444cd754357d6819caacd8ab095bd" upstream="refs/heads/release-R106-15054.B-chromeos-5.54" dest-branch="refs/heads/release-R106-15054.B-chromeos-5.54"/>
+  <project name="chromiumos/third_party/bluez" path="src/third_party/bluez/upstream" revision="60663d4af3ffb6f82e75a3a4bc73b8b8887a3353">
+    <annotation name="branch-mode" value="pin"/>
+  </project>
+  <project name="chromiumos/third_party/bootstub" path="src/third_party/bootstub" revision="076cb8e624d2f9d8ab75fc07f614e3c1288e0b2e" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="firmware"/>
+  <project name="chromiumos/third_party/cbootimage" path="src/third_party/cbootimage" revision="b7d5b2d6a6dd05874d86ee900ff441d261f9034c" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="firmware"/>
+  <project name="chromiumos/third_party/chre" path="src/third_party/chre" revision="c58a01b5ac2ee96b9451b681ae7583c7105ff5bd" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/third_party/clspv" path="src/third_party/clspv" revision="9037cf2b08453dc436afd481d131d68eacf3c04c" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/third_party/clvk" path="src/third_party/clvk" revision="2dcb0192961499018668a7301cbc625965b7c895" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/third_party/coreboot" path="src/third_party/coreboot" revision="28654b970211ef4669b50ac5cac55029587d410a" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="firmware"/>
+  <project name="chromiumos/third_party/coreboot/amd_blobs" path="src/third_party/coreboot/3rdparty/amd_blobs" revision="5cd5f53ecdab2c4ba06d026d08325d4647d5daf9" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="firmware"/>
+  <project name="chromiumos/third_party/coreboot/blobs" path="src/third_party/coreboot/3rdparty/blobs" revision="d2e55573069041a3b6d6eb07267113b58d39bf5f" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="firmware"/>
+  <project name="chromiumos/third_party/coreboot/intel-microcode" path="src/third_party/coreboot/3rdparty/intel-microcode" revision="ee319ae7bc59e88b60142f40a9ec1b46656de4db" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="firmware"/>
+  <project name="chromiumos/third_party/coreboot/libgfxinit" path="src/third_party/coreboot/3rdparty/libgfxinit" revision="df648e302fc9a3a8a23d040d56eb3f35a33f8585" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="firmware"/>
+  <project name="chromiumos/third_party/coreboot/libhwbase" path="src/third_party/coreboot/3rdparty/libhwbase" revision="9946827bbae199477cfcb68dcc5ed257aaa9ba7d" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="firmware"/>
+  <project name="chromiumos/third_party/coreboot/qc_blobs" path="src/third_party/coreboot/3rdparty/qc_blobs" revision="e570e0219bdc0fd750cafdb6dcf77ed96bcbcea3" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="firmware"/>
+  <project name="chromiumos/third_party/cros-adapta" path="src/third_party/cros-adapta" revision="46fd2136aa799bb17dfb1002278f98e6397e5806" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/third_party/cryptoc" path="src/third_party/cryptoc" revision="11a97df4133f905bbdf9ddb48b5d56d617ec949b" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="firmware"/>
+  <project name="chromiumos/third_party/cups" path="src/third_party/cups" revision="689c1144584a06227cc879b3515337c1b2cdc6c0" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/third_party/daisydog" path="src/third_party/daisydog" revision="4b0c966fb6a35eabd6f06633a5c48ecff27ce2a5" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/third_party/edk2" path="src/third_party/amd-firmware/binarypi/picasso-edk2" revision="e2fc5e5879135d2c7e638a83ca066b2a08e134d5" upstream="refs/heads/release-R106-15054.B-pco" dest-branch="refs/heads/release-R106-15054.B-pco" groups="firmware"/>
+  <project name="chromiumos/third_party/edk2" path="src/third_party/edk2" revision="8523e9c995e7204e1067c1660ac04177932d4b1b" upstream="refs/heads/release-R106-15054.B-chromeos-2017.08" dest-branch="refs/heads/release-R106-15054.B-chromeos-2017.08" groups="firmware"/>
+  <project name="chromiumos/third_party/edk2" path="src/third_party/fsp/cml/edk2/branch1" revision="4de539eb3f1bcc304ac2ea88c3a8d4b5cc76a5d6" upstream="refs/heads/release-R106-15054.B-chromeos-cml-branch1" dest-branch="refs/heads/release-R106-15054.B-chromeos-cml-branch1" groups="firmware"/>
+  <project name="chromiumos/third_party/edk2" path="src/third_party/fsp/cnl/edk2" revision="995dede2362e4947c91f631069444552a1d2eeff" upstream="refs/heads/release-R106-15054.B-chromeos-cnl" dest-branch="refs/heads/release-R106-15054.B-chromeos-cnl" groups="firmware"/>
+  <project name="chromiumos/third_party/edk2" path="src/third_party/fsp/glk/edk2" revision="f84e90881271300af73761bbd6a6fa8b8f82c266" upstream="refs/heads/release-R106-15054.B-chromeos-glk" dest-branch="refs/heads/release-R106-15054.B-chromeos-glk" groups="firmware"/>
+  <project name="chromiumos/third_party/em100" path="src/third_party/em100" revision="a1d938f8b4253c76fb31e69de33266cb71bda141" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="firmware"/>
+  <project name="chromiumos/third_party/fastrpc" path="src/third_party/fastrpc" revision="c2d1cdc0fb781ee673077c5d4b243eb239c73bb5" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/third_party/flashmap" path="src/third_party/flashmap" revision="9c71c8331ad52a11d29496ffb10cbdb1a51e2ccb" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="firmware"/>
+  <project name="chromiumos/third_party/flashrom" path="src/third_party/flashrom" revision="611e95e31ee2c8824cef306b8b199aacf771d96b" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="paygen,firmware"/>
+  <project name="chromiumos/third_party/fwupd" path="src/third_party/fwupd" revision="b48c2ddec5e75c89b1c8eb95029e8926c7bdb672" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/third_party/hdctools" path="src/third_party/hdctools" revision="6ae7567c9bc745fd94f89c34aba2655b3b3b3c54" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="paygen,labtools"/>
+  <project name="chromiumos/third_party/hostap" path="src/third_party/wpa_supplicant" revision="c297db6ffd38d6694fe5f8b04b55aa74e00e9c77" upstream="refs/heads/release-R106-15054.B-master" dest-branch="refs/heads/release-R106-15054.B-master"/>
+  <project name="chromiumos/third_party/hostap" path="src/third_party/wpa_supplicant-cros/current" revision="621410e2e3d8507237e27889136f98af3ae1ebb7" upstream="refs/heads/release-R106-15054.B-wpa_supplicant-2.9.1" dest-branch="refs/heads/release-R106-15054.B-wpa_supplicant-2.9.1"/>
+  <project name="chromiumos/third_party/hostap" path="src/third_party/wpa_supplicant-cros/next" revision="621410e2e3d8507237e27889136f98af3ae1ebb7" upstream="refs/heads/release-R106-15054.B-wpa_supplicant-2.9.1" dest-branch="refs/heads/release-R106-15054.B-wpa_supplicant-2.9.1"/>
+  <project name="chromiumos/third_party/huddly-updater" path="src/third_party/huddly-updater" revision="13f5da57bf04915c58c06de760565583b883b915" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/third_party/igt-gpu-tools" path="src/third_party/igt-gpu-tools" revision="c8edfca649da71b296d882bb0319181d94e619eb" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/third_party/intel-wifi-fw-dump" path="src/third_party/intel-wifi-fw-dump" revision="d4dd3967c51e3d255fb9beb5581e6d9a3938ca07" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/third_party/kernel" path="src/third_party/kernel/upstream" revision="3ce3e1c35030861b8a5a60a9367109d885703471">
+    <annotation name="branch-mode" value="pin"/>
+  </project>
+  <project name="chromiumos/third_party/kernel" path="src/third_party/kernel/v4.4" revision="eed01c3898b21ecc590cff0fab71f13ca9b8f034" upstream="refs/heads/release-R106-15054.B-chromeos-4.4" dest-branch="refs/heads/release-R106-15054.B-chromeos-4.4"/>
+  <project name="chromiumos/third_party/kernel" path="src/third_party/kernel/v4.14" revision="d1f3f46afcb01f16c5a7aa8176820ef6dc0b5056" upstream="refs/heads/release-R106-15054.B-chromeos-4.14" dest-branch="refs/heads/release-R106-15054.B-chromeos-4.14"/>
+  <project name="chromiumos/third_party/kernel" path="src/third_party/kernel/v4.19" revision="a5ef616743fe0bb357188474a73f19d4ca788332" upstream="refs/heads/release-R106-15054.B-chromeos-4.19" dest-branch="refs/heads/release-R106-15054.B-chromeos-4.19"/>
+  <project name="chromiumos/third_party/kernel" path="src/third_party/kernel/v5.4" revision="58913344151bf16e22740567fc502b0054d85039" upstream="refs/heads/release-R106-15054.B-chromeos-5.4" dest-branch="refs/heads/release-R106-15054.B-chromeos-5.4"/>
+  <project name="chromiumos/third_party/kernel" path="src/third_party/kernel/v5.10" revision="7a24dee39fa076aa2816b327a89e9b372fa26ab8" upstream="refs/heads/release-R106-15054.B-chromeos-5.10" dest-branch="refs/heads/release-R106-15054.B-chromeos-5.10"/>
+  <project name="chromiumos/third_party/kernel" path="src/third_party/kernel/v5.10-arcvm" revision="12c9ae48aa486fa8dd80fe35a5c84942b5af3596" upstream="refs/heads/release-R106-15054.B-chromeos-5.10-arcvm" dest-branch="refs/heads/release-R106-15054.B-chromeos-5.10-arcvm"/>
+  <project name="chromiumos/third_party/kernel" path="src/third_party/kernel/v5.10-manatee" revision="983e45b44343db57acdb37fa04c88e4bcb33b929" upstream="refs/heads/release-R106-15054.B-chromeos-5.10-manatee" dest-branch="refs/heads/release-R106-15054.B-chromeos-5.10-manatee"/>
+  <project name="chromiumos/third_party/kernel" path="src/third_party/kernel/v5.15" revision="3d3ad41dd531946f756b44252353db82ab16db42" upstream="refs/heads/release-R106-15054.B-chromeos-5.15" dest-branch="refs/heads/release-R106-15054.B-chromeos-5.15"/>
+  <project name="chromiumos/third_party/khronos" path="src/third_party/khronos" revision="c9d952582b74f9609bf68e0402856a2fc1e536c0" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/third_party/labpack" path="src/third_party/labpack/files" revision="c12d4bd39f683ac89da28124568417221b46906b" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="labtools"/>
+  <project name="chromiumos/third_party/lexmark-fax-pnh" path="src/third_party/lexmark-fax-pnh" revision="f131d8f851366e6a2f8e8fa8f3042285d021d6c6" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/third_party/libcamera" path="src/third_party/libcamera" revision="72b6c710d448d5a1ff9407f9f7c7780660ee556a" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/third_party/libdrm" path="src/third_party/libdrm" revision="003eb2a554edd55c410678568328847a23b97e1a" upstream="refs/heads/release-R106-15054.B-upstream-main" dest-branch="refs/heads/release-R106-15054.B-upstream-main"/>
+  <project name="chromiumos/third_party/libiio" path="src/third_party/libiio" revision="213eca340c157b96232242da15539e12efb2d5c9" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/third_party/libmbim" path="src/third_party/libmbim" revision="3145e614841cc5d3e94830bf7502311285e2b71a" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/third_party/libqmi" path="src/third_party/libqmi" revision="030e85bda532776247fa6d24547e41510b7f3fba" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/third_party/libqrtr" path="src/third_party/libqrtr" revision="ba87335b33afcc0c1e0860ed41d0a98abc804184" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/third_party/libqrtr-glib" path="src/third_party/libqrtr-glib" revision="419e7b388895d5894ee50fddb334955b5cbcd636" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/third_party/libsigrok" path="src/third_party/libsigrok" revision="199fe31115c76231746f5953271795d58679561c" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/third_party/libsigrok-cli" path="src/third_party/sigrok-cli" revision="c9edfa218e5a5972531b6f4a3ece8d33a44ae1b5" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/third_party/libsigrokdecode" path="src/third_party/libsigrokdecode" revision="3279c2825684c7009775b731d0a9e37815778282" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/third_party/libtextclassifier" path="src/third_party/libtextclassifier" revision="01652c17e116baa8ebd7083e8cbc3dede513ac9e" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/third_party/libv4lplugins" path="src/third_party/libv4lplugins" revision="6446d6609a6f5004fac8e2a174e0c177a0906f81" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/third_party/linux-firmware" path="src/third_party/linux-firmware" revision="ac0df43f2c919c25924c1bc45bd74447b00d6c9e" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/third_party/logitech-updater" path="src/third_party/logitech-updater" revision="f4c70da20b88ef2ab6eff8136870df1a2f052a06" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/third_party/marvell" path="src/third_party/marvell" revision="a1da785c038730d7d900415945688f6fb76175f4" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/third_party/mesa" path="src/third_party/mesa" revision="37aa92a3cd88c84b3372094b3d1a35daa36b7dd9" upstream="refs/heads/release-R106-15054.B-upstream-main" dest-branch="refs/heads/release-R106-15054.B-upstream-main"/>
+  <project name="chromiumos/third_party/mesa" path="src/third_party/mesa-amd" revision="84b0501b8c8fc6173d01052bcd6e3591daf23ac7" upstream="refs/heads/release-R106-15054.B-chromeos-amd" dest-branch="refs/heads/release-R106-15054.B-chromeos-amd"/>
+  <project name="chromiumos/third_party/mesa" path="src/third_party/mesa-arcvm" revision="b39d467a8bcfd5571818e22c3b0379a46bb1c205" upstream="refs/heads/release-R106-15054.B-chromeos-arcvm" dest-branch="refs/heads/release-R106-15054.B-chromeos-arcvm"/>
+  <project name="chromiumos/third_party/mesa" path="src/third_party/mesa-debian" revision="c36b89b82bcd270e1f9ee7d0824c9e265a39e95b" upstream="refs/heads/release-R106-15054.B-debian" dest-branch="refs/heads/release-R106-15054.B-debian"/>
+  <project name="chromiumos/third_party/mesa" path="src/third_party/mesa-freedreno" revision="bbebe4e23120374587083abd7c8bd9a9cc33832d" upstream="refs/heads/release-R106-15054.B-chromeos-freedreno" dest-branch="refs/heads/release-R106-15054.B-chromeos-freedreno"/>
+  <project name="chromiumos/third_party/mesa" path="src/third_party/mesa-img" revision="2e7833ad916c493969d00871cdf56db4407b80eb" upstream="refs/heads/release-R106-15054.B-mesa-19.0" dest-branch="refs/heads/release-R106-15054.B-mesa-19.0"/>
+  <project name="chromiumos/third_party/mesa" path="src/third_party/mesa-iris" revision="4565e43d111b112581daf4cf9cdd1454daf80510" upstream="refs/heads/release-R106-15054.B-chromeos-iris" dest-branch="refs/heads/release-R106-15054.B-chromeos-iris"/>
+  <project name="chromiumos/third_party/mesa" path="src/third_party/mesa-reven" revision="b45a1e8a3f2cf39d6fdd8de8585ad44573d78205" upstream="refs/heads/release-R106-15054.B-chromeos-reven" dest-branch="refs/heads/release-R106-15054.B-chromeos-reven"/>
+  <project name="chromiumos/third_party/mimo-updater" path="src/third_party/mimo-updater" revision="fb448bbd2986c743f3c37dbc784ae972e24b1a23" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/third_party/mmc-utils" path="src/third_party/mmc-utils" revision="7be960e2b84b5dfcbec44d3b722fb02d16b9eaf1" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/third_party/modemmanager-next" path="src/third_party/modemmanager-next" revision="3ff7fca84c66da1125c1db0e74cc9a262fadc2c3" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/third_party/novatek-tcon-fw-update-tool" path="src/third_party/novatek-tcon-fw-update-tool" revision="a78b7b0ba128471af835e44dc97698d39fd89bbf" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/third_party/poly-updater" path="src/third_party/poly-updater" revision="87ad2edeea039892515f68c948bc2b8f94999553" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/third_party/portage_tool" path="src/third_party/portage_tool" revision="a19bc4604bad58cf743719b704732722339ea315" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/third_party/pyelftools" path="chromite/third_party/pyelftools" revision="6fec9f599bef566fe8f6f6ca6c2102508b664792" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="minilayout,paygen,firmware,buildtools"/>
+  <project name="chromiumos/third_party/qemu" path="src/third_party/qemu" revision="fdd76fecdde1ad444ff4deb7f1c4f7e4a1ef97d6" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/third_party/rootdev" path="src/third_party/rootdev" revision="7082cbf0ae51eb1044fe1a0749245e97e4fcfc89" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/third_party/rust-vmm/vhost" path="src/third_party/rust-vmm/vhost" revision="7c95b4a2c1e378f7328d8bc0510bbb6998f54581" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="crosvm"/>
+  <project name="chromiumos/third_party/rust_crates" path="src/third_party/rust_crates" revision="93ba47302b41b7418e076c61d5c7307ab1f66b2b">
+    <annotation name="branch-mode" value="pin"/>
+  </project>
+  <project name="chromiumos/third_party/seabios" path="src/third_party/seabios" revision="27b56c6e94fe37e9308392fefd25ba641d8be496" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="firmware"/>
+  <project name="chromiumos/third_party/shellcheck" path="src/third_party/shellcheck" revision="3e1b3e32c31461a6185f96fb68ef9ec3962fb9cb" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/third_party/sis-updater" path="src/third_party/sis-updater" revision="0e41acf19950b8c60d1e0c46ff7b64a24c51dea1" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/third_party/sound-open-firmware" path="src/third_party/sound-open-firmware" revision="35691bd4813b901c78ab938a4ec8bcc7fcb7f35f" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/third_party/svunit" path="src/third_party/svunit" revision="76ffd92958212a8e427a8eb6d24956df6ec19dbe" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/third_party/sysbios" path="src/third_party/sysbios" revision="33e1db34b8162de72a5e9bbbc44e6bce38978396" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="firmware"/>
+  <project name="chromiumos/third_party/systemd" path="src/third_party/systemd" revision="58d3fbc2d946d741887b2300d4c70dbe9cddcc7c" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/third_party/tlsdate" path="src/third_party/tlsdate" revision="cf13bc4fd99a3ef6d696307649299ac9badfb7e2" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/third_party/toolchain-utils" path="src/third_party/toolchain-utils" revision="28899da2f8029bbbef1d04b54986fb97060570a3" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="minilayout,paygen"/>
+  <project name="chromiumos/third_party/tpm2" path="src/third_party/tpm2" revision="2de0a64491451f72c7ffe5eb92301f4da509d0ad" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="firmware,crosvm"/>
+  <project name="chromiumos/third_party/trousers" path="src/third_party/trousers" revision="0ae53566c87c2d02476fe0e22b2862abbd42da15" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/third_party/u-boot" path="src/third_party/u-boot/files" revision="2c933c4ed374e7f16ae351bd7a6880c20db41e85" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/third_party/upstart" path="src/third_party/upstart" revision="2a2330a6114bef0a5c5bff7afe0d32a911b3f774" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/third_party/virglrenderer" path="src/third_party/virglrenderer" revision="486d891a9242d978cef6bb5ae80d0d9b6aa420c8" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="crosvm"/>
+  <project name="chromiumos/third_party/virtual-usb-printer" path="src/third_party/virtual-usb-printer" revision="cc853488d68fa87aeff57718b79f99387fd8886f" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/third_party/webrtc-apm" path="src/third_party/webrtc-apm" revision="6c381af40185c6e65a26b6525137df3d028f86e0" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
+  <project name="chromiumos/third_party/zephyr" path="src/third_party/zephyr/main" revision="49e580515dba8f01b3c572e8d30223021b609099" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="firmware,zephyr"/>
+  <project name="chromiumos/third_party/zephyr/cmsis" path="src/third_party/zephyr/cmsis" revision="45216bc4be443ec7c48a26cd958cb1a951564dec" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="firmware,zephyr"/>
+  <project name="chromiumos/third_party/zephyr/hal_stm32" path="src/third_party/zephyr/hal_stm32" revision="74a5a2025e40b599ffc71a68efd3444b0daf30a9" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="firmware,zephyr"/>
+  <project name="chromiumos/third_party/zephyr/nanopb" path="src/third_party/zephyr/nanopb" revision="0cdcea9140d23ce6f739850f93dcf3a2f4f6e4d4" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="firmware,zephyr"/>
+  <project name="external/git.kernel.org/fs/xfs/xfstests-dev" path="src/third_party/xfstests" revision="b91889d79e1d92e22860504e40108a2e4d054c33"/>
+  <project name="external/pigweed/pigweed/pigweed" path="src/third_party/pigweed" revision="9201c46264e5e52cc6f9aec6ec590bb2c10f8562"/>
+  <project name="infra/luci/client-py" path="chromite/third_party/swarming.client" remote="chromium" revision="34b20305c7a69eb89e1abd5e2a94708db999f0a9" groups="buildtools,chromeos-admin,firmware,labtools,minilayout,paygen"/>
+  <project name="linux-syscall-support" path="src/third_party/breakpad/src/third_party/lss" revision="e1e7b0ad8ee99a875b272c8e33e308472e897660"/>
+  <project name="platform/external/bsdiff" path="src/aosp/external/bsdiff" remote="aosp" revision="60e2a9b62a69784088406b31d711c3c74e79a866" groups="paygen"/>
+  <project name="platform/external/marisa-trie" path="src/aosp/external/marisa-trie" remote="aosp" revision="c90fe3d1e4f69b3aebd24764868797e76f12dba4">
+    <annotation name="branch-mode" value="pin"/>
+  </project>
+  <project name="platform/external/puffin" path="src/aosp/external/puffin" remote="aosp" revision="9932c5ede55e8a273ea21c5505a5d7ee141125e6" groups="paygen"/>
+  <project name="platform/system/keymaster" path="src/aosp/system/keymaster" remote="aosp" revision="49dfc58d6c4c66f5d0b0d06f0161da4e602a1293"/>
+  
+  <repo-hooks in-project="chromiumos/repohooks" enabled-list="pre-upload"/>
+</manifest>

--- a/config/rootfs/chromiumos/cros-snapshot-release-R106-15054.B.xml
+++ b/config/rootfs/chromiumos/cros-snapshot-release-R106-15054.B.xml
@@ -9,6 +9,9 @@
   <remote name="cros" fetch="https://chromium.googlesource.com" review="https://chromium-review.googlesource.com">
     <annotation name="public" value="true"/>
   </remote>
+  <remote name="cros-kernelci-dev" fetch="https://gitlab.collabora.com/aratiu" alias="cros">
+    <annotation name="public" value="true"/>
+  </remote>
   
   <default remote="cros" sync-j="8"/>
   
@@ -70,8 +73,8 @@
   <project name="chromiumos/infra/test_analyzer" path="infra/test_analyzer" revision="14119cc21c146544791fe387f64a4b809c4ea789" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
   <project name="chromiumos/infra_virtualenv" path="infra_virtualenv" revision="cab8a95f2961561eb56a95d6f2bfc685686db75a" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="minilayout,paygen,firmware,buildtools,chromeos-admin,labtools,sysmon,devserver"/>
   <project name="chromiumos/manifest" path="manifest" revision="9d54e1e24f3ce54baec8e5b483eed2d52dddb5b1" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
-  <project name="chromiumos/overlays/board-overlays" path="src/overlays" revision="2e4cfc31172542c771583fd85dd6d192987f0a1e" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="minilayout,paygen,firmware"/>
-  <project name="chromiumos/overlays/chromiumos-overlay" path="src/third_party/chromiumos-overlay" revision="869a043ba27159b606ca97197718b888d65b3f19" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="minilayout,paygen,firmware,labtools" sync-c="true"/>
+  <project remote="cros-kernelci-dev" name="board-overlays" path="src/overlays" revision="f96aa385ef594d48bc7602ebdb1b45d298961175" upstream="refs/heads/dev/kernelci/R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="minilayout,paygen,firmware"/>
+  <project remote="cros-kernelci-dev" name="chromiumos-overlay" path="src/third_party/chromiumos-overlay" revision="368d296bc518e803cd50d4cc35e51b077f97c3b2" upstream="refs/heads/dev/kernelci/R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="minilayout,paygen,firmware,labtools" sync-c="true"/>
   <project name="chromiumos/overlays/eclass-overlay" path="src/third_party/eclass-overlay" revision="e9e78ef1eaa6a78e05df5af2dd3f9fd7dd8883f0" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="minilayout,paygen,firmware,labtools"/>
   <project name="chromiumos/overlays/portage-stable" path="src/third_party/portage-stable" revision="5588c0f87d858b5c46f6bb1fc6f5e555959ab0b7" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="minilayout,paygen,firmware,labtools"/>
   <project name="chromiumos/platform/assets" path="src/platform/assets" revision="8a2276f22f0678bee89b8ac6c46d9dd597c6d549" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
@@ -127,7 +130,7 @@
   <project name="chromiumos/platform/libva-fake-driver" path="src/platform/libva-fake-driver" revision="7754dd6e00355bb0d7bb5f597b482b6d5ff5cab5" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
   <project name="chromiumos/platform/lithium" path="src/platform/lithium" revision="1b54b0fa69bb183ed19945a79b72bc17145eafe4" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="firmware"/>
   <project name="chromiumos/platform/microbenchmarks" path="src/platform/microbenchmarks" revision="ec4ae6c0d54618c01a5e1c78d80c44bc80af6ad6" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
-  <project name="chromiumos/platform/minigbm" path="src/platform/minigbm" revision="64de5175a02f9a36a4b0aa6fa54e0dd1d64985bf" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="crosvm"/>
+  <project remote="cros-kernelci-dev" name="minigbm" path="src/platform/minigbm" revision="6d5857cfc853d165b73ce04013df879b048d055d" upstream="refs/heads/dev/kernelci/R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="crosvm"/>
   <project name="chromiumos/platform/minijail" path="src/platform/minijail" revision="485c8a098c5b1a63f079461826ed45571f2a0032" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B" groups="crosvm"/>
   <project name="chromiumos/platform/mosys" path="src/platform/mosys" revision="f5a6d1de0179bc3b1583861befd111b7b74dd876" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
   <project name="chromiumos/platform/mttools" path="src/platform/mttools" revision="957a434f10b7663bbafc85fb19afe1a3318c0a10" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
@@ -195,7 +198,7 @@
   <project name="chromiumos/third_party/huddly-updater" path="src/third_party/huddly-updater" revision="13f5da57bf04915c58c06de760565583b883b915" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
   <project name="chromiumos/third_party/igt-gpu-tools" path="src/third_party/igt-gpu-tools" revision="c8edfca649da71b296d882bb0319181d94e619eb" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
   <project name="chromiumos/third_party/intel-wifi-fw-dump" path="src/third_party/intel-wifi-fw-dump" revision="d4dd3967c51e3d255fb9beb5581e6d9a3938ca07" upstream="refs/heads/release-R106-15054.B" dest-branch="refs/heads/release-R106-15054.B"/>
-  <project name="chromiumos/third_party/kernel" path="src/third_party/kernel/upstream" revision="3ce3e1c35030861b8a5a60a9367109d885703471">
+  <project remote="cros-kernelci-dev" name="linux-public" path="src/third_party/kernel/upstream" revision="5058a4681471915260d2b52b9a0e619716193e82">
     <annotation name="branch-mode" value="pin"/>
   </project>
   <project name="chromiumos/third_party/kernel" path="src/third_party/kernel/v4.4" revision="eed01c3898b21ecc590cff0fab71f13ca9b8f034" upstream="refs/heads/release-R106-15054.B-chromeos-4.4" dest-branch="refs/heads/release-R106-15054.B-chromeos-4.4"/>

--- a/config/rootfs/chromiumos/scripts/build_board.sh
+++ b/config/rootfs/chromiumos/scripts/build_board.sh
@@ -51,58 +51,44 @@ echo "Board ${BOARD} setup"
 # Future possible option --profile=x, for example kernel-5_15, profiles are at /mnt/host/source/src/overlays/overlay-${BOARD}/profiles/
 cros_sdk setup_board --board=${BOARD}
 
-# Certain boards need temporary fixes/patches to build successully
-if [ "${BOARD}" == "coral" ]; then
-echo "Patching coral specific issues"
-sed ':a;N;$!ba;s/DEPEND="\n\tchromeos-base\/fibocom-firmware\n"/# DEPEND="\n\t# chromeos-base\/fibocom-firmware\n# "/g' -i src/overlays/overlay-coral/chromeos-base/modemfwd-helpers/modemfwd-helpers-0.0.1.ebuild
-sed -i s,'media-libs/apl-hotword-support','# media-libs/apl-hotword-support', src/overlays/overlay-coral/media-libs/lpe-support-topology/lpe-support-topology-0.0.1.ebuild
-sed -i s,'USE="${USE} cros_ec"','# USE="${USE} cros_ec"', src/overlays/baseboard-coral/profiles/base/make.defaults
-fi
-
-if [ "${BOARD}" == "dedede" ]; then
-echo "Patching dedede specific issue"
-echo 'USE="${USE} -tpm tpm2 cr50_onboard"' >>src/overlays/baseboard-dedede/profiles/base/make.defaults
-fi
-
-if [ "${BOARD}" == "hatch" ]; then
-echo "Patching hatch specific issue"
-sed -i 's/EC_BOARDS=()/EC_BOARDS=(hatch)/' src/third_party/chromiumos-overlay/eclass/cros-ec-board.eclass
-echo 'USE="${USE} -tpm tpm2"' >>src/overlays/baseboard-hatch/profiles/base/make.defaults
-fi
-
-if [ "${BOARD}" == "nami" ]; then
-echo "Patching nami specific issue"
-echo 'USE="${USE} -tpm tpm2"' >>src/overlays/baseboard-nami/profiles/base/make.defaults
-fi
-
-if [ "${BOARD}" == "octopus" ]; then
-echo "Patching octopus specific issue"
-sed -i s,'use fuzzer || die',"#use fuzzer || die", src/third_party/chromiumos-overlay/eclass/cros-ec-board.eclass
-# Workaround b/244460939 T38487 - octopus missing proper tpm USE flags
-echo 'USE="${USE} -tpm tpm2"' >>src/overlays/baseboard-octopus/profiles/base/make.defaults
-fi
-
-# rammus doesn't require any fixes
-
-if [ "${BOARD}" == "sarien" ]; then
-echo "Patching sarien specific issues"
-sed ':a;N;$!ba;s/DEPEND="\n\tchromeos-base\/fibocom-firmware\n"/# DEPEND="\n\t# chromeos-base\/fibocom-firmware\n# "/g' -i src/overlays/overlay-sarien/chromeos-base/modemfwd-helpers/modemfwd-helpers-0.0.1.ebuild
-fi
-
-if [ "${BOARD}" == "volteer" ]; then
-echo "Patching volteer specific issues"
-echo 'USE="${USE} -tpm tpm2"' >>src/overlays/baseboard-volteer/profiles/base/make.defaults
-fi
-
-if [ "${BOARD}" == "zork" ]; then
-echo "Patching zork specific issues"
-echo 'USE="${USE} -tpm tpm2"' >>src/overlays/overlay-zork/profiles/base/make.defaults
-fi
-
-if [ "${BOARD}" == "grunt" ]; then
-echo "Patching grunt specific issue"
-echo 'USE="${USE} -tpm tpm2"' >>src/overlays/baseboard-grunt/profiles/base/make.defaults
-fi
+echo "Patching ${BOARD} specific issues"
+case ${BOARD} in
+    coral)
+    sed ':a;N;$!ba;s/DEPEND="\n\tchromeos-base\/fibocom-firmware\n"/# DEPEND="\n\t# chromeos-base\/fibocom-firmware\n# "/g' -i src/overlays/overlay-coral/chromeos-base/modemfwd-helpers/modemfwd-helpers-0.0.1.ebuild
+    sed -i s,'media-libs/apl-hotword-support','# media-libs/apl-hotword-support', src/overlays/overlay-coral/media-libs/lpe-support-topology/lpe-support-topology-0.0.1.ebuild
+    sed -i s,'USE="${USE} cros_ec"','# USE="${USE} cros_ec"', src/overlays/baseboard-coral/profiles/base/make.defaults
+    ;;
+    dedede)
+    echo 'USE="${USE} -tpm tpm2 cr50_onboard"' >>src/overlays/baseboard-dedede/profiles/base/make.defaults
+    ;;
+    hatch)
+    sed -i 's/EC_BOARDS=()/EC_BOARDS=(hatch)/' src/third_party/chromiumos-overlay/eclass/cros-ec-board.eclass
+    echo 'USE="${USE} -tpm tpm2"' >>src/overlays/baseboard-hatch/profiles/base/make.defaults
+    ;;
+    nami)
+    echo 'USE="${USE} -tpm tpm2"' >>src/overlays/baseboard-nami/profiles/base/make.defaults
+    ;;
+    octopus)
+    sed -i s,'use fuzzer || die',"#use fuzzer || die", src/third_party/chromiumos-overlay/eclass/cros-ec-board.eclass
+    # Workaround b/244460939 T38487 - octopus missing proper tpm USE flags
+    echo 'USE="${USE} -tpm tpm2"' >>src/overlays/baseboard-octopus/profiles/base/make.defaults
+    ;;
+    sarien)
+    sed ':a;N;$!ba;s/DEPEND="\n\tchromeos-base\/fibocom-firmware\n"/# DEPEND="\n\t# chromeos-base\/fibocom-firmware\n# "/g' -i src/overlays/overlay-sarien/chromeos-base/modemfwd-helpers/modemfwd-helpers-0.0.1.ebuild
+    ;;
+    volteer)
+    echo 'USE="${USE} -tpm tpm2"' >>src/overlays/baseboard-volteer/profiles/base/make.defaults
+    ;;
+    zork)
+    echo 'USE="${USE} -tpm tpm2"' >>src/overlays/overlay-zork/profiles/base/make.defaults
+    ;;
+    grunt)
+    echo 'USE="${USE} -tpm tpm2"' >>src/overlays/baseboard-grunt/profiles/base/make.defaults
+    ;;
+    *)
+    echo "No issues found for this board"
+    ;;
+esac
 
 # Disable SELinux in upstart and other packages to allow booting newer kernels on
 # CrOS images which don't define all selinux policies
@@ -138,6 +124,21 @@ echo "Extracting additional artifacts"
 sudo tar -cJf "${DATA_DIR}/${BOARD}/modules.tar.xz" -C ./chroot/build/${BOARD} lib/modules
 sudo cp "./chroot/build/${BOARD}/boot/vmlinuz" "${DATA_DIR}/${BOARD}/bzImage"
 sudo cp ./chroot/build/${BOARD}/boot/config* "${DATA_DIR}/${BOARD}/kernel.config"
+
+echo "Extracting ${BOARD} specific artifacts"
+case ${BOARD} in
+    trogdor)
+    # arm64 needs dtb to boot
+    mkdir -p ${DATA_DIR}/${BOARD}/dtbs/qcom
+    sudo cp ./chroot/build/trogdor/var/cache/portage/sys-kernel/chromeos-kernel-*/arch/arm64/boot/dts/qcom/*.dtb ${DATA_DIR}/${BOARD}/dtbs/qcom
+    # ARM64 depthcharge need different kernel image file
+    sudo cp "./chroot/build/${BOARD}/boot/Image*" "${DATA_DIR}/${BOARD}/Image"
+    ;;
+    *)
+    echo "No issues found for this board"
+    ;;
+esac
+
 
 echo "Creating manifest file"
 python3 "${SCRIPTPATH}/create_manifest.py" "${BOARD}" "${DATA_DIR}/${BOARD}"

--- a/config/rootfs/chromiumos/scripts/build_board.sh
+++ b/config/rootfs/chromiumos/scripts/build_board.sh
@@ -130,9 +130,9 @@ case ${BOARD} in
     trogdor)
     # arm64 needs dtb to boot
     mkdir -p ${DATA_DIR}/${BOARD}/dtbs/qcom
-    sudo cp ./chroot/build/trogdor/var/cache/portage/sys-kernel/chromeos-kernel-*/arch/arm64/boot/dts/qcom/*.dtb ${DATA_DIR}/${BOARD}/dtbs/qcom
+    sudo cp ./chroot/build/${BOARD}/var/cache/portage/sys-kernel/chromeos-kernel-*/arch/arm64/boot/dts/qcom/*.dtb ${DATA_DIR}/${BOARD}/dtbs/qcom
     # ARM64 depthcharge need different kernel image file
-    sudo cp "./chroot/build/${BOARD}/boot/Image*" "${DATA_DIR}/${BOARD}/Image"
+    sudo cp ./chroot/build/${BOARD}/boot/Image* "${DATA_DIR}/${BOARD}/Image"
     ;;
     *)
     echo "No issues found for this board"

--- a/config/rootfs/chromiumos/scripts/build_board.sh
+++ b/config/rootfs/chromiumos/scripts/build_board.sh
@@ -55,8 +55,6 @@ echo Building SDK
 cros_sdk --create
 
 echo "Board ${BOARD} setup"
-# Compiling ChromiumOS image
-# Future possible option --profile=x, for example kernel-5_15, profiles are at /mnt/host/source/src/overlays/overlay-${BOARD}/profiles/
 cros_sdk setup_board --board=${BOARD}
 
 echo "Patching ${BOARD} specific issues"

--- a/config/rootfs/chromiumos/scripts/build_board.sh
+++ b/config/rootfs/chromiumos/scripts/build_board.sh
@@ -5,6 +5,9 @@ BRANCH=$2
 SERIAL=$3
 DATA_DIR=$(pwd)
 USERNAME=$(/usr/bin/id -run)
+SCRIPT=$(realpath "$0")
+SCRIPTPATH=$(dirname "$SCRIPT")
+MANIFESTDIR=$(dirname "$SCRIPTPATH")
 
 function cleanup()
 {
@@ -30,7 +33,13 @@ cd chromiumos-sdk
 git config --global user.email "bot@kernelci.org"
 git config --global user.name "KernelCI Bot"
 git config --global color.ui false
-repo init --repo-url https://chromium.googlesource.com/external/repo --manifest-url https://chromium.googlesource.com/chromiumos/manifest --manifest-name default.xml --manifest-branch ${BRANCH}
+
+# To generate manifest snapshot:
+# repo init --repo-url https://chromium.googlesource.com/external/repo --manifest-url https://chromium.googlesource.com/chromiumos/manifest --manifest-name default.xml --manifest-branch ${BRANCH}
+# repo manifest -r -o cros-snapshot.xml
+
+# Fetching current manifest snapshot
+repo init -u https://github.com/kernelci/kernelci-core -b chromeos.kernelci.org -m "config/rootfs/chromiumos/cros-snapshot-$2.xml"
 repo sync -j$(nproc)
 echo Building SDK
 cros_sdk --create

--- a/config/rootfs/chromiumos/scripts/build_board.sh
+++ b/config/rootfs/chromiumos/scripts/build_board.sh
@@ -59,6 +59,13 @@ echo "Patching octopus specific issue"
 sed -i s,'use fuzzer || die',"#use fuzzer || die", src/third_party/chromiumos-overlay/eclass/cros-ec-board.eclass
 fi
 
+if [ "${BOARD}" == "coral" ]; then
+echo "Patching coral specific issues"
+sed ':a;N;$!ba;s/DEPEND="\n\tchromeos-base\/fibocom-firmware\n"/# DEPEND="\n\t# chromeos-base\/fibocom-firmware\n# "/g' -i src/overlays/overlay-coral/chromeos-base/modemfwd-helpers/modemfwd-helpers-0.0.1.ebuild
+sed -i s,'media-libs/apl-hotword-support','# media-libs/apl-hotword-support', src/overlays/overlay-coral/media-libs/lpe-support-topology/lpe-support-topology-0.0.1.ebuild
+sed -i s,'USE="${USE} cros_ec"','# USE="${USE} cros_ec"', src/overlays/baseboard-coral/profiles/base/make.defaults
+fi
+
 # Temporary workaround as chrome-icu build fails at 10/08/2022 due corrupt git cache
 cros_sdk sync_chrome --tag=102.0.5005.171 --reset --gclient=/mnt/host/depot_tools/gclient /var/cache/chromeos-cache/distfiles/chrome-src --skip_cache
 

--- a/config/rootfs/chromiumos/scripts/build_board.sh
+++ b/config/rootfs/chromiumos/scripts/build_board.sh
@@ -51,11 +51,28 @@ echo "Board ${BOARD} setup"
 # Future possible option --profile=x, for example kernel-5_15, profiles are at /mnt/host/source/src/overlays/overlay-${BOARD}/profiles/
 cros_sdk setup_board --board=${BOARD}
 
-# Without workarounds hatch and octopus build failing
+# Certain boards need temporary fixes/patches to build successully
+if [ "${BOARD}" == "coral" ]; then
+echo "Patching coral specific issues"
+sed ':a;N;$!ba;s/DEPEND="\n\tchromeos-base\/fibocom-firmware\n"/# DEPEND="\n\t# chromeos-base\/fibocom-firmware\n# "/g' -i src/overlays/overlay-coral/chromeos-base/modemfwd-helpers/modemfwd-helpers-0.0.1.ebuild
+sed -i s,'media-libs/apl-hotword-support','# media-libs/apl-hotword-support', src/overlays/overlay-coral/media-libs/lpe-support-topology/lpe-support-topology-0.0.1.ebuild
+sed -i s,'USE="${USE} cros_ec"','# USE="${USE} cros_ec"', src/overlays/baseboard-coral/profiles/base/make.defaults
+fi
+
+if [ "${BOARD}" == "dedede" ]; then
+echo "Patching dedede specific issue"
+echo 'USE="${USE} -tpm tpm2 cr50_onboard"' >>src/overlays/baseboard-dedede/profiles/base/make.defaults
+fi
+
 if [ "${BOARD}" == "hatch" ]; then
 echo "Patching hatch specific issue"
 sed -i 's/EC_BOARDS=()/EC_BOARDS=(hatch)/' src/third_party/chromiumos-overlay/eclass/cros-ec-board.eclass
 echo 'USE="${USE} -tpm tpm2"' >>src/overlays/baseboard-hatch/profiles/base/make.defaults
+fi
+
+if [ "${BOARD}" == "nami" ]; then
+echo "Patching nami specific issue"
+echo 'USE="${USE} -tpm tpm2"' >>src/overlays/baseboard-nami/profiles/base/make.defaults
 fi
 
 if [ "${BOARD}" == "octopus" ]; then
@@ -65,11 +82,21 @@ sed -i s,'use fuzzer || die',"#use fuzzer || die", src/third_party/chromiumos-ov
 echo 'USE="${USE} -tpm tpm2"' >>src/overlays/baseboard-octopus/profiles/base/make.defaults
 fi
 
-if [ "${BOARD}" == "coral" ]; then
-echo "Patching coral specific issues"
-sed ':a;N;$!ba;s/DEPEND="\n\tchromeos-base\/fibocom-firmware\n"/# DEPEND="\n\t# chromeos-base\/fibocom-firmware\n# "/g' -i src/overlays/overlay-coral/chromeos-base/modemfwd-helpers/modemfwd-helpers-0.0.1.ebuild
-sed -i s,'media-libs/apl-hotword-support','# media-libs/apl-hotword-support', src/overlays/overlay-coral/media-libs/lpe-support-topology/lpe-support-topology-0.0.1.ebuild
-sed -i s,'USE="${USE} cros_ec"','# USE="${USE} cros_ec"', src/overlays/baseboard-coral/profiles/base/make.defaults
+# rammus doesn't require any fixes
+
+if [ "${BOARD}" == "sarien" ]; then
+echo "Patching sarien specific issues"
+sed ':a;N;$!ba;s/DEPEND="\n\tchromeos-base\/fibocom-firmware\n"/# DEPEND="\n\t# chromeos-base\/fibocom-firmware\n# "/g' -i src/overlays/overlay-sarien/chromeos-base/modemfwd-helpers/modemfwd-helpers-0.0.1.ebuild
+fi
+
+if [ "${BOARD}" == "volteer" ]; then
+echo "Patching volteer specific issues"
+echo 'USE="${USE} -tpm tpm2"' >>src/overlays/baseboard-volteer/profiles/base/make.defaults
+fi
+
+if [ "${BOARD}" == "zork" ]; then
+echo "Patching zork specific issues"
+echo 'USE="${USE} -tpm tpm2"' >>src/overlays/overlay-zork/profiles/base/make.defaults
 fi
 
 if [ "${BOARD}" == "grunt" ]; then

--- a/config/rootfs/chromiumos/scripts/build_board.sh
+++ b/config/rootfs/chromiumos/scripts/build_board.sh
@@ -76,7 +76,7 @@ fi
 sed -i 's/selinux/-selinux/g' src/third_party/chromiumos-overlay/profiles/features/selinux/package.use
 
 # Temporary workaround as chrome-icu build fails at 10/08/2022 due corrupt git cache
-cros_sdk sync_chrome --tag=102.0.5005.171 --reset --gclient=/mnt/host/depot_tools/gclient /var/cache/chromeos-cache/distfiles/chrome-src --skip_cache
+cros_sdk sync_chrome --tag=106.0.5249.134 --reset --gclient=/mnt/host/depot_tools/gclient /var/cache/chromeos-cache/distfiles/chrome-src --skip_cache
 
 # Add serial support
 echo "Add serial ${SERIAL} support"

--- a/config/rootfs/chromiumos/scripts/build_board.sh
+++ b/config/rootfs/chromiumos/scripts/build_board.sh
@@ -98,10 +98,6 @@ case ${BOARD} in
     ;;
 esac
 
-# Disable SELinux in upstart and other packages to allow booting newer kernels on
-# CrOS images which don't define all selinux policies
-sed -i 's/ selinux/ -selinux/g' src/third_party/chromiumos-overlay/profiles/features/selinux/package.use
-
 # Temporary workaround as chrome-icu build fails at 10/08/2022 due corrupt git cache
 if [ ! -f .cache/distfiles/chrome-src/.gclient ]; then
   cros_sdk sync_chrome --tag=106.0.5249.134 --reset --gclient=/mnt/host/depot_tools/gclient /var/cache/chromeos-cache/distfiles/chrome-src --skip_cache

--- a/config/rootfs/chromiumos/scripts/build_board.sh
+++ b/config/rootfs/chromiumos/scripts/build_board.sh
@@ -72,6 +72,11 @@ sed -i s,'media-libs/apl-hotword-support','# media-libs/apl-hotword-support', sr
 sed -i s,'USE="${USE} cros_ec"','# USE="${USE} cros_ec"', src/overlays/baseboard-coral/profiles/base/make.defaults
 fi
 
+if [ "${BOARD}" == "grunt" ]; then
+echo "Patching grunt specific issue"
+echo 'USE="${USE} -tpm tpm2"' >>src/overlays/baseboard-grunt/profiles/base/make.defaults
+fi
+
 # Disable SELinux in upstart and other packages to allow booting newer kernels on
 # CrOS images which don't define all selinux policies
 sed -i 's/selinux/-selinux/g' src/third_party/chromiumos-overlay/profiles/features/selinux/package.use

--- a/config/rootfs/chromiumos/scripts/build_board.sh
+++ b/config/rootfs/chromiumos/scripts/build_board.sh
@@ -59,6 +59,9 @@ echo "Patching octopus specific issue"
 sed -i s,'use fuzzer || die',"#use fuzzer || die", src/third_party/chromiumos-overlay/eclass/cros-ec-board.eclass
 fi
 
+# Temporary workaround as chrome-icu build fails at 10/08/2022 due corrupt git cache
+cros_sdk sync_chrome --tag=102.0.5005.171 --reset --gclient=/mnt/host/depot_tools/gclient /var/cache/chromeos-cache/distfiles/chrome-src --skip_cache
+
 # Add serial support
 echo "Add serial ${SERIAL} support"
 cros_sdk USE=pcserial build_packages --board=${BOARD}

--- a/config/rootfs/chromiumos/scripts/build_board.sh
+++ b/config/rootfs/chromiumos/scripts/build_board.sh
@@ -102,7 +102,8 @@ if [ ! -f .cache/distfiles/chrome-src/.gclient ]; then
 fi
 
 echo "Building packages (${SERIAL})"
-cros_sdk USE="tty_console_${SERIAL} pcserial" build_packages --board=${BOARD}
+cros_sdk USE="tty_console_${SERIAL} pcserial cr50_skip_update" \
+	 build_packages --board=${BOARD}
 
 echo "Building image (${SERIAL})"
 cros_sdk ./build_image --enable_serial ${SERIAL} --board="${BOARD}" --boot_args "earlyprintk=serial,keep console=tty0" --noenable_rootfs_verification test

--- a/config/rootfs/chromiumos/scripts/build_board.sh
+++ b/config/rootfs/chromiumos/scripts/build_board.sh
@@ -56,9 +56,12 @@ if [ "${BOARD}" == "hatch" ]; then
 echo "Patching hatch specific issue"
 sed -i 's/EC_BOARDS=()/EC_BOARDS=(hatch)/' src/third_party/chromiumos-overlay/eclass/cros-ec-board.eclass
 fi
+
 if [ "${BOARD}" == "octopus" ]; then
 echo "Patching octopus specific issue"
 sed -i s,'use fuzzer || die',"#use fuzzer || die", src/third_party/chromiumos-overlay/eclass/cros-ec-board.eclass
+# Workaround b/244460939 T38487 - octopus missing proper tpm USE flags
+echo 'USE="${USE} -tpm tpm2"' >>src/overlays/baseboard-octopus/profiles/base/make.defaults
 fi
 
 if [ "${BOARD}" == "coral" ]; then

--- a/config/rootfs/chromiumos/scripts/build_board.sh
+++ b/config/rootfs/chromiumos/scripts/build_board.sh
@@ -55,6 +55,7 @@ cros_sdk setup_board --board=${BOARD}
 if [ "${BOARD}" == "hatch" ]; then
 echo "Patching hatch specific issue"
 sed -i 's/EC_BOARDS=()/EC_BOARDS=(hatch)/' src/third_party/chromiumos-overlay/eclass/cros-ec-board.eclass
+echo 'USE="${USE} -tpm tpm2"' >>src/overlays/baseboard-hatch/profiles/base/make.defaults
 fi
 
 if [ "${BOARD}" == "octopus" ]; then

--- a/config/rootfs/chromiumos/scripts/build_board.sh
+++ b/config/rootfs/chromiumos/scripts/build_board.sh
@@ -128,6 +128,8 @@ echo "Extracting additional artifacts"
 sudo tar -cJf "${DATA_DIR}/${BOARD}/modules.tar.xz" -C ./chroot/build/${BOARD} lib/modules
 sudo cp "./chroot/build/${BOARD}/boot/vmlinuz" "${DATA_DIR}/${BOARD}/bzImage"
 sudo cp ./chroot/build/${BOARD}/boot/config* "${DATA_DIR}/${BOARD}/kernel.config"
+# Extract CR50 firmware, but dont crash in case it is missing
+sudo mv ./chroot/build/${BOARD}/opt/google/cr50/firmware/* "${DATA_DIR}/${BOARD}/" || true
 
 echo "Extracting ${BOARD} specific artifacts"
 case ${BOARD} in

--- a/config/rootfs/chromiumos/scripts/build_board.sh
+++ b/config/rootfs/chromiumos/scripts/build_board.sh
@@ -7,7 +7,6 @@ DATA_DIR=$(pwd)
 USERNAME=$(/usr/bin/id -run)
 SCRIPT=$(realpath "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
-MANIFESTDIR=$(dirname "$SCRIPTPATH")
 
 function cleanup()
 {
@@ -89,6 +88,8 @@ sudo chown -R "${USERNAME}" "${DATA_DIR}/${BOARD}"
 gzip -1 "${DATA_DIR}/${BOARD}/chromiumos_test_image.bin"
 sudo tar -cJf "${DATA_DIR}/${BOARD}/modules.tar.xz" -C ./chroot/build/${BOARD} lib/modules
 sudo cp "./chroot/build/${BOARD}/boot/vmlinuz" "${DATA_DIR}/${BOARD}/bzImage"
+sudo cp ./chroot/build/${BOARD}/boot/config* "${DATA_DIR}/${BOARD}/kernel.config"
+python3 "${SCRIPTPATH}/create_manifest.py" "${BOARD}" "${DATA_DIR}/${BOARD}"
 
 # Probably redundant, but better safe than sorry
 cleanup

--- a/config/rootfs/chromiumos/scripts/build_board.sh
+++ b/config/rootfs/chromiumos/scripts/build_board.sh
@@ -101,10 +101,9 @@ if [ ! -f .cache/distfiles/chrome-src/.gclient ]; then
   cros_sdk sync_chrome --tag=106.0.5249.134 --reset --gclient=/mnt/host/depot_tools/gclient /var/cache/chromeos-cache/distfiles/chrome-src --skip_cache
 fi
 
-# Add serial support
-echo "Add serial ${SERIAL} support"
-cros_sdk USE=pcserial build_packages --board=${BOARD}
-cros_sdk USE="tty_console_${SERIAL}" emerge-"${BOARD}" chromeos-base/tty
+echo "Building packages (${SERIAL})"
+cros_sdk USE="tty_console_${SERIAL} pcserial" build_packages --board=${BOARD}
+
 echo "Building image (${SERIAL})"
 cros_sdk ./build_image --enable_serial ${SERIAL} --board="${BOARD}" --boot_args "earlyprintk=serial,keep console=tty0" --noenable_rootfs_verification test
 

--- a/config/rootfs/chromiumos/scripts/build_board.sh
+++ b/config/rootfs/chromiumos/scripts/build_board.sh
@@ -66,6 +66,10 @@ sed -i s,'media-libs/apl-hotword-support','# media-libs/apl-hotword-support', sr
 sed -i s,'USE="${USE} cros_ec"','# USE="${USE} cros_ec"', src/overlays/baseboard-coral/profiles/base/make.defaults
 fi
 
+# Disable SELinux in upstart and other packages to allow booting newer kernels on
+# CrOS images which don't define all selinux policies
+sed -i 's/selinux/-selinux/g' src/third_party/chromiumos-overlay/profiles/features/selinux/package.use
+
 # Temporary workaround as chrome-icu build fails at 10/08/2022 due corrupt git cache
 cros_sdk sync_chrome --tag=102.0.5005.171 --reset --gclient=/mnt/host/depot_tools/gclient /var/cache/chromeos-cache/distfiles/chrome-src --skip_cache
 

--- a/config/rootfs/chromiumos/scripts/build_board.sh
+++ b/config/rootfs/chromiumos/scripts/build_board.sh
@@ -140,6 +140,12 @@ case ${BOARD} in
     # ARM64 depthcharge need different kernel image file
     sudo cp ./chroot/build/${BOARD}/boot/Image* "${DATA_DIR}/${BOARD}/Image"
     ;;
+    asurada|jacuzzi|cherry|geralt)
+    mkdir -p ${DATA_DIR}/${BOARD}/dtbs/mediatek
+    sudo cp ./chroot/build/${BOARD}/var/cache/portage/sys-kernel/chromeos-kernel-*/arch/arm64/boot/dts/mediatek/*.dtb \
+	 ${DATA_DIR}/${BOARD}/dtbs/mediatek
+    sudo cp ./chroot/build/${BOARD}/boot/Image* "${DATA_DIR}/${BOARD}/Image"
+    ;;
     *)
     echo "No issues found for this board"
     ;;

--- a/config/rootfs/chromiumos/scripts/create_manifest.py
+++ b/config/rootfs/chromiumos/scripts/create_manifest.py
@@ -1,0 +1,38 @@
+#!/usr/env/bin python3
+
+import json
+import os
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+
+
+def main(args):
+    manifest_git_cmd = "git -C .repo/manifests log --oneline -1"
+    tree = ET.parse('.repo/manifest.xml')
+    root = tree.getroot()
+    xml_file = root[0].get('name')
+    manifest_fname = os.path.join(args[1], 'manifest.json')
+    date = subprocess.check_output("date -u", shell=True).decode().strip()
+    distro_version = os.readlink(f'src/build/images/{args[0]}/latest')
+    manifest_git = subprocess.check_output(manifest_git_cmd,
+                                           shell=True).decode().strip()
+
+    build_info = {
+        'date': date,
+        'distro': 'ChromiumOS',
+        'distro_version': distro_version,
+        'manifest_git': manifest_git,
+        'manifest_file': xml_file,
+    }
+
+    with open(manifest_fname, 'w') as manifest:
+        json.dump(build_info, manifest, indent=4)
+
+
+if __name__ == '__main__':
+    if len(sys.argv) == 3:
+        main(sys.argv[1:])
+    else:
+        print("Board name and destination directory required")
+        sys.exit(1)

--- a/config/rootfs/debos/scripts/bullseye-cros-flash.sh
+++ b/config/rootfs/debos/scripts/bullseye-cros-flash.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Important: This script is run under QEMU
+
+set -e
+
+# Build-depends needed to build the test suites, they'll be removed later
+BUILD_DEPS="\
+    build-essential \
+    ca-certificates \
+    git \
+    wget \
+    pkg-config \
+    libssl-dev \
+    libusb-1.0-0-dev
+"
+
+apt-get install --no-install-recommends -y  ${BUILD_DEPS}
+
+mkdir -p /tmp/tests
+cd /tmp/tests
+wget --no-verbose --inet4-only --no-clobber --tries 5 \
+    https://chromium.googlesource.com/chromiumos/platform/ec/+archive/refs/heads/cr50_stab.tar.gz
+
+tar -xzf cr50_stab.tar.gz
+cd extra/usb_updater
+make
+cp gsctool /usr/bin
+
+########################################################################
+# Cleanup: remove files and packages we don't want in the images       #
+########################################################################
+cd /tmp
+rm -rf /tmp/tests
+
+apt-get remove --purge -y ${BUILD_DEPS}
+apt-get autoremove --purge -y
+apt-get clean
+
+# re-add some stuff that is removed by accident
+apt-get install -y initramfs-tools


### PR DESCRIPTION
This PR contains commits related to Chrome OS  rootfs images definitions and build tools.
They have been cherry-picked from the `chromeos` branch as a part of the upstreaming process.

They need to be thoroughly tested to make sure nothing has been missed.