### PR TITLE
kernelci.build: sparc64 need vmlinux

### DIFF
--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -51,7 +51,7 @@ MAKE_TARGETS = {
     'i386': 'bzImage',
     'x86_64': 'bzImage',
     'mips': 'uImage.gz',
-    'sparc': 'zImage',
+    'sparc': 'vmlinux',
 }
 
 # Hard-coded binary kernel image names for each CPU architecture


### PR DESCRIPTION
qemu-sparc64 cannot boot zImage, this lead to:
OpenBIOS for Sparc64
Configuration device id QEMU version 1 machine id 0 kernel phys 404000 virt 40004000 size 0x47d664
kernel cmdline console=ttyS0,115200 root=/dev/ram0 debug verbose console_msg_format=syslog earlycon CPUs: 1 x SUNW,UltraSPARC-IIi
UUID: 00000000-0000-0000-0000-000000000000
Welcome to OpenBIOS v1.1 built on May 14 2023 10:45
  Type 'help' for detailed information
[sparc64] Kernel already loaded
Unhandled Exception 0x0000000000000020
PC = 0x0000000040004000 NPC = 0x0000000040004004
Stopping execution

with vmlinux, the qemu boot fine.