### PR TITLE
tests-config: Add Aaeon UP squared 6000 with X6425RE

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -692,6 +692,10 @@ test_plans:
       job_timeout: '20'
 
 device_types:
+  aaeon-UPN-EHLX4RE-A10-0864:
+    mach: x86
+    arch: x86_64
+    boot_method: grub
 
   acer-R721T-grunt:
     mach: x86
@@ -2181,6 +2185,10 @@ device_types:
 
 
 test_configs:
+  - device_type: aaeon-UPN-EHLX4RE-A10-0864
+    test_plans:
+      - baseline
+      - baseline-nfs
 
   - device_type: acer-R721T-grunt
     test_plans:


### PR DESCRIPTION
The UP squared 6000 boards comes in various different SKUs this device-type is specifically for the variant with an industrial X6425RE CPU which has manufactorer SKU UPN-EHLX4RE-A10-0864

This board is available in both the collabora staging and production labs. Starting with just baseline tests for now.