### PR TITLE
Enable decoder conformance tests on mt8192-asurada-spherion-r0

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -3102,6 +3102,15 @@ test_configs:
 # Disabling to reduce load
 #      - v4l2-compliance-uvc
 
+  - device_type: mt8192-asurada-spherion-r0
+    test_plans:
+      - v4l2-decoder-conformance-h264
+      - v4l2-decoder-conformance-vp8
+      - v4l2-decoder-conformance-vp9
+    filters: &chromebook-decoders-filter
+      - passlist: {defconfig: ['videodec']}
+      - regex: {'tree': '(next|mainline|media)'}
+
   - device_type: mt8365-evk
     test_plans:
       - baseline
@@ -3360,9 +3369,7 @@ test_configs:
       - v4l2-decoder-conformance-h264
       - v4l2-decoder-conformance-vp8
       - v4l2-decoder-conformance-vp9
-    filters: &chromebook-decoders-filter
-      - passlist: {defconfig: ['videodec']}
-      - regex: {'tree': '(next|mainline|media)'}
+    filters: *chromebook-decoders-filter
 
   - device_type: rk3399-puma-haikou
     test_plans:


### PR DESCRIPTION
Enable V4L2 decoder conformance tests on mt8192-asurada-spherion-r0 for H264, VP8 and VP9 formats.
Set a 90s timeout for each decoding.