### PR TITLE
kernelci.cli: kci: fix default value for --indent

### DIFF
--- a/kernelci/cli/base_api.py
+++ b/kernelci/cli/base_api.py
@@ -32,7 +32,7 @@ class APICommand(Command):  # pylint: disable=too-few-public-methods
 
     @classmethod
     def _print_json(cls, data, indent=None):
-        n_indent = 0 if indent is None else int(indent)
+        n_indent = None if indent is None else int(indent)
         print(json.dumps(data, indent=n_indent))
 
     @classmethod


### PR DESCRIPTION
When not providing a value for --indent when a command returns some JSON data, do not indent at all rather than indenting with 0 spaces.

Fixes: de31ee73e926 ("kernelci.cli.base: add ._print_json() helper method")