### PR TITLE
config/lava/boot: add context in generic-qemu-boot-template.jinja2

### DIFF
--- a/config/lava/boot/generic-qemu-boot-template.jinja2
+++ b/config/lava/boot/generic-qemu-boot-template.jinja2
@@ -31,6 +31,12 @@
 {% endblock %}
 {% block actions %}
 
+{% if context %}
+context:
+{% for key, value in context.items() %}  {{ key }}: {{ value }}
+{% endfor %}
+{% endif %}
+
 actions:
 - deploy:
     timeout:


### PR DESCRIPTION
I'm trying to submit job to my local lava lab, met: Job error: Invalid job data: ["2.1.1 execute-qemu: Missing 'arch' in job context"]

![企业微信截图_16932170361436](https://github.com/kernelci/kernelci-core/assets/22901336/9bc0b83c-0c41-4357-a6fb-96bb6ee054c4)

I think arch is needed in job template.