### PR TITLE
config: add `rustc-1.68` build environment

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -702,6 +702,11 @@ build_environments:
     arch_params:
       x86_64: *x86_64_params
 
+  rustc-1.68:
+    cc: clang
+    cc_version: 15
+    arch_params:
+      x86_64: *x86_64_params
 
 # Default config with full build coverage
 build_configs_defaults:

--- a/config/docker/rustc-1.68-x86.jinja2
+++ b/config/docker/rustc-1.68-x86.jinja2
@@ -1,0 +1,9 @@
+{%- set sub_arch = 'amd64' %}
+{% extends 'rustc-1.68.jinja2' %}
+
+{% block packages %}
+{{ super() }}
+
+RUN dpkg --add-architecture amd64
+
+{%- endblock %}

--- a/config/docker/rustc-1.68.jinja2
+++ b/config/docker/rustc-1.68.jinja2
@@ -1,0 +1,43 @@
+{% extends 'clang-15.jinja2' %}
+
+{% block packages %}
+{{ super() }}
+
+ARG RUST_VER=1.68.2
+ARG BINDGEN_VER=0.56.0
+
+ARG RUST_TRIPLE=rust-${RUST_VER}-x86_64-unknown-linux-gnu
+
+ENV CARGO_HOME=/home/kernelci/.cargo
+ENV PATH=/usr/${RUST_TRIPLE}/bin:${CARGO_HOME}/bin:${PATH}
+
+ARG SHA256SUM=df7c7466ef35556e855c0d35af7ff08e133040400452eb3427c53202b6731926
+
+# fetch, verify the toolchain
+RUN wget https://static.rust-lang.org/dist/${RUST_TRIPLE}.tar.gz && \
+    echo "${SHA256SUM} ${RUST_TRIPLE}.tar.gz" | sha256sum --check --quiet
+
+# install & cleanup tmp files
+RUN tar -xf ${RUST_TRIPLE}.tar.gz  -C /tmp/ && \
+    /tmp/${RUST_TRIPLE}/install.sh --prefix=/usr/${RUST_TRIPLE} \
+        --components=rustc,cargo,rust-std-x86_64-unknown-linux-gnu && \
+    rm -rf /tmp/${RUST_TRIPLE} && \
+    rm /${RUST_TRIPLE}*
+
+# This image is based on clang-*jinja2 which only has clang installed, but rustc
+# defaults to linker "cc" which usually points to the GNU/GCC stack. Pointing cc
+# to clang ensures both cargo and kernel build rustc invocations use llvm/clang.
+RUN update-alternatives --install /usr/bin/cc cc $(which clang) 30 && \
+    update-alternatives --set cc $(which clang)
+
+RUN git clone --recurse-submodules --branch $RUST_VER \
+        https://github.com/rust-lang/rust \
+        $(rustc --print sysroot)/lib/rustlib/src/rust
+
+RUN cargo install --locked --version ${BINDGEN_VER} bindgen
+
+# kernel build generates some rust code and tries to format it, if rustfmt is
+# missing it will print non-fatal error noise
+RUN cargo install rustfmt
+
+{%- endblock %}


### PR DESCRIPTION
Rust 1.68.2 will be the next version supported by the kernel, already submitted to the LKML.

Furthermore, I would like to start tracking the latest version, please see the commit message at [2] and a previous discussion at [3].

Therefore, add `rustc-1.68` as a new build environment.

Link: https://lore.kernel.org/rust-for-linux/20230418214347.324156-1-ojeda@kernel.org/ [1]
Link: https://lore.kernel.org/all/20230418214347.324156-4-ojeda@kernel.org/ [2]
Link: https://lore.kernel.org/rust-for-linux/CANiq72mT3bVDKdHgaea-6WiZazd8Mvurqmqegbe5JZxVyLR8Yg@mail.gmail.com/ [3]