### PR TITLE
CHROMEOS rootfs-configs-chromeos.yaml: Add guybrush board

### DIFF
--- a/config/core/rootfs-configs-chromeos.yaml
+++ b/config/core/rootfs-configs-chromeos.yaml
@@ -73,6 +73,14 @@ rootfs_configs:
     arch_list:
       - amd64
 
+  chromiumos-guybrush:
+    rootfs_type: chromiumos
+    board: guybrush
+    branch: release-R114-15437.B
+    serial: ttyS0
+    arch_list:
+      - amd64
+
   chromiumos-hatch:
     rootfs_type: chromiumos
     board: hatch


### PR DESCRIPTION
Add new rootfs type for guybrush board. Already built, tested and deployed rootfs for it.