### PR TITLE
build-configs.yaml: Kernel configs for MT8195 Tomato

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -344,6 +344,7 @@ fragments:
       - 'CONFIG_VIDEO_OV02A10=m'
       - 'CONFIG_VIDEO_OV5695=m'
       - 'CONFIG_VIDEO_OV8856=m'
+      - '# CONFIG_ARM_DSU_PMU is not set'
       - 'CONFIG_EXTRA_FIRMWARE="
       mediatek/mt8173/vpu_d.bin
       mediatek/mt8173/vpu_p.bin

--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -345,6 +345,11 @@ fragments:
       - 'CONFIG_VIDEO_OV5695=m'
       - 'CONFIG_VIDEO_OV8856=m'
       - '# CONFIG_ARM_DSU_PMU is not set'
+      - 'CONFIG_CROS_KBD_LED_BACKLIGHT=m'
+      - 'CONFIG_SND_SOC_MT8195=m'
+      - 'CONFIG_SND_SOC_MT8195_MT6359=m'
+      - 'CONFIG_DRM_MEDIATEK_DP=m'
+      - 'CONFIG_SND_SOC_SOF_MT8195=m'
       - 'CONFIG_EXTRA_FIRMWARE="
       mediatek/mt8173/vpu_d.bin
       mediatek/mt8173/vpu_p.bin


### PR DESCRIPTION
Kernel config changes to get MT8195 booting and with full platform support (once missing firmware and kernel series for the display land).

This should land after #1957, as that's the PR enabling baseline tests on MT8195 Tomato in the first place.