### PR TITLE
kernelci.cli: config: add "list" command to list entries

### DIFF
--- a/kernelci/cli/config.py
+++ b/kernelci/cli/config.py
@@ -5,6 +5,8 @@
 
 """Tool to manage the KernelCI YAML configuration"""
 
+import yaml
+
 import kernelci.config
 from .base import Args, Command, sub_main
 
@@ -35,6 +37,32 @@ class cmd_validate(Command):  # pylint: disable=invalid-name
             return False
         if args.verbose:
             print("YAML configuration validation completed.")
+        return True
+
+
+class cmd_list(Command):  # pylint: disable=invalid-name
+    """List entries from the YAML configuration"""
+    args = Command.args + [
+        {
+            'name': 'config',
+            'help': "Name of the YAML config to list, e.g. jobs or runtimes",
+        },
+    ]
+    opt_args = Command.opt_args + [Args.indent]
+
+    def __call__(self, configs, args):
+        config_data = configs.get(args.config)
+        if not config_data:
+            print(f"Configs not found: {args.config}")
+            return False
+        if isinstance(config_data, dict):
+            for name, data in config_data.items():
+                print(name)
+                print('-' * len(name))
+                print(yaml.dump(data, indent=args.indent))
+        else:
+            for data in config_data:
+                print(yaml.dump(data, indent=args.indent))
         return True
 
 


### PR DESCRIPTION
Add a "kci config list" command to dump all the entries in a given section of the YAML configuration.  This has a few advantages over the raw YAML: it should be easier to read, anchors are expanded and the entries are loaded from all the YAML config files found.