### PR TITLE
kernelci.runtime: lava: add LAVA log parser

### DIFF
--- a/kernelci/runtime/lava.py
+++ b/kernelci/runtime/lava.py
@@ -40,7 +40,7 @@ class LogParser:
             dtime, level, msg = (line.get(key) for key in ['dt', 'lvl', 'msg'])
             if not isinstance(msg, str):
                 continue
-            msg = msg.strip()
+            msg = msg.strip().replace('\x1b', '^[')
             if msg:
                 raw_log.append((dtime, level, msg))
         return raw_log


### PR DESCRIPTION
Add a LogParser class to handle the LAVA job log and get a plain text log with the output from the platform's serial console.

Fixes: https://github.com/kernelci/kernelci-pipeline/issues/214