### PR TITLE
test-configs.yaml: Fix list of fluster tests on kingoftown Chromebooks

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -3400,8 +3400,8 @@ test_configs:
 #      - kselftest-alsa
 #      - kselftest-tpm2
       - v4l2-decoder-conformance-h264
+      - v4l2-decoder-conformance-h265
       - v4l2-decoder-conformance-vp8
-      - v4l2-decoder-conformance-vp9
     filters: *chromebook-decoders-filter
 
   - device_type: sc7180-trogdor-kingoftown-r1


### PR DESCRIPTION
The formats that can be tested by fluster on trogdor Chromebooks are H.264, H.265 and VP8. Fix the list of fluster decoder test plans accordingly.