### PR TITLE
config/docker: fix indentation in GitHub URLs

### DIFF
--- a/config/docker/base/host-tools.jinja2
+++ b/config/docker/base/host-tools.jinja2
@@ -25,9 +25,9 @@ WORKDIR /root/debs
 
 # Get patch to enable compression
 ADD https://raw.githubusercontent.com/kernelci/kernelci-core/\
-    kernelci.org/\
-    config/docker/data/kmod_kci.patch \
-    .
+kernelci.org/\
+config/docker/data/kmod_kci.patch \
+.
 
 # Prepare kmod sources, patch, install dependencies, build
 RUN apt-get source kmod

--- a/config/docker/cros-baseline.jinja2
+++ b/config/docker/cros-baseline.jinja2
@@ -20,9 +20,9 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 {{ super() }}
 
 ADD https://raw.githubusercontent.com/kernelci/kernelci-core/\
-    kernelci.org/\
-    config/rootfs/debos/overlays/baseline/opt/kernelci/dmesg.sh \
-    /home/cros/dmesg.sh
+kernelci.org/\
+config/rootfs/debos/overlays/baseline/opt/kernelci/dmesg.sh \
+/home/cros/dmesg.sh
 
 # Needed by LAVA to install the overlay
 USER root

--- a/config/docker/cros-qemu-modules.jinja2
+++ b/config/docker/cros-qemu-modules.jinja2
@@ -18,9 +18,9 @@ ENV LIBGUESTFS_BACKEND=direct \
     HOME=/root
 
 ADD https://raw.githubusercontent.com/kernelci/kernelci-core/\
-    kernelci.org/\
-    config/docker/data/add_modules.sh \
-    /add_modules.sh
+kernelci.org/\
+config/docker/data/add_modules.sh \
+/add_modules.sh
 
 # Needed by LAVA to install the overlay
 USER root

--- a/config/docker/cros-tast.jinja2
+++ b/config/docker/cros-tast.jinja2
@@ -22,14 +22,14 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 {{ super() }}
 
 ADD https://raw.githubusercontent.com/kernelci/kernelci-core/\
-    kernelci.org/\
-    config/docker/data/tast_parser.py \
-    /home/cros/tast_parser.py
+kernelci.org/\
+config/docker/data/tast_parser.py \
+/home/cros/tast_parser.py
 
 ADD https://raw.githubusercontent.com/kernelci/kernelci-core/\
-    kernelci.org/\
-    config/docker/data/ssh_retry.sh \
-    /home/cros/ssh_retry.sh
+kernelci.org/\
+config/docker/data/ssh_retry.sh \
+/home/cros/ssh_retry.sh
 
 # Needed by LAVA to install the overlay
 USER root

--- a/config/docker/gcc-10-x86.jinja2
+++ b/config/docker/gcc-10-x86.jinja2
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 RUN apt-get update && apt-get install --no-install-recommends -y curl patch
 RUN cd / && \
     curl -s https://raw.githubusercontent.com/kernelci/kernelci-core/\
-    kernelci.org/\
-    config/docker/data/gcc-header-fix.patch \
+kernelci.org/\
+config/docker/data/gcc-header-fix.patch \
     | patch -p1
 {%- endblock %}


### PR DESCRIPTION
Fix indentation in GitHub file URLs wrapped over multiple lines.  The indentation was being added in the middle of the URLs, causing a failure to build the image.

Fixes: 6ea6fcbdce1a ("config/docker: use kernelci.org branch for data files")