### PR TITLE
clang-17.jinja2: Fix clang-17 repository

### DIFF
--- a/config/docker/clang-17.jinja2
+++ b/config/docker/clang-17.jinja2
@@ -3,7 +3,7 @@
 {% block packages %}
 {{ super() }}
 RUN wget -q -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-RUN echo 'deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye main' \
+RUN echo 'deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-17 main' \
    >> /etc/apt/sources.list.d/clang.list
 
 RUN apt-get update && apt-get install --no-install-recommends -y \


### PR DESCRIPTION
clang-17 repo name slightly changed, update it