### PR TITLE
test-configs.yaml: update the filters for v4l2 decoder test configs

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -655,10 +655,10 @@ test_plans:
             - 'defconfig+virtualvideo'
             - 'multi_v7_defconfig+virtualvideo'
 
-  v4l2-decoder-conformance-av1:
+  v4l2-decoder-conformance-av1: &v4l2-decoder-conformance
     rootfs: debian_bullseye-gst-fluster_nfs
     pattern: 'v4l2-decoder-conformance/{category}-{method}-{protocol}-{rootfs}-v4l2-decoder-conformance-template.jinja2'
-    params:
+    params: &v4l2-decoder-conformance-params
       job_timeout: '30'
       testsuite: 'AV1-TEST-VECTORS'
       decoders:
@@ -669,59 +669,39 @@ test_plans:
       - passlist: {defconfig: ['videodec']}
 
   v4l2-decoder-conformance-h264:
-    rootfs: debian_bullseye-gst-fluster_nfs
-    pattern: 'v4l2-decoder-conformance/{category}-{method}-{protocol}-{rootfs}-v4l2-decoder-conformance-template.jinja2'
+    <<: *v4l2-decoder-conformance
     params:
-      job_timeout: '30'
+      <<: *v4l2-decoder-conformance-params
       testsuite: 'JVT-AVC_V1'
       decoders:
         - 'GStreamer-H.264-V4L2-Gst1.0'
         - 'GStreamer-H.264-V4L2SL-Gst1.0'
-      videodec_parallel_jobs: '1'
-      videodec_timeout: 90
-    filters:
-      - passlist: {defconfig: ['videodec']}
 
   v4l2-decoder-conformance-h265:
-    rootfs: debian_bullseye-gst-fluster_nfs
-    pattern: 'v4l2-decoder-conformance/{category}-{method}-{protocol}-{rootfs}-v4l2-decoder-conformance-template.jinja2'
+    <<: *v4l2-decoder-conformance
     params:
-      job_timeout: '30'
+      <<: *v4l2-decoder-conformance-params
       testsuite: 'JCT-VC-HEVC_V1'
       decoders:
         - 'GStreamer-H.265-V4L2-Gst1.0'
         - 'GStreamer-H.265-V4L2SL-Gst1.0'
-      videodec_parallel_jobs: '1'
-      videodec_timeout: 90
-    filters:
-      - passlist: {defconfig: ['videodec']}
 
   v4l2-decoder-conformance-vp8:
-    rootfs: debian_bullseye-gst-fluster_nfs
-    pattern: 'v4l2-decoder-conformance/{category}-{method}-{protocol}-{rootfs}-v4l2-decoder-conformance-template.jinja2'
+    <<: *v4l2-decoder-conformance
     params:
-      job_timeout: '30'
+      <<: *v4l2-decoder-conformance-params
       testsuite: 'VP8-TEST-VECTORS'
       decoders:
         - 'GStreamer-VP8-V4L2-Gst1.0'
         - 'GStreamer-VP8-V4L2SL-Gst1.0'
-      videodec_parallel_jobs: '1'
-      videodec_timeout: 90
-    filters:
-      - passlist: {defconfig: ['videodec']}
 
   v4l2-decoder-conformance-vp9:
-    rootfs: debian_bullseye-gst-fluster_nfs
-    pattern: 'v4l2-decoder-conformance/{category}-{method}-{protocol}-{rootfs}-v4l2-decoder-conformance-template.jinja2'
+    <<: *v4l2-decoder-conformance
     params:
-      job_timeout: '30'
+      <<: *v4l2-decoder-conformance-params
       testsuite: 'VP9-TEST-VECTORS'
       decoders:
         - 'GStreamer-VP9-V4L2SL-Gst1.0'
-      videodec_parallel_jobs: '1'
-      videodec_timeout: 90
-    filters:
-      - passlist: {defconfig: ['videodec']}
 
   vdso:
     rootfs: debian_bullseye-vdso_nfs

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -665,6 +665,8 @@ test_plans:
         - 'GStreamer-AV1-V4L2SL-Gst1.0'
       videodec_parallel_jobs: '1'
       videodec_timeout: 90
+    filters:
+      - passlist: {defconfig: ['videodec']}
 
   v4l2-decoder-conformance-h264:
     rootfs: debian_bullseye-gst-fluster_nfs
@@ -677,6 +679,8 @@ test_plans:
         - 'GStreamer-H.264-V4L2SL-Gst1.0'
       videodec_parallel_jobs: '1'
       videodec_timeout: 90
+    filters:
+      - passlist: {defconfig: ['videodec']}
 
   v4l2-decoder-conformance-h265:
     rootfs: debian_bullseye-gst-fluster_nfs
@@ -689,6 +693,8 @@ test_plans:
         - 'GStreamer-H.265-V4L2SL-Gst1.0'
       videodec_parallel_jobs: '1'
       videodec_timeout: 90
+    filters:
+      - passlist: {defconfig: ['videodec']}
 
   v4l2-decoder-conformance-vp8:
     rootfs: debian_bullseye-gst-fluster_nfs
@@ -701,6 +707,8 @@ test_plans:
         - 'GStreamer-VP8-V4L2SL-Gst1.0'
       videodec_parallel_jobs: '1'
       videodec_timeout: 90
+    filters:
+      - passlist: {defconfig: ['videodec']}
 
   v4l2-decoder-conformance-vp9:
     rootfs: debian_bullseye-gst-fluster_nfs
@@ -712,6 +720,8 @@ test_plans:
         - 'GStreamer-VP9-V4L2SL-Gst1.0'
       videodec_parallel_jobs: '1'
       videodec_timeout: 90
+    filters:
+      - passlist: {defconfig: ['videodec']}
 
   vdso:
     rootfs: debian_bullseye-vdso_nfs

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -3412,6 +3412,7 @@ test_configs:
       - v4l2-decoder-conformance-h264
       - v4l2-decoder-conformance-vp8
       - v4l2-decoder-conformance-vp9
+    filters: *chromebook-decoders-filter
 
   - device_type: sc7180-trogdor-kingoftown-r1
     test_plans:
@@ -3424,6 +3425,7 @@ test_configs:
       - v4l2-decoder-conformance-h264
       - v4l2-decoder-conformance-h265
       - v4l2-decoder-conformance-vp8
+    filters: *chromebook-decoders-filter
 
   - device_type: sc7180-trogdor-lazor-limozeen
     test_plans:
@@ -3444,6 +3446,7 @@ test_configs:
       - v4l2-decoder-conformance-h264
       - v4l2-decoder-conformance-h265
       - v4l2-decoder-conformance-vp8
+    filters: *chromebook-decoders-filter
 
   - device_type: snow
     test_plans:


### PR DESCRIPTION
Update the filters to run the v4l2-decoder-conformance-* tests only on next, mainline and media trees using the common anchor.