### PR TITLE
rootfs-configs: Build Bookworm kselftest rootfs for armel

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -5,6 +5,7 @@ rootfs_configs:
     arch_list:
       - amd64
       - arm64
+      - armel
       - armhf
     extra_packages:
       - alsa-ucm-conf


### PR DESCRIPTION
The AT91SAM9G20-EK has interesting audio hardware, build the
kselftest-bookworm rootfs so we can run the ALSA selftests on it.

Signed-off-by: Mark Brown <broonie@kernel.org>
