### PR TITLE
kernelci.runtime: add ._user and ._token

### DIFF
--- a/kernelci/runtime/__init__.py
+++ b/kernelci/runtime/__init__.py
@@ -91,6 +91,8 @@ class Runtime(abc.ABC):
         """
         self._config = config
         self._templates = self.TEMPLATES
+        self._user = user
+        self._token = token
 
     @property
     def config(self):


### PR DESCRIPTION
Store the provided user and token as private class attributes so that derived classes can make use of it.