### PR TITLE
test-configs.ymal: Add sigaltstack kselftest coverage

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -408,6 +408,13 @@ test_plans:
       job_timeout: '10'
       kselftest_collections: "seccomp"
 
+  kselftest-sigaltstack:
+    <<: *kselftest
+    params:
+      job_timeout: '10'
+      kselftest_collections: "sigaltstack"
+    filters: *kselftest_no_fragment
+
   kselftest-timens:
     <<: *kselftest
     params:
@@ -2414,6 +2421,7 @@ test_configs:
       - kselftest-mincore
       - kselftest-openat2
       - kselftest-seccomp
+      - kselftest-sigaltstack
       - kselftest-timers
       - ltp-crypto
       - ltp-dio
@@ -3327,6 +3335,7 @@ test_configs:
       - kselftest-cpufreq
       - kselftest-kvm
       - kselftest-rseq
+      - kselftest-sigaltstack
       - kselftest-timers
       - libhugetlbfs
       - ltp-cpuhotplug


### PR DESCRIPTION
The sigaltstack test is *tiny* so the time taken to boot a test platform is
going to dwarf the time taken to actually run the tests but it's relevant
to some development work I'm doing so let's add some test coverage for it.
Add the fragment for it and run it on two platforms in my lab.

Signed-off-by: Mark Brown <broonie@kernel.org>
