### PR TITLE
T41945 kernelci.api: update `Node._id` field

### DIFF
--- a/kernelci/api/__init__.py
+++ b/kernelci/api/__init__.py
@@ -119,11 +119,11 @@ class API(abc.ABC):
 
     @abc.abstractmethod
     def create_node(self, node: dict) -> dict:
-        """Create a new node object (no _id)"""
+        """Create a new node object (no id)"""
 
     @abc.abstractmethod
     def update_node(self, node: dict) -> dict:
-        """Update an existing node object (with _id)"""
+        """Update an existing node object (with id)"""
 
     # -------------------------------------------------------------------------
     # Private methods

--- a/kernelci/api/helper.py
+++ b/kernelci/api/helper.py
@@ -90,7 +90,7 @@ class APIHelper:
     def create_job_node(self, job_config, input_node):
         """Create a new job node based on input and configuration"""
         job_node = {
-            'parent': input_node['_id'],
+            'parent': input_node['id'],
             'name': job_config.name,
             'path': input_node['path'] + [job_config.name],
             'group': job_config.name,
@@ -128,7 +128,7 @@ class APIHelper:
         Submit a hierarchy of test results with 'node' containing data for a
         particular result or parent entry for sub-tests and 'child_nodes'
         containing a list of sub-results.  The root node needs to have been
-        previously retrieved from the API with an existing _id.
+        previously retrieved from the API with an existing id.
 
         `root` is the root node for all the child results
         `results` are the child results with the following recursive format:
@@ -164,6 +164,6 @@ class APIHelper:
         data = self._prepare_results(root_results, parent, base)
         # Once this has been consolidated at the API level:
         # self.api.create_node_hierarchy(data)
-        node_id = data['node']['_id']
+        node_id = data['node']['id']
         # pylint: disable=protected-access
         return self.api._put(f'nodes/{node_id}', data).json()

--- a/kernelci/api/latest.py
+++ b/kernelci/api/latest.py
@@ -128,7 +128,7 @@ class LatestAPI(API):
         return self._post('node', node).json()
 
     def update_node(self, node: dict) -> dict:
-        return self._put('/'.join(['node', node['_id']]), node).json()
+        return self._put('/'.join(['node', node['id']]), node).json()
 
 
 def get_api(config, token):

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -19,7 +19,7 @@ class APIHelperTestData:
     """Sample test data for APIHelper unit tests"""
     def __init__(self):
         self._checkout_node = {
-            "_id": "6332d8f51a45d41c279e7a01",
+            "id": "6332d8f51a45d41c279e7a01",
             "kind": "node",
             "name": "checkout",
             "path": [
@@ -87,7 +87,7 @@ class APIHelperTestData:
             "holdoff": None,
             "regression_data": [
                 {
-                    "_id": "6361440f8f94e20c6826b0b7",
+                    "id": "6361440f8f94e20c6826b0b7",
                     "kind": "node",
                     "name": "kver",
                     "path": [
@@ -124,7 +124,7 @@ class APIHelperTestData:
             ]
         }
         self._kunit_node = {
-            "_id": "6332d92f1a45d41c279e7a06",
+            "id": "6332d92f1a45d41c279e7a06",
             "kind": "node",
             "name": "kunit",
             "path": [
@@ -187,7 +187,7 @@ class APIHelperTestData:
     def get_regression_node_with_id(self):
         """Get regression node with node ID"""
         self._regression_node.update({
-            "_id": "6361442d8f94e20c6826b0b9"
+            "id": "6361442d8f94e20c6826b0b9"
         })
         return self._regression_node
 
@@ -205,7 +205,7 @@ class APIHelperTestData:
         """Update kunit child node with timestamp fields and other fields set
         from parent kunit"""
         self._kunit_child_node.update({
-            "_id": "6332d9741a45d41c279e7a07",
+            "id": "6332d9741a45d41c279e7a07",
             "created": "2022-11-01T16:06:39.509000",
             "group": self._kunit_node["group"],
             "holdoff": None,
@@ -228,7 +228,7 @@ class APIHelperTestData:
         }
         data = {
             "op": "created",
-            "id": self.checkout_node["_id"],
+            "id": self.checkout_node["id"],
         }
         return CloudEvent(attributes=attributes, data=data)
 

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -64,7 +64,7 @@ def test_get_node_from_event(get_api_config, mock_api_get_node_from_id):
             event=APIHelperTestData().get_test_cloud_event()
         )
         assert node.keys() == {
-            '_id',
+            'id',
             'artifacts',
             'created',
             'group',
@@ -91,7 +91,7 @@ def test_submit_regression(get_api_config, mock_api_post_regression):
         )
         assert resp.status_code == 200
         assert resp.json().keys() == {
-            '_id',
+            'id',
             'artifacts',
             'created',
             'group',
@@ -180,7 +180,7 @@ def test_submit_results(get_api_config, mock_api_put_nodes,
             )
         assert len(resp) == 2
         assert resp[1].keys() == {
-            '_id',
+            'id',
             'artifacts',
             'created',
             'group',
@@ -210,7 +210,7 @@ def test_receive_event_node(get_api_config, mock_receive_event,
         )
         resp = helper.receive_event_node(sub_id=sub_id)
         assert resp.keys() == {
-            '_id',
+            'id',
             'artifacts',
             'created',
             'group',


### PR DESCRIPTION
Now the API will send responses with field names and not with alias, update `Node._id` to `Node.id` in kernelci API module.
Update unit tests for `APIHelper` class according to the latest change for `Node._id` field in `kernelci.api` module.