### PR TITLE
Update requirements to latest releases

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ jinja2==3.1.2
 kubernetes==26.1.0
 paramiko==3.2.0
 pyelftools==0.29
-pytest==7.1.2
+pytest==7.4.0
 pyyaml==6.0
 requests==2.31.0
 scp==0.14.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ docker==6.1.2
 jinja2==3.1.2
 kubernetes==26.1.0
 paramiko==3.2.0
-pyelftools==0.28
+pyelftools==0.29
 pytest==7.1.2
 pyyaml==6.0
 requests==2.31.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ pyelftools==0.29
 pytest==7.4.0
 pyyaml==6.0
 requests==2.31.0
-scp==0.14.4
+scp==0.14.5
 toml==0.10.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 cloudevents==1.9.0
 docker==6.1.2
 jinja2==3.1.2
-kubernetes==23.3.0
+kubernetes==26.1.0
 paramiko==2.12.0
 pyelftools==0.28
 pytest==7.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ cloudevents==1.9.0
 docker==6.1.2
 jinja2==3.1.2
 kubernetes==26.1.0
-paramiko==2.12.0
+paramiko==3.2.0
 pyelftools==0.28
 pytest==7.1.2
 pyyaml==6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 cloudevents==1.9.0
 docker==6.1.2
-jinja2==3.1.1
+jinja2==3.1.2
 kubernetes==23.3.0
 paramiko==2.12.0
 pyelftools==0.28


### PR DESCRIPTION
Update all the PyPI requirement package versions to the latest stable releases to get bug fixes and drop support for early Python versions.

Depends on #1980