### PR TITLE
CHROMEOS MT8192-asurada-spherion passing tast on 6.1

### DIFF
--- a/config/core/build-configs-chromeos.yaml
+++ b/config/core/build-configs-chromeos.yaml
@@ -98,6 +98,11 @@ build_configs:
     branch: 'linux-6.1.y'
     variants: *chromeos_6_1_variants
 
+  chromeos-stable_6.1-backported-arm64:
+    tree: kernelci
+    branch: 'linux-6.1.y-arm64-chromeos'
+    variants: *chromeos_6_1_variants
+
   collabora-chromeos-kernel:
     tree: collabora-chromeos-kernel
     branch: 'for-kernelci'

--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -240,6 +240,7 @@ fragments:
       - 'CONFIG_SX9324=m'
       - 'CONFIG_TCG_TIS_I2C_CR50=y'
       - 'CONFIG_QCOM_OCMEM=y'
+      - 'CONFIG_DRM_VGEM=y'
       # Mediatek specific options start here
       - 'CONFIG_RTC_DRV_PM8XXX=y'
       - 'CONFIG_SND_SOC_MT8183=y'


### PR DESCRIPTION
This PR adds the needed kernel config and patches to get ChromeOS working and the tast tests passing on mt8192-asurada-spherion running 6.1.

This is the list of backported patches (all of them are merged upstream, except for the last one, which should be merged soon):
* [MT8192 Asurada devicetree - Part 2](https://lore.kernel.org/all/20221102190611.283546-1-nfraprado@collabora.com/#r)
* [soc: mediatek: Introduce mediatek-regulator-coupler driver](https://lore.kernel.org/all/20221006115816.66853-1-angelogioacchino.delregno@collabora.com/#r)
* [MTK: Undesired set_rate on main PLLs and GPU DVFS](https://lore.kernel.org/all/20221024102307.33722-1-angelogioacchino.delregno@collabora.com/#r)
* [arm64: dts: mt8186: Add power domains controller](https://lore.kernel.org/all/20221123135531.23221-3-allen-kh.cheng@mediatek.com/#r) (just to resolve conflict)
* [Panfrost: Improve and add MediaTek SoCs support](https://lore.kernel.org/all/20230228102704.708150-1-angelogioacchino.delregno@collabora.com/)
* [Enable GPU with DVFS support on MediaTek SoCs](https://lore.kernel.org/all/20230301095523.428461-1-angelogioacchino.delregno@collabora.com/#r)