### PR TITLE
T41723 tests/api: fix child node `path` field

### DIFF
--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -210,7 +210,9 @@ class APIHelperTestData:
             "group": self._kunit_node["group"],
             "holdoff": None,
             "kind": self._kunit_node["kind"],
-            "path": self._kunit_node["path"],
+            "path": (
+                self._kunit_node["path"] + [self._kunit_child_node["name"]]
+            ),
             "revision": self._kunit_node["revision"],
             "state": self._kunit_node["state"],
             "timeout": "2022-11-02T16:06:39.509000",


### PR DESCRIPTION
Append child node name to `Node.path` field in `APIHelperTestData.update_kunit_child_node` just like `APIHelper._prepare_results` method that generates various fields for child nodes.