### PR TITLE
Run v4l2-compliance on mt8192-asurada-spherion's encoder

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -313,6 +313,12 @@ rootfs_configs:
     extra_firmware:
         - qcom/venus-5.4/venus.mdt
         - qcom/venus-5.4/venus.mbn
+        - mediatek/mt8173/vpu_d.bin
+        - mediatek/mt8173/vpu_p.bin
+        - mediatek/mt8183/scp.img
+        - mediatek/mt8186/scp.img
+        - mediatek/mt8192/scp.img
+        - mediatek/mt8195/scp.img
     script: "scripts/bullseye-v4l2.sh"
     test_overlay: "overlays/v4l2"
 

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2941,6 +2941,7 @@ test_configs:
       - lc-compliance
       - preempt-rt
       - sleep
+      - v4l2-compliance-mtk-vcodec-enc
       - v4l2-compliance-uvc
 
   - device_type: mt8365-evk

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -614,6 +614,11 @@ test_plans:
   usb:
     rootfs: debian_bullseye_ramdisk
 
+  v4l2-compliance-mtk-vcodec-enc:
+    rootfs: debian_bullseye-v4l2_ramdisk
+    pattern: 'v4l2-compliance/{category}-{method}-{protocol}-{rootfs}-v4l2-compliance-template.jinja2'
+    params: {v4l2_driver: "mtk-vcodec-enc"}
+
   v4l2-compliance-uvc:
     rootfs: debian_bullseye-v4l2_ramdisk
     # FIXME - this is not very sustainable, improve template naming scheme


### PR DESCRIPTION
This PR enables v4l2-compliance on the encoder video node of mt8192-asurada-spherion.

The firmwares are added for other MediaTek SoCs as well to make it easier to enable the same test on them.

Using the latest v4l2-compliance, there are two issues on mt8192-asurada-spherion's encoder:

```
[..]
Control ioctls:
[..]
		fail: v4l2-test-controls.cpp(1167): node->codec_mask & STATEFUL_ENCODER
	test VIDIOC_(UN)SUBSCRIBE_EVENT/DQEVENT: FAIL
[..]
Format ioctls:
[..]
		fail: v4l2-test-formats.cpp(924): sel.r.width != fmt.g_width()
	test VIDIOC_S_FMT: FAIL

[..]
Total for mtk-vcodec-enc device /dev/video1: 45, Succeeded: 43, Failed: 2, Warnings: 0
```

I'll be sending a patch to fix the second issue, and asking where the first should be fixed, shortly.