### PR TITLE
test-configs: Enable capabilities selftest on at91sam9g20ek

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2312,6 +2312,7 @@ test_configs:
     test_plans:
       - baseline
       - baseline-nfs
+      - kselftest-capabilities
 
   - device_type: bcm2711-rpi-4-b
     test_plans:


### PR DESCRIPTION
The board has a reasonable amount of capacity, enable the capabilities
kselftest.

Signed-off-by: Mark Brown <broonie@kernel.org>
