### PR TITLE
TOML settings: use dotted keys

### DIFF
--- a/kernelci.toml.sample
+++ b/kernelci.toml.sample
@@ -5,8 +5,9 @@
 # are typical ones that shouldn't change in every command line call when used
 # manually for local development purposes.  Any command line argument can have
 # a default value stored in this file.  Components such as databases and labs
-# have their own section too, with a naming convention of the form ["db:db-name"]
-# or ["lab:lab-name"].
+# have their own section too, with a naming convention of the form [db.db-name]
+# or [lab.lab-name]. Make sure to surround sub-section name with "" (double-quotes)
+# if it contains "." (dot) in the name e.g [db."staging.kernelci.org"].
 
 [DEFAULT]
 
@@ -17,20 +18,23 @@
 
 # -- Sample test lab --
 #
-["lab:my-lava-lab"]
+# [lab.my-lava-lab]
 #
 # user = "user-name"
 # lab_token = "1234-5678"
 
 # -- Sample database --
 #
-["db:localhost"]
+[db.localhost]
 #
 # db_token = "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
 # api = "http://192.168.122.1:5001"
 # callback_id = "kernelci-callback-local"
 # callback_url = "http://localhost:5001"
 
+# [db."staging.kernelci.org"]
+
+# db_token = "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
 
 # -- Sample command line defaults --
 

--- a/kernelci/cli/base.py
+++ b/kernelci/cli/base.py
@@ -601,7 +601,7 @@ instead.", file=sys.stderr)
             section_config = self.get(section_config_option)
             if not section_config:
                 return None
-            section = ':'.join([section_name, section_config])
+            section = (section_name, section_config)
         else:
             section = self._section
         return self.get_from_section(section, option, as_list)
@@ -620,6 +620,8 @@ instead.", file=sys.stderr)
         *as_list* is like for .get() for options with multiple values
         """
         if self._deprecated_settings:
+            if isinstance(section, tuple):
+                section = ':'.join([section[0], section[1]])
             if not self._settings.has_option(section, option):
                 return None
             value = self._settings.get(section, option).split()
@@ -627,7 +629,11 @@ instead.", file=sys.stderr)
                 value = value[0]
         else:
             value = None
-            section_data = self._settings.get(section)
+            if isinstance(section, tuple):
+                section_data = self._settings.get(
+                    section[0], {}).get(section[1])
+            else:
+                section_data = self._settings.get(section)
             if section_data:
                 value = section_data.get(option)
             if value is None and self._default_section:

--- a/kernelci/runtime/__init__.py
+++ b/kernelci/runtime/__init__.py
@@ -199,7 +199,7 @@ def get_all_runtimes(runtime_configs, opts):
     *opts* is an Options object loaded from the CLI args and settings file
     """
     for config_name, config in runtime_configs.items():
-        section = ':'.join(('runtime', config_name))
+        section = ('runtime', config_name)
         user, token = (
             opts.get_from_section(section, opt)
             for opt in ('user', 'runtime_token')


### PR DESCRIPTION
The older settings file `.conf` is using `":"` to define sub-section of components such as databases and runtimes e.g. `db:docker-host`. Use dotted keys for these components as it is a more standard way to define child sections in TOML. The syntax is `section_name.section_config` e.g. `db.docker-host`. In case the section configuration has `"."` (dot)
in the name, it needs to be surrounded by `""` (double-quotes) to parse it properly with TOML decoder e.g. `db."staging.kernelci.org"`