### PR TITLE
Runtime params rework

### DIFF
--- a/config/runtime/base/python.jinja2
+++ b/config/runtime/base/python.jinja2
@@ -26,9 +26,9 @@ import kernelci.storage
 
 {%- block python_globals %}
 API_CONFIG_YAML = """
-{{ api_config_yaml }}"""
+{{ kci_yaml_dump(api_config) }}"""
 STORAGE_CONFIG_YAML = """
-{{ storage_config_yaml }}"""
+{{ kci_yaml_dump(storage_config) }}"""
 NODE_ID = '{{ node_id }}'
 TARBALL_URL = '{{ tarball_url }}'
 JOB_NAME = '{{ name }}'

--- a/config/runtime/base/python.jinja2
+++ b/config/runtime/base/python.jinja2
@@ -29,8 +29,7 @@ API_CONFIG_YAML = """
 {{ kci_yaml_dump(api_config) }}"""
 STORAGE_CONFIG_YAML = """
 {{ kci_yaml_dump(storage_config) }}"""
-NODE_ID = '{{ node_id }}'
-TARBALL_URL = '{{ tarball_url }}'
+NODE = {{ node }}
 JOB_NAME = '{{ name }}'
 WORKSPACE = '/tmp/kci'
 {%- endblock %}
@@ -75,8 +74,8 @@ class BaseJob:
     def _run(self, src_path):
         raise NotImplementedError("_run() method required to run job")
 
-    def _submit(self, result, node_id, api):
-        node = api.get_node(node_id)
+    def _submit(self, result, node, api):
+        node = node.copy()
         node.update({
             'result': result,
             'state': 'done',
@@ -91,9 +90,9 @@ class BaseJob:
         print("Running job...")
         return self._run(src_path)
 
-    def submit(self, result, node_id, api_config_yaml):
+    def submit(self, result, node, api_config_yaml):
         api = self._get_api(api_config_yaml)
-        self._submit(result, node_id, api)
+        self._submit(result, node, api)
 {% endblock %}
 
 {% block python_job -%}
@@ -105,9 +104,10 @@ class Job(BaseJob):
 def main(args):
     job = Job({% block python_job_constr %}workspace=WORKSPACE{% endblock %})
     try:
-        results = job.run(TARBALL_URL)
-        if NODE_ID and API_CONFIG_YAML:
-            job.submit(results, NODE_ID, API_CONFIG_YAML)
+        tarball_url = NODE['artifacts'].get('tarball')
+        results = job.run(tarball_url)
+        if NODE and API_CONFIG_YAML:
+            job.submit(results, NODE, API_CONFIG_YAML)
     except requests.exceptions.HTTPError as ex:
         print(ex, file=sys.stderr)
         detail = ex.response.json().get('detail')

--- a/kernelci/runtime/__init__.py
+++ b/kernelci/runtime/__init__.py
@@ -126,11 +126,9 @@ class Runtime(abc.ABC):
             'api_config': api_config or {},
             'storage_config': job.storage_config or {},
             'name': job.name,
-            'node_id': job.node['id'],
-            'revision': job.node['revision'],
+            'node': job.node,
             'runtime': self.config.lab_type,
             'runtime_image': job.config.image,
-            'tarball_url': job.node['artifacts']['tarball'],
         }
         params.update(job.config.params)
         params.update(job.platform_config.params)

--- a/kernelci/runtime/__init__.py
+++ b/kernelci/runtime/__init__.py
@@ -123,8 +123,8 @@ class Runtime(abc.ABC):
     def get_params(self, job, api_config=None):
         """Get job template parameters"""
         params = {
-            'api_config_yaml': yaml.dump(api_config or {}),
-            'storage_config_yaml': yaml.dump(job.storage_config or {}),
+            'api_config': api_config or {},
+            'storage_config': job.storage_config or {},
             'name': job.name,
             'node_id': job.node['id'],
             'revision': job.node['revision'],

--- a/kernelci/runtime/kubernetes.py
+++ b/kernelci/runtime/kubernetes.py
@@ -28,7 +28,7 @@ class Kubernetes(Runtime):
 
     def generate(self, job, params):
         template = self._get_template(job.config)
-        job_name = '-'.join(['kci', params['node_id'], params['name'][:24]])
+        job_name = '-'.join(['kci', job.node['id'], job.name[:24]])
         safe_name = re.sub(r'[\:/_+=]', '-', job_name).lower()
         rand_sx = ''.join(random.sample(self.JOB_NAME_CHARACTERS, 8))
         k8s_job_name = '-'.join([safe_name[:(62 - len(rand_sx))], rand_sx])


### PR DESCRIPTION
Rework the template parameters to directly pass objects rather than YAML dumps or just the node ID.  This relies on the `yaml_dump()` custom Jinja2 function added by #1918.  Update the `python.jinja2` base template accordingly to use the objects and reduce the number of parameters.