### PR TITLE
kernelci.storage: fix urljoin relative path

### DIFF
--- a/kernelci/storage/__init__.py
+++ b/kernelci/storage/__init__.py
@@ -57,7 +57,7 @@ class Storage:
         self._upload([file_path], dest_path)
         return urljoin(
             self.config.base_url,
-            '/'.join([dest_path, file_path[1]])
+            '/'.join(['.', dest_path, file_path[1]])
         )
 
     def upload_multiple(self, file_paths, dest_path=''):
@@ -82,7 +82,7 @@ class Storage:
         """
         self._upload(file_paths, dest_path)
         return [
-            urljoin(self.config.base_url, '/'.join([dest_path, file_dst]))
+            urljoin(self.config.base_url, '/'.join(['.', dest_path, file_dst]))
             for (file_src, file_dst) in file_paths
         ]
 


### PR DESCRIPTION
Fix how urljoin is being used to produce the public URL for uploaded artifacts by using a relative path for the 2nd part of the URL. Otherwise, any trailing path after the hostname in the base URL would be discarded.

For example, when joining this base URL with this artifact file name:

  http://storage.something.com/blah
  node-1234/file.txt

the returned URL as-is would be:

  http://storage.something.com/node-1234/file.txt

However, when using ./node-1234/file.txt, the returned value is now:

  http://storage.something.com/blah/node-1234/file.txt

which is the expected one.

As a result, always add a leading '.' to the artifact file path when joining it with the base URL to get the full correct public URL.

Fixes: 670c867141c1 ("kernelci.storage: add base Storage interface class")