### PR TITLE
CHROMEOS test-configs-chromeos.yaml: add test config for cherry

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -353,6 +353,8 @@ fragments:
       - 'CONFIG_SND_SOC_SOF_MT8195=m'
       # Fix ui.WindowCyclePerf tests on asurada with 6.6
       - 'CONFIG_DEVFREQ_THERMAL=y'
+      # Needed for cherry to be able to run Tast tests on 6.6
+      - 'CONFIG_PHY_MTK_DP=y'
       - 'CONFIG_EXTRA_FIRMWARE="
       mediatek/mt8173/vpu_d.bin
       mediatek/mt8173/vpu_p.bin

--- a/config/core/test-configs-chromeos.yaml
+++ b/config/core/test-configs-chromeos.yaml
@@ -1201,6 +1201,14 @@ test_configs:
 #      - cros-tast-video_qemu
 
   - device_type: mt8195-cherry-tomato-r2_chromeos
+    filters: *mediatek-filter
+    test_plans: *chromebook-arm64-test-plans
+
+  - device_type: mt8195-cherry-tomato-r2_chromeos
+    filters: *collabora-chromeos-kernel-filter
+    test_plans: *chromebook-arm64-test-plans
+
+  - device_type: mt8195-cherry-tomato-r2_chromeos
     filters: *collabora-chromeos-kernel-filter
     test_plans:
       - v4l2-decoder-conformance-h264_chromeos


### PR DESCRIPTION
Tested on upstream 6.6, works as well as for other MTK devices