### PR TITLE
test-configs.yaml: Update for vm selftests rename to mm

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -366,6 +366,15 @@ test_plans:
       kselftest_collections: "mincore"
     filters: *kselftest_no_fragment
 
+  kselftest-mm:
+    <<: *kselftest
+    params:
+      job_timeout: '10'
+      kselftest_collections: "mm"
+    filters:
+      - passlist: {defconfig: ['kselftest']}
+      - blocklist: {kernel: ['v3.', 'v4.', 'v5.', 'v6.0', 'v6,1', 'v6.2']}
+
   kselftest-net:
     <<: *kselftest
     params:
@@ -425,6 +434,10 @@ test_plans:
     params:
       job_timeout: '10'
       kselftest_collections: "vm"
+    filters:
+      - passlist:
+          defconfig: ['kselftest']
+          kernel: ['v3.', 'v4.', 'v5.', 'v6.0', 'v6,1', 'v6.2']
 
   lc-compliance:
     rootfs: debian_bullseye-libcamera_nfs
@@ -2319,6 +2332,7 @@ test_configs:
       - cros-ec
       - kselftest-alsa
       - kselftest-lib
+      - kselftest-mm
       - kselftest-vm
       - ltp-ipc
 
@@ -2497,6 +2511,7 @@ test_configs:
       - kselftest-lib
       - kselftest-livepatch
       - kselftest-lkdtm
+      - kselftest-mm
       - kselftest-rtc
       - kselftest-seccomp
       - kselftest-tpm2


### PR DESCRIPTION
The selftests previously known as vm have been renamed upstream to mm.
Update our configurations to reflect this, leaving the old vm name in place
so that runs on older kernels from before the rename continue to happen and
using filters to avoid scheduling each on the kernels where they don't
exist.

Signed-off-by: Mark Brown <broonie@kernel.org>
