### PR TITLE
Rework custom Jinja2 functions

### DIFF
--- a/kernelci/legacy/lava/__init__.py
+++ b/kernelci/legacy/lava/__init__.py
@@ -12,7 +12,17 @@ import json
 import os
 import sys
 
-from kernelci.runtime import add_kci_raise
+
+def add_kci_raise(jinja2_env):
+    """Add a kci_raise function to use in templates
+
+    This adds a `kci_raise` function to a given Jinja2 environment `jinja2_env`
+    so it can be used to raise exceptions from template files when for example
+    some template parameters are not valid.
+    """
+    def template_exception(msg):
+        raise Exception(msg)
+    jinja2_env.globals['kci_raise'] = template_exception
 
 
 class LavaRuntime:

--- a/kernelci/runtime/__init__.py
+++ b/kernelci/runtime/__init__.py
@@ -105,7 +105,10 @@ class Runtime(abc.ABC):
         return self._templates
 
     def _get_template(self, job_config):
-        jinja2_env = Environment(loader=FileSystemLoader(self.templates))
+        jinja2_env = Environment(
+            loader=FileSystemLoader(self.templates),
+            extensions=["jinja2.ext.do"]
+        )
         return jinja2_env.get_template(job_config.template)
 
     def match(self, filter_data):

--- a/kernelci/runtime/__init__.py
+++ b/kernelci/runtime/__init__.py
@@ -14,18 +14,6 @@ import yaml
 from jinja2 import Environment, FileSystemLoader
 
 
-def add_kci_raise(jinja2_env):
-    """Add a kci_raise function to use in templates
-
-    This adds a `kci_raise` function to a given Jinja2 environment `jinja2_env`
-    so it can be used to raise exceptions from template files when for example
-    some template parameters are not valid.
-    """
-    def template_exception(msg):
-        raise Exception(msg)
-    jinja2_env.globals['kci_raise'] = template_exception
-
-
 class Job:
     """Pipeline job"""
 
@@ -109,7 +97,20 @@ class Runtime(abc.ABC):
             loader=FileSystemLoader(self.templates),
             extensions=["jinja2.ext.do"]
         )
+        self._add_kci_raise(jinja2_env)
         return jinja2_env.get_template(job_config.template)
+
+    @classmethod
+    def _add_kci_raise(cls, jinja2_env):
+        """Add a kci_raise function to use in templates
+
+        This adds a `kci_raise` function to a given Jinja2 environment
+        `jinja2_env` so it can be used to raise exceptions from template files
+        when for example some template parameters are not valid.
+        """
+        def kci_raise(msg):
+            raise Exception(msg)
+        jinja2_env.globals['kci_raise'] = kci_raise
 
     def match(self, filter_data):
         """Apply filters and return True if they match, False otherwise."""

--- a/kernelci/runtime/__init__.py
+++ b/kernelci/runtime/__init__.py
@@ -97,28 +97,24 @@ class Runtime(abc.ABC):
             loader=FileSystemLoader(self.templates),
             extensions=["jinja2.ext.do"]
         )
-        self._add_kci_raise(jinja2_env)
-        self._add_kci_yaml_dump(jinja2_env)
+        jinja2_env.globals.update(self._get_jinja2_functions())
         return jinja2_env.get_template(job_config.template)
 
     @classmethod
-    def _add_kci_raise(cls, jinja2_env):
-        """Add a kci_raise function to use in templates
-
-        This adds a `kci_raise` function to a given Jinja2 environment
-        `jinja2_env` so it can be used to raise exceptions from template files
-        when for example some template parameters are not valid.
-        """
+    def _get_jinja2_functions(cls):
+        """Add custom functions to use in Jinja2 templates"""
         def kci_raise(msg):
+            """Raise an exception"""
             raise Exception(msg)
-        jinja2_env.globals['kci_raise'] = kci_raise
 
-    @classmethod
-    def _add_kci_yaml_dump(cls, jinja2_env):
-        """Add a yaml_dump function to use in Jinja2 templates"""
         def kci_yaml_dump(data):
+            """Dump data to YAML"""
             return yaml.dump(data, indent=2)
-        jinja2_env.globals['kci_yaml_dump'] = kci_yaml_dump
+
+        return {
+            'kci_raise': kci_raise,
+            'kci_yaml_dump': kci_yaml_dump,
+        }
 
     def match(self, filter_data):
         """Apply filters and return True if they match, False otherwise."""

--- a/kernelci/runtime/__init__.py
+++ b/kernelci/runtime/__init__.py
@@ -98,6 +98,7 @@ class Runtime(abc.ABC):
             extensions=["jinja2.ext.do"]
         )
         self._add_kci_raise(jinja2_env)
+        self._add_kci_yaml_dump(jinja2_env)
         return jinja2_env.get_template(job_config.template)
 
     @classmethod
@@ -111,6 +112,13 @@ class Runtime(abc.ABC):
         def kci_raise(msg):
             raise Exception(msg)
         jinja2_env.globals['kci_raise'] = kci_raise
+
+    @classmethod
+    def _add_kci_yaml_dump(cls, jinja2_env):
+        """Add a yaml_dump function to use in Jinja2 templates"""
+        def kci_yaml_dump(data):
+            return yaml.dump(data, indent=2)
+        jinja2_env.globals['kci_yaml_dump'] = kci_yaml_dump
 
     def match(self, filter_data):
         """Apply filters and return True if they match, False otherwise."""


### PR DESCRIPTION
Rework the code that registers Jinja2 custom functions directly into the Runtime class.  This is in preparation for handling LAVA job templates in particular.