### PR TITLE
config/lava/kselftest: Don't use a skipfile

### DIFF
--- a/config/lava/kselftest/kselftest.jinja2
+++ b/config/lava/kselftest/kselftest.jinja2
@@ -21,7 +21,7 @@
       name: {{ plan }}
       parameters:
         TESTPROG_URL: {{ kselftests_url }}
-        SKIPFILE: skipfile-lkft.yaml
+        SKIPFILE: /dev/null
         TST_CMDFILES: {{ kselftest_collections }}
         TST_CASENAME: {{ kselftest_tests }}
         BOARD: {{ device_type }}


### PR DESCRIPTION
Currently we are using the LKFT skipfile for kselftest however this is
not ideal since it contains a lot of bitrotten entries for tests that
now run correctly (eg, the recently removed skip for the futex tests)
and masks any changes in state for the listed tests.  Since the
test-defintions integration will try to insert defaults if we don't
supply anything at all use /dev/null as the default test list, providing
an empty skiplist.

This also means we don't need to worry about getting skipgen installed
on the targets and running it which speeds things up ever so slightly.

If we need to skip tests we should probably maintain our own lists.

Signed-off-by: Mark Brown <broonie@kernel.org>
