### PR TITLE
`kci user` commands for user profiles

### DIFF
--- a/kernelci/api/__init__.py
+++ b/kernelci/api/__init__.py
@@ -141,6 +141,17 @@ class API(abc.ABC):
     ) -> Sequence[dict]:
         """Get user groups that match the provided attributes"""
 
+    # -------------
+    # User profiles
+    # -------------
+
+    @abc.abstractmethod
+    def get_user_profiles(
+        self, attributes: dict,
+        offset: Optional[int] = None, limit: Optional[int] = None
+    ) -> Sequence[dict]:
+        """Get user profiles that match the provided attributes"""
+
     # -------------------------------------------------------------------------
     # Private methods
     #

--- a/kernelci/api/latest.py
+++ b/kernelci/api/latest.py
@@ -147,6 +147,14 @@ class LatestAPI(API):
         return self._get_api_objs(params=params, path='groups',
                                   limit=limit, offset=offset)
 
+    def get_user_profiles(
+        self, attributes: dict,
+        offset: Optional[int] = None, limit: Optional[int] = None
+    ) -> Sequence[dict]:
+        params = attributes.copy() if attributes else {}
+        return self._get_api_objs(params=params, path='users/profile',
+                                  limit=limit, offset=offset)
+
 
 def get_api(config, token):
     """Get an API object for the latest version"""

--- a/kernelci/cli/base.py
+++ b/kernelci/cli/base.py
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2018-2023 Collabora Limited
 # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+# Author: Jeny Sadadia <jeny.sadadia@collabora.com>
 
 """Common definitions for KernelCI command line tools
 
@@ -265,6 +266,15 @@ class Args:  # pylint: disable=too-few-public-methods
         'help': "Path to log file",
     }
 
+    limit = {
+        'name': '--limit',
+        'type': int,
+        'help': """\
+Maximum number of results to retrieve. When set to 0, no limit is used and all
+the matching results are retrieved.""",
+        'default': 10,
+    }
+
     mach = {
         'name': '--mach',
         'help': "Mach name (aka SoC family)",
@@ -284,6 +294,12 @@ class Args:  # pylint: disable=too-few-public-methods
     output = {
         'name': '--output',
         'help': "Path the output directory",
+    }
+
+    offset = {
+        'name': '--offset',
+        'type': int,
+        'help': "Offset for paginated results",
     }
 
     password = {

--- a/kernelci/cli/node.py
+++ b/kernelci/cli/node.py
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2022-2023 Collabora Limited
 # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+# Author: Jeny Sadadia <jeny.sadadia@collabora.com>
 
 """Tool to manage KernelCI API node objects"""
 
@@ -30,20 +31,7 @@ class cmd_get(NodeCommand):  # pylint: disable=invalid-name
 class cmd_find(AttributesCommand):  # pylint: disable=invalid-name
     """Find nodes with arbitrary attributes"""
     opt_args = AttributesCommand.opt_args + [
-        {
-            'name': '--limit',
-            'type': int,
-            'help': """\
-Maximum number of nodes to retrieve. When set to 0, no limit is used and all
-the matching nodes are retrieved.\
-""",
-            'default': 10,
-        },
-        {
-            'name': '--offset',
-            'type': int,
-            'help': "Offset when paginating results with a number of nodes",
-        },
+        Args.limit, Args.offset
     ]
 
     def _api_call(self, api, configs, args):

--- a/kernelci/cli/user.py
+++ b/kernelci/cli/user.py
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2023 Collabora Limited
 # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+# Author: Jeny Sadadia <jeny.sadadia@collabora.com>
 
 """Tool to manage KernelCI API users"""
 
@@ -83,6 +84,32 @@ the matching groups are retrieved.\
         attributes = self._split_attributes(args.attributes)
         groups = api.get_groups(attributes, args.offset, args.limit)
         self._print_json(groups, args.indent)
+        return True
+
+
+class cmd_find_users(AttributesCommand):  # pylint: disable=invalid-name
+    """Find user profiles with arbitrary attributes"""
+    opt_args = AttributesCommand.opt_args + [
+        {
+            'name': '--limit',
+            'type': int,
+            'help': """\
+Maximum number of user profiles to retrieve. When set to 0, no limit is used and all
+the matching profiles are retrieved.\
+""",
+            'default': 10,
+        },
+        {
+            'name': '--offset',
+            'type': int,
+            'help': "Offset when paginating results with a number of profiles",
+        },
+    ]
+
+    def _api_call(self, api, configs, args):
+        attributes = self._split_attributes(args.attributes)
+        profiles = api.get_user_profiles(attributes, args.offset, args.limit)
+        self._print_json(profiles, args.indent)
         return True
 
 

--- a/kernelci/cli/user.py
+++ b/kernelci/cli/user.py
@@ -64,20 +64,7 @@ class cmd_get_group(APICommand):  # pylint: disable=invalid-name
 class cmd_find_groups(AttributesCommand):  # pylint: disable=invalid-name
     """Find user groups with arbitrary attributes"""
     opt_args = AttributesCommand.opt_args + [
-        {
-            'name': '--limit',
-            'type': int,
-            'help': """\
-Maximum number of groups to retrieve. When set to 0, no limit is used and all
-the matching groups are retrieved.\
-""",
-            'default': 10,
-        },
-        {
-            'name': '--offset',
-            'type': int,
-            'help': "Offset when paginating results with a number of groups",
-        },
+        Args.limit, Args.offset
     ]
 
     def _api_call(self, api, configs, args):
@@ -90,20 +77,7 @@ the matching groups are retrieved.\
 class cmd_find_users(AttributesCommand):  # pylint: disable=invalid-name
     """Find user profiles with arbitrary attributes"""
     opt_args = AttributesCommand.opt_args + [
-        {
-            'name': '--limit',
-            'type': int,
-            'help': """\
-Maximum number of user profiles to retrieve. When set to 0, no limit is used and all
-the matching profiles are retrieved.\
-""",
-            'default': 10,
-        },
-        {
-            'name': '--offset',
-            'type': int,
-            'help': "Offset when paginating results with a number of profiles",
-        },
+       Args.limit, Args.offset
     ]
 
     def _api_call(self, api, configs, args):


### PR DESCRIPTION
Fixes https://github.com/kernelci/kernelci-core/issues/2016

Added commands to `kci user` for getting user profiles by attributes.
Newly added sample commands:
```
kci user find_users
kci user find_users --limit 2
kci user find_users profile.username=admin
```
Added pagination related optional arguments to `kernelci.cli.base` as they have been used by multiple commands like `kci node find` and `kci user find_groups`.
Optimized `kci node find` command handler.