### PR TITLE
test-configs.yaml: Limit trees we test on FVP

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1097,7 +1097,7 @@ device_types:
     boot_method: fvp
     filters:
       - passlist: {defconfig: ['defconfig']}
-
+      - regex: {'tree': '^(next|mainline|stable|arm64)$'}
 
   hi6220-hikey:
     mach: hisilicon


### PR DESCRIPTION
The FVP is extremely slow and we've got some quite CPU intensive tests
scheduled for it, including things like the KVM selftests which are very
CPU intensive and end up taking on the order of six hours to run.  Since
we only have a few donated FVPs we're routinely dropping jobs on the
floor, restrict to just running core upstream trees plus the arm64
architecture tree to give us more chance of making it through the jobs
we schedule.  I've included stable but it might need to be removed too
given that we tend to get a lot of stable updates together.

Signed-off-by: Mark Brown <broonie@kernel.org>
