### PR TITLE
config/docker: use kernelci.org branch for data files

### DIFF
--- a/config/docker/base/host-tools.jinja2
+++ b/config/docker/base/host-tools.jinja2
@@ -19,15 +19,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     cdbs \
     devscripts \
     equivs \
-    fakeroot \
-    wget
+    fakeroot
 
 WORKDIR /root/debs
 
 # Get patch to enable compression
-RUN wget -q https://raw.githubusercontent.com/kernelci/kernelci-core/\
-8642bf83db5a26ddc22ec738586b435499d01137/\
-config/docker-new/data/kmod_kci.patch
+ADD https://raw.githubusercontent.com/kernelci/kernelci-core/\
+    kernelci.org/\
+    config/docker/data/kmod_kci.patch \
+    .
 
 # Prepare kmod sources, patch, install dependencies, build
 RUN apt-get source kmod

--- a/config/docker/cros-baseline.jinja2
+++ b/config/docker/cros-baseline.jinja2
@@ -19,7 +19,10 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 
 {{ super() }}
 
-ADD https://raw.githubusercontent.com/kernelci/kernelci-core/chromeos.kernelci.org/config/rootfs/debos/overlays/baseline/opt/kernelci/dmesg.sh /home/cros/dmesg.sh
+ADD https://raw.githubusercontent.com/kernelci/kernelci-core/\
+    kernelci.org/\
+    config/rootfs/debos/overlays/baseline/opt/kernelci/dmesg.sh \
+    /home/cros/dmesg.sh
 
 # Needed by LAVA to install the overlay
 USER root

--- a/config/docker/cros-qemu-modules.jinja2
+++ b/config/docker/cros-qemu-modules.jinja2
@@ -18,9 +18,9 @@ ENV LIBGUESTFS_BACKEND=direct \
     HOME=/root
 
 ADD https://raw.githubusercontent.com/kernelci/kernelci-core/\
-7f58ddf26d08bd046ddff553681b59a0e7b48bc6/\
-config/docker/data/add_modules.sh \
-/add_modules.sh
+    kernelci.org/\
+    config/docker/data/add_modules.sh \
+    /add_modules.sh
 
 # Needed by LAVA to install the overlay
 USER root

--- a/config/docker/cros-tast.jinja2
+++ b/config/docker/cros-tast.jinja2
@@ -22,14 +22,14 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 {{ super() }}
 
 ADD https://raw.githubusercontent.com/kernelci/kernelci-core/\
-7f58ddf26d08bd046ddff553681b59a0e7b48bc6/\
-config/docker/data/tast_parser.py \
-/home/cros/tast_parser.py
+    kernelci.org/\
+    config/docker/data/tast_parser.py \
+    /home/cros/tast_parser.py
 
 ADD https://raw.githubusercontent.com/kernelci/kernelci-core/\
-7f58ddf26d08bd046ddff553681b59a0e7b48bc6/\
-config/docker/data/ssh_retry.sh \
-/home/cros/ssh_retry.sh
+    kernelci.org/\
+    config/docker/data/ssh_retry.sh \
+    /home/cros/ssh_retry.sh
 
 # Needed by LAVA to install the overlay
 USER root

--- a/config/docker/gcc-10-x86.jinja2
+++ b/config/docker/gcc-10-x86.jinja2
@@ -10,16 +10,15 @@ RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 500
 
 # 32-bit support for host tools and kselftest
 RUN apt-get update && apt-get install --no-install-recommends -y \
-   gcc-multilib \
-   libc6-i386 \
-   libc6-dev-i386
+    gcc-multilib \
+    libc6-i386 \
+    libc6-dev-i386
 
 # GCC i386.h header fix for the Debian package
 RUN apt-get update && apt-get install --no-install-recommends -y curl patch
-RUN \
-    cd / && \
+RUN cd / && \
     curl -s https://raw.githubusercontent.com/kernelci/kernelci-core/\
-fa6ae5ed63e9f2b22d0996af4d9fa60cb3def79f/\
-config/docker-new/data/gcc-header-fix.patch \
+    kernelci.org/\
+    config/docker/data/gcc-header-fix.patch \
     | patch -p1
 {%- endblock %}


### PR DESCRIPTION
Use the kernelci.org production branch when downloading Docker data files at build time rather than the fixed git sha1 revisions.  This was needed initially to bootstrap the templates before they got merged, now we can use the kernelci.org branch to get updates automatically in sync with production.