### PR TITLE
rustc-1.6*-x86.jinja2: Add arch specific templates

### DIFF
--- a/config/docker/rustc-1.62-x86.jinja2
+++ b/config/docker/rustc-1.62-x86.jinja2
@@ -1,0 +1,9 @@
+{%- set sub_arch = 'amd64' %}
+{% extends 'rustc-1.62.jinja2' %}
+
+{% block packages %}
+{{ super() }}
+
+RUN dpkg --add-architecture amd64
+
+{%- endblock %}

--- a/config/docker/rustc-1.66-x86.jinja2
+++ b/config/docker/rustc-1.66-x86.jinja2
@@ -1,0 +1,9 @@
+{%- set sub_arch = 'amd64' %}
+{% extends 'rustc-1.66.jinja2' %}
+
+{% block packages %}
+{{ super() }}
+
+RUN dpkg --add-architecture amd64
+
+{%- endblock %}


### PR DESCRIPTION
As we have now docker image template with arch, such as: compiler:arch-fragments...
We need to add also template for rustc arch, x86 at moment.