### PR TITLE
build-configs-stable.yaml: Add Linux 6.3 stable trees

### DIFF
--- a/config/core/build-configs-stable.yaml
+++ b/config/core/build-configs-stable.yaml
@@ -186,6 +186,11 @@ build_configs:
     branch: 'linux-6.1.y'
     variants: *stable_variants
 
+  stable_6.3:
+    tree: stable
+    branch: 'linux-6.3.y'
+    variants: *stable_variants
+
   stable-rc_3.16:
     tree: stable-rc
     branch: 'linux-3.16.y'
@@ -298,6 +303,14 @@ build_configs:
       tree: stable
       branch: 'linux-6.1.y'
 
+  stable-rc_6.3:
+    tree: stable-rc
+    branch: 'linux-6.3.y'
+    variants: *stable_variants
+    reference:
+      tree: stable
+      branch: 'linux-6.3.y'
+
   stable-rc_queue-4.4:
     tree: stable-rc
     branch: 'queue/4.4'
@@ -401,3 +414,11 @@ build_configs:
     reference:
       tree: stable
       branch: 'linux-6.1.y'
+
+  stable-rc_queue-6.3:
+    tree: stable-rc
+    branch: 'queue/6.3'
+    variants: *stable_variants
+    reference:
+      tree: stable
+      branch: 'linux-6.3.y'


### PR DESCRIPTION
Even though it's not an LTS, I still think it's worth testing the latest stable releases and release candidates.

Note we missed adding v6.2.y testing.