### PR TITLE
test-configs.yaml: Move decoder tests for trogdor to separate plan

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -3396,6 +3396,9 @@ test_configs:
       - cros-ec
       - kselftest-alsa
       - kselftest-tpm2
+
+  - device_type: sc7180-trogdor-kingoftown
+    test_plans:
       - v4l2-decoder-conformance-h264
       - v4l2-decoder-conformance-h265
       - v4l2-decoder-conformance-vp8
@@ -3408,6 +3411,9 @@ test_configs:
       - cros-ec
       - kselftest-alsa
       - kselftest-tpm2
+
+  - device_type: sc7180-trogdor-kingoftown-r1
+    test_plans:
       - v4l2-decoder-conformance-h264
       - v4l2-decoder-conformance-h265
       - v4l2-decoder-conformance-vp8
@@ -3428,6 +3434,9 @@ test_configs:
       - kselftest-timers
       - kselftest-tpm2
       - usb
+
+  - device_type: sc7180-trogdor-lazor-limozeen
+    test_plans:
       - v4l2-decoder-conformance-h264
       - v4l2-decoder-conformance-h265
       - v4l2-decoder-conformance-vp8

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -3101,7 +3101,6 @@ test_configs:
       - v4l2-decoder-conformance-vp8
       - v4l2-decoder-conformance-vp9
     filters: &chromebook-decoders-filter
-      - passlist: {defconfig: ['videodec']}
       - regex: {'tree': '(next|mainline|media)'}
 
   - device_type: mt8195-cherry-tomato-r2


### PR DESCRIPTION
The decoder conformance tests require the chromebook-decoders-filter, specifically defined for these tests only. Move the tests to a dedicated test plan. This re-enables baseline tests for trogdor Chromebooks on the stable kernel tree.