### PR TITLE
config/lava: Add qemu binary for sparc

### DIFF
--- a/config/lava/boot/generic-qemu-boot-template.jinja2
+++ b/config/lava/boot/generic-qemu-boot-template.jinja2
@@ -23,6 +23,10 @@
 {% set console_dev = console_dev|default('ttyS0') %}
 {% set qemu_binary = 'qemu-system-mipsel' %}
 {% endif %}
+{% if arch == 'sparc' %}
+{% set console_dev = console_dev|default('ttyS0') %}
+{% set qemu_binary = 'qemu-system-sparc64' %}
+{% endif %}
 {% block metadata %}
 {{ super() }}
 {% endblock %}


### PR DESCRIPTION
The qemu template miss the binary for the sparc architecture.