### PR TITLE
kernelci.config.runtime: add Docker API timeout

### DIFF
--- a/kernelci/config/runtime.py
+++ b/kernelci/config/runtime.py
@@ -113,11 +113,13 @@ class RuntimeLAVA(Runtime):
 class RuntimeDocker(Runtime):
     """Configuration for Docker runtime environments"""
 
-    def __init__(self, env_file=None, volumes=None, user=None, **kwargs):
+    def __init__(self, env_file=None, volumes=None, user=None, timeout=None,
+                 **kwargs):
         super().__init__(**kwargs)
         self._env_file = env_file
         self._volumes = volumes or []
         self._user = user
+        self._timeout = timeout
 
     @property
     def env_file(self):
@@ -134,10 +136,15 @@ class RuntimeDocker(Runtime):
         """Specified user to run in the container"""
         return self._user
 
+    @property
+    def timeout(self):
+        """Timeout for Docker API calls in seconds"""
+        return self._timeout
+
     @classmethod
     def _get_yaml_attributes(cls):
         attrs = super()._get_yaml_attributes()
-        attrs.update({'env_file', 'volumes', 'user'})
+        attrs.update({'env_file', 'volumes', 'user', 'timeout'})
         return attrs
 
 

--- a/kernelci/runtime/docker.py
+++ b/kernelci/runtime/docker.py
@@ -26,7 +26,7 @@ class Docker(Runtime):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._client = docker.from_env()
+        self._client = docker.from_env(timeout=self.config.timeout)
         self._env = self._load_env()
 
     def _load_env(self):


### PR DESCRIPTION
Add a `timeout` parameter for the docker runtime which specifies a timeout for the Docker API.  If not set, the client will be using the SDK's default which is typically 60s.

Update kernelci.runtime.docker accordingly to use it.