### PR TITLE
build-configs.yaml: Drop broken riscv clang-11 config

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -1151,7 +1151,41 @@ build_configs:
       # Minimum version
       clang-11:
         build_environment: clang-11
-        architectures: *arch_clang_configs
+        architectures:
+          arm64:
+            extra_configs:
+# Disabling to reduce load
+#            - 'allmodconfig'
+            - 'allnoconfig'
+            - 'defconfig+CONFIG_ARM64_64K_PAGES=y'
+          arm:
+            base_defconfig: 'multi_v7_defconfig'
+            filters:
+              - regex: {
+
+# Disabling to reduce load
+#                  defconfig: '(?:aspeed_g5_def|multi_v5_def|multi_v7_def|allmod|allno)config',
+                  defconfig: '(?:aspeed_g5_def|multi_v5_def|multi_v7_def|allno)config',
+              }
+            extra_configs:
+              - 'aspeed_g5_defconfig'
+              - 'multi_v5_defconfig'
+# Disabling to reduce load
+#              - 'allmodconfig'
+              - 'allnoconfig'
+          x86_64:
+            base_defconfig: 'x86_64_defconfig'
+            extra_configs:
+# Disabling to reduce load
+#              - 'allmodconfig'
+              - 'allnoconfig'
+          i386:
+            base_defconfig: 'i386_defconfig'
+            extra_configs:
+# Disabling to reduce load
+#              - 'allmodconfig'
+              - 'allnoconfig'
+
       # Latest stable release
       clang-16:
         build_environment: clang-16


### PR DESCRIPTION
The clang-11 toolchain doesn't support riscv but the mainline build config for riscv relies on the standard arch list which is also used for clang-16 and clang-17 which do support riscv.  As a result, some builds were being scheduled with clang-11 for riscv and since the clang-11 build environment config doesn't list riscv there's no translation to the Debian arch name riscv64 causing the build jobs to fail to pull the Docker image (and causing some congestion in Kubernetes as a side-effect).

Fix this by removing riscv from the clang-11 mainline build config.

Fixes: ddb1c84f466f ("build-configs: update riscv_clang_configs")