### PR TITLE
CHROMEOS cros-tast.jinja2: Don't fail if gsutil already latest

### DIFF
--- a/config/docker/cros-tast.jinja2
+++ b/config/docker/cros-tast.jinja2
@@ -19,9 +19,6 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     wget
 
 {% include 'fragment/cros-lava.jinja2' %}
-# Update gsutil to latest version, so it doesnt download it in LAVA
-# docker each time
-RUN gsutil update -n
 
 {{ super() }}
 


### PR DESCRIPTION
If gsutil already latest version it will return on exit(1), and will break Docker building recipe.
We add || true to not fail, if it is already latest version, or even if update failed, as it is not critical procedure.