### PR TITLE
kernelci.storage.ssh: Replace scp binary calls with paramiko

### DIFF
--- a/kernelci/storage/ssh.py
+++ b/kernelci/storage/ssh.py
@@ -2,11 +2,15 @@
 #
 # Copyright (C) 2022, 2023 Collabora Limited
 # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+# Author: Michal Galka <michal.galka@collabora.com>
 
 """KernelCI storage implementation for SSH"""
 
 import os
-import kernelci
+
+from paramiko import client, SSHClient
+from scp import SCPClient
+
 from . import Storage
 
 
@@ -18,27 +22,21 @@ class StorageSSH(Storage):
     """
 
     def _upload(self, file_paths, dest_path):
-        for src, dst in file_paths:
-            dst_file = os.path.join(self.config.path, dest_path, dst)
-            dst_dir = os.path.dirname(dst_file)
-            kernelci.shell_cmd("""\
-ssh \
-  -i {key} \
-  -p {port} \
-  -o StrictHostKeyChecking=no \
-  -o UserKnownHostsFile=/dev/null \
-  {user}@{host} \
-  mkdir -p {dst_dir} && \
-scp \
-  -i {key} \
-  -P {port} \
-  -o StrictHostKeyChecking=no \
-  -o UserKnownHostsFile=/dev/null \
-  {src} \
-  {user}@{host}:{dst_file}
-""".format(host=self.config.host, port=self.config.port,  # noqa
-           key=self.credentials, user=self.config.user,
-           src=src, dst_dir=dst_dir, dst_file=dst_file))
+        with SSHClient() as ssh:
+            ssh.set_missing_host_key_policy(client.AutoAddPolicy)
+            ssh.connect(
+                hostname=self.config.host,
+                port=self.config.port,
+                username=self.config.user,
+                key_filename=self.credentials,
+                timeout=5000
+            )
+            with SCPClient(ssh.get_transport()) as scp:
+                for src, dst in file_paths:
+                    dst_file = os.path.join(self.config.path, dest_path, dst)
+                    dst_dir = os.path.dirname(dst_file)
+                    ssh.exec_command(f'mkdir -p {dst_dir}')
+                    scp.put(src, dst_file)
 
 
 def get_storage(config, credentials):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
 cloudevents==1.9.0
 jinja2==3.1.1
 kubernetes==23.3.0
+paramiko==2.12.0
 pyelftools==0.28
 pytest==7.1.2
 pyyaml==6.0
 requests==2.27.1
+scp==0.14.4

--- a/setup.py
+++ b/setup.py
@@ -75,10 +75,12 @@ setuptools.setup(
         "cloudevents",
         "jinja2",
         "kubernetes",
+        "paramiko",
         "pyelftools",
         "pytest",
         "pyyaml",
         "requests",
+        "scp",
     ],
     extras_require={
         'dev': [


### PR DESCRIPTION
Storage_ssh class implementation relied on scp binary being installed in the operating system. Implementation based on paramiko and scp Python packages reduces the dependency on underlying system tools and adds better control of the file transfer.

Replaces #1594 (rebased with new `file_paths` 2-tuple argument and destination directory)