### PR TITLE
build_board.sh: Add libsandbox bug workaround

### DIFF
--- a/config/rootfs/chromiumos/scripts/build_board.sh
+++ b/config/rootfs/chromiumos/scripts/build_board.sh
@@ -96,6 +96,13 @@ case ${BOARD} in
     ;;
 esac
 
+# if environment variable SANDBOX_BUG is set, then we need to use sandbox workaround
+# This is very strange floating bug that appears only on some builders
+if [ -n "${SANDBOX_BUG}" ]; then
+  echo "Applying sandbox workaround for Chromium"
+  cros_sdk FEATURES="-usersandbox" USE="tty_console_${SERIAL} pcserial cr50_skip_update -builtin_fw_mali_g57" emerge-${BOARD} chromeos-chrome
+fi
+
 echo "Building packages (${SERIAL})"
 # Disable `builtin_fw_mali_g57` flag as it is not required when `panfrost` is enabled
 cros_sdk USE="tty_console_${SERIAL} pcserial cr50_skip_update -builtin_fw_mali_g57" \


### PR DESCRIPTION
During build of ChromiumOS on certain builders it fail during ChromiumOS build with multiple malloc failure messages. Similar but reported for Gentoo and libsandbox, as workaround they just disable build sandbox feature, and we do the same.