### PR TITLE
kernelci.config: add Job.runtimes attribute

### DIFF
--- a/kernelci/config/job.py
+++ b/kernelci/config/job.py
@@ -15,12 +15,13 @@ class Job(YAMLConfigObject):
 
     # pylint: disable=too-many-arguments
     def __init__(self, name, template, image=None,
-                 conditions=None, params=None):
+                 conditions=None, params=None, runtimes=None):
         self._name = name
         self._template = template
         self._image = image
         self._conditions = conditions or []
         self._params = params or {}
+        self._runtimes = runtimes or []
 
     @property
     def name(self):
@@ -47,10 +48,15 @@ class Job(YAMLConfigObject):
         """Arbitrary parameters passed to the template"""
         return dict(self._params)
 
+    @property
+    def runtimes(self):
+        """List of runtimes configured to run this job"""
+        return list(dict(runtime) for runtime in self._runtimes)
+
     @classmethod
     def _get_yaml_attributes(cls):
         attrs = super()._get_yaml_attributes()
-        attrs.update({'template', 'image', 'conditions', 'params'})
+        attrs.update({'template', 'image', 'conditions', 'params', 'runtimes'})
         return attrs
 
 

--- a/tests/configs/jobs.yaml
+++ b/tests/configs/jobs.yaml
@@ -14,21 +14,35 @@ jobs:
     conditions: *checkout
     params:
       config: x86_64_defconfig
+    runtimes:
+      - type: kubernetes
+        platform: kubernetes
 
   kunit: &kunit-job
     template: 'kunit.jinja2'
     image: 'gcc-10:x86-kunit-kernelci'
     conditions: *checkout
     params: {}
+    runtimes:
+      - type: kubernetes
+        platform: kubernetes
 
   kunit-x86_64:
     <<: *kunit-job
     image: 'kernelci/staging-gcc-10:x86-kunit-qemu-kernelci'
     params:
       arch: x86_64
+    runtimes:
+      - type: shell
+        platform: shell
 
   kver:
     template: 'kver.jinja2'
     image: 'kernelci'
     conditions: *checkout
     params: {}
+    runtimes:
+      - type: shell
+        platform: shell
+      - type: docker
+        platform: docker


### PR DESCRIPTION
Add Job.runtimes as a list of dictionaries containing parameters to choose which runtimes the pipeline job should be run in.

Update unit tests accordingly.

This is an initial step to remove the hard-coded logic in runner.py, it will need to be redesigned to take into full consideration all the parameters and platform attributes too.  Finally the YAML configuration should be validated against a schema (e.g. Pydantic models) to specify the required fields with their types etc. Currently the runtimes parameters here are arbitrary and not validated when loading the configuration since this is still being worked on.