### PR TITLE
kernelci.cli: fix __getattr__() for private attributes

### DIFF
--- a/kernelci/cli/base.py
+++ b/kernelci/cli/base.py
@@ -528,6 +528,8 @@ class Options:
         self._section = section
 
     def __getattr__(self, name):
+        if name.startswith('_'):
+            return super().__getattr__(name)
         return self.get(name)
 
     @property


### PR DESCRIPTION
When accessing "private" attributes which by convention have a name that starts with _, rely on the standard method as settings don't normally start with '_'.  This will avoid obscure issues when trying to access a private attribute and the code looks for an option with the attribute's name instead.