### PR TITLE
qemu: kselftest: remove debug parameter

### DIFF
--- a/config/lava/kselftest/generic-qemu-ramdisk-kselftest-template.jinja2
+++ b/config/lava/kselftest/generic-qemu-ramdisk-kselftest-template.jinja2
@@ -7,5 +7,5 @@
 {% endblock %}
 
 {%- block image_arg %}
-        image_arg: '-kernel {kernel} -append "console={{ console_dev }},115200 root=/dev/ram0 debug verbose {{ extra_kernel_args }}"'
+        image_arg: '-kernel {kernel} -append "console={{ console_dev }},115200 root=/dev/ram0 verbose {{ extra_kernel_args }}"'
 {%- endblock %}


### PR DESCRIPTION
On kselftest jobs for riscV, the debug parameter lead to lot of systemd output and so jobs fail.
Anyway having systemd debug output is not necessry at all and perhaps should be removed for all jobs some day.

Closes: #2008