### PR TITLE
install-modules: Enforce root ownership

### DIFF
--- a/config/rootfs/debos/overlays/cros-flash/opt/chromeos/install-modules
+++ b/config/rootfs/debos/overlays/cros-flash/opt/chromeos/install-modules
@@ -53,6 +53,8 @@ install_modules()
         -xf \
         "$root_path/$modules_tarball"
     ls -l lib/modules
+    # Ensure proper permissions and ownership
+    chown -R root:root lib/modules
     cd "$root_path"
     umount "$mount_dir"
     sync


### PR DESCRIPTION
We need to ensure proper ownership, otherwise it might trigger self_repair which might delete persistent partition