### PR TITLE
config/runtime: lava: add storage_config_name metadata

### DIFF
--- a/config/runtime/base/lava.jinja2
+++ b/config/runtime/base/lava.jinja2
@@ -62,6 +62,7 @@ metadata:
   # integers are accepted by the schema.  See this issue for more details:
   # https://git.lavasoftware.org/lava/lava/-/issues/610
   api_config_name: {{ api_config.name }}
+  storage_config_name: {{ storage_config.name }}
 
 actions:
 


### PR DESCRIPTION
Add a metadata entry with the name of the storage config so that the callback handler can upload artifacts to storage (e.g. job logs).

Fixes: https://github.com/kernelci/kernelci-pipeline/issues/214