### PR TITLE
rootfs-configs.yaml: enable armel for bookworm-kselftest

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -5,6 +5,7 @@ rootfs_configs:
     arch_list:
       - amd64
       - arm64
+      - armel
       - armhf
     extra_packages:
       - alsa-ucm-conf

--- a/config/core/rootfs-images.yaml
+++ b/config/core/rootfs-images.yaml
@@ -9,21 +9,21 @@ file_systems:
     type: buildroot
   debian_bookworm-kselftest_nfs:
     boot_protocol: tftp
-    nfs: bookworm-kselftest/20230407.0/{arch}/full.rootfs.tar.xz
+    nfs: bookworm-kselftest/20230413.0/{arch}/full.rootfs.tar.xz
     params:
       os_config: debian
     prompt: '/ #'
-    ramdisk: bookworm-kselftest/20230407.0/{arch}/initrd.cpio.gz
+    ramdisk: bookworm-kselftest/20230413.0/{arch}/initrd.cpio.gz
     root_type: nfs
-    type: debian
+    type: debian-staging
   debian_bookworm-kselftest_ramdisk:
     boot_protocol: ramdisk
     params:
       os_config: debian
     prompt: '/ #'
-    ramdisk: bookworm-kselftest/20230407.0/{arch}/rootfs.cpio.gz
+    ramdisk: bookworm-kselftest/20230413.0/{arch}/rootfs.cpio.gz
     root_type: ramdisk
-    type: debian
+    type: debian-staging
   debian_bullseye-cros-ec_ramdisk:
     boot_protocol: tftp
     params: {}


### PR DESCRIPTION
Add the armel architecture to bookworm-kselftest for running kselftest-alsa on at91sam9g20ek to start with.

For #1627

(Duplicate of #1831)