### PR TITLE
CHROMEOS test-configs-chromeos.yaml: Update x86 kernel

### DIFF
--- a/config/core/test-configs-chromeos.yaml
+++ b/config/core/test-configs-chromeos.yaml
@@ -536,7 +536,7 @@ device_types:
         rootfs: 'full.rootfs.tar.xz'
         rootfs_compression: 'xz'
       cros_flash_kernel:
-        base_url: 'https://storage.chromeos.kernelci.org/images/kernel/cros---chromeos-6.1-x86_64-chromiumos-x86_64.flavour.config+x86-chromebook/clang-14/'
+        base_url: 'https://storage.chromeos.kernelci.org/images/kernel/cros-20230815-amd64/clang-14/'
         image: 'kernel/bzImage'
         modules: 'modules.tar.xz'
         modules_compression: 'xz'


### PR DESCRIPTION
We need better support of onboard ethernet, we can use one of KernelCI built kernels for that.