### PR TITLE
config/lava: Add missing extra_kernel_args to NFS variants

### DIFF
--- a/config/lava/boot-nfs/generic-depthcharge-tftp-nfs-template.jinja2
+++ b/config/lava/boot-nfs/generic-depthcharge-tftp-nfs-template.jinja2
@@ -3,6 +3,9 @@
 {{ super() }}
 {% endblock %}
 {% block main %}
+{%- if extra_kernel_args %}
+{% do context.update({"extra_kernel_args": extra_kernel_args}) %}
+{% endif %}
 {{ super() }}
 {% endblock %}
 {% block actions %}

--- a/config/lava/boot-nfs/generic-uboot-tftp-nfs-template.jinja2
+++ b/config/lava/boot-nfs/generic-uboot-tftp-nfs-template.jinja2
@@ -3,6 +3,9 @@
 {{ super() }}
 {% endblock %}
 {% block main %}
+{%- if extra_kernel_args %}
+{% do context.update({"extra_kernel_args": extra_kernel_args}) %}
+{% endif %}
 {{ super() }}
 {% endblock %}
 {% block actions %}


### PR DESCRIPTION
The depthcharge and uboot templates add extra_kernel_args to the context only on the ramdisk templates, but not in the NFS ones. Update the NFS templates so they also set the kernel arguments.

Thanks to @crazoes for noticing this issue.

Note that this only syncs the ramdisk and NFS so that they're the same (except for the `nfs/ramdisk` command) for all boot methods. The barebox, grub and ipxe templates don't set the kernel arguments on neither the ramdisk nor the nfs templates, so they're not touched.