### PR TITLE
kernelci.runtime: docker: check if env_file exists

### DIFF
--- a/kernelci/runtime/docker.py
+++ b/kernelci/runtime/docker.py
@@ -30,7 +30,7 @@ class Docker(Runtime):
         self._env = self._load_env()
 
     def _load_env(self):
-        if self.config.env_file:
+        if self.config.env_file and os.path.isfile(self.config.env_file):
             with open(self.config.env_file, encoding='utf-8') as env:
                 return [line.strip() for line in env.readlines()]
         return None


### PR DESCRIPTION
The default YAML pipeline configuration might provide an env_file attribute even though the local setup doesn't have one present.  To avoid hitting errors whenever this happens, which is typically when the user doesn't want to run jobs in the Docker runtime, check if the file specified by env_file is present and ignore it if not (effectively behaving as if it was an empty file).

Fixes: 394af48f6c96 ("kernelci.runtime.docker: initial implementation")

Fixes https://github.com/kernelci/kernelci-pipeline/issues/209