### PR TITLE
build-configs-android.yaml: add new 6.1 and 5.15 branches

### DIFF
--- a/config/core/build-configs-android.yaml
+++ b/config/core/build-configs-android.yaml
@@ -168,9 +168,32 @@ build_configs:
     branch: 'android14-5.15'
     variants:
       <<: *android_variants
+      <<: *clang_android_variants
+
+  android14-5.15-lts:
+    tree: android
+    branch: 'android14-5.15-lts'
+    variants:
+      <<: *android_variants
+      <<: *clang_android_variants
 
   android14-6.1:
     tree: android
     branch: 'android14-6.1'
     variants:
       <<: *android_variants
+      <<: *clang_android_variants
+
+  android14-6.1-lts:
+    tree: android
+    branch: 'android14-6.1-lts'
+    variants:
+      <<: *android_variants
+      <<: *clang_android_variants
+
+  android15-6.1:
+    tree: android
+    branch: 'android15-6.1'
+    variants:
+      <<: *android_variants
+      <<: *clang_android_variants


### PR DESCRIPTION
Add the following branches for the Android common kernel as requested by Todd:

- android15-6.1
- android14-6.1-lts
- android14-5.15-lts