### PR TITLE
Build qcom-venus firmware into kernel image

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -348,6 +348,8 @@ fragments:
       mediatek/mt8173/vpu_d.bin
       mediatek/mt8173/vpu_p.bin
       rockchip/dptx.bin
+      qcom/venus-5.4/venus.mdt
+      qcom/venus-5.4/venus.mbn
       "'
 
 

--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -311,8 +311,6 @@ rootfs_configs:
       - e2fslibs
       - e2fsprogs
     extra_firmware:
-        - qcom/venus-5.4/venus.mdt
-        - qcom/venus-5.4/venus.mbn
         - mediatek/mt8173/vpu_d.bin
         - mediatek/mt8173/vpu_p.bin
         - mediatek/mt8183/scp.img


### PR DESCRIPTION
The qcom-venus driver is loaded quite early on in boot and requires the venus firmware. As the firmware binary is relatively small, build it into the Chromebooks kernel image to allow the video codecs driver to probe correctly on `trogdor` devices.

Remove the firmware binary from the `bullseye-v4l2` ramdisk/rootfs config.