### PR TITLE
test-configs.yaml: Enable futex selftests on at91sam9g20ek

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2312,6 +2312,7 @@ test_configs:
     test_plans:
       - baseline
       - baseline-nfs
+      - kselftest-futex
 
   - device_type: bcm2711-rpi-4-b
     test_plans:


### PR DESCRIPTION
There is capacity available on the at91sam9g20ek, cover the futex tests
there.

Signed-off-by: Mark Brown <broonie@kernel.org>
