### PR TITLE
test-configs: Add Radxa Rock 5b board

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1910,6 +1910,11 @@ device_types:
     class: arm64-dtb
     boot_method: uboot
 
+  rk3588-rock-5b:
+    mach: rockchip
+    class: arm64-dtb
+    boot_method: uboot
+
   sc7180-trogdor-kingoftown:
     mach: qcom
     class: arm64-dtb
@@ -3220,6 +3225,10 @@ test_configs:
     test_plans:
       - baseline
       - baseline-nfs
+
+  - device_type: rk3588-rock-5b
+    test_plans:
+      - baseline
 
   - device_type: sc7180-trogdor-kingoftown
     test_plans:


### PR DESCRIPTION
Add the Radxa Rock 5b board, based on the Rockchip RK3588 SoC. This board is available in the collabora staging lab at the moment and should soon be available in the collabora production lab as well. Mainline suppot is minimal at the moment, specficially no networking yet, thus starting with just baseline for now.