### PR TITLE
CHROMEOS test-configs-chromeos.yaml: Remove missing tests

### DIFF
--- a/config/core/test-configs-chromeos.yaml
+++ b/config/core/test-configs-chromeos.yaml
@@ -337,9 +337,6 @@ test_plans:
         camera.V4L2.supported_formats
         camera.Suspend
         camera.V4L2
-        graphics.VAAPIUnittest.webp_decoder
-        graphics.VAAPIUnittest.jpeg_decoder
-        graphics.VAAPIUnittest.common
         video.PlatformVAAPIUnittest
         graphics.Clvk.api_tests
         graphics.Clvk.simple_test


### PR DESCRIPTION
Some tests while shown in list - doesn't exist in reality. Remove them, so they dont break testing