### PR TITLE
Tweak format of `kci show` and avoid unnecessary API queries

### DIFF
--- a/kernelci/cli/show.py
+++ b/kernelci/cli/show.py
@@ -64,18 +64,21 @@ class cmd_results(APICommand):  # pylint: disable=invalid-name
             print(fmt.format(key=self._color(key, 'blue'), value=value))
 
     def _dump_results(self, api, node, indent=0, max_depth=0):
-        fmt = f"{{space}}{{name:{64-indent*2}s}}{{result:6}}{{node_id}}"
-        node_id = node['id']
+        fmt = f"{{name:{64-indent*2}s}}{{result:6}}{{node_id}}"
+        name = node['name']
         result = node['result'] or '----'
+        node_id = node['id']
         line = fmt.format(
-            space='  '*indent,
-            name=node['name'],
+            name=name,
             result=result,
             node_id=node_id,
         )
         color = self.COLOR_RESULT.get(result)
         if color:
             line = self._color(line, color)
+        if name == node['group']:
+            line = self._color(line, 'underline')
+        print('  '*indent, end='')
         print(line)
         child_nodes = api.get_nodes({'parent': node_id})
         if max_depth and indent == max_depth:

--- a/kernelci/cli/show.py
+++ b/kernelci/cli/show.py
@@ -80,9 +80,9 @@ class cmd_results(APICommand):  # pylint: disable=invalid-name
             line = self._color(line, 'underline')
         print('  '*indent, end='')
         print(line)
-        child_nodes = api.get_nodes({'parent': node_id})
         if max_depth and indent == max_depth:
             return
+        child_nodes = api.get_nodes({'parent': node_id})
         for child in child_nodes:
             self._dump_results(api, child, indent+1, max_depth)
 

--- a/kernelci/cli/show.py
+++ b/kernelci/cli/show.py
@@ -64,12 +64,12 @@ class cmd_results(APICommand):  # pylint: disable=invalid-name
             print(fmt.format(key=self._color(key, 'blue'), value=value))
 
     def _dump_results(self, api, node, indent=0, max_depth=0):
-        fmt = f"{{space}}{{path:{64-indent*2}s}}{{result:6}}{{node_id}}"
+        fmt = f"{{space}}{{name:{64-indent*2}s}}{{result:6}}{{node_id}}"
         node_id = node['id']
         result = node['result'] or '----'
         line = fmt.format(
             space='  '*indent,
-            path='.'.join(node['path']),
+            name=node['name'],
             result=result,
             node_id=node_id,
         )


### PR DESCRIPTION
Add underlines for each job (or group of results) and only show the node names rather than the full path to improve readability.  Also avoid doing queries to get child nodes when the maximum recursion depth has been reached.

![image](https://github.com/kernelci/kernelci-core/assets/3894008/7b516e6e-0050-4d4e-af4d-9c293e61b11f)
