### PR TITLE
Add `Runtime.wait()` method and use it with `kci job submit --wait`

### DIFF
--- a/kernelci/cli/job.py
+++ b/kernelci/cli/job.py
@@ -111,12 +111,22 @@ class cmd_submit(Command):  # pylint: disable=invalid-name
             'help': "Path of the job file to submit",
         },
     ]
+    opt_args = Command.opt_args + [
+        {
+            'name': '--wait',
+            'action': 'store_true',
+            'help': "Wait for job to complete and get exit status code",
+        },
+    ]
 
     def __call__(self, configs, args):
         runtime_config = configs['runtimes'][args.runtime_config]
         runtime = kernelci.runtime.get_runtime(runtime_config)
         job = runtime.submit(args.job_path)
         print(runtime.get_job_id(job))
+        if args.wait:
+            ret = runtime.wait(job)
+            return ret == 0
         return True
 
 

--- a/kernelci/runtime/__init__.py
+++ b/kernelci/runtime/__init__.py
@@ -163,6 +163,10 @@ class Runtime(abc.ABC):
     def get_job_id(self, job_object):
         """Get an id for a given job object as returned by submit()."""
 
+    @abc.abstractmethod
+    def wait(self, job_object):
+        """Wait for a job to complete and get the exit status code"""
+
 
 def get_runtime(config, user=None, token=None):
     """Get the Runtime object for a given runtime config.

--- a/kernelci/runtime/docker.py
+++ b/kernelci/runtime/docker.py
@@ -78,6 +78,10 @@ class Docker(Runtime):
     def get_job_id(self, job_object):
         return job_object.id
 
+    def wait(self, job_object):
+        ret = job_object.wait()
+        return ret['StatusCode']
+
 
 def get_runtime(runtime_config, **kwargs):
     """Get a Docker runtime object"""

--- a/kernelci/runtime/shell.py
+++ b/kernelci/runtime/shell.py
@@ -33,6 +33,10 @@ class Shell(Runtime):
     def get_job_id(self, job_object):
         return job_object.pid
 
+    def wait(self, job_object):
+        job_object.wait()
+        return job_object.returncode
+
 
 def get_runtime(runtime_config, **kwargs):
     """Get a Shell runtime object"""


### PR DESCRIPTION
Add a `Runtime.wait()` abstract method with implementations for `shell`, `docker` and `kubernetes` to wait for a given job to complete and get the exit status code.  Use it with `kci job submit --wait`.