### PR TITLE
[WIP] Enable bpf-next tree build and test

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -22,6 +22,9 @@ trees:
   arnd:
     url: "https://git.kernel.org/pub/scm/linux/kernel/git/arnd/playground.git"
 
+  bpf-next:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git"
+
   broonie-misc:
     url: "https://git.kernel.org/pub/scm/linux/kernel/git/broonie/misc.git"
 
@@ -144,7 +147,6 @@ trees:
 
   weiny2:
     url: "https://github.com/weiny2/linux-kernel"
-
 
 fragments:
 
@@ -360,6 +362,31 @@ fragments:
       mediatek/mt8195/scp.img
       "'
 
+  bpf:
+    path: "kernel/configs/bpf.config"
+    configs:
+      - "CONFIG_BPF=y"
+      - "CONFIG_HAVE_EBPF_JIT=y"
+      - "CONFIG_ARCH_WANT_DEFAULT_BPF_JIT=y"
+      - "CONFIG_BPF_SYSCALL=y"
+      - "CONFIG_BPF_JIT=y"
+      - "CONFIG_BPF_JIT_DEFAULT_ON=y"
+      - "CONFIG_BPF_PRELOAD=y"
+      - "CONFIG_BPF_PRELOAD_UMD=m"
+      - "CONFIG_BPF_LSM=y"
+      - "CONFIG_CGROUP_BPF=y"
+      - "CONFIG_IPV6_SEG6_BPF=y"
+      - "CONFIG_NETFILTER_XT_MATCH_BPF=y"
+      - "CONFIG_BPFILTER=y"
+      - "CONFIG_BPFILTER_UMH=m"
+      - "CONFIG_NET_CLS_BPF=m"
+      - "CONFIG_NET_ACT_BPF=y"
+      - "CONFIG_BPF_STREAM_PARSER=y"
+      - "CONFIG_LWTUNNEL_BPF=y"
+      - "CONFIG_BPF_LIRC_MODE2=y"
+      - "CONFIG_BPF_EVENTS=y"
+      - "CONFIG_BPF_KPROBE_OVERRIDE=y"
+      - "CONFIG_TEST_BPF=m"
 
   crypto:
     path: "kernel/configs/crypto.config"
@@ -936,6 +963,15 @@ chrome_platform_variants: &chrome_platform_variants
         <<: *x86_64_defconfig
         fragments: [x86-chromebook]
 
+bpf_variants: &bpf_variants
+  clang-17:
+    build_environment: clang-17
+    architectures:
+      x86_64:
+        <<: *x86_64_defconfig
+        extra_configs:
+          - "allnoconfig"
+        fragments: [bpf]
 
 build_configs:
 
@@ -982,6 +1018,11 @@ build_configs:
     tree: arnd
     branch: 'to-build'
     variants: *minimal_variants
+
+  bpf-next:
+    tree: bpf-next
+    branch: 'for-next'
+    variants: *bpf_variants
 
   broonie-misc:
     tree: broonie-misc

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -285,6 +285,12 @@ test_plans:
       kselftest_collections: "arm64"
     filters: *kselftest_no_fragment
 
+  kselftest-bpf:
+    <<: *kselftest
+    params:
+      job_timeout: '10'
+      kselftest_collections: "bpf"
+
   kselftest-capabilities:
     <<: *kselftest
     params:

--- a/config/docker/fragment/pahole.jinja2
+++ b/config/docker/fragment/pahole.jinja2
@@ -1,0 +1,19 @@
+ARG PAHOLE_VER=1.25
+ARG SHA256SUM=db31d13c3dad8d9f4e38296bd35c4586e98b9c950e07dabba212985e6d051631
+ARG PAHOLE_TRIPLE=dwarves-${PAHOLE_VER}
+
+RUN apt-get update && apt-get install -y elfutils libelf-dev libdw-dev cmake
+
+# https://lwn.net/Articles/928617/
+RUN wget https://fedorapeople.org/~acme/dwarves/${PAHOLE_TRIPLE}.tar.xz && \
+    wget https://fedorapeople.org/~acme/dwarves/${PAHOLE_TRIPLE}.tar.sign && \
+    tar -xf ${PAHOLE_TRIPLE}.tar.xz -C /tmp/ && \
+    cd /tmp/${PAHOLE_TRIPLE} && \
+    ls /tmp/${PAHOLE_TRIPLE} && \
+    cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -D__LIB=lib . && \
+    make -j$(nproc) && \
+    make install && \
+    rm -rf /tmp/${PAHOLE_TRIPLE} && \
+    rm /${PAHOLE_TRIPLE}*
+
+ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-}:/usr/local/lib


### PR DESCRIPTION
I'd like to enable `bpf-next` tree build and testing on KernelCI. 

BPF subsystem [requires](https://www.kernel.org/doc/readme/tools-testing-selftests-bpf-README.rst) cutting edge `llvm` (comes with clang) and `pahole` (added) to maximize passing tests. I added most of the parts required for build, not sure if I tie them together correctly though.

### Progress
- [x] Configure `bpf-next` tree checkout
- [x] Add llvm + pahole build image
- [x] Add `bpf-next` build config
- [x] Test `bpf-next` build configuration with `kci_build`
- [ ] Configure `bpf-next` kselftest
- [ ] Test `bpf-next` kselftest configuration with `kci_test`

### Testing

1. Build clang-17 + pahole image
```
$ ./kci docker build clang-17 pahole kselftest kernelci --prefix=yurinnick/
$ docker images
REPOSITORY                       TAG                         IMAGE ID       CREATED              SIZE
yurinnick/clang-17               pahole-kselftest-kernelci   50697711d09e   36 seconds ago       1.4GB
```

2. Add `kernelci.toml` config
```
$ cat kernelci.toml
...
[kci_build]
mirror = "bpf-next.git"
kdir = "linux-bpf"
output = "linux-bpf/build-x86"
build_env = "gcc-10"
build_config = "bpf-next"
arch = "x86_64"
j = 13
install = true
...
```

3. Following [kci_build docs](https://kernelci.org/docs/core/kci_build/) build `bpf-next` kernel
```
$ ./kci_build update_mirrot
$ ./kci_build update_repo
$ ./kci_build generate_fragments
$ ./kci_build init_bmeta
$ docker run -it -v $PWD:/home/kernelci yurinnick/clang-17:pahole-kselftest-kernelci /bin/bash
./kci_build make_config --defconfig=x86_64_defconfig+bpf
./kci_build fetch_firmware
./kci_build make_kernel
./kci_build make_modules
``` 