### PR TITLE
Scheduler event config

### DIFF
--- a/kernelci/cli/sched.py
+++ b/kernelci/cli/sched.py
@@ -13,26 +13,6 @@ import kernelci.scheduler
 from .base import Args, Command, sub_main
 
 
-class cmd_list_jobs(Command):  # pylint: disable=invalid-name
-    """List the jobs to run matching an event provided on stdin"""
-    opt_args = Command.opt_args + [
-        {
-            'name': '--channel',
-            'help': "Name of the pub/sub channel, or 'node' by default",
-        },
-    ]
-
-    def __call__(self, configs, args):
-        rconfigs = configs['runtimes']
-        runtimes = dict(kernelci.runtime.get_all_runtimes(rconfigs, args))
-        sched = kernelci.scheduler.Scheduler(configs, runtimes)
-        event = json.loads(sys.stdin.read())
-        channel = args.channel or 'node'
-        for job in sched.get_jobs(event, channel):
-            print(job.name)
-        return True
-
-
 class cmd_get_schedule(Command):  # pylint: disable=invalid-name
     """Get scheduler configs matching an event provided on stdin"""
     opt_args = Command.opt_args + [

--- a/kernelci/config/job.py
+++ b/kernelci/config/job.py
@@ -14,12 +14,10 @@ class Job(YAMLConfigObject):
     yaml_tag = '!Job'
 
     # pylint: disable=too-many-arguments
-    def __init__(self, name, template, image=None,
-                 run_on=None, params=None):
+    def __init__(self, name, template, image=None, params=None):
         self._name = name
         self._template = template
         self._image = image
-        self._run_on = run_on or []
         self._params = params or {}
 
     @property
@@ -38,11 +36,6 @@ class Job(YAMLConfigObject):
         return self._image
 
     @property
-    def run_on(self):
-        """Criteria for the job to be run"""
-        return list(dict(crit) for crit in self._run_on)
-
-    @property
     def params(self):
         """Arbitrary parameters passed to the template"""
         return dict(self._params)
@@ -50,7 +43,7 @@ class Job(YAMLConfigObject):
     @classmethod
     def _get_yaml_attributes(cls):
         attrs = super()._get_yaml_attributes()
-        attrs.update({'template', 'image', 'run_on', 'params'})
+        attrs.update({'template', 'image', 'params'})
         return attrs
 
 

--- a/kernelci/config/scheduler.py
+++ b/kernelci/config/scheduler.py
@@ -13,9 +13,10 @@ class SchedulerEntry(YAMLConfigObject):
 
     yaml_tag = '!SchedulerEntry'
 
-    def __init__(self, job, runtime, platforms=None):
+    def __init__(self, job, runtime, event, platforms=None):
         self._job = job
         self._runtime = runtime
+        self._event = event
         self._platforms = platforms or []
 
     @property
@@ -29,6 +30,11 @@ class SchedulerEntry(YAMLConfigObject):
         return dict(self._runtime)
 
     @property
+    def event(self):
+        """Criteria for an event to cause the job to be run"""
+        return dict(self._event)
+
+    @property
     def platforms(self):
         """List of platform names"""
         return list(self._platforms)
@@ -36,7 +42,7 @@ class SchedulerEntry(YAMLConfigObject):
     @classmethod
     def _get_yaml_attributes(cls):
         attrs = super()._get_yaml_attributes()
-        attrs.update({'job', 'runtime', 'platforms'})
+        attrs.update({'job', 'runtime', 'event', 'platforms'})
         return attrs
 
 

--- a/kernelci/scheduler.py
+++ b/kernelci/scheduler.py
@@ -29,22 +29,14 @@ class Scheduler:
             runtime_type.append(runtime)
         self._platforms = configs['device_types']
 
-    def get_jobs(self, event, channel='node'):
-        """Get the job configs matching a given event"""
-        for _, job in self._jobs.items():
-            for run_on in job.run_on:
-                run_on_channel = run_on.get('channel')
-                if run_on_channel == channel:
-                    run_on = run_on.copy()
-                    run_on.pop('channel')
-                    if run_on.items() <= event.items():
-                        yield job
-
     def get_configs(self, event, channel='node'):
-        """Get the scheduler configs to run jobs matching a given event"""
-        for job in self.get_jobs(event, channel):
-            for entry in self._scheduler:
-                if entry.job == job.name:
+        """Get the scheduler configs matching a given event"""
+        for entry in self._scheduler:
+            sched_event_channel = entry.event.get('channel')
+            if sched_event_channel == channel:
+                sched_event = entry.event.copy()
+                sched_event.pop('channel')
+                if sched_event.items() <= event.items():
                     yield entry
 
     def get_schedule(self, event, channel='node'):

--- a/tests/configs/jobs.yaml
+++ b/tests/configs/jobs.yaml
@@ -1,24 +1,14 @@
-_aliases:
-
-  checkout: &checkout
-  - event: node
-    name: checkout
-    result: pass
-
-
 jobs:
 
   kbuild-gcc-10-x86:
     template: 'kbuild.jinja2'
     image: 'gcc-10:{arch}{fragments}'
-    run_on: *checkout
     params:
       config: x86_64_defconfig
 
   kunit: &kunit-job
     template: 'kunit.jinja2'
     image: 'gcc-10:x86-kunit-kernelci'
-    run_on: *checkout
     params: {}
 
   kunit-x86_64:
@@ -30,5 +20,4 @@ jobs:
   kver:
     template: 'kver.jinja2'
     image: 'kernelci'
-    run_on: *checkout
     params: {}

--- a/tests/configs/scheduler.yaml
+++ b/tests/configs/scheduler.yaml
@@ -1,16 +1,30 @@
+_aliases:
+
+  checkout: &checkout
+    event: node
+    name: checkout
+    result: pass
+
+
 scheduler:
 
   - job: baseline-x86
+    event:
+      channel: node
+      name: kbuild-gcc-10-x86
+      result: pass
     runtime:
       type: lava
     platforms: [qemu-x86]
 
   - job: kunit
+    event: *checkout
     runtime:
       name: k8s-gke-eu-west4
     platforms: []
 
   - job: kbuild-gcc-10-x86
+    event: *checkout
     runtime:
       type: kubernetes
     platforms: []


### PR DESCRIPTION
Update the YAML config to have `event` attributes in the scheduler entries rather than `Job.run_on` as discussed on the mailing list and GitHub.

Fixes https://github.com/kernelci/kernelci-pipeline/issues/221