### PR TITLE
kernelci.cli.show: add command to show results

### DIFF
--- a/kernelci/cli/__init__.py
+++ b/kernelci/cli/__init__.py
@@ -14,6 +14,7 @@ from . import (
     job,
     node,
     pubsub,
+    show,
     user,
 )
 
@@ -23,6 +24,7 @@ _COMMANDS = {
     'job': job.main,
     'node': node.main,
     'pubsub': pubsub.main,
+    'show': show.main,
     'user': user.main,
 }
 

--- a/kernelci/cli/base.py
+++ b/kernelci/cli/base.py
@@ -179,6 +179,11 @@ class Args:  # pylint: disable=too-few-public-methods
         'help': "Path to the dtbs.json file",
     }
 
+    id = {
+            'name': 'id',
+            'help': "Node id",
+    }
+
     id_only = {
         'name': '--id-only',
         'action': 'store_true',

--- a/kernelci/cli/node.py
+++ b/kernelci/cli/node.py
@@ -35,12 +35,7 @@ class NodeAttributesCommand(NodeCommand):
 
 class cmd_get(NodeCommand):  # pylint: disable=invalid-name
     """Get a node with a given ID"""
-    args = NodeCommand.args + [
-        {
-            'name': 'id',
-            'help': "Node id",
-        },
-    ]
+    args = NodeCommand.args + [Args.id]
 
     def _api_call(self, api, configs, args):
         node = api.get_node(args.id)

--- a/kernelci/cli/show.py
+++ b/kernelci/cli/show.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2023 Collabora Limited
+# Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+
+"""Tool to show results and things from the API"""
+
+from datetime import datetime
+
+from .base import APICommand, sub_main
+
+
+class cmd_results(APICommand):  # pylint: disable=invalid-name
+    """Show all the results for a given node"""
+
+    COLORS = {
+        'green': '\033[92m',
+        'yellow': '\033[93m',
+        'red': '\033[91m',
+        'blue': '\033[94m',
+        'bold': '\033[1m',
+        'underline': '\033[4m',
+        'clear': '\033[0m',
+    }
+
+    COLOR_RESULT = {
+        'pass': 'green',
+        'fail': 'red',
+        '----': 'yellow',
+    }
+
+    args = APICommand.args + [
+        {
+            'name': 'id',
+            'help': "Node id",
+        },
+    ]
+
+    def _color(self, msg, color):
+        return ''.join([self.COLORS[color], msg, self.COLORS['clear']])
+
+    def _print_color(self, msg, color):
+        print(self._color(msg, color))
+
+    @classmethod
+    def _get_checkout(cls, api, node):
+        while node['name'] != 'checkout':
+            node = api.get_node(node['parent'])
+        return node
+
+    def _dump_results(self, api, node, indent=0):
+        fmt = f"{{space}}{{path:{64-indent*2}s}}{{result:6}}{{node_id}}"
+        node_id = node['_id']
+        result = node['result'] or '----'
+        line = fmt.format(
+            space='  '*indent,
+            path='.'.join(node['path']),
+            result=result,
+            node_id=node_id,
+        )
+        color = self.COLOR_RESULT.get(result)
+        if color:
+            line = self._color(line, color)
+        print(line)
+        child_nodes = api.get_nodes({'parent': node_id})
+        for child in child_nodes:
+            self._dump_results(api, child, indent+1)
+
+    def _dump(self, api, args):
+        node = api.get_node(args.id)
+        parent_id = node['parent'] or '----'
+        checkout = self._get_checkout(api, node)
+        revision = node['revision']
+        created = datetime.fromisoformat(node['created'])
+        print(f"""\
+{self._color('Node', 'bold')}
+  {self._color('path', 'blue')}      {'.'.join(node['path'])}
+  {self._color('id', 'blue')}        {args.id}
+  {self._color('parent', 'blue')}    {parent_id}
+  {self._color('created', 'blue')}   {created.strftime('%Y-%m-%d at %H:%M:%S')}
+
+{self._color('Kernel', 'bold')}
+  {self._color('tree', 'blue')}      {revision['tree']}
+  {self._color('branch', 'blue')}    {revision['branch']}
+  {self._color('commit', 'blue')}    {revision['commit']}
+  {self._color('describe', 'blue')}  {revision['describe']}
+  {self._color('tarball', 'blue')}   {checkout['artifacts'].get('tarball')}
+
+{self._color('Results', 'bold')}""")
+        self._dump_results(api, node)
+
+    def _api_call(self, api, configs, args):
+        self._dump(api, args)
+        return True
+
+
+def main(args=None):
+    """Entry point for the command line tool"""
+    sub_main("show", globals(), args)

--- a/kernelci/cli/show.py
+++ b/kernelci/cli/show.py
@@ -7,7 +7,7 @@
 
 from datetime import datetime
 
-from .base import APICommand, sub_main
+from .base import APICommand, Args, sub_main
 
 
 class cmd_results(APICommand):  # pylint: disable=invalid-name
@@ -29,12 +29,7 @@ class cmd_results(APICommand):  # pylint: disable=invalid-name
         '----': 'yellow',
     }
 
-    args = APICommand.args + [
-        {
-            'name': 'id',
-            'help': "Node id",
-        },
-    ]
+    args = APICommand.args + [Args.id]
 
     def _color(self, msg, color):
         return ''.join([self.COLORS[color], msg, self.COLORS['clear']])


### PR DESCRIPTION
Add "kci show results" to show results from a node and recursively all its child nodes hierarchy in a human-readable way.