### PR TITLE
kernelci.cli: config: validate runtimes and api configs

### DIFF
--- a/kernelci/cli/config.py
+++ b/kernelci/cli/config.py
@@ -25,8 +25,10 @@ class cmd_validate(Command):  # pylint: disable=invalid-name
 
     def __call__(self, configs, args):
         entries = [
+            'api_configs',
             'device_types',
             'jobs',
+            'runtimes',
             'storage_configs',
         ]
         err = kernelci.config.validate_yaml(args.yaml_config, entries)


### PR DESCRIPTION
Add 'runtimes' and 'api_configs' to the list of YAML configs to validate.