### PR TITLE
config/docker: azure-cli: clean up formatting

### DIFF
--- a/config/docker/fragment/azure-cli.jinja2
+++ b/config/docker/fragment/azure-cli.jinja2
@@ -3,13 +3,14 @@
 # https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-apt
 #
 
-RUN curl -sL https://packages.microsoft.com/keys/microsoft.asc | \
-    gpg --dearmor |  tee /etc/apt/trusted.gpg.d/microsoft.asc.gpg > /dev/null
+RUN curl -sL https://packages.microsoft.com/keys/microsoft.asc \
+    | gpg --dearmor \
+    | tee /etc/apt/trusted.gpg.d/microsoft.asc.gpg > /dev/null
 
 RUN AZ_REPO=bullseye && \
     echo "\
 deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ \
-$AZ_REPO main" | \
-    tee /etc/apt/sources.list.d/azure-cli.list
+$AZ_REPO main" \
+    | tee /etc/apt/sources.list.d/azure-cli.list
 
 RUN apt-get update && apt-get install -y azure-cli


### PR DESCRIPTION
Remove extra whitespace and wrap lines before the pipe | character to make it easier to read and more consistent with the other files.