### PR TITLE
build-configs.yaml: Add guybrush missing firmware files

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -591,6 +591,18 @@ fragments:
       - 'CONFIG_X86_AMD_PLATFORM_DEVICE=y'
       - 'CONFIG_X86_INTEL_LPSS=y'
       - 'CONFIG_EXTRA_FIRMWARE="
+      amdgpu/green_sardine_asd.bin
+      amdgpu/green_sardine_ce.bin
+      amdgpu/green_sardine_sdma.bin
+      amdgpu/green_sardine_dmcub.bin
+      amdgpu/green_sardine_pfp.bin
+      amdgpu/green_sardine_vcn.bin
+      amdgpu/green_sardine_ta.bin
+      amdgpu/green_sardine_dmcub.bin
+      amdgpu/green_sardine_me.bin
+      amdgpu/green_sardine_mec.bin
+      amdgpu/green_sardine_mec2.bin
+      amdgpu/green_sardine_rlc.bin
       amdgpu/raven2_asd.bin
       amdgpu/raven2_ce.bin
       amdgpu/raven2_gpu_info.bin


### PR DESCRIPTION
At current moment amdgpu fails to init, due missing firmware files, for example:
```
3.604417] amdgpu 0000:03:00.0: Direct firmware load for amdgpu/green_sardine_asd.bin failed with error -2
```