### PR TITLE
Add `APIHelper.receive_event_data()` method

### DIFF
--- a/kernelci/api/helper.py
+++ b/kernelci/api/helper.py
@@ -39,9 +39,13 @@ class APIHelper:
             self._filters.pop(sub_id)
         self.api.unsubscribe(sub_id)
 
-    def get_node_from_event(self, event):
+    def receive_event_data(self, sub_id):
+        """Receive CloudEvent from Pub/Sub and return its data payload"""
+        return self.api.receive_event(sub_id).data
+
+    def get_node_from_event(self, event_data):
         """Listen for an event and get the matching node object from it"""
-        return self.api.get_node(event.data['id'])
+        return self.api.get_node(event_data['id'])
 
     def pubsub_event_filter(self, sub_id, event):
         """Filter Pub/Sub events
@@ -81,10 +85,10 @@ class APIHelper:
         Return node if event matches with the filter.
         """
         while True:
-            event = self.api.receive_event(sub_id)
+            event = self.receive_event_data(sub_id)
             node = self.get_node_from_event(event)
             if all(self.pubsub_event_filter(sub_id, obj)
-                   for obj in [node, event.data]):
+                   for obj in [node, event]):
                 return node
 
     def create_job_node(self, job_config, input_node):

--- a/kernelci/cli/pubsub.py
+++ b/kernelci/cli/pubsub.py
@@ -8,6 +8,8 @@
 import json
 import sys
 
+import kernelci
+
 from .base import Args, sub_main
 from .base_api import APICommand
 
@@ -64,13 +66,14 @@ class cmd_receive_event(APICommand):  # pylint: disable=invalid-name
     opt_args = APICommand.opt_args + [Args.indent]
 
     def _api_call(self, api, configs, args):
-        event = api.receive_event(args.sub_id)
-        if isinstance(event.data, str):
-            print(event.data.strip())
-        elif isinstance(event.data, dict):
-            self._print_json(event.data, args.indent)
+        helper = kernelci.api.helper.APIHelper(api)
+        event = helper.receive_event_data(args.sub_id)
+        if isinstance(event, str):
+            print(event.strip())
+        elif isinstance(event, dict):
+            self._print_json(event, args.indent)
         else:
-            print(event.data)
+            print(event)
         return True
 
 

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -61,7 +61,7 @@ def test_get_node_from_event(get_api_config, mock_api_get_node_from_id):
         api = kernelci.api.get_api(api_config)
         helper = kernelci.api.helper.APIHelper(api)
         node = helper.get_node_from_event(
-            event=APIHelperTestData().get_test_cloud_event()
+            APIHelperTestData().get_test_cloud_event()
         )
         assert node.keys() == {
             'id',


### PR DESCRIPTION
Add a `APIHelper.receive_event_data()` method to directly return the payload of the CloudEvent object.  Update unit tests accordingly and also use it in the `kci pubsub` implementation.