### PR TITLE
CHROMEOS cros-tast.jinja2: Reduce chance of filesystem corruption

### DIFF
--- a/config/lava/chromeos/cros-tast.jinja2
+++ b/config/lava/chromeos/cros-tast.jinja2
@@ -38,6 +38,13 @@
             - >-
               ./tast_parser.py
               {{ tests|wordwrap(1, False, "\n              ") }}
+            - >-
+              ./ssh_retry.sh
+              -o StrictHostKeyChecking=no
+              -o UserKnownHostsFile=/dev/null
+              -i /home/cros/.ssh/id_rsa
+              root@$(lava-target-ip)
+              sync && poweroff && exit 0
       from: inline
       name: tast
       path: inline/cros-tast.yaml


### PR DESCRIPTION
As some of DUT might have batteries removed, abrupt poweroff might cause issues with storage. Better to make sure all buffers are sync and try to poweroff gracefully.
Not sure yet, if we will give them enough time, probably worth to add small additional delay later.