### PR TITLE
bullseye-cros-flash.sh: Update repository for CR50 flashing tools

### DIFF
--- a/config/rootfs/debos/scripts/bullseye-cros-flash.sh
+++ b/config/rootfs/debos/scripts/bullseye-cros-flash.sh
@@ -19,10 +19,11 @@ apt-get install --no-install-recommends -y  ${BUILD_DEPS}
 
 mkdir -p /tmp/tests
 cd /tmp/tests
-wget --no-verbose --inet4-only --no-clobber --tries 5 \
-    https://chromium.googlesource.com/chromiumos/platform/ec/+archive/refs/heads/cr50_stab.tar.gz
 
-tar -xzf cr50_stab.tar.gz
+wget --no-verbose --inet4-only --no-clobber --tries 5 \
+    https://chromium.googlesource.com/chromiumos/platform/ec/+archive/refs/heads/gsc_utils.tar.gz
+
+tar -xzf gsc_utils.tar.gz
 cd extra/usb_updater
 make
 cp gsctool /usr/bin


### PR DESCRIPTION
As we faced error while extracting CR50 archive, https://github.com/kernelci/kernelci-core/issues/1968, it is better to ignore modified time in tar archive.