### PR TITLE
CHROMEOS Enable fluster tests on asurada with collabora-chromeos-kernel

### DIFF
--- a/config/core/test-configs-chromeos.yaml
+++ b/config/core/test-configs-chromeos.yaml
@@ -522,6 +522,52 @@ test_plans:
       <<: *cros-tast-base-qemu-params
       tests: *cros-tast-video-tests
 
+  v4l2-decoder-conformance-av1_chromeos: &v4l2-decoder-conformance_chromeos
+    rootfs: debian_bullseye-gst-fluster_nfs
+    pattern: 'v4l2-decoder-conformance/{category}-{method}-{protocol}-{rootfs}-v4l2-decoder-conformance-template.jinja2'
+    params: &v4l2-decoder-conformance-params_chromeos
+      job_timeout: '30'
+      testsuite: 'AV1-TEST-VECTORS'
+      decoders:
+        - 'GStreamer-AV1-V4L2SL-Gst1.0'
+      videodec_parallel_jobs: '1'
+      videodec_timeout: 90
+
+  v4l2-decoder-conformance-h264_chromeos:
+    <<: *v4l2-decoder-conformance_chromeos
+    params:
+      <<: *v4l2-decoder-conformance-params_chromeos
+      testsuite: 'JVT-AVC_V1'
+      decoders:
+        - 'GStreamer-H.264-V4L2-Gst1.0'
+        - 'GStreamer-H.264-V4L2SL-Gst1.0'
+
+  v4l2-decoder-conformance-h265_chromeos:
+    <<: *v4l2-decoder-conformance_chromeos
+    params:
+      <<: *v4l2-decoder-conformance-params_chromeos
+      testsuite: 'JCT-VC-HEVC_V1'
+      decoders:
+        - 'GStreamer-H.265-V4L2-Gst1.0'
+        - 'GStreamer-H.265-V4L2SL-Gst1.0'
+
+  v4l2-decoder-conformance-vp8_chromeos:
+    <<: *v4l2-decoder-conformance_chromeos
+    params:
+      <<: *v4l2-decoder-conformance-params_chromeos
+      testsuite: 'VP8-TEST-VECTORS'
+      decoders:
+        - 'GStreamer-VP8-V4L2-Gst1.0'
+        - 'GStreamer-VP8-V4L2SL-Gst1.0'
+
+  v4l2-decoder-conformance-vp9_chromeos:
+    <<: *v4l2-decoder-conformance_chromeos
+    params:
+      <<: *v4l2-decoder-conformance-params_chromeos
+      testsuite: 'VP9-TEST-VECTORS'
+      decoders:
+        - 'GStreamer-VP9-V4L2SL-Gst1.0'
+
 device_types:
 
   acer-R721T-grunt_chromeos:

--- a/config/core/test-configs-chromeos.yaml
+++ b/config/core/test-configs-chromeos.yaml
@@ -1096,6 +1096,13 @@ test_configs:
     filters: *collabora-chromeos-kernel-filter
     test_plans: *chromebook-arm64-test-plans
 
+  - device_type: mt8192-asurada-spherion-r0_chromeos
+    filters: *collabora-chromeos-kernel-filter
+    test_plans:
+      - v4l2-decoder-conformance-h264_chromeos
+      - v4l2-decoder-conformance-vp8_chromeos
+      - v4l2-decoder-conformance-vp9_chromeos
+
 # Test plans temporarily disabled as QEMU build doesnt work
 #  - device_type: qemu_x86_64-uefi-chromeos
 #    test_plans:


### PR DESCRIPTION
Run the fluster decoder conformance tests on the `collabora-chromeos-kernel` tree.