### PR TITLE
config/runtime: kubernetes: use Azure Files SAS instead of SSH

### DIFF
--- a/config/runtime/base/kubernetes.jinja2
+++ b/config/runtime/base/kubernetes.jinja2
@@ -74,7 +74,11 @@ spec:
 
         - name: KCI_STORAGE_CREDENTIALS
           # FIXME: convert to template parameter
-          value: {{ "/home/kernelci/.ssh/id_rsa_tarball-staging" }}
+          #value: {{ "/home/kernelci/.ssh/id_rsa_tarball-staging" }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ "kci-api-azure-files-sas-staging" }}
+              key: azure-files-sas
 {% block k8s_command %}
         command: ["/bin/sh", "-c"]
 {% endblock %}


### PR DESCRIPTION
Switch the storage credentials to the upload SAS token for Azure Files temporarily.  Ideally this should be done dynamically in the template.