### PR TITLE
Small fixes in `python.jinja2`

### DIFF
--- a/config/runtime/base/kubernetes-python.jinja2
+++ b/config/runtime/base/kubernetes-python.jinja2
@@ -3,6 +3,8 @@
 
 {% extends 'base/kubernetes.jinja2' %}
 
+{%- set always_exit_0 = true %}
+
 {%- block k8s_command %}
         command: ["/usr/bin/env", "python3", "-c"]
 {%- endblock %}

--- a/config/runtime/base/python.jinja2
+++ b/config/runtime/base/python.jinja2
@@ -31,6 +31,7 @@ STORAGE_CONFIG_YAML = """
 {{ storage_config_yaml }}"""
 NODE_ID = '{{ node_id }}'
 TARBALL_URL = '{{ tarball_url }}'
+JOB_NAME = '{{ name }}'
 WORKSPACE = '/tmp/kci'
 {%- endblock %}
 

--- a/config/runtime/base/python.jinja2
+++ b/config/runtime/base/python.jinja2
@@ -116,7 +116,12 @@ def main(args):
 
 
 if __name__ == '__main__':
+{%- if always_exit_0 %}
+    main(sys.argv)
+    sys.exit(0)
+{%- else %}
     results = main(sys.argv)
     sys.exit(1 if results is None else 0)
+{%- endif %}
 {% endblock %}
 {%- endblock %}

--- a/config/runtime/base/python.jinja2
+++ b/config/runtime/base/python.jinja2
@@ -7,13 +7,16 @@
 {% block commands %}
 {% block python_imports %}
 import os
-import requests
 import sys
 import tarfile
 import traceback
 import urllib.parse
-import yaml
 {% endblock %}
+
+{%- block python_thirdparty_imports %}
+import requests
+import yaml
+{%- endblock %}
 
 {%- block python_local_imports %}
 import kernelci.api


### PR DESCRIPTION
This PR fixes a couple of loose ends in `python.jinja2`:
* fix order of imports to pass pylint checks (system, third-party, local)
* always return 0 with Kubernetes jobs to avoid restarts when test cases failed