### PR TITLE
kernelci.config.runtime: convert to proper YAML objects

### DIFF
--- a/kernelci/config/runtime.py
+++ b/kernelci/config/runtime.py
@@ -5,11 +5,13 @@
 
 """KernelCI Runtime environment configuration"""
 
-from kernelci.config.base import FilterFactory, _YAMLObject
+from kernelci.config.base import FilterFactory, YAMLConfigObject
 
 
-class Runtime(_YAMLObject):
+class Runtime(YAMLConfigObject):
     """Runtime environment configuration"""
+
+    yaml_tag = '!Runtime'
 
     def __init__(self, name, lab_type, filters=None):
         """A runtime environment configuration object
@@ -39,6 +41,24 @@ class Runtime(_YAMLObject):
         attrs.update({'lab_type'})
         return attrs
 
+    @classmethod
+    def _to_yaml_dict(cls, data):
+        yaml_dict = {
+            key: getattr(data, key)
+            for key in cls._get_yaml_attributes()
+        }
+        yaml_dict.update({
+            # pylint: disable=protected-access
+            'filters': [{fil.name: fil} for fil in data._filters],
+        })
+        return yaml_dict
+
+    @classmethod
+    def to_yaml(cls, dumper, data):
+        return dumper.represent_mapping(
+            'tag:yaml.org,2002:map', cls._to_yaml_dict(data)
+        )
+
     def match(self, data):
         """Match configuration filters with provided input data"""
         return all(f.match(**data) for f in self._filters)
@@ -46,6 +66,8 @@ class Runtime(_YAMLObject):
 
 class RuntimeLAVA(Runtime):
     """Configuration for LAVA runtime environments"""
+
+    yaml_tag = '!RuntimeLAVA'
 
     PRIORITIES = {
         'low': 0,
@@ -113,6 +135,8 @@ class RuntimeLAVA(Runtime):
 class RuntimeDocker(Runtime):
     """Configuration for Docker runtime environments"""
 
+    yaml_tag = '!RuntimeDocker'
+
     def __init__(self, env_file=None, volumes=None, user=None, timeout=None,
                  **kwargs):
         super().__init__(**kwargs)
@@ -150,6 +174,8 @@ class RuntimeDocker(Runtime):
 
 class RuntimeKubernetes(Runtime):
     """Configuration for Kubernetes runtime environments"""
+
+    yaml_tag = '!RuntimeKubernetes'
 
     def __init__(self, context=None, **kwargs):
         super().__init__(**kwargs)
@@ -190,7 +216,7 @@ class RuntimeFactory:  # pylint: disable=too-few-public-methods
             'filters': FilterFactory.from_data(config, default_filters),
         }
         lab_cls = cls._lab_types[lab_type] if lab_type else Runtime
-        return lab_cls.from_yaml(config, **kwargs)
+        return lab_cls.load_from_yaml(config, **kwargs)
 
 
 def from_yaml(data, filters):

--- a/tests/configs/lava-runtimes.yaml
+++ b/tests/configs/lava-runtimes.yaml
@@ -1,0 +1,79 @@
+runtimes:
+
+  lab-baylibre:
+    lab_type: legacy.lava_xmlrpc
+    url: 'https://lava.baylibre.com/RPC2/'
+    queue_timeout:
+      days: 1
+    filters:
+      - blocklist:
+          tree:
+            - drm-tip
+            - android
+      - passlist:
+          plan:
+            - baseline
+            - kselftest
+            - preempt-rt
+            - ltp
+
+  lab-broonie:
+    lab_type: legacy.lava_xmlrpc
+    url: 'https://lava.sirena.org.uk/RPC2/'
+    priority_min: 0
+    priority_max: 40
+    queue_timeout:
+      days: 1
+    filters:
+      - blocklist: {tree: [android]}
+
+  lab-collabora-staging:
+    lab_type: legacy.lava_rest
+    url: 'https://staging.lava.collabora.dev/'
+    priority: 45
+    queue_timeout:
+      hours: 1
+    filters:
+      - blocklist:
+          tree: [android]
+
+  lab-min-12-max-40:
+    lab_type: legacy.lava_xmlrpc
+    url: 'https://fake.kernelci.org/RPC2/'
+    priority_min: 12
+    priority_max: 40
+
+  lab-min-12-max-40-new-runtime:
+    lab_type: lava.lava_xmlrpc
+    url: 'https://fake.kernelci.org/RPC2/'
+    priority_min: 12
+    priority_max: 40
+
+
+file_system_types:
+
+  buildroot:
+    url: 'http://storage.kernelci.org/images/rootfs/buildroot'
+
+
+file_systems:
+
+  buildroot-baseline_ramdisk:
+    boot_protocol: tftp
+    prompt: '/ #'
+    ramdisk: buildroot-baseline/20230120.0/{arch}/rootfs.cpio.gz
+    root_type: ramdisk
+    type: buildroot
+
+
+test_plans:
+
+  baseline:
+    rootfs: buildroot-baseline_ramdisk
+    params:
+      priority: 90
+
+  baseline-nfs:
+    rootfs: buildroot-baseline_ramdisk
+    params:
+      priority: 85

--- a/tests/configs/runtimes.yaml
+++ b/tests/configs/runtimes.yaml
@@ -2,18 +2,24 @@ runtimes:
 
   docker:
     lab_type: docker
+    filters: []
     env_file: 'docker-env'
     user: 'root'
+    timeout: 123
     volumes:
       - 'data:/home/kernelci/data'
 
   k8s-gke-eu-west4:
     lab_type: kubernetes
+    filters: []
     context: 'gke_android-kernelci-external_europe-west4-c_kci-eu-west4'
 
   lab-baylibre:
     lab_type: legacy.lava_xmlrpc
     url: 'https://lava.baylibre.com/RPC2/'
+    priority: 0
+    priority_min: 0
+    priority_max: 100
     queue_timeout:
       days: 1
     filters:
@@ -28,66 +34,18 @@ runtimes:
             - preempt-rt
             - ltp
 
-  lab-broonie:
-    lab_type: legacy.lava_xmlrpc
-    url: 'https://lava.sirena.org.uk/RPC2/'
-    priority_min: 0
-    priority_max: 40
-    queue_timeout:
-      days: 1
-    filters:
-      - blocklist: {tree: [android]}
-
   lab-collabora-staging:
     lab_type: legacy.lava_rest
     url: 'https://staging.lava.collabora.dev/'
     priority: 45
+    priority_min: 45
+    priority_max: 45
     queue_timeout:
       hours: 1
     filters:
       - blocklist:
           tree: [android]
 
-  lab-min-12-max-40:
-    lab_type: legacy.lava_xmlrpc
-    url: 'https://fake.kernelci.org/RPC2/'
-    priority_min: 12
-    priority_max: 40
-
-  lab-min-12-max-40-new-runtime:
-    lab_type: lava.lava_xmlrpc
-    url: 'https://fake.kernelci.org/RPC2/'
-    priority_min: 12
-    priority_max: 40
-
   shell:
     lab_type: shell
-
-
-file_system_types:
-
-  buildroot:
-    url: 'http://storage.kernelci.org/images/rootfs/buildroot'
-
-
-file_systems:
-
-  buildroot-baseline_ramdisk:
-    boot_protocol: tftp
-    prompt: '/ #'
-    ramdisk: buildroot-baseline/20230120.0/{arch}/rootfs.cpio.gz
-    root_type: ramdisk
-    type: buildroot
-
-
-test_plans:
-
-  baseline:
-    rootfs: buildroot-baseline_ramdisk
-    params:
-      priority: 90
-
-  baseline-nfs:
-    rootfs: buildroot-baseline_ramdisk
-    params:
-      priority: 85
+    filters: []

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -198,9 +198,9 @@ class TestAPIConfigs(ConfigTest):
 class TestRuntimeConfigs(ConfigTest):
     """Tests related to runtime configs"""
 
-    def test_runtimes(self):
-        """Test the runtime configs"""
-        ref_data, config = self._load_config('tests/configs/runtimes.yaml')
+    def test_lava_runtime(self):
+        """Test the LAVA runtime configs"""
+        _, config = self._load_config('tests/configs/lava-runtimes.yaml')
         runtimes = config['runtimes']
         lava_lab_prio = {
             'lab-baylibre': (None, None, None),
@@ -214,14 +214,22 @@ class TestRuntimeConfigs(ConfigTest):
             assert lab_config.priority == fixed_p
             assert lab_config.priority_min == min_p
             assert lab_config.priority_max == max_p
+
+    def test_runtimes(self):
+        """Test all the runtime configs"""
+        ref_data, config = self._load_config('tests/configs/runtimes.yaml')
+        ref_configs = ref_data['runtimes']
+        runtimes = self._reload(ref_data, config, 'runtimes')
         runtime_names = [
             'docker',
             'k8s-gke-eu-west4',
-            'lab-min-12-max-40-new-runtime',
+            'lab-baylibre',
+            'lab-collabora-staging',
             'shell',
         ]
-        runtime_names.extend(lava_lab_prio)
-        assert all(name in ref_data['runtimes'] for name in runtime_names)
+        assert all(name in ref_configs for name in runtime_names)
+        assert all(name in runtimes for name in runtime_names)
+        assert runtimes['docker']['user'] == 'root'
 
 
 class TestStorageConfigs(ConfigTest):

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -27,7 +27,7 @@ def test_runtimes_init():
 
 def test_lava_priority_scale():
     """Test the logic for determining the priority of LAVA jobs"""
-    config = kernelci.config.load('tests/configs/runtimes.yaml')
+    config = kernelci.config.load('tests/configs/lava-runtimes.yaml')
     runtimes = config['runtimes']
     plans = config['test_plans']
 


### PR DESCRIPTION
Convert the Runtime configuration to proper YAML objects so they can be dumped back to plain YAML.  Update unit tests accordingly with a separate config file for LAVA with checks for the lab priorities.