### PR TITLE
test-configs.yaml: Move videodec_timeout param and kernel tree filter for decoder tests

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -664,8 +664,6 @@ test_plans:
       decoder: 'GStreamer-AV1-V4L2SL-Gst1.0'
       videodec_parallel_jobs: '1'
       videodec_timeout: 90
-    filters:
-      - regex: {'tree': '(next|mainline|media)'}
 
   v4l2-decoder-conformance-h264:
     rootfs: debian_bullseye-gst-fluster_nfs
@@ -676,8 +674,6 @@ test_plans:
       decoder: 'GStreamer-H.264-V4L2SL-Gst1.0'
       videodec_parallel_jobs: '1'
       videodec_timeout: 90
-    filters:
-      - regex: {'tree': '(next|mainline|media)'}
 
   v4l2-decoder-conformance-h265:
     rootfs: debian_bullseye-gst-fluster_nfs
@@ -688,8 +684,6 @@ test_plans:
       decoder: 'GStreamer-H.265-V4L2SL-Gst1.0'
       videodec_parallel_jobs: '1'
       videodec_timeout: 90
-    filters:
-      - regex: {'tree': '(next|mainline|media)'}
 
   v4l2-decoder-conformance-vp8:
     rootfs: debian_bullseye-gst-fluster_nfs
@@ -700,8 +694,6 @@ test_plans:
       decoder: 'GStreamer-VP8-V4L2SL-Gst1.0'
       videodec_parallel_jobs: '1'
       videodec_timeout: 90
-    filters:
-      - regex: {'tree': '(next|mainline|media)'}
 
   v4l2-decoder-conformance-vp9:
     rootfs: debian_bullseye-gst-fluster_nfs
@@ -712,8 +704,6 @@ test_plans:
       decoder: 'GStreamer-VP9-V4L2SL-Gst1.0'
       videodec_parallel_jobs: '1'
       videodec_timeout: 90
-    filters:
-      - regex: {'tree': '(next|mainline|media)'}
 
   vdso:
     rootfs: debian_bullseye-vdso_nfs
@@ -3286,8 +3276,9 @@ test_configs:
       - v4l2-decoder-conformance-h264
       - v4l2-decoder-conformance-vp8
       - v4l2-decoder-conformance-vp9
-    filters:
+    filters: &chromebook-decoders-filter
       - passlist: {defconfig: ['videodec']}
+      - regex: {'tree': '(next|mainline|media)'}
 
   - device_type: rk3399-puma-haikou
     test_plans:

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -663,6 +663,7 @@ test_plans:
       testsuite: 'AV1-TEST-VECTORS'
       decoder: 'GStreamer-AV1-V4L2SL-Gst1.0'
       videodec_parallel_jobs: '1'
+      videodec_timeout: 90
     filters:
       - regex: {'tree': '(next|mainline|media)'}
 
@@ -674,6 +675,7 @@ test_plans:
       testsuite: 'JVT-AVC_V1'
       decoder: 'GStreamer-H.264-V4L2SL-Gst1.0'
       videodec_parallel_jobs: '1'
+      videodec_timeout: 90
     filters:
       - regex: {'tree': '(next|mainline|media)'}
 
@@ -685,6 +687,7 @@ test_plans:
       testsuite: 'JCT-VC-HEVC-V1'
       decoder: 'GStreamer-H.265-V4L2SL-Gst1.0'
       videodec_parallel_jobs: '1'
+      videodec_timeout: 90
     filters:
       - regex: {'tree': '(next|mainline|media)'}
 
@@ -696,6 +699,7 @@ test_plans:
       testsuite: 'VP8-TEST-VECTORS'
       decoder: 'GStreamer-VP8-V4L2SL-Gst1.0'
       videodec_parallel_jobs: '1'
+      videodec_timeout: 90
     filters:
       - regex: {'tree': '(next|mainline|media)'}
 
@@ -707,6 +711,7 @@ test_plans:
       testsuite: 'VP9-TEST-VECTORS'
       decoder: 'GStreamer-VP9-V4L2SL-Gst1.0'
       videodec_parallel_jobs: '1'
+      videodec_timeout: 90
     filters:
       - regex: {'tree': '(next|mainline|media)'}
 
@@ -1933,8 +1938,6 @@ device_types:
     class: arm64-dtb
     boot_method: depthcharge
     filters: *arm64-chromebook-filters
-    params:
-      videodec_timeout: 90
 
   rk3399-puma-haikou:
     mach: rockchip


### PR DESCRIPTION
Move the kernel tree filter used for the V4L2 decoder conformance tests out of the test plan definitions and specify the reference trees on a per-device basis. Use the same `videodec_timeout` value for all the devices running these decoder tests.