### PR TITLE
config/lava: Extend deferred_probe_timeout

### DIFF
--- a/config/lava/base/kernel-ci-base.jinja2
+++ b/config/lava/base/kernel-ci-base.jinja2
@@ -1,4 +1,4 @@
-{% set extra_kernel_args = "console_msg_format=syslog earlycon" %}
+{% set extra_kernel_args = "console_msg_format=syslog earlycon deferred_probe_timeout=60" %}
 
 {%- block metadata %}
 metadata:


### PR DESCRIPTION
The deferred_probe_timeout kernel parameter establishes how long to wait until the remaining devices might start being probed without their dependencies satisfied. Its default value is 10, however I've observed that at least on arm64 platforms, it consistently takes slightly longer, around 13 seconds, from when the timer is started to when udev is run and loads the modules for the remaining devices.

Increase the timeout to 20 seconds in order to give enough time for the machines to boot and probe all devices and their dependencies. This timeout is run in a separate kernel thread, so changing it shouldn't have any impact on the boot time.

Machines that I checked the boot delay on:
mt8192-asurada-spherion: https://lava.collabora.dev/scheduler/job/11063320
mt8195-cherry-tomato: https://lava.collabora.dev/scheduler/job/11063496
rk3399-gru-kevin: https://lava.collabora.dev/scheduler/job/11063571
bcm2711-rpi-4-b: https://lava.collabora.dev/scheduler/job/11073828

(The difference in time from when `deferred_probe_timeout_work_func` is called to the first `module_load` shows how longer the timeout needs to be )

Interestingly, the boot on the x86 machines is much quicker (takes ~5 seconds) eg. on rammus: https://lava.collabora.dev/scheduler/job/11064106.

In any case, this increase won't harm boot time, and will only prevent issues to happen on the machines that take longer to boot. Besides, 20 seconds is still within a reasonable range.

