### PR TITLE
Add initial `Job` config class and rework `Runtime` accordingly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ pylint:
 		kernelci.api \
 		kernelci.cli \
 		kernelci.config.api \
+		kernelci.config.job \
 		kernelci.config.runtime \
 		kernelci.config.storage \
 		kernelci.storage \

--- a/kernelci/cli/config.py
+++ b/kernelci/cli/config.py
@@ -26,7 +26,7 @@ class cmd_validate(Command):  # pylint: disable=invalid-name
     def __call__(self, configs, args):
         entries = [
             'device_types',
-            'test_plans',
+            'jobs',
             'storage_configs',
         ]
         err = kernelci.config.validate_yaml(args.yaml_config, entries)

--- a/kernelci/cli/job.py
+++ b/kernelci/cli/job.py
@@ -12,7 +12,13 @@ from .base_api import APICommand
 
 class cmd_init(APICommand):  # pylint: disable=invalid-name
     """Initialise job data before running it"""
-    args = APICommand.args + [Args.api_token, Args.plan]
+    args = APICommand.args + [
+        Args.api_token,
+        {
+            'name': 'job',
+            'help': "Job name",
+        },
+    ]
 
     opt_args = APICommand.opt_args + [
         Args.indent, Args.id_only,
@@ -28,12 +34,12 @@ class cmd_init(APICommand):  # pylint: disable=invalid-name
 
     # This should in fact be using a generic method in the API class
     # pylint: disable=no-self-use
-    def _create_node(self, api, input_node, plan_config):
+    def _create_node(self, api, input_node, job_config):
         job_node = {
             'parent': input_node['_id'],
-            'name': plan_config.name,
-            'path': input_node['path'] + [plan_config.name],
-            'group': plan_config.name,
+            'name': job_config.name,
+            'path': input_node['path'] + [job_config.name],
+            'group': job_config.name,
             'artifacts': input_node['artifacts'],
             'revision': input_node['revision'],
         }
@@ -48,8 +54,8 @@ class cmd_init(APICommand):  # pylint: disable=invalid-name
             print("\
 Invalid arguments.  Either --input-node-id or --input-node-json is required.")
             return False
-        plan_config = configs['test_plans'][args.plan]
-        node = self._create_node(api, input_node, plan_config)
+        job_config = configs['jobs'][args.job]
+        node = self._create_node(api, input_node, job_config)
         self._print_node(node, args.id_only, args.indent)
         return True
 
@@ -88,7 +94,7 @@ class cmd_generate(APICommand):  # pylint: disable=invalid-name
             print("\
 Invalid arguments.  Either --node-id or --node-json is required.")
             return False
-        plan_config = configs['test_plans'][job_node['name']]
+        job_config = configs['jobs'][job_node['name']]
         platform_config = configs['device_types'][args.platform]
         runtime_config = configs['runtimes'][args.runtime_config]
         runtime = kernelci.runtime.get_runtime(runtime_config)
@@ -97,9 +103,9 @@ Invalid arguments.  Either --node-id or --node-json is required.")
             if args.storage_config else None
         )
         params = runtime.get_params(
-            job_node, plan_config, platform_config, api.config, storage_config
+            job_node, job_config, platform_config, api.config, storage_config
         )
-        job = runtime.generate(params, plan_config)
+        job = runtime.generate(params, job_config)
         if args.output:
             output_file = runtime.save_file(job, args.output, params)
             print(f"Job saved in {output_file}")

--- a/kernelci/config/__init__.py
+++ b/kernelci/config/__init__.py
@@ -24,6 +24,7 @@ import kernelci.config
 import kernelci.config.api
 import kernelci.config.build
 import kernelci.config.db
+import kernelci.config.job
 import kernelci.config.runtime
 import kernelci.config.rootfs
 import kernelci.config.storage
@@ -166,6 +167,7 @@ def load_data(data):
     config.update(kernelci.config.api.from_yaml(data, filters))
     config.update(kernelci.config.build.from_yaml(data, filters))
     config.update(kernelci.config.db.from_yaml(data, filters))
+    config.update(kernelci.config.job.from_yaml(data, filters))
     config.update(kernelci.config.runtime.from_yaml(data, filters))
     config.update(kernelci.config.rootfs.from_yaml(data, filters))
     config.update(kernelci.config.storage.from_yaml(data, filters))

--- a/kernelci/config/job.py
+++ b/kernelci/config/job.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2023 Collabora Limited
+# Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+
+"""KernelCI pipeline job configuration"""
+
+from kernelci.config.base import YAMLConfigObject
+
+
+class Job(YAMLConfigObject):
+    """Pipeline job definition"""
+
+    yaml_tag = '!Job'
+
+    # pylint: disable=too-many-arguments
+    def __init__(self, name, template, image=None,
+                 conditions=None, params=None):
+        self._name = name
+        self._template = template
+        self._image = image
+        self._conditions = conditions or []
+        self._params = params or {}
+
+    @property
+    def name(self):
+        """Job name"""
+        return self._name
+
+    @property
+    def template(self):
+        """Template file name"""
+        return self._template
+
+    @property
+    def image(self):
+        """Runtime environment image name"""
+        return self._image
+
+    @property
+    def conditions(self):
+        """Conditions for the job to be run"""
+        return list(dict(cond) for cond in self._conditions)
+
+    @property
+    def params(self):
+        """Arbitrary parameters passed to the template"""
+        return dict(self._params)
+
+    @classmethod
+    def _get_yaml_attributes(cls):
+        attrs = super()._get_yaml_attributes()
+        attrs.update({'template', 'image', 'conditions', 'params'})
+        return attrs
+
+
+def from_yaml(data, _):
+    """Create the pipeline job definitions using data loaded from YAML"""
+    jobs = {
+        name: Job.load_from_yaml(config, name=name)
+        for name, config in data.get('jobs', {}).items()
+    }
+
+    return {
+        'jobs': jobs,
+    }

--- a/kernelci/runtime/__init__.py
+++ b/kernelci/runtime/__init__.py
@@ -61,10 +61,9 @@ class Runtime(abc.ABC):
     def _get_devices(self):  # pylint: disable=no-self-use
         return []
 
-    def _get_template(self, plan_config):
+    def _get_template(self, job_config):
         jinja2_env = Environment(loader=FileSystemLoader(self.templates))
-        template_path = plan_config.get_template_path(None)
-        return jinja2_env.get_template(template_path)
+        return jinja2_env.get_template(job_config.template)
 
     def import_devices(self, data):
         """Import devices information
@@ -96,32 +95,31 @@ class Runtime(abc.ABC):
 
     # This could be refactored with a Job object containing all the config data
     # pylint: disable=too-many-arguments
-    def get_params(self, node, plan_config, platform_config,
+    def get_params(self, node, job_config, platform_config,
                    api_config=None, storage_config=None):
         """Get job template parameters"""
         params = {
             'api_config_yaml': yaml.dump(api_config or {}),
             'storage_config_yaml': yaml.dump(storage_config or {}),
-            'name': plan_config.name,
+            'name': job_config.name,
             'node_id': node['_id'],
             'revision': node['revision'],
             'runtime': self.config.lab_type,
-            'runtime_image': plan_config.image,
+            'runtime_image': job_config.image,
             'tarball_url': node['artifacts']['tarball'],
         }
-        params.update(plan_config.params)
+        params.update(job_config.params)
         params.update(platform_config.params)
         return params
 
     @abc.abstractmethod
-    def generate(self, params, plan_config):
+    def generate(self, params, job_config):
         """Generate a test job definition.
 
         *params* is a dictionary with the test parameters which can be used
              when generating a job definition using templates
 
-        *plan_config* is a TestPlan configuration object for the target test
-             plan
+        *job_config* is a Job configuration object for the target job
         """
 
     def save_file(self, job, output_path, params, encoding='utf-8'):

--- a/kernelci/runtime/docker.py
+++ b/kernelci/runtime/docker.py
@@ -39,13 +39,13 @@ class Docker(Runtime):
     def _meta_path(cls, script_file_path):
         return '.'.join((script_file_path, 'meta'))
 
-    def generate(self, params, plan_config):
-        template = self._get_template(plan_config)
+    def generate(self, params, job_config):
+        template = self._get_template(job_config)
         return {
             'job': template.render(params),
             'metadata': {
                 'runtime': self.config.name,
-                'image': plan_config.image,
+                'image': job_config.image,
             },
         }
 

--- a/kernelci/runtime/kubernetes.py
+++ b/kernelci/runtime/kubernetes.py
@@ -22,8 +22,8 @@ class Kubernetes(Runtime):
 
     JOB_NAME_CHARACTERS = string.ascii_lowercase + string.digits
 
-    def generate(self, params, plan_config):
-        template = self._get_template(plan_config)
+    def generate(self, params, job_config):
+        template = self._get_template(job_config)
         job_name = '-'.join(['kci', params['node_id'], params['name'][:24]])
         safe_name = re.sub(r'[\:/_+=]', '-', job_name).lower()
         rand_sx = ''.join(random.sample(self.JOB_NAME_CHARACTERS, 8))

--- a/kernelci/runtime/shell.py
+++ b/kernelci/runtime/shell.py
@@ -18,8 +18,8 @@ class Shell(Runtime):
     Popen object so the caller can wait for it to complete and get its output.
     """
 
-    def generate(self, params, plan_config):
-        template = self._get_template(plan_config)
+    def generate(self, params, job_config):
+        template = self._get_template(job_config)
         return template.render(params)
 
     def save_file(self, *args, **kwargs):

--- a/tests/configs/jobs.yaml
+++ b/tests/configs/jobs.yaml
@@ -1,0 +1,34 @@
+_aliases:
+
+  checkout: &checkout
+  - event: node
+    name: checkout
+    result: pass
+
+
+jobs:
+
+  kbuild-gcc-10-x86:
+    template: 'kbuild.jinja2'
+    image: 'gcc-10:{arch}{fragments}'
+    conditions: *checkout
+    params:
+      config: x86_64_defconfig
+
+  kunit: &kunit-job
+    template: 'kunit.jinja2'
+    image: 'gcc-10:x86-kunit-kernelci'
+    conditions: *checkout
+    params: {}
+
+  kunit-x86_64:
+    <<: *kunit-job
+    image: 'kernelci/staging-gcc-10:x86-kunit-qemu-kernelci'
+    params:
+      arch: x86_64
+
+  kver:
+    template: 'kver.jinja2'
+    image: 'kernelci'
+    conditions: *checkout
+    params: {}

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -164,6 +164,22 @@ class TestTestConfigs(ConfigTest):
         )
 
 
+class TestJobConfigs(ConfigTest):
+    """Tests for pipeline job definitions"""
+
+    def test_jobs(self):
+        """Test the job configs"""
+        ref_data, config = self._load_config('tests/configs/jobs.yaml')
+        jobs = self._reload(ref_data, config, 'jobs')
+        job_names = ['kbuild-gcc-10-x86', 'kunit', 'kunit-x86_64', 'kver']
+        assert all(name in ref_data['jobs'] for name in job_names)
+        assert all(name in jobs for name in job_names)
+        assert (
+            jobs['kunit-x86_64']['image'] ==
+            'kernelci/staging-gcc-10:x86-kunit-qemu-kernelci'
+        )
+
+
 class TestAPIConfigs(ConfigTest):
     """Tests for configs related to the KernelCI API"""
 


### PR DESCRIPTION
This is a first step to move away from build and test configurations and start using a new common job definition.  Update `kci job` accordingly.