### PR TITLE
config/runtime: set restartPolicy to Never

### DIFF
--- a/config/runtime/base/kubernetes.jinja2
+++ b/config/runtime/base/kubernetes.jinja2
@@ -8,9 +8,12 @@ metadata:
 
 spec:
   completions: 1
+  ttlSecondsAfterFinished: 30
   template:
     spec:
-      restartPolicy: OnFailure
+      backoffLimit: 1
+      restartPolicy: Never
+      terminationGracePeriodSeconds: 10
 
       volumes:
       - name: scratch-volume


### PR DESCRIPTION
As these jobs are "batch" jobs, disable automatic restarts and add options to automatically delete the jobs when they're done after a short period of time.  This is still useful to manually inspect logs when some jobs fail.