### PR TITLE
CHROMEOS tast_parser.py: Raise critical error if tast run fails

### DIFF
--- a/config/docker/cros-sdk.jinja2
+++ b/config/docker/cros-sdk.jinja2
@@ -21,7 +21,11 @@ RUN apt-get update \
         ssh \
         wget
 
-RUN useradd -u 996 -ms /bin/sh cros
+# We have uid conflict with jenkins useradd, WORKAROUND
+RUN userdel -r jenkins || true
+RUN userdel -r buildslave || true
+
+RUN useradd -ou 996 -ms /bin/sh cros
 RUN adduser cros sudo && echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 RUN mkdir -p /home/cros/chromiumos
 RUN chown -R cros /home/cros/chromiumos

--- a/config/docker/cros-tast.jinja2
+++ b/config/docker/cros-tast.jinja2
@@ -22,8 +22,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 {{ super() }}
 
 ADD https://raw.githubusercontent.com/kernelci/kernelci-core/\
-kernelci.org/\
-config/docker/data/tast_parser.py \
+chromeos.kernelci.org/config/docker/data/tast_parser.py \
 /home/cros/tast_parser.py
 
 ADD https://raw.githubusercontent.com/kernelci/kernelci-core/\

--- a/config/docker/data/tast_parser.py
+++ b/config/docker/data/tast_parser.py
@@ -135,7 +135,7 @@ def parse_measurements(results_chart):
 
 
 def main(tests):
-    if (run_tests(tests) != 0):
+    if run_tests(tests) != 0:
         report_lava_critical("Tast tests run_tests failed")
         sys.exit(1)
     json_file = os.path.join(RESULTS_DIR, RESULTS_FILE)

--- a/config/docker/fragment/cros-lava.jinja2
+++ b/config/docker/fragment/cros-lava.jinja2
@@ -5,7 +5,7 @@ RUN \
   useradd cros -d /home/cros && \
   chown cros: -R /home/cros && \
   adduser cros sudo && \
-  echo 'PATH=/home/cros-tast/trunk/chromite/scripts:$PATH' >/home/cros-tast/.profile && \
+  echo 'PATH=/home/cros/trunk/chromite/scripts:$PATH' >/home/cros/.profile && \
   echo "cros ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 USER cros
 ENV HOME=/home/cros


### PR DESCRIPTION
Often tast execution fail and parser quit silently, not even raising error, which leads to hidden failures that are caught too late. This patch fixes that.