### PR TITLE
github: Always run actions for push/pull_requests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,12 +4,8 @@ name: CI
 
 # Controls when the action will run.
 on:
-  # Triggers the workflow on push or pull request events but only for the
-  # main branch
   push:
-    branches: [ main, chromeos ]
   pull_request:
-    branches: [ main, chromeos ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
With the current settings the github action checks will only run for either pushes or pull requests to main/chromeos branches. This can be annoying when working on a personal branch as the actions (linters, sanity checks) aren't run until a PR is created.

The current actions are quite quick (less then one minute) so it shouldn't be a problem to simply always run them.