### PR TITLE
test-configs: remove oxnas board

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1562,11 +1562,6 @@ device_types:
     class: arm-dtb
     boot_method: uboot
 
-  ox820-cloudengines-pogoplug-series-3:
-    mach: oxnas
-    class: arm-dtb
-    boot_method: uboot
-
   panda:
     mach: omap2
     class: arm-dtb
@@ -2975,11 +2970,6 @@ test_configs:
 
 
   - device_type: orion5x-rd88f5182-nas
-    test_plans:
-      - baseline
-      - baseline-nfs
-
-  - device_type: ox820-cloudengines-pogoplug-series-3
     test_plans:
       - baseline
       - baseline-nfs


### PR DESCRIPTION
This board has not been booting successfully in KernelCI for a long time, and the SoC support was removed upstream for v6.4[1], so let's just drop this board that nobody cares about anymore.

[1] https://lore.kernel.org/r/20230331-topic-oxnas-upstream-remove-v2-0-e51078376f08@linaro.org