### PR TITLE
rootfs-images.yaml: use new bullseye-gst-fluster arm64 image

### DIFF
--- a/config/core/rootfs-images.yaml
+++ b/config/core/rootfs-images.yaml
@@ -33,10 +33,10 @@ file_systems:
     type: debian
   debian_bullseye-gst-fluster_nfs:
     boot_protocol: tftp
-    nfs: bullseye-gst-fluster/20230623.0/{arch}/full.rootfs.tar.xz
+    nfs: bullseye-gst-fluster/20230717.0/{arch}/full.rootfs.tar.xz
     params: {}
     prompt: '/ #'
-    ramdisk: bullseye-gst-fluster/20230623.0/{arch}/initrd.cpio.gz
+    ramdisk: bullseye-gst-fluster/20230717.0/{arch}/initrd.cpio.gz
     root_type: nfs
     type: debian
   debian_bullseye-igt_ramdisk:


### PR DESCRIPTION
The bullseye-gst-fluster rootfs image for arm64 has been rebuilt to extend coverage.  Update the URL accordingly and by hand since rootfs automated updates are currently disabled.