### PR TITLE
CHROMEOS docker/data add tast_test_list script

### DIFF
--- a/config/docker/cros-tast.jinja2
+++ b/config/docker/cros-tast.jinja2
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     inetutils-ping \
     python3 \
     python-pkg-resources \
+    python3-pip \
     sudo \
     ssh \
     wget
@@ -27,10 +28,11 @@ RUN gsutil update -n || true
 
 ADD https://raw.githubusercontent.com/kernelci/kernelci-core/chromeos.kernelci.org/config/docker/data/tast_parser.py /home/cros/tast_parser.py
 ADD https://raw.githubusercontent.com/kernelci/kernelci-core/chromeos.kernelci.org/config/docker/data/ssh_retry.sh /home/cros/ssh_retry.sh
+ADD https://raw.githubusercontent.com/kernelci/kernelci-core/chromeos.kernelci.org/config/docker/data/tast_test_list.py /home/cros/tast_test_list.py
 
 # Needed by LAVA to install the overlay
 USER root
-RUN chmod +x /home/cros/tast_parser.py /home/cros/ssh_retry.sh
+RUN chmod +x /home/cros/tast_parser.py /home/cros/ssh_retry.sh /home/cros/tast_test_list.py
 
 # Create symlink to /usr/local/bin for tast gs:// downloads
 RUN ln -s /home/cros/trunk/chromite/scripts/gsutil /usr/local/bin/

--- a/config/docker/data/tast_test_list.py
+++ b/config/docker/data/tast_test_list.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2023 Collabora Limited
+# Author: Alexandra Pereira <alexandra.pereira@collabora.com>
+#
+# This script is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+import argparse
+import re
+import requests
+import subprocess
+import sys
+from urllib.parse import urljoin
+
+TAST_PATH = './tast'
+
+
+def fetch_dut():
+    output = subprocess.check_output("lava-target-ip", shell=True).strip()
+    return output
+
+
+def get_tast_tests(output_filename):
+    try:
+        remote_ip = fetch_dut()
+        cmd = [
+            TAST_PATH,
+            'list',
+            '-json',
+            '-build=false',
+            remote_ip
+        ]
+        with open(output_filename, 'w') as test_output_file:
+            subprocess.run(cmd, check=True, stdout=test_output_file)
+        return True
+    except OSError as e:
+        print(f"ERROR writing file: {e}")
+        return False
+    except subprocess.SubprocessError as e:
+        print(f"ERROR running subprocess: {e}")
+        return False
+
+
+def get_release_info():
+    try:
+        with open('os-release.txt', 'r') as os_release:
+            release_info = os_release.readlines()
+        for info in release_info:
+            build_version = re.search(r'VERSION_ID=(\w+)', info)
+            if build_version is not None:
+                return build_version.group(1)
+        return None
+    except Exception as e:
+        print(f"ERROR getting cros release info: {e}")
+        return None
+
+
+def publish_tast_tests(token, storage_api, filename, data_path):
+    try:
+        headers = {
+            'Authorization': token,
+        }
+        data = {
+            'path': data_path,
+        }
+        files = {
+            'file': (filename, open(filename, 'rb'))
+        }
+        url = urljoin(storage_api, 'upload')
+        resp = requests.post(url, headers=headers,
+                             data=data, files=files, timeout=30)
+        resp.raise_for_status()
+    except Exception as e:
+        print(f"ERROR uploading file to storage: {e}")
+        return False
+    return True
+
+
+def set_up_parser():
+    parser = argparse.ArgumentParser(
+        description='Collect tast tests list from Chrome OS release and upload to a storage area')
+    subparsers = parser.add_subparsers(
+        dest="command", required=True)
+    subparsers.add_parser(
+        "get_tast_tests", help="Get tast list from Chrome OS release")
+    publish_test_list = subparsers.add_parser(
+        "publish_tast_tests", help="Upload tast tests list to storage")
+    publish_test_list.add_argument(
+        "--token", help="Auth token to access the storage", required=True)
+    publish_test_list.add_argument(
+        "--storage-api", help="API address to the storage", required=True)
+    publish_test_list.add_argument("--data-path", default="tast-tracker",
+                                   help="Dir to save the file in the storage. Default=tast-tracker")
+    return parser
+
+
+def main(argv):
+    parser = set_up_parser()
+    args = parser.parse_args(argv)
+    build_version = get_release_info()
+    if not build_version:
+        return False
+    filename = f'cros_R{build_version}_tests.json'
+    if args.command == "get_tast_tests":
+        return get_tast_tests(filename)
+    if args.command == "publish_tast_tests":
+        return publish_tast_tests(args.token, args.storage_api, filename, args.data_path)
+
+
+if __name__ == '__main__':
+    status = main(sys.argv[1:])
+    sys.exit(0 if status else 1)


### PR DESCRIPTION
Copy the script responsible for getting the list of tast tests available on the current build to the docker image used by cros.

After discussing with @mgalka we decided to make this script available on the public repository of the Kernel CI project because we had a problem sharing the file with the LAVA, once it was available in a Gitlab repository with limited access by the members. Other pros involve installing a dependency on the image and making it available; it will also avoid blocking a LAVA device when installing pip and requests library, which is a requirement for the script. 
I did not apply the changes on the `old-docker`. I assumed it is something deprecated on some level, but let me know if I am wrong.
