### PR TITLE
kernelci.cli: add .base_api module for APICommand

### DIFF
--- a/kernelci/cli/api.py
+++ b/kernelci/cli/api.py
@@ -5,7 +5,8 @@
 
 """Tool to interact with the KernelCI API"""
 
-from .base import APICommand, Args, sub_main
+from .base import Args, sub_main
+from .base_api import APICommand
 
 
 class cmd_hello(APICommand):  # pylint: disable=invalid-name

--- a/kernelci/cli/base.py
+++ b/kernelci/cli/base.py
@@ -13,13 +13,11 @@ the commands registration mechanism.
 import abc
 import argparse
 import configparser
-import json
 import os.path
 import sys
 
 from requests.exceptions import HTTPError
 
-import kernelci.api
 import kernelci.config
 
 
@@ -479,46 +477,6 @@ class Command(abc.ABC):
         namespace.  For example, `--db-token` gets convereted to `db_token`.
         """
         return arg_name.strip('-').replace('-', '_')
-
-
-class APICommand(Command):  # pylint: disable=too-few-public-methods
-    """Base command class for interacting with the KernelCI API
-
-    The Args.api_token argument needs to be added for commands that require
-    authentication with the API.
-    """
-    args = Command.args + [Args.api_config]
-
-    @classmethod
-    def _get_api(cls, configs, args):
-        config = configs['api_configs'][args.api_config]
-        return kernelci.api.get_api(config, args.api_token)
-
-    @classmethod
-    def _print_json(cls, data, indent=None):
-        n_indent = 0 if indent is None else int(indent)
-        print(json.dumps(data, indent=n_indent))
-
-    @classmethod
-    def _load_json(cls, json_path, encoding='utf-8'):
-        with open(json_path, encoding=encoding) as json_file:
-            return json.load(json_file)
-
-    @classmethod
-    def _print_node(cls, node, id_only, indent):
-        if id_only:
-            print(node['_id'])
-        else:
-            cls._print_json(node, indent)
-
-    @abc.abstractmethod
-    def _api_call(self, api, configs, args):
-        """Entry point to implement commands that use the API"""
-
-    @catch_http_error
-    def __call__(self, configs, args):
-        api = self._get_api(configs, args)
-        return self._api_call(api, configs, args)
 
 
 class Options:

--- a/kernelci/cli/base_api.py
+++ b/kernelci/cli/base_api.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2023 Collabora Limited
+# Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+
+"""Common definitions for commands that interact with the API
+
+In order to avoid adding a dependency on all the commands to the kernelci.api
+module, the common code for commands that need to interact with the API is
+provided here separately instead.
+"""
+
+import abc
+import json
+
+import kernelci.api
+from .base import Command, Args, catch_http_error
+
+
+class APICommand(Command):  # pylint: disable=too-few-public-methods
+    """Base command class for interacting with the KernelCI API
+
+    The Args.api_token argument needs to be added for commands that require
+    authentication with the API.
+    """
+    args = Command.args + [Args.api_config]
+
+    @classmethod
+    def _get_api(cls, configs, args):
+        config = configs['api_configs'][args.api_config]
+        return kernelci.api.get_api(config, args.api_token)
+
+    @classmethod
+    def _print_json(cls, data, indent=None):
+        n_indent = 0 if indent is None else int(indent)
+        print(json.dumps(data, indent=n_indent))
+
+    @classmethod
+    def _load_json(cls, json_path, encoding='utf-8'):
+        with open(json_path, encoding=encoding) as json_file:
+            return json.load(json_file)
+
+    @classmethod
+    def _print_node(cls, node, id_only, indent):
+        if id_only:
+            print(node['_id'])
+        else:
+            cls._print_json(node, indent)
+
+    @abc.abstractmethod
+    def _api_call(self, api, configs, args):
+        """Entry point to implement commands that use the API"""
+
+    @catch_http_error
+    def __call__(self, configs, args):
+        api = self._get_api(configs, args)
+        return self._api_call(api, configs, args)

--- a/kernelci/cli/job.py
+++ b/kernelci/cli/job.py
@@ -6,7 +6,8 @@
 """Tool to generate and run KernelCI jobs"""
 
 import kernelci.runtime
-from .base import APICommand, Args, Command, sub_main
+from .base import Args, Command, sub_main
+from .base_api import APICommand
 
 
 class cmd_init(APICommand):  # pylint: disable=invalid-name

--- a/kernelci/cli/node.py
+++ b/kernelci/cli/node.py
@@ -8,7 +8,8 @@
 import json
 import sys
 
-from .base import APICommand, Args, sub_main
+from .base import Args, sub_main
+from .base_api import APICommand
 
 
 class NodeCommand(APICommand):  # pylint: disable=too-few-public-methods

--- a/kernelci/cli/pubsub.py
+++ b/kernelci/cli/pubsub.py
@@ -7,7 +7,8 @@
 
 import sys
 
-from .base import APICommand, Args, sub_main
+from .base import Args, sub_main
+from .base_api import APICommand
 
 
 class cmd_subscribe(APICommand):  # pylint: disable=invalid-name

--- a/kernelci/cli/show.py
+++ b/kernelci/cli/show.py
@@ -7,7 +7,8 @@
 
 from datetime import datetime
 
-from .base import APICommand, Args, sub_main
+from .base import Args, sub_main
+from .base_api import APICommand
 
 
 class cmd_results(APICommand):  # pylint: disable=invalid-name

--- a/kernelci/cli/user.py
+++ b/kernelci/cli/user.py
@@ -7,7 +7,8 @@
 
 import getpass
 
-from .base import Args, APICommand, sub_main
+from .base import Args, sub_main
+from .base_api import APICommand
 
 
 class cmd_whoami(APICommand):  # pylint: disable=invalid-name


### PR DESCRIPTION
Move APICommand to a new module kernelci.cli.base_api so that dependencies such as cloudevents aren't imported in kernelci.cli.base. This allows commands that don't use the API to be run without having cloudevents (or other API-specific dependencies) installed and limits the base module to only common base code for all the commands.

Update all the related tools using APICommand accordingly.