### PR TITLE
Make storage YAML config available in job templates

### DIFF
--- a/config/runtime/base/kubernetes.jinja2
+++ b/config/runtime/base/kubernetes.jinja2
@@ -22,6 +22,12 @@ spec:
       - name: dev-shm
         emptyDir: { medium: "Memory" }
 
+      # FIXME: add template conditional based on storage type
+      - name: ssh-key
+        secret:
+          # FIXME: convert to template parameter
+          secretName: {{ "kci-storage-ssh-staging" }}
+
       tolerations:
       - key: "kubernetes.azure.com/scalesetpriority"
         operator: "Equal"
@@ -52,12 +58,23 @@ spec:
         - mountPath: "/dev/shm"
           name: dev-shm
 
+        # FIXME: add template conditional based on storage type
+        volumeMounts:
+        - mountPath: "/home/kernelci/.ssh"
+          name: ssh-key
+          readOnly: true
+
         env:
         - name: API_TOKEN
           valueFrom:
             secretKeyRef:
+              # FIXME: convert to template parameter
               name: {{ "kci-api-jwt-staging" }}
               key: token
+
+        - name: KCI_STORAGE_CREDENTIALS
+          # FIXME: convert to template parameter
+          value: {{ "/home/kernelci/.ssh/id_rsa_tarball-staging" }}
 {% block k8s_command %}
         command: ["/bin/sh", "-c"]
 {% endblock %}

--- a/config/runtime/base/python.jinja2
+++ b/config/runtime/base/python.jinja2
@@ -18,11 +18,14 @@ import yaml
 {%- block python_local_imports %}
 import kernelci.api
 import kernelci.config
+import kernelci.storage
 {%- endblock %}
 
 {%- block python_globals %}
 API_CONFIG_YAML = """
 {{ api_config_yaml }}"""
+STORAGE_CONFIG_YAML = """
+{{ storage_config_yaml }}"""
 NODE_ID = '{{ node_id }}'
 TARBALL_URL = '{{ tarball_url }}'
 WORKSPACE = '/tmp/kci'
@@ -46,6 +49,15 @@ class BaseJob:
             raise ValueError("API_TOKEN environment variable not found")
 
         return kernelci.api.get_api(api_config, api_token)
+
+    def _get_storage(self):
+        storage_config = kernelci.config.storage.StorageFactory.from_yaml(
+            name='storage', config=yaml.safe_load(STORAGE_CONFIG_YAML)
+        )
+        if not storage_config:
+            return None
+        storage_cred = os.getenv('KCI_STORAGE_CREDENTIALS')
+        return kernelci.storage.get_storage(storage_config, storage_cred)
 
     def _get_source(self, url):
         resp = requests.get(url, stream=True)

--- a/kernelci/cli/job.py
+++ b/kernelci/cli/job.py
@@ -63,6 +63,7 @@ class cmd_generate(APICommand):  # pylint: disable=invalid-name
         },
     ]
     opt_args = APICommand.opt_args + [
+        Args.storage_config,
         {
             'name': '--node-id',
             'help': "ID of the job's node",
@@ -90,8 +91,12 @@ Invalid arguments.  Either --node-id or --node-json is required.")
         platform_config = configs['device_types'][args.platform]
         runtime_config = configs['runtimes'][args.runtime_config]
         runtime = kernelci.runtime.get_runtime(runtime_config)
+        storage_config = (
+            configs['storage_configs'][args.storage_config]
+            if args.storage_config else None
+        )
         params = runtime.get_params(
-            job_node, plan_config, platform_config, api.config
+            job_node, plan_config, platform_config, api.config, storage_config
         )
         job = runtime.generate(params, plan_config)
         if args.output:

--- a/kernelci/runtime/__init__.py
+++ b/kernelci/runtime/__init__.py
@@ -94,10 +94,14 @@ class Runtime(abc.ABC):
         """Apply filters and return True if they match, False otherwise."""
         return self.config.match(filter_data)
 
-    def get_params(self, node, plan_config, platform_config, api_config=None):
+    # This could be refactored with a Job object containing all the config data
+    # pylint: disable=too-many-arguments
+    def get_params(self, node, plan_config, platform_config,
+                   api_config=None, storage_config=None):
         """Get job template parameters"""
         params = {
-            'api_config_yaml': yaml.dump(api_config),
+            'api_config_yaml': yaml.dump(api_config or {}),
+            'storage_config_yaml': yaml.dump(storage_config or {}),
             'name': plan_config.name,
             'node_id': node['_id'],
             'revision': node['revision'],


### PR DESCRIPTION
Add the ability to provide a storage configuration in the job templates so that job definitions can upload files to storage.