### PR TITLE
Add missing abstract method for changing user's password

### DIFF
--- a/kernelci/api/__init__.py
+++ b/kernelci/api/__init__.py
@@ -66,6 +66,10 @@ class API(abc.ABC):
         """Get an encryption hash for a given password"""
 
     @abc.abstractmethod
+    def change_password(self, username: str, current: str, new: str) -> dict:
+        """Change a password for a given user"""
+
+    @abc.abstractmethod
     def create_token(self, username: str, password: str,
                      scopes: Optional[Sequence[str]] = None) -> str:
         """Create a new API token for the current user

--- a/kernelci/api/latest.py
+++ b/kernelci/api/latest.py
@@ -52,6 +52,7 @@ class LatestAPI(API):
         return self._post('/hash', {'password': password}).json()
 
     def change_password(self, username: str, current: str, new: str) -> dict:
+        """Change a password for a given user"""
         return self._post(
             '/password',
             {

--- a/kernelci/api/latest.py
+++ b/kernelci/api/latest.py
@@ -52,7 +52,6 @@ class LatestAPI(API):
         return self._post('/hash', {'password': password}).json()
 
     def change_password(self, username: str, current: str, new: str) -> dict:
-        """Change a password for a given user"""
         return self._post(
             '/password',
             {

--- a/kernelci/cli/user.py
+++ b/kernelci/cli/user.py
@@ -55,11 +55,12 @@ class cmd_change_password(APICommand):  # pylint: disable=invalid-name
     args = APICommand.args + [Args.username]
 
     def _api_call(self, api, configs, args):
-        # TODO(pawiecz): Add a prefix to clarify which password is requested
-        current = getpass.getpass()
-        # TODO(pawiecz): Request new password twice to ensure it has been
-        # typed properly
-        new = getpass.getpass()
+        current = getpass.getpass("Current password: ")
+        new = getpass.getpass("New password: ")
+        retyped = getpass.getpass("Retype new password: ")
+        if new != retyped:
+            print("Sorry, passwords do not match.")
+            return False
         api.change_password(args.username, current, new)
         return True
 

--- a/kernelci/cli/user.py
+++ b/kernelci/cli/user.py
@@ -50,6 +50,20 @@ class cmd_password_hash(APICommand):  # pylint: disable=invalid-name
         return True
 
 
+class cmd_change_password(APICommand):  # pylint: disable=invalid-name
+    """Change a password for a given user"""
+    args = APICommand.args + [Args.username]
+
+    def _api_call(self, api, configs, args):
+        # TODO(pawiecz): Add a prefix to clarify which password is requested
+        current = getpass.getpass()
+        # TODO(pawiecz): Request new password twice to ensure it has been
+        # typed properly
+        new = getpass.getpass()
+        api.change_password(args.username, current, new)
+        return True
+
+
 class cmd_get_group(APICommand):  # pylint: disable=invalid-name
     """Get a user group with a given ID"""
     args = APICommand.args + [Args.group_id]


### PR DESCRIPTION
This addresses concern raised in [#2048](https://github.com/kernelci/kernelci-core/pull/2048#pullrequestreview-1568153072).

Linter will not raise a missing docstring error if it's set in the abstract method.

