### PR TITLE
kernelci.config: fix get_config_paths() when single file

### DIFF
--- a/kernelci/config/__init__.py
+++ b/kernelci/config/__init__.py
@@ -49,6 +49,8 @@ def get_config_paths(config_paths):
             if os.path.isdir(config_path):
                 config_paths.append(config_path)
                 break
+    elif isinstance(config_paths, str):
+        config_paths = [config_paths]
     return config_paths
 
 


### PR DESCRIPTION
Fix get_config_paths() when called with a single file as a string. The returned value is always expected to be a list, so when returning a string the caller would then iterate over the characters in the string.

Fixes: 0f4d9da028a4 ("kernelci.config: add .get_config_path() with defaults")