### PR TITLE
build-configs.yaml: move `rust-next` to Rust 1.68

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -1189,8 +1189,8 @@ build_configs:
         architectures:
           <<: *arch_clang_configs
 
-      rustc-1.62:
-        build_environment: rustc-1.62
+      rustc-1.68:
+        build_environment: rustc-1.68
         fragments: [rust, rust-samples, kselftest]
         architectures:
           x86_64:
@@ -1350,8 +1350,8 @@ build_configs:
     tree: rust-for-linux
     branch: 'rust-next'
     variants:
-      rustc-1.62:
-        build_environment: rustc-1.62
+      rustc-1.68:
+        build_environment: rustc-1.68
         fragments: [rust, rust-samples, kselftest]
         architectures:
           x86_64:


### PR DESCRIPTION
This moves both `rust-for-linux_rust-next` and `next`'s Rust variant.

As discussed [1], for this kind of upgrades, we will move KernelCI first and then I will apply push the branch. The run is expected to fail if it happens to run between those two moves.

Link: https://github.com/kernelci/kernelci-core/pull/1890#issuecomment-1515062402 [1]