### PR TITLE
Add `runtimes.get_all_runtimes()` using tokens for the Scheduler

### DIFF
--- a/kernelci/cli/base.py
+++ b/kernelci/cli/base.py
@@ -580,6 +580,21 @@ instead.", file=sys.stderr)
             section = ':'.join([section_name, section_config])
         else:
             section = self._section
+        return self.get_from_section(section, option, as_list)
+
+    def get_from_section(self, section, option, as_list=False):
+        """Get an option from an arbitrary section
+
+        While the .get() method will use other arguments such as --api-config
+        to look up the matching section in the settings file, this makes it
+        possible to retrieve values from any arbitrary section.  It is
+        primarily useful when the code needs to get options from multiple
+        sections, for example to iterate over all the runtimes.
+
+        *section* is the name of the section in the settings
+        *option* is the name of the option within that sectino
+        *as_list* is like for .get() for options with multiple values
+        """
         if self._deprecated_settings:
             if not self._settings.has_option(section, option):
                 return None

--- a/kernelci/cli/sched.py
+++ b/kernelci/cli/sched.py
@@ -8,6 +8,7 @@
 import json
 import sys
 
+import kernelci.runtime
 import kernelci.scheduler
 from .base import Args, Command, sub_main
 
@@ -22,7 +23,9 @@ class cmd_list_jobs(Command):  # pylint: disable=invalid-name
     ]
 
     def __call__(self, configs, args):
-        sched = kernelci.scheduler.Scheduler(configs)
+        rconfigs = configs['runtimes']
+        runtimes = dict(kernelci.runtime.get_all_runtimes(rconfigs, args))
+        sched = kernelci.scheduler.Scheduler(configs, runtimes)
         event = json.loads(sys.stdin.read())
         channel = args.channel or 'node'
         for job in sched.get_jobs(event, channel):
@@ -41,7 +44,9 @@ class cmd_get_schedule(Command):  # pylint: disable=invalid-name
     ]
 
     def __call__(self, configs, args):
-        sched = kernelci.scheduler.Scheduler(configs)
+        rconfigs = configs['runtimes']
+        runtimes = dict(kernelci.runtime.get_all_runtimes(rconfigs, args))
+        sched = kernelci.scheduler.Scheduler(configs, runtimes)
         event = json.loads(sys.stdin.read())
         channel = args.channel or 'node'
         for job, runtime, platform in sched.get_schedule(event, channel):

--- a/kernelci/runtime/__init__.py
+++ b/kernelci/runtime/__init__.py
@@ -186,3 +186,22 @@ def get_runtime(config, user=None, token=None):
     module_name = '.'.join(['kernelci', 'runtime', config.lab_type])
     runtime_module = importlib.import_module(module_name)
     return runtime_module.get_runtime(config, user=user, token=token)
+
+
+def get_all_runtimes(runtime_configs, opts):
+    """Get all the Runtime objects based on the runtime configs and options
+
+    This will iterate over all the runtimes configs and yield a (name, runtime)
+    2-tuple for each Runtime object being constructed.  The options are used to
+    find the user name and token for each runtime, if applicable.
+
+    *runtime_configs* is the 'runtimes' config loaded from YAML
+    *opts* is an Options object loaded from the CLI args and settings file
+    """
+    for config_name, config in runtime_configs.items():
+        section = ':'.join(('runtime', config_name))
+        user, token = (
+            opts.get_from_section(section, opt)
+            for opt in ('user', 'runtime_token')
+        )
+        yield config_name, get_runtime(config, user, token)

--- a/kernelci/scheduler.py
+++ b/kernelci/scheduler.py
@@ -7,8 +7,6 @@
 
 import random
 
-import kernelci.runtime
-
 
 class Scheduler:
     """Core logic for implementing a pipeline scheduler
@@ -19,16 +17,12 @@ class Scheduler:
     API via the Pub/Sub interface.
     """
 
-    def __init__(self, configs, runtimes_list=None):
+    def __init__(self, configs, runtimes):
         self._scheduler = configs['scheduler']
         self._jobs = configs['jobs']
-        self._runtimes_by_name = {
-            config_name: kernelci.runtime.get_runtime(config)
-            for config_name, config in configs['runtimes'].items()
-            if not runtimes_list or config_name in runtimes_list
-        }
+        self._runtimes = runtimes
         self._runtimes_by_type = {}
-        for _, runtime in self._runtimes_by_name.items():
+        for _, runtime in self._runtimes.items():
             runtime_type = self._runtimes_by_type.setdefault(
                 runtime.config.lab_type, []
             )
@@ -59,7 +53,7 @@ class Scheduler:
             runtime_name = config.runtime.get('name')
             runtime_type = config.runtime.get('type')
             if runtime_name:
-                runtime = self._runtimes_by_name.get(runtime_name)
+                runtime = self._runtimes.get(runtime_name)
             elif runtime_type:
                 # Pick one at random until there's more criteria
                 runtimes = self._runtimes_by_type.get(runtime_type)


### PR DESCRIPTION
Add `Options.get_from_section()` and `kernelci.runtime.get_all_runtimes()` to get all the Runtime objects even if they require some tokens to be constructed (e.g. LAVA labs).  The tokens can be loaded from the settings file without relying on `--runtime-config` since this doesn't apply when iterating through all the runtimes.