### PR TITLE
kci_build: fix missing "meta" variable for GKI builds

### DIFF
--- a/kci_build
+++ b/kci_build
@@ -362,7 +362,7 @@ class cmd_push_kernel(Command):
     args = [Args.kdir, Args.storage_config]
     opt_args = [Args.storage_cred, Args.output]
 
-    def _compress_gki_artifacts(self, install):
+    def _compress_gki_artifacts(self, install, meta):
         # gki_defconfig kernel builds are exceptional and generate hundreds of
         # megabytes in several files.  This requires compression to work around
         # upload limits with kernelci-backend.
@@ -394,7 +394,7 @@ class cmd_push_kernel(Command):
 
         defconfig = meta.get('bmeta', 'kernel', 'defconfig')
         if defconfig == "gki_defconfig":
-            self._compress_gki_artifacts(install)
+            self._compress_gki_artifacts(install, meta)
 
         storage_conf = configs['storage_configs'][args.storage_config]
         storage = kernelci.storage.get_storage(storage_conf, args.storage_cred)


### PR DESCRIPTION
Pass the "meta" variable to _compress_gki_artifacts() so it can get the kernel image name.  This had been failing silently for a while as testing GKI builds isn't always easy.

Fixes: df511e1088c0 ("kci_build: rework push_kernel to use Storage")