### PR TITLE
kernelci.cli:kci:catch JSONDecodeError exception

### DIFF
--- a/kernelci/cli/base.py
+++ b/kernelci/cli/base.py
@@ -18,7 +18,7 @@ import os.path
 import sys
 import toml
 
-from requests.exceptions import HTTPError
+from requests.exceptions import HTTPError, JSONDecodeError
 
 import kernelci.config
 
@@ -417,9 +417,12 @@ def catch_http_error(func):
             return func(*args, **kwargs)
         except HTTPError as ex:
             print(ex, file=sys.stderr)
-            detail = ex.response.json().get('detail')
-            if detail:
-                print(detail, file=sys.stderr)
+            try:
+                detail = ex.response.json().get('detail')
+                if detail:
+                    print(detail, file=sys.stderr)
+            except JSONDecodeError:
+                pass
             return False
     return call
 


### PR DESCRIPTION
Reduce error message when `kci` try to request a invalid url, by catch and ignore JSONDecodeError exception.
I'm using a dockerd kernelci-backend, version is 2022.2.0 .

Here is the **new** output with catch and pass `JSONDecodeError`:

![企业微信截图_16940795251081](https://github.com/kernelci/kernelci-core/assets/22901336/d0af7219-7460-4f6e-968d-0771c58f2877)


Compared with the **old** output with `JSONDecodeError` raised, I think this is useless message and may not very friendly to user:

![企业微信截图_16940794794198](https://github.com/kernelci/kernelci-core/assets/22901336/7dc69726-2b60-4aef-8144-6101bb23b5f2)

