### PR TITLE
Clean up the `Runtime` base class

### DIFF
--- a/kci_test
+++ b/kci_test
@@ -209,8 +209,10 @@ class cmd_list_jobs(Command):
 
         runtime_config = configs['runtimes'][args.runtime_config]
         runtime = kernelci.runtime.get_runtime(
-            runtime_config, args.user, args.runtime_token, args.runtime_json
+            runtime_config, args.user, args.runtime_token
         )
+        if args.runtime_json:
+            runtime.import_devices(args.runtime_json)
         configs = kernelci.test.match_configs(
             configs['test_configs'], meta, runtime_config)
         jobs = list()
@@ -300,8 +302,10 @@ class cmd_generate(Command):
 
         runtime_config = configs['runtimes'][args.runtime_config]
         runtime = kernelci.runtime.get_runtime(
-            runtime_config, args.user, args.runtime_token, args.runtime_json
+            runtime_config, args.user, args.runtime_token
         )
+        if args.runtime_json:
+            runtime.import_devices(args.runtime_json)
         if args.target and args.plan:
             device_config = configs['device_types'][args.target]
             plan_config = configs['test_plans'][args.plan]

--- a/kernelci/legacy/lava/__init__.py
+++ b/kernelci/legacy/lava/__init__.py
@@ -8,6 +8,7 @@
 # Author: Michal Galka <michal.galka@collabora.com>
 
 from jinja2 import Environment, FileSystemLoader
+import json
 import os
 
 from kernelci.runtime import add_kci_raise
@@ -37,8 +38,9 @@ class LavaRuntime:
     def _connect(self, *args, **kwargs):
         return None
 
-    def import_devices(self, data):
-        self._devices = data
+    def import_devices(self, runtime_json):
+        with open(runtime_json, encoding='utf-8') as json_file:
+            self._devices = json.load(json_file)['devices']
 
     def device_type_online(self, device_type_config):
         return True

--- a/kernelci/runtime/__init__.py
+++ b/kernelci/runtime/__init__.py
@@ -54,11 +54,6 @@ class Runtime(abc.ABC):
         jinja2_env = Environment(loader=FileSystemLoader(self.templates))
         return jinja2_env.get_template(job_config.template)
 
-    # pylint: disable=no-self-use
-    def job_file_name(self, params):
-        """Get the file name where to store the generated job definition."""
-        return params['name']
-
     def match(self, filter_data):
         """Apply filters and return True if they match, False otherwise."""
         return self.config.match(filter_data)
@@ -82,6 +77,11 @@ class Runtime(abc.ABC):
         params.update(platform_config.params)
         return params
 
+    @classmethod
+    def _get_job_file_name(cls, params):
+        """Get the file name where to store the generated job definition."""
+        return params['name']
+
     def save_file(self, job, output_path, params, encoding='utf-8'):
         """Save a test job definition in a file.
 
@@ -91,7 +91,7 @@ class Runtime(abc.ABC):
 
         Return the full path where the job definition file was saved.
         """
-        file_name = self.job_file_name(params)
+        file_name = self._get_job_file_name(params)
         output_file = os.path.join(output_path, file_name)
         with open(output_file, 'w', encoding=encoding) as output:
             output.write(job)

--- a/kernelci/runtime/__init__.py
+++ b/kernelci/runtime/__init__.py
@@ -82,16 +82,6 @@ class Runtime(abc.ABC):
         params.update(platform_config.params)
         return params
 
-    @abc.abstractmethod
-    def generate(self, params, job_config):
-        """Generate a test job definition.
-
-        *params* is a dictionary with the test parameters which can be used
-             when generating a job definition using templates
-
-        *job_config* is a Job configuration object for the target job
-        """
-
     def save_file(self, job, output_path, params, encoding='utf-8'):
         """Save a test job definition in a file.
 
@@ -106,6 +96,16 @@ class Runtime(abc.ABC):
         with open(output_file, 'w', encoding=encoding) as output:
             output.write(job)
         return output_file
+
+    @abc.abstractmethod
+    def generate(self, params, job_config):
+        """Generate a test job definition.
+
+        *params* is a dictionary with the test parameters which can be used
+             when generating a job definition using templates
+
+        *job_config* is a Job configuration object for the target job
+        """
 
     @abc.abstractmethod
     def submit(self, job_path):

--- a/kernelci/runtime/kubernetes.py
+++ b/kernelci/runtime/kubernetes.py
@@ -22,6 +22,10 @@ class Kubernetes(Runtime):
 
     JOB_NAME_CHARACTERS = string.ascii_lowercase + string.digits
 
+    @classmethod
+    def _get_job_file_name(cls, params):
+        return '.'.join([params['k8s_job_name'], 'yaml'])
+
     def generate(self, params, job_config):
         template = self._get_template(job_config)
         job_name = '-'.join(['kci', params['node_id'], params['name'][:24]])
@@ -30,9 +34,6 @@ class Kubernetes(Runtime):
         k8s_job_name = '-'.join([safe_name[:(62 - len(rand_sx))], rand_sx])
         params['k8s_job_name'] = k8s_job_name
         return template.render(params)
-
-    def job_file_name(self, params):
-        return '.'.join([params['k8s_job_name'], 'yaml'])
 
     def submit(self, job_path):
         kubernetes.config.load_kube_config(context=self.config.context)

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -58,9 +58,8 @@ def test_lava_priority_scale():
             runtime_config.priority_max,
         ])
         print(f"{runtime_name}: {priorities}")
-        lab = kernelci.runtime.get_runtime(
-            runtime_config, runtime_json=f'tests/configs/{runtime_name}.json'
-        )
+        lab = kernelci.runtime.get_runtime(runtime_config)
+        lab.import_devices(f'tests/configs/{runtime_name}.json')
         for plan_name, priority in specs.items():
             plan_config = plans[plan_name]
             lab_priority = lab._get_priority(plan_config)


### PR DESCRIPTION
Remove unused code from the base `kernelci.runtime.Runtime` now that we have `shell`, `docker` and `kubernetes` runtimes implemented.