### PR TITLE
rootfs-configs.yaml: Fetch ALSA UCM files from git

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -7,7 +7,6 @@ rootfs_configs:
       - arm64
       - armhf
     extra_packages:
-      - alsa-ucm-conf
       - alsa-utils
       - bc
       - ca-certificates
@@ -38,6 +37,7 @@ rootfs_configs:
       - tpm2-tools
       - wget
       - xz-utils
+    script: "scripts/bookworm-kselftest.sh"
 
   buildroot-baseline:
     rootfs_type: buildroot

--- a/config/rootfs/debos/scripts/bookworm-kselftest.sh
+++ b/config/rootfs/debos/scripts/bookworm-kselftest.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Important: This script is run under QEMU
+
+set -e
+
+# Build-depends needed to build the test suites, they'll be removed later
+BUILD_DEPS="\
+    ca-certificates \
+    curl \
+    libssl-dev \
+"
+
+apt-get install --no-install-recommends -y  ${BUILD_DEPS}
+
+mkdir /usr/share/alsa
+curl -L -o /tmp/alsa-ucm-conf.tar.gz https://github.com/alsa-project/alsa-ucm-conf/archive/refs/heads/master.tar.gz
+tar xvzf /tmp/alsa-ucm-conf.tar.gz -C /usr/share/alsa --strip-components=1 --wildcards "*/ucm" "*/ucm2"
+
+########################################################################
+# Cleanup: remove files and packages we don't want in the images       #
+########################################################################
+cd /tmp
+rm -rf /tmp/tests
+
+apt-get remove --purge -y ${BUILD_DEPS}
+apt-get autoremove --purge -y
+apt-get clean
+
+# re-add some stuff that is removed by accident
+apt-get install -y initramfs-tools


### PR DESCRIPTION
The releases for alsa-ucm-conf are sparse. Instead of relying on the alsa-ucm-conf debian package, fetch the UCM directly from the main branch in the git repository to avoid having to wait for releases. This will allow us to start testing audio on machines using alsa-kselftest as soon as the machine's UCM is merged upstream.

It's worth pointing out that this is fetching the latest UCM files from git while still using the latest tagged release for alsa-lib and alsa-utils. It is possible that a UCM could be updated to rely on functionality from the latest alsa-lib, causing a regression for the machines that use that UCM, which would only be fixed when a new alsa-lib version gets released and packaged. A way around this would be to also build alsa-lib and alsa-utils from source. But since I'm not sure this will even happen, I'm starting with the simplest approach, so we can add this complexity once it becomes necessary.

Also, for now it seems unnecessary, but if we start building everything from source, might make sense to test both using the latest tagged release and the latest commit, so we can have a more stable reference in case there's a regression in alsa-lib.
