### PR TITLE
T41945 Update Node._id in `kernelci.cli` and `kernelci.runtime` module

### DIFF
--- a/kernelci/cli/base_api.py
+++ b/kernelci/cli/base_api.py
@@ -43,7 +43,7 @@ class APICommand(Command):  # pylint: disable=too-few-public-methods
     @classmethod
     def _print_node(cls, node, id_only, indent):
         if id_only:
-            print(node['_id'])
+            print(node['id'])
         else:
             cls._print_json(node, indent)
 

--- a/kernelci/cli/node.py
+++ b/kernelci/cli/node.py
@@ -87,7 +87,7 @@ class cmd_submit(APICommand):  # pylint: disable=invalid-name
 
     def _api_call(self, api, configs, args):
         data = json.load(sys.stdin)
-        if '_id' in data:
+        if 'id' in data:
             node = api.update_node(data)
         else:
             node = api.create_node(data)

--- a/kernelci/cli/show.py
+++ b/kernelci/cli/show.py
@@ -65,7 +65,7 @@ class cmd_results(APICommand):  # pylint: disable=invalid-name
 
     def _dump_results(self, api, node, indent=0, max_depth=0):
         fmt = f"{{space}}{{path:{64-indent*2}s}}{{result:6}}{{node_id}}"
-        node_id = node['_id']
+        node_id = node['id']
         result = node['result'] or '----'
         line = fmt.format(
             space='  '*indent,

--- a/kernelci/runtime/__init__.py
+++ b/kernelci/runtime/__init__.py
@@ -116,7 +116,7 @@ class Runtime(abc.ABC):
             'api_config_yaml': yaml.dump(api_config or {}),
             'storage_config_yaml': yaml.dump(job.storage_config or {}),
             'name': job.name,
-            'node_id': job.node['_id'],
+            'node_id': job.node['id'],
             'revision': job.node['revision'],
             'runtime': self.config.lab_type,
             'runtime_image': job.config.image,


### PR DESCRIPTION
Now the API will send responses with field names and not with alias, update `Node._id` to `Node.id` in `kernelci.cli` and `kernelci.runtime` module.
This was breaking `runner` service.