### PR TITLE
build-configs.yaml: Add mt8192 and mt8195 scp firmware to bullseye-g…

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -350,6 +350,8 @@ fragments:
       rockchip/dptx.bin
       qcom/venus-5.4/venus.mdt
       qcom/venus-5.4/venus.mbn
+      mediatek/mt8192/scp.img
+      mediatek/mt8195/scp.img
       "'
 
 


### PR DESCRIPTION
…st-fluster

Add scp firmware for MT8192 and MT8195 platforms to the bullseye-gst-fluster rootfs. This is required to enable V4L2 decoder conformance tests on the asurada and cherry Chromebooks.