### PR TITLE
CHROMEOS test-configs-chromeos.yaml: Update bullseye to bookworm in flash rootfs

### DIFF
--- a/config/core/test-configs-chromeos.yaml
+++ b/config/core/test-configs-chromeos.yaml
@@ -546,7 +546,7 @@ device_types:
       - passlist: {defconfig: ['chromeos-amd-stoneyridge']}
     params: &chromebook-generic-params
       cros_flash_nfs:
-        base_url: 'https://storage.chromeos.kernelci.org/images/rootfs/debian/bullseye-cros-flash/20230717.0/amd64/'
+        base_url: 'https://storage.chromeos.kernelci.org/images/rootfs/debian/bookworm-cros-flash/20230915.0/amd64/'
         initrd: 'initrd.cpio.gz'
         initrd_compression: 'gz'
         rootfs: 'full.rootfs.tar.xz'
@@ -855,7 +855,7 @@ device_types:
     filters: [blocklist: {}]
     params: &chromebook-arm64-params
       cros_flash_nfs:
-        base_url: 'https://storage.chromeos.kernelci.org/images/rootfs/debian/bullseye-cros-flash/20230717.0/arm64/'
+        base_url: 'https://storage.chromeos.kernelci.org/images/rootfs/debian/bookworm-cros-flash/20230915.0/arm64/'
         initrd: 'initrd.cpio.gz'
         initrd_compression: 'gz'
         rootfs: 'full.rootfs.tar.xz'


### PR DESCRIPTION
Flash rootfs is used to install modules and for ChromeOS imaging. Let's try newer distro, as also we need newer ext4 tools.