### PR TITLE
Add dependencies for cros-codecs CI

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -137,6 +137,21 @@ rootfs_configs:
       - libp11-kit0
       - libunistring2
       - sensible-utils
+    extra_packages:
+      - ca-certificates
+      - libgbm1
+      - libdrm2
+      - libva2
+      - libva-drm2
+      - libwayland-server0
+      - libxau6
+      - libxcb1
+      - libxdmcp6
+      - mesa-va-drivers
+      - python3-requests
+      - python3-yaml
+      - unzip
+      - wget
     script: "scripts/bullseye-gst-fluster.sh"
     test_overlay: "overlays/fluster"
 

--- a/config/rootfs/debos/overlays/fluster/usr/bin/fluster_parser.py
+++ b/config/rootfs/debos/overlays/fluster/usr/bin/fluster_parser.py
@@ -67,7 +67,7 @@ def _load_results_file(filename):
     return ret
 
 
-def _run_fluster(test_suite=None, timeout=None, jobs=None, decoders=None):
+def _run_fluster(test_suite=None, timeout=None, jobs=None, decoders=None, skips=None):
     cmd = ['python3', 'fluster.py', '-ne', 'run',
            '-f', 'junitxml', '-so', RESULTS_FILE]
 
@@ -77,6 +77,9 @@ def _run_fluster(test_suite=None, timeout=None, jobs=None, decoders=None):
         cmd.extend(['-t', timeout])
     if jobs:
         cmd.extend(['-j', jobs])
+    if skips:
+        for index, skip in enumerate(skips):
+            cmd.extend(['-sv', skip] if not index else [skip])
     for index, dec in enumerate(decoders):
         cmd.extend(['-d', dec] if not index else [dec])
 
@@ -93,7 +96,7 @@ def main(args):
         cmd = cmd.fromkeys(cmd, 'echo')
 
     # run fluster tests
-    _run_fluster(args.test_suite, args.timeout, args.jobs, args.decoders)
+    _run_fluster(args.test_suite, args.timeout, args.jobs, args.decoders, args.skip_vectors)
 
     # load test results
     junitxml = _load_results_file(f'{FLUSTER_PATH}/{RESULTS_FILE}')
@@ -128,5 +131,6 @@ if __name__ == '__main__':
     parser.add_argument('-t', '--timeout')
     parser.add_argument('-j', '--jobs')
     parser.add_argument('-d', '--decoders', nargs='+')
+    parser.add_argument('-sv', '--skip-vectors', nargs='+')
     args = parser.parse_args()
     sys.exit(main(args))

--- a/config/rootfs/debos/scripts/bullseye-gst-fluster.sh
+++ b/config/rootfs/debos/scripts/bullseye-gst-fluster.sh
@@ -16,7 +16,8 @@ BUILD_DEPS="\
 	  ca-certificates \
 	  jq \
 	  wget \
-	  unzip
+	  unzip \
+	  software-properties-common
 "
 
 GST_DEPS="\
@@ -34,6 +35,13 @@ apt-mark manual python3 libpython3-stdlib libpython3.9-stdlib python3.9 libglib2
 
 # Get latest meson from pip
 pip3 install meson
+
+if [ "$(uname -m)" == "x86_64" ]; then
+  # Install non-free intel media-driver
+  apt-add-repository -y non-free
+  apt-get update
+  apt-get install -y intel-media-va-driver-non-free
+fi
 
 # Verify if CACHING_SERVICE is reachable by curl, if not, unset it
 if [ ! -z ${CACHING_SERVICE} ]; then


### PR DESCRIPTION
In https://github.com/chromeos/cros-codecs/issues/6, we want to run `cros-codecs` through fluster in LAVA to make sure nothing is broken on each PR.
The idea would be to use the already existing `bullseye-gst-fluster` rootfs in this repository.

To do that some dependencies are added to access the VA device with the rootfs.
This PR also adds `wget` in the rootfs to retrieve the built `ccdec` binary.

Another dependency is `intel-media-va-driver-non-free` from the `non-free` repository on `amd64` as the free version has issues with a lot of the test vectors.

Tests jobs will be submitted by the `cros-codecs` Github action and this rootfs will be downloaded by LAVA for each commit on the repository

The rootfs size deltas are as follow:
|       File        | [Before](https://storage.kernelci.org/images/rootfs/debian/bullseye-gst-fluster/20230703.0/amd64/) |  After  | Delta |
|-------------------|----------------------------------------------------------------------------------------------------|---------|-------|
|full.rootfs.cpio.gz| 310.5 MiB                                                                                          | 328 MiB | 17.5M |
|full.rootfs.tar.xz | 244.1 MiB                                                                                          | 261 MiB | 16.9M |
|rootfs.cpio.gz     | 199.7 MiB                                                                                          | 211 MiB | 11.3M |
|rootfs.ext4.xz     | 254.4 MiB                                                                                          | 266 MiB | 11.6M |

It looks like `amd64` is in the `arch_list` for the `bullseye-gst-fluster` rootfs but the latest builds do not include it (last one to do so is 20230703.0).