### PR TITLE
config/docker: helm: add template fragment to install Helm

### DIFF
--- a/config/docker/fragment/helm.jinja2
+++ b/config/docker/fragment/helm.jinja2
@@ -1,0 +1,8 @@
+# -----------------------------------------------------------------------------
+# Helm
+# https://helm.sh/
+#
+
+RUN curl -s \
+    https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 \
+    | /bin/bash

--- a/config/docker/k8s.jinja2
+++ b/config/docker/k8s.jinja2
@@ -6,6 +6,7 @@
 
 {%- set fragments = [
   'fragment/kubernetes.jinja2',
+  'fragment/helm.jinja2',
   'fragment/gcloud.jinja2',
   'fragment/azure-cli.jinja2']
   + fragments
@@ -16,5 +17,6 @@
 {% block packages %}
 {{ super() }}
 RUN apt-get update && apt-get install --no-install-recommends -y \
+    curl \
     wget
 {%- endblock %}


### PR DESCRIPTION
Add a Docker template fragment to install the Helm tool in k8s images. This is useful for deploying new packages such as ingress-nginx and cert-manager for the API deployment in particular.