### PR TITLE
kernelci.config: fix validate_yaml() for list of dicts

### DIFF
--- a/kernelci/config/__init__.py
+++ b/kernelci/config/__init__.py
@@ -66,7 +66,10 @@ def validate_yaml(config_paths, entries):
                 if isinstance(value, dict):
                     keys = value.keys()
                 elif isinstance(value, list):
-                    keys = value
+                    keys = (
+                        [] if len(value) and isinstance(value[0], dict)
+                        else value
+                    )
                 else:
                     keys = []
                 err = kernelci.sort_check(keys)


### PR DESCRIPTION
Config entries that are a list of strings can be sorted, but lists of dicts can't.  Skip the alphabetical order check for those (e.g. the scheduler configs).

Fixes: 7e936c9672b5 ("kernelci.config: add validate_yaml() method")