### PR TITLE
cros-ec.jinja2: remove verbosity flag

### DIFF
--- a/config/lava/cros-ec/cros-ec.jinja2
+++ b/config/lava/cros-ec/cros-ec.jinja2
@@ -14,7 +14,7 @@
           - functional
         run:
           steps:
-            - python3 -m cros.runners.lava_runner --verbosity 2
+            - python3 -m cros.runners.lava_runner -v
       lava-signal: kmsg
       from: inline
       name: {{ plan }}


### PR DESCRIPTION
Remove the verbosity flag.  Use "-v" and "-q" instead which was already in unittest framework.