### PR TITLE
CHROMEOS test-configs-chromeos.yaml: Run cros-tast-mm-decode on trogdor

### DIFF
--- a/config/core/test-configs-chromeos.yaml
+++ b/config/core/test-configs-chromeos.yaml
@@ -992,6 +992,7 @@ test_configs:
 
   - device_type: sc7180-trogdor-kingoftown_chromeos
     test_plans:
+      - cros-tast-mm-decode
       - cros-tast-mm-decode-v4l2-stateful-h264
       - cros-tast-mm-decode-v4l2-stateful-hevc
       - cros-tast-mm-decode-v4l2-stateful-vp8
@@ -1007,6 +1008,7 @@ test_configs:
 
   - device_type: sc7180-trogdor-lazor-limozeen_chromeos
     test_plans:
+      - cros-tast-mm-decode
       - cros-tast-mm-decode-v4l2-stateful-h264
       - cros-tast-mm-decode-v4l2-stateful-hevc
       - cros-tast-mm-decode-v4l2-stateful-vp8


### PR DESCRIPTION
Enable the cros-tast-mm-decode test plan on trogdor Chromebooks.