### PR TITLE
CHROMEOS test-configs-chromeos.yaml: Add more tast tests

### DIFF
--- a/config/core/test-configs-chromeos.yaml
+++ b/config/core/test-configs-chromeos.yaml
@@ -112,6 +112,18 @@ test_plans:
         hardware.SensorIioserviceHard
         hardware.SensorLight
         hardware.SensorPresence
+        hardware.SensorActivity
+        graphics.HardwareProbe
+        health.ProbeSensorInfo
+        health.DiagnosticsRun.*
+        health.ProbeAudioHardwareInfo
+        health.ProbeAudioInfo
+        health.ProbeBacklightInfo
+        health.ProbeCPUInfo
+        health.ProbeFanInfo
+        inputs.PhysicalKeyboardKernelMode
+        graphics.KernelConfig
+        graphics.KernelMemory
 
   cros-tast-kernel: &cros-tast-kernel
     <<: *cros-tast-base


### PR DESCRIPTION
We discovered more useful tast tests that can be used for KernelCI.