### PR TITLE
Add support for creating new API users

### DIFF
--- a/kernelci/api/__init__.py
+++ b/kernelci/api/__init__.py
@@ -156,6 +156,10 @@ class API(abc.ABC):  # pylint: disable=too-many-public-methods
     ) -> Sequence[dict]:
         """Get user profiles that match the provided attributes"""
 
+    @abc.abstractmethod
+    def create_user(self, username: str, password: str, profile: dict) -> dict:
+        """Create a new user"""
+
     # -------------------------------------------------------------------------
     # Private methods
     #

--- a/kernelci/api/latest.py
+++ b/kernelci/api/latest.py
@@ -22,7 +22,7 @@ class NodeStates(enum.Enum):
     DONE = 'done'
 
 
-class LatestAPI(API):
+class LatestAPI(API):  # pylint: disable=too-many-public-methods
     """Latest API version
 
     The 'latest' version is used to refer to the current development version,
@@ -166,6 +166,15 @@ class LatestAPI(API):
         params = attributes.copy() if attributes else {}
         return self._get_api_objs(params=params, path='users/profile',
                                   limit=limit, offset=offset)
+
+    def create_user(self, username: str, password: str, profile: dict) -> dict:
+        data = {
+            'password': password,
+        }
+        params = {
+            'email': profile['email'],
+        }
+        return self._post(f'user/{username}', data, params)
 
 
 def get_api(config, token):

--- a/kernelci/cli/user.py
+++ b/kernelci/cli/user.py
@@ -89,6 +89,29 @@ class cmd_find_groups(AttributesCommand):  # pylint: disable=invalid-name
         return True
 
 
+class cmd_add(APICommand):  # pylint: disable=invalid-name
+    """Add a new user account"""
+    args = APICommand.args + [
+        Args.api_token,
+        {
+            'name': 'username',
+            'help': "Username of the new user",
+        },
+        {
+            'name': 'email',
+            'help': "Email address of the new user",
+        },
+    ]
+
+    def _api_call(self, api, configs, args):
+        profile = {
+            'email': args.email,
+        }
+        password = getpass.getpass()
+        api.create_user(args.username, password, profile)
+        return True
+
+
 class cmd_find_users(AttributesCommand):  # pylint: disable=invalid-name
     """Find user profiles with arbitrary attributes"""
     opt_args = AttributesCommand.opt_args + [


### PR DESCRIPTION
Add an API method and `kci user add` command to create new API users.