### PR TITLE
Add kind field to job node

### DIFF
--- a/kernelci/api/helper.py
+++ b/kernelci/api/helper.py
@@ -90,6 +90,7 @@ class APIHelper:
     def create_job_node(self, job_config, input_node):
         """Create a new job node based on input and configuration"""
         job_node = {
+            'kind': job_config.kind,
             'parent': input_node['_id'],
             'name': job_config.name,
             'path': input_node['path'] + [job_config.name],

--- a/kernelci/config/job.py
+++ b/kernelci/config/job.py
@@ -14,10 +14,11 @@ class Job(YAMLConfigObject):
     yaml_tag = '!Job'
 
     # pylint: disable=too-many-arguments
-    def __init__(self, name, template, image=None,
+    def __init__(self, name, template, kind='node', image=None,
                  conditions=None, params=None):
         self._name = name
         self._template = template
+        self._kind = kind
         self._image = image
         self._conditions = conditions or []
         self._params = params or {}
@@ -31,6 +32,11 @@ class Job(YAMLConfigObject):
     def template(self):
         """Template file name"""
         return self._template
+
+    @property
+    def kind(self):
+        """Kind of node"""
+        return self._kind
 
     @property
     def image(self):
@@ -50,7 +56,7 @@ class Job(YAMLConfigObject):
     @classmethod
     def _get_yaml_attributes(cls):
         attrs = super()._get_yaml_attributes()
-        attrs.update({'template', 'image', 'conditions', 'params'})
+        attrs.update({'template', 'kind', 'image', 'conditions', 'params'})
         return attrs
 
 

--- a/tests/configs/jobs.yaml
+++ b/tests/configs/jobs.yaml
@@ -12,6 +12,7 @@ jobs:
     template: 'kbuild.jinja2'
     image: 'gcc-10:{arch}{fragments}'
     conditions: *checkout
+    kind: kbuild
     params:
       config: x86_64_defconfig
 
@@ -19,6 +20,7 @@ jobs:
     template: 'kunit.jinja2'
     image: 'gcc-10:x86-kunit-kernelci'
     conditions: *checkout
+    kind: node
     params: {}
 
   kunit-x86_64:
@@ -31,4 +33,5 @@ jobs:
     template: 'kver.jinja2'
     image: 'kernelci'
     conditions: *checkout
+    kind: node
     params: {}


### PR DESCRIPTION
Add a `kind` field to the pipeline job configuration and use it when creating a node for a new job.