### PR TITLE
`kci user` command for user groups

### DIFF
--- a/kernelci/api/__init__.py
+++ b/kernelci/api/__init__.py
@@ -133,6 +133,13 @@ class API(abc.ABC):
     def get_group(self, group_id: str) -> dict:
         """Get the user group matching the given group id"""
 
+    @abc.abstractmethod
+    def get_groups(
+        self, attributes: dict,
+        offset: Optional[int] = None, limit: Optional[int] = None
+    ) -> Sequence[dict]:
+        """Get user groups that match the provided attributes"""
+
     # -------------------------------------------------------------------------
     # Private methods
     #

--- a/kernelci/api/__init__.py
+++ b/kernelci/api/__init__.py
@@ -125,6 +125,14 @@ class API(abc.ABC):
     def update_node(self, node: dict) -> dict:
         """Update an existing node object (with id)"""
 
+    # -----------
+    # User groups
+    # -----------
+
+    @abc.abstractmethod
+    def get_group(self, group_id: str) -> dict:
+        """Get the user group matching the given group id"""
+
     # -------------------------------------------------------------------------
     # Private methods
     #

--- a/kernelci/api/latest.py
+++ b/kernelci/api/latest.py
@@ -124,29 +124,8 @@ class LatestAPI(API):
         offset: Optional[int] = None, limit: Optional[int] = None
     ) -> Sequence[dict]:
         params = attributes.copy() if attributes else {}
-        nodes = []
-
-        if any((offset, limit)):
-            params.update({
-                'offset': offset or None,
-                'limit': limit or None,
-            })
-            resp = self._get('nodes', params=params)
-            nodes = resp.json()['items']
-        else:
-            offset = 0
-            limit = 100
-            params['limit'] = limit
-            while True:
-                params['offset'] = offset
-                resp = self._get('nodes', params=params)
-                items = resp.json()['items']
-                nodes.extend(items)
-                if len(items) < limit:
-                    break
-                offset += limit
-
-        return nodes
+        return self._get_api_objs(params=params, path='nodes',
+                                  limit=limit, offset=offset)
 
     def count_nodes(self, attributes: dict) -> int:
         return self._get('count', params=attributes).json()

--- a/kernelci/api/latest.py
+++ b/kernelci/api/latest.py
@@ -130,6 +130,9 @@ class LatestAPI(API):
     def update_node(self, node: dict) -> dict:
         return self._put('/'.join(['node', node['id']]), node).json()
 
+    def get_group(self, group_id: str) -> dict:
+        return self._get(f'group/{group_id}').json()
+
 
 def get_api(config, token):
     """Get an API object for the latest version"""

--- a/kernelci/cli/base.py
+++ b/kernelci/cli/base.py
@@ -178,6 +178,11 @@ class Args:  # pylint: disable=too-few-public-methods
         'help': "Path to the dtbs.json file",
     }
 
+    group_id = {
+        'name': 'group_id',
+        'help': "User group id",
+    }
+
     id = {
             'name': 'id',
             'help': "Node id",

--- a/kernelci/cli/base_api.py
+++ b/kernelci/cli/base_api.py
@@ -55,3 +55,20 @@ class APICommand(Command):  # pylint: disable=too-few-public-methods
     def __call__(self, configs, args):
         api = self._get_api(configs, args)
         return self._api_call(api, configs, args)
+
+
+class AttributesCommand(APICommand):
+    """Base command class for API queries with arbitrary attributes"""
+    opt_args = APICommand.opt_args + [
+        {
+            'name': 'attributes',
+            'nargs': '*',
+            'help': "Attributes in name=value format",
+        },
+    ]
+
+    @classmethod
+    def _split_attributes(cls, attributes):
+        return dict(
+            tuple(attr.split('=')) for attr in attributes
+        ) if attributes else {}

--- a/kernelci/cli/node.py
+++ b/kernelci/cli/node.py
@@ -9,29 +9,12 @@ import json
 import sys
 
 from .base import Args, sub_main
-from .base_api import APICommand
+from .base_api import APICommand, AttributesCommand
 
 
 class NodeCommand(APICommand):  # pylint: disable=too-few-public-methods
     """Base command class for interacting with Node objects"""
     opt_args = APICommand.opt_args + [Args.indent]
-
-
-class NodeAttributesCommand(NodeCommand):
-    """Base command class for node queries with arbitrary attributes"""
-    opt_args = NodeCommand.opt_args + [
-        {
-            'name': 'attributes',
-            'nargs': '*',
-            'help': "Attributes to find nodes in name=value format",
-        },
-    ]
-
-    @classmethod
-    def _split_attributes(cls, attributes):
-        return dict(
-            tuple(attr.split('=')) for attr in attributes
-        ) if attributes else {}
 
 
 class cmd_get(NodeCommand):  # pylint: disable=invalid-name
@@ -44,9 +27,9 @@ class cmd_get(NodeCommand):  # pylint: disable=invalid-name
         return True
 
 
-class cmd_find(NodeAttributesCommand):  # pylint: disable=invalid-name
+class cmd_find(AttributesCommand):  # pylint: disable=invalid-name
     """Find nodes with arbitrary attributes"""
-    opt_args = NodeAttributesCommand.opt_args + [
+    opt_args = AttributesCommand.opt_args + [
         {
             'name': '--limit',
             'type': int,
@@ -70,7 +53,7 @@ the matching nodes are retrieved.\
         return True
 
 
-class cmd_count(NodeAttributesCommand):  # pylint: disable=invalid-name
+class cmd_count(AttributesCommand):  # pylint: disable=invalid-name
     """Count nodes with arbitrary attributes"""
 
     def _api_call(self, api, configs, args):

--- a/kernelci/cli/user.py
+++ b/kernelci/cli/user.py
@@ -49,6 +49,17 @@ class cmd_password_hash(APICommand):  # pylint: disable=invalid-name
         return True
 
 
+class cmd_get_group(APICommand):  # pylint: disable=invalid-name
+    """Get a user group with a given ID"""
+    args = APICommand.args + [Args.group_id]
+    opt_args = APICommand.opt_args + [Args.indent]
+
+    def _api_call(self, api, configs, args):
+        group = api.get_group(args.group_id)
+        self._print_json(group, args.indent)
+        return True
+
+
 def main(args=None):
     """Entry point for the command line tool"""
     sub_main("user", globals(), args)

--- a/kernelci/cli/user.py
+++ b/kernelci/cli/user.py
@@ -8,24 +8,7 @@
 import getpass
 
 from .base import Args, sub_main
-from .base_api import APICommand
-
-
-class UserAttributesCommand(APICommand):
-    """Base command class for user queries with arbitrary attributes"""
-    opt_args = APICommand.opt_args + [
-        {
-            'name': 'attributes',
-            'nargs': '*',
-            'help': "Attributes to find users or groups in name=value format",
-        },
-    ]
-
-    @classmethod
-    def _split_attributes(cls, attributes):
-        return dict(
-            tuple(attr.split('=')) for attr in attributes
-        ) if attributes else {}
+from .base_api import APICommand, AttributesCommand
 
 
 class cmd_whoami(APICommand):  # pylint: disable=invalid-name
@@ -77,9 +60,9 @@ class cmd_get_group(APICommand):  # pylint: disable=invalid-name
         return True
 
 
-class cmd_find_groups(UserAttributesCommand):  # pylint: disable=invalid-name
+class cmd_find_groups(AttributesCommand):  # pylint: disable=invalid-name
     """Find user groups with arbitrary attributes"""
-    opt_args = UserAttributesCommand.opt_args + [
+    opt_args = AttributesCommand.opt_args + [
         {
             'name': '--limit',
             'type': int,


### PR DESCRIPTION
Added commands to `kci user` for getting user groups by ID and attributes.
Newly added sample commands:
```
kci user get_group <group-id>
kci user find_groups
kci user find_groups name=admin
```