### PR TITLE
test-configs.yaml: Add one more device entry for different dtb file

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1928,12 +1928,17 @@ device_types:
     class: arm64-dtb
     boot_method: uboot
 
-  sc7180-trogdor-kingoftown:
+  sc7180-trogdor-kingoftown: &sc7180-trogdor-kingoftown
     mach: qcom
     class: arm64-dtb
     boot_method: depthcharge
-    dtb: 'qcom/sc7180-trogdor-kingoftown-r1.dtb'
+    dtb: 'qcom/sc7180-trogdor-kingoftown.dtb'
     filters: *arm64-chromebook-filters
+
+  sc7180-trogdor-kingoftown-r1:
+    <<: *sc7180-trogdor-kingoftown
+    base_name: sc7180-trogdor-kingoftown
+    dtb: 'qcom/sc7180-trogdor-kingoftown-r1.dtb'
 
   sc7180-trogdor-lazor-limozeen:
     mach: qcom
@@ -3254,6 +3259,14 @@ test_configs:
       - baseline
 
   - device_type: sc7180-trogdor-kingoftown
+    test_plans:
+      - baseline
+      - baseline-nfs
+      - cros-ec
+      - kselftest-alsa
+      - kselftest-tpm2
+
+  - device_type: sc7180-trogdor-kingoftown-r1
     test_plans:
       - baseline
       - baseline-nfs


### PR DESCRIPTION
As kingoftown got different dtb name in new kernels, as mentioned in https://github.com/kernelci/kernelci-core/issues/1941 , one of ways to solve this issue to add one more device entry with base_name pointing to initial device name.
