### PR TITLE
build-configs.yaml: add entry for chrome-platform-firmware

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -918,6 +918,19 @@ preempt_rt_variants: &preempt_rt_variants
           - 'x86_64_defconfig+preempt_rt+x86-chromebook'
 
 
+chrome_platform_variants: &chrome_platform_variants
+  gcc-10:
+    build_environment: gcc-10
+    architectures:
+      arm: *arm_defconfig
+      arm64:
+        <<: *arm64_defconfig
+        fragments: [arm64-chromebook]
+      x86_64:
+        <<: *x86_64_defconfig
+        fragments: [x86-chromebook]
+
+
 build_configs:
 
   agross:
@@ -1018,17 +1031,12 @@ build_configs:
   chrome-platform:
     tree: chrome-platform
     branch: 'for-kernelci'
-    variants:
-      gcc-10:
-        build_environment: gcc-10
-        architectures:
-          arm: *arm_defconfig
-          arm64:
-            <<: *arm64_defconfig
-            fragments: [arm64-chromebook]
-          x86_64:
-            <<: *x86_64_defconfig
-            fragments: [x86-chromebook]
+    variants: *chrome_platform_variants
+
+  chrome-platform-firmware:
+    tree: chrome-platform
+    branch: 'for-firmware-kernelci'
+    variants: *chrome_platform_variants
 
   clk:
     tree: clk


### PR DESCRIPTION
Add "for-firmware-kernelci" branch for chrome-platform-firmware.

Also move the variants to chrome_platform_variants as it is common for chrome-platform and chrome-platform-firmware.