### PR TITLE
rootfs-configs.yaml: Add sparc64 arch to buildroot-baseline image

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -51,6 +51,7 @@ rootfs_configs:
       - armel
       - mipsel
       - riscv
+      - sparc64
       - x86
     frags:
       - baseline

--- a/config/docker/qemu.jinja2
+++ b/config/docker/qemu.jinja2
@@ -19,6 +19,7 @@ RUN apt-get update && \
         qemu-system-ppc \
         qemu-system-s390x \
         qemu-system-sparc \
+        qemu-system-sparc64 \
         qemu-system-x86 \
         qemu-utils
 


### PR DESCRIPTION
Add sparc64 build for baseline-baseline rootfs image.

Depends on https://github.com/kernelci/buildroot/pull/15