### PR TITLE
config/runtime: kubernetes: use early access JWT

### DIFF
--- a/config/runtime/base/kubernetes.jinja2
+++ b/config/runtime/base/kubernetes.jinja2
@@ -69,7 +69,7 @@ spec:
           valueFrom:
             secretKeyRef:
               # FIXME: convert to template parameter
-              name: {{ "kci-api-jwt-staging" }}
+              name: {{ "kci-api-jwt-early-access" }}
               key: token
 
         - name: KCI_STORAGE_CREDENTIALS


### PR DESCRIPTION
Use the early access JWT token rather than the staging one by default. Then staging can have a patch to use the staging one.

This is also a temporary measure until it's all fixed with template parameters.