### PR TITLE
test-configs: add TI K3 boards

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1,3 +1,4 @@
+
 # See the KernelCI wiki page regarding the format of this file:
 # https://github.com/kernelci/kernelci-doc/wiki/Test-configurations
 
@@ -1286,6 +1287,21 @@ device_types:
     mach: vexpress
     class: arm64-dtb
     dtb: 'arm/juno.dtb'
+    boot_method: uboot
+
+  k3-am625-sk:
+    mach: ti
+    class: arm64-dtb
+    boot_method: uboot
+
+  k3-j721e-beagleboneai64:
+    mach: ti
+    class: arm64-dtb
+    boot_method: uboot
+
+  k3-j721e-sk:
+    mach: ti
+    class: arm64-dtb
     boot_method: uboot
 
   kirkwood-db-88f6282:
@@ -2684,6 +2700,18 @@ test_configs:
       - ltp-crypto
       # ltp-mm - runs system out of memory
       - smc
+
+  - device_type: k3-am625-sk
+    test_plans:
+      - baseline
+
+  - device_type: k3-j721e-beagleboneai64
+    test_plans:
+      - baseline
+
+  - device_type: k3-j721e-sk
+    test_plans:
+      - baseline
 
   - device_type: kirkwood-db-88f6282
     test_plans:


### PR DESCRIPTION
Add 3 TI K3 boards, all supported upstream in mainline and availabe in lab-baylibre.

- k3-am625-sk
- k3-j721e-sk
- k3-j721e-beagleboneai64

For now, just enable baseline.