### PR TITLE
CHROMEOS build_board.sh: Add trogdor and grunt R111 workarounds

### DIFF
--- a/config/rootfs/chromiumos/scripts/build_board.sh
+++ b/config/rootfs/chromiumos/scripts/build_board.sh
@@ -54,6 +54,15 @@ repo sync -j$(nproc)
 echo Building SDK
 cros_sdk --create
 
+# if board trogdor we need to revert patch early, here
+if [ "${BOARD}" == "trogdor" ]; then
+    # issue/284169814 revert caf6c399cb013fb44b767d32853a7ba181a59c23 in chromiumos/overlays/board-overlays
+    echo "Reverting issue/284169814 commit caf6c399cb013fb44b767d32853a7ba181a59c23 for trogdor"
+    cd src/overlays
+    git revert caf6c399cb013fb44b767d32853a7ba181a59c23
+    cd -
+fi
+
 echo "Board ${BOARD} setup"
 cros_sdk setup_board --board=${BOARD}
 

--- a/config/rootfs/chromiumos/scripts/build_board.sh
+++ b/config/rootfs/chromiumos/scripts/build_board.sh
@@ -63,6 +63,9 @@ if [ "${BOARD}" == "trogdor" ]; then
     cd -
 fi
 
+# grunt/StoneyRidge kernel 4.14 broken, so switch to 5.10
+sed -i 's/kernel-4_14/kernel-5_10/g' src/overlays/chipset-stnyridge/profiles/base/make.defaults
+
 echo "Board ${BOARD} setup"
 cros_sdk setup_board --board=${BOARD}
 


### PR DESCRIPTION
This is patches to make ChromiumOS work for trogdor and grunt