### PR TITLE
rootfs-images.yaml: Test new fluster builds

### DIFF
--- a/config/core/rootfs-images.yaml
+++ b/config/core/rootfs-images.yaml
@@ -33,10 +33,10 @@ file_systems:
     type: debian
   debian_bullseye-gst-fluster_nfs:
     boot_protocol: tftp
-    nfs: bullseye-gst-fluster/20230623.0/{arch}/full.rootfs.tar.xz
+    nfs: bullseye-gst-fluster/20230703.0/{arch}/full.rootfs.tar.xz
     params: {}
     prompt: '/ #'
-    ramdisk: bullseye-gst-fluster/20230623.0/{arch}/initrd.cpio.gz
+    ramdisk: bullseye-gst-fluster/20230703.0/{arch}/initrd.cpio.gz
     root_type: nfs
     type: debian
   debian_bullseye-igt_ramdisk:


### PR DESCRIPTION
We need to test new builds of fluster, i built rootfs images manually, as we have many PR pending for weeks.