### PR TITLE
config/docker: kunit: install QEMU for x86

### DIFF
--- a/config/docker/fragment/kunit.jinja2
+++ b/config/docker/fragment/kunit.jinja2
@@ -2,3 +2,8 @@
 RUN apt-get update && apt-get install --no-install-recommends -y g++-10
 RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 500
 RUN apt-get update && apt-get install --no-install-recommends -y python3
+
+# Install minimal QEMU packages to run KUnit on x86
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    qemu-system \
+    qemu-system-x86


### PR DESCRIPTION
Install minimal QEMU packages to run KUnit on x86.  This is useful as an alternative to UML, but adding all the architectures shouldn't be necessary as KUnit tests aren't supposed to depend on a real CPU architecture.