### PR TITLE
kernelci.api: add missing API bindings for changing user's password

### DIFF
--- a/kernelci/api/__init__.py
+++ b/kernelci/api/__init__.py
@@ -18,7 +18,7 @@ import requests
 import kernelci.config.api
 
 
-class API(abc.ABC):
+class API(abc.ABC):  # pylint: disable=too-many-public-methods
     """Base class for the KernelCI API Python bindings"""
 
     def __init__(self, config: kernelci.config.api.API, token: str):
@@ -64,6 +64,10 @@ class API(abc.ABC):
     @abc.abstractmethod
     def password_hash(self, password: str) -> dict:
         """Get an encryption hash for a given password"""
+
+    @abc.abstractmethod
+    def change_password(self, username: str, current: str, new: str) -> dict:
+        """Change a password for a given user"""
 
     @abc.abstractmethod
     def create_token(self, username: str, password: str,

--- a/kernelci/api/latest.py
+++ b/kernelci/api/latest.py
@@ -52,7 +52,6 @@ class LatestAPI(API):
         return self._post('/hash', {'password': password}).json()
 
     def change_password(self, username: str, current: str, new: str) -> dict:
-        """Change a password for a given user"""
         return self._post(
             '/password',
             {


### PR DESCRIPTION
    Add a missing abstract method entry in the API abstract base class.
    
    Disable the too-many-public-methods pylint checks as the class now has
    too many method to pass.
    
    Fixes: f3227a3b3891 ("kernelci.api.latest: implement method for changing user password")
    Signed-off-by: Paweł Wieczorek <pawiecz@collabora.com>
    Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>
