### PR TITLE
test-configs.yaml: Expand coverage for i.MX8MP-EVK

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2777,6 +2777,9 @@ test_configs:
   - device_type: imx8mp-evk
     test_plans:
       - baseline
+      - baseline-nfs
+      - igt-gpu-etnaviv
+      - kselftest-alsa
 
   - device_type: imx8mq-zii-ultra-zest
     test_plans:


### PR DESCRIPTION
The i.MX8MP has networking so we can at least cover the baseline-nfs
tests, and the main reason it's in my lab is that it has interesting
audio hardware so run the ALSA selftests too (the audio isn't in the
upstream DT yet but the tests handle this gracefully).

Signed-off-by: Mark Brown <broonie@kernel.org>
