### PR TITLE
kernelci.cli: pubsub: print dict and str payloads

### DIFF
--- a/kernelci/cli/pubsub.py
+++ b/kernelci/cli/pubsub.py
@@ -53,10 +53,16 @@ class cmd_send_event(APICommand):  # pylint: disable=invalid-name
 class cmd_receive_event(APICommand):  # pylint: disable=invalid-name
     """Wait and receive an event from a subscription and print on stdout"""
     args = APICommand.args + [Args.api_token, Args.sub_id]
+    opt_args = APICommand.opt_args + [Args.indent]
 
     def _api_call(self, api, configs, args):
         event = api.receive_event(args.sub_id)
-        print(event.data.strip())
+        if isinstance(event.data, str):
+            print(event.data.strip())
+        elif isinstance(event.data, dict):
+            self._print_json(event.data, args.indent)
+        else:
+            print(event.data)
         return True
 
 


### PR DESCRIPTION
Check the type of the event data payload and print it as JSON if it's a dictionary, or strip line returns if it's a string.  If neither, rely on the default string representation.