### PR TITLE
build_board.sh: Improve DTB copy wildcard pattern

### DIFF
--- a/config/rootfs/chromiumos/scripts/build_board.sh
+++ b/config/rootfs/chromiumos/scripts/build_board.sh
@@ -142,7 +142,7 @@ case ${BOARD} in
     ;;
     asurada|jacuzzi|cherry|geralt)
     mkdir -p ${DATA_DIR}/${BOARD}/dtbs/mediatek
-    sudo cp ./chroot/build/${BOARD}/var/cache/portage/sys-kernel/chromeos-kernel-*/arch/arm64/boot/dts/mediatek/*.dtb \
+    sudo cp ./chroot/build/${BOARD}/var/cache/portage/sys-kernel/*kernel*/arch/arm64/boot/dts/mediatek/*.dtb \
 	 ${DATA_DIR}/${BOARD}/dtbs/mediatek
     sudo cp ./chroot/build/${BOARD}/boot/Image* "${DATA_DIR}/${BOARD}/Image"
     ;;


### PR DESCRIPTION
In case of newest kernels built for cherry, as in PR #1832 we need a bit different wildcard pattern to extract dtb. This commit was tested by hand on cherry and asurada targets