### PR TITLE
test-configs.yaml: Add fluster tests to Trogdor

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -3260,6 +3260,9 @@ test_configs:
       - cros-ec
       - kselftest-alsa
       - kselftest-tpm2
+      - v4l2-decoder-conformance-h264
+      - v4l2-decoder-conformance-vp8
+      - v4l2-decoder-conformance-vp9
 
   - device_type: sc7180-trogdor-lazor-limozeen
     test_plans:
@@ -3276,6 +3279,9 @@ test_configs:
       - kselftest-timers
       - kselftest-tpm2
       - usb
+      - v4l2-decoder-conformance-h264
+      - v4l2-decoder-conformance-vp8
+      - v4l2-decoder-conformance-vp9
 
   - device_type: snow
     test_plans:


### PR DESCRIPTION
It will be useful to cover by fluster tests one more arm64 platform