### PR TITLE
test-configs.yaml: Fix suite name in v4l2-decoder-conformance-h265 plan

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -683,7 +683,7 @@ test_plans:
     pattern: 'v4l2-decoder-conformance/{category}-{method}-{protocol}-{rootfs}-v4l2-decoder-conformance-template.jinja2'
     params:
       job_timeout: '30'
-      testsuite: 'JCT-VC-HEVC-V1'
+      testsuite: 'JCT-VC-HEVC_V1'
       decoders:
         - 'GStreamer-H.265-V4L2-Gst1.0'
         - 'GStreamer-H.265-V4L2SL-Gst1.0'


### PR DESCRIPTION
Fix fluster test suite name in the  v4l2-decoder-conformance-h265 test plan.