### PR TITLE
Handle file collision better in case of very long test names

### DIFF
--- a/kci_test
+++ b/kci_test
@@ -344,6 +344,9 @@ class cmd_generate(Command):
                 return False
             if args.output:
                 output_file = runtime.save_file(job, args.output, params)
+                if output_file is None:
+                    print("Failed to save the job definition, file collision")
+                    return False
                 print(output_file)
             else:
                 print("# Job: {}".format(params['name']))

--- a/kernelci/legacy/lava/__init__.py
+++ b/kernelci/legacy/lava/__init__.py
@@ -9,6 +9,7 @@
 
 from jinja2 import Environment, FileSystemLoader
 import os
+import sys
 
 from kernelci.runtime import add_kci_raise
 
@@ -75,6 +76,11 @@ class LavaRuntime:
     def save_file(self, job, output_path, params):
         file_name = self.job_file_name(params)
         output_file = os.path.join(output_path, file_name)
+        if os.path.isfile(output_file):
+            # print error message to stderr
+            print("ERROR: file already exists: %s" % output_file,
+                  file=sys.stderr)
+            return None
         with open(output_file, 'w') as output:
             output.write(job)
         return output_file

--- a/kernelci/test.py
+++ b/kernelci/test.py
@@ -20,6 +20,22 @@ import urllib.parse
 
 COMPRESSION_FORMATS = ['gz', 'bz2', 'xz']
 
+SHORTEN_KEYWORDS = {
+    'chromeos-amd-stoneyridge.flavour.config': 'ston',
+    'chromeos-intel-denverton.flavour.config': 'denv',
+    'chromeos-intel-pineview.flavour.config': 'pine',
+    'chromiumos-arm.flavour.config': 'arm',
+    'chromiumos-arm64.flavour.config': 'arm64',
+    'chromiumos-mediatek.flavour.config': 'mtk',
+    'chromiumos-qualcomm.flavour.config': 'qcom',
+    'chromiumos-rockchip.flavour.config': 'rk32',
+    'chromiumos-rockchip64.flavour.config': 'rk64',
+    'chromiumos-x86_64.flavour.config': 'x86',
+    'cros---chromeos-5.15': 'cros-5.15',
+    'cros---chromeos-6.1': 'cros-6.1',
+    'CONFIG_MODULE_COMPRESS_GZIP=n': 'no-gz',
+}
+
 
 def match_configs(configs, meta, lab):
     """Filter the test configs for a given kernel build and lab.
@@ -99,6 +115,9 @@ def get_params(meta, target, plan_config, storage, device_id):
     publish_path = kernel['publish_path']
     job_px = publish_path.replace('/', '-')
     url_px = publish_path
+    # replace keywords by SHORTEN_KEYWORDS lookup
+    for key, value in SHORTEN_KEYWORDS.items():
+        job_px = job_px.replace(key, value)
     # Truncate to <200 characters, LAVA limit
     job_name = '-'.join([job_px, target.name, plan_config.name])[:199]
     base_url = urllib.parse.urljoin(storage, '/'.join([url_px, '']))


### PR DESCRIPTION
Right now some test names might exceed LAVA name limit and as result overwrite each other definition filenames.
We need to handle it properly:
1)Better to fail on generation, than silently overwrite
2)Try to shorten some keywords, when it is possible