### PR TITLE
config/runtime: move job.submit() in try-except block

### DIFF
--- a/config/runtime/base/python.jinja2
+++ b/config/runtime/base/python.jinja2
@@ -102,12 +102,11 @@ def main(args):
     job = Job({% block python_job_constr %}workspace=WORKSPACE{% endblock %})
     try:
         results = job.run(TARBALL_URL)
+        if NODE_ID and API_CONFIG_YAML:
+            job.submit(results, NODE_ID, API_CONFIG_YAML)
     except Exception:
         print(traceback.format_exc())
         results = None
-
-    if NODE_ID and API_CONFIG_YAML:
-        job.submit(results, NODE_ID, API_CONFIG_YAML)
 
     return results
 


### PR DESCRIPTION
Move the call to job.submit() in python.jinja2 inside the top-level try-except block to catch any exceptions while submitting results. This is to avoid getting failing jobs stuck in a restart loop in Kubernetes.

Some fine-tuning could be done later if legitimate infrastructure errors can be separated from bugs to benefit from restarts.  Maybe this could be a staging vs production policy choice.