### PR TITLE
CHROMEOS test-configs-chromeos.yaml: Update dtb filename in reference

### DIFF
--- a/config/core/test-configs-chromeos.yaml
+++ b/config/core/test-configs-chromeos.yaml
@@ -823,7 +823,7 @@ device_types:
       reference_kernel:
         image: 'https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-trogdor/20230620.0/arm64/Image'
         modules: 'https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-trogdor/20230620.0/arm64/modules.tar.xz'
-        dtb: 'https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-trogdor/20230620.0/arm64/dtbs/qcom/sc7180-trogdor-kingoftown-r1.dtb'
+        dtb: 'https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-trogdor/20230620.0/arm64/dtbs/qcom/sc7180-trogdor-kingoftown.dtb'
       block_device: detect
 
   sc7180-trogdor-lazor-limozeen_chromeos:


### PR DESCRIPTION
Reference kernel in R114 doesn't use -r1 suffix as in newest kernels in upstream.