### PR TITLE
kernelci.cli: job: drop submit --api-token

### DIFF
--- a/kernelci/cli/job.py
+++ b/kernelci/cli/job.py
@@ -107,7 +107,7 @@ Invalid arguments.  Either --node-id or --node-json is required.")
 class cmd_submit(Command):  # pylint: disable=invalid-name
     """Submit a job definition from a file"""
     args = Command.args + [
-        Args.api_token, Args.runtime_config,
+        Args.runtime_config,
         {
             'name': 'job_path',
             'help': "Path of the job file to submit",


### PR DESCRIPTION
Drop "kci job submit --api-token" argument as it's not used.  That way we can submit jobs without having to provide an API token.

Fixes: 3f9b582c6676 ("kernelci.cli: drop Args.api_token for anonymous requests")