### PR TITLE
Upgrade docker PyPI package to 6.1.2

### DIFF
--- a/kernelci/runtime/docker.py
+++ b/kernelci/runtime/docker.py
@@ -26,7 +26,7 @@ class Docker(Runtime):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._client = docker.from_env(timeout=self.config.timeout)
+        self._docker_client = None
         self._env = self._load_env()
 
     def _load_env(self):
@@ -38,6 +38,12 @@ class Docker(Runtime):
     @classmethod
     def _meta_path(cls, script_file_path):
         return '.'.join((script_file_path, 'meta'))
+
+    @property
+    def _client(self):
+        if self._docker_client is None:
+            self._docker_client = docker.from_env(timeout=self.config.timeout)
+        return self._docker_client
 
     def generate(self, job, params):
         template = self._get_template(job.config)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cloudevents==1.9.0
-docker==4.1.0
+docker==6.1.2
 jinja2==3.1.1
 kubernetes==23.3.0
 paramiko==2.12.0


### PR DESCRIPTION
Upgrade the `docker` PyPI package from 4.1.0 to 6.1.2.  Also update the Docker Runtime implementation to only create a client object when needed so that unit tests don't require Docker-in-Docker to be run.