### PR TITLE
T41623 config/docker/README.md: update documentation for `kci docker`

### DIFF
--- a/config/docker/README.md
+++ b/config/docker/README.md
@@ -1,6 +1,6 @@
 ## Prerequisites
 
-The `kci_docker` tool only requires Python 3 and the `docker` and `jinja2`
+The `kci docker` tool only requires Python 3 and the `docker` and `jinja2`
 packages.  To install all this on a Debian-based distribution:
 
 ```
@@ -15,7 +15,7 @@ The base name for each Docker image follows the main application contained in
 the image.  For example: `clang-14`, `gcc-10`, `k8s`, `kernelci`.  Then the tag
 is composed of an optional kernel CPU architecture name when applicable
 (currently only with GCC images) followed by optional additional fragments.  A
-prefix can be used to specify the Docker Hub account where the image should be
+prefix must be provided to specify the Docker Hub account where the image should be
 pushed, or for local name spaces.  The overall pattern looks like this:
 
     {{ prefix }}{{ image }}:{{ arch }}{{ -fragment1 }}{{ -fragment2 }}{{ ... }}
@@ -39,26 +39,26 @@ Here are a few image names examples:
 
 ## Command line syntax
 
-See `kci_docker --help` for the full details about how to use the tool.  It
+See `kci docker --help` for the full details about how to use the tool.  It
 generates a `Dockerfile` on the fly based on Jinja2 templates then builds it
 and tags it with the Python SDK directly.  It's possible to dump it in a
 `Dockerfile` and do a manual build.  Here are a few examples to get started:
 
 Get the full name of a Docker image without building it:
 
-    $ ./kci_docker name gcc-10 --arch=x86 --fragment=kernelci
+    $ ./kci docker name gcc-10 kernelci --arch=x86 --prefix=kernelci/
     kernelci/gcc-10:x86-kernelci
 
 Build an image with GCC only and a local prefix:
 
-    $ ./kci_docker build gcc-10 --arch=x86 --prefix=my-stuff/ --verbose
+    $ ./kci docker build gcc-10 --arch=x86 --prefix=my-stuff/ --verbose
     Building my-stuff/gcc-10:x86
     $ docker images | grep my-stuff
     my-stuff/gcc-10                  x86                  8deb3fdc7ad9   17 seconds ago   584MB
 
 Build an image with just the KernelCI core tools:
 
-    $ ./kci_docker build kernelci --prefix=my-stuff/
+    $ ./kci docker build kernelci --prefix=my-stuff/
     Building my-stuff/kernelci
 
 The plain images with just the compiler toolchains can be used to build Linux
@@ -71,9 +71,9 @@ with both the compiler and KernelCI core tools.
 For example, to build an image with Clang 14 and extra kselftest tools
 installed, as well as the KernelCI core tools:
 
-    $ ./kci_docker build clang-14 --prefix=my-stuff/ --fragment=kselftest --fragment=kernelci
+    $ ./kci docker build clang-14 kselftest kernelci --prefix=my-stuff/
     Building my-stuff/clang-14:kselftest-kernelci
 
 Build the `kernelci` image with a particular revision using `--build-arg`:
 
-    ./kci_docker build kernelci --build-arg core_rev=staging-20220728.1
+    ./kci docker build kernelci --build-arg core_rev=staging-20220728.1 --prefix=kernelci/

--- a/config/docker/README.md
+++ b/config/docker/README.md
@@ -18,7 +18,7 @@ is composed of an optional kernel CPU architecture name when applicable
 prefix can be used to specify the Docker Hub account where the image should be
 pushed, or for local name spaces.  The overall pattern looks like this:
 
-    {{ prefix }}{{ image }}:{{ arch }}{{ -fragment2 }}{{ -fragment2 }}{{ ... }}
+    {{ prefix }}{{ image }}:{{ arch }}{{ -fragment1 }}{{ -fragment2 }}{{ ... }}
 
 The fragment names are additional features to be added to the image.  These are
 typically useful when running jobs in a local shell all in the same container.

--- a/config/docker/README.md
+++ b/config/docker/README.md
@@ -22,7 +22,7 @@ pushed, or for local name spaces.  The overall pattern looks like this:
 
 The fragment names are additional features to be added to the image.  These are
 typically useful when running jobs in a local shell all in the same container.
-For Kubernetes deployment in produciton, each step should be run in a separate
+For Kubernetes deployment in production, each step should be run in a separate
 container which would only include one application.
 
 Here are a few image names examples:


### PR DESCRIPTION
 Since the `kci_docker` script has been converted to `kci docker` command line tool, update the documentation to modify all the sample commands and related instructions.
The commands are modified based on latest changes to update `fragments` option to be positional argument.
Also, added `--prefix` argument to commands as the default value of the flag has been discarded in the tool.
Also, fix a minor typo  in `Docker images and tag names` section.