### PR TITLE
Revert "test-configs.yaml: block minnowboard-turbot in lab-collabora"

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1583,8 +1583,6 @@ device_types:
     mach: x86
     arch: x86_64
     boot_method: grub
-    filters:
-      - blocklist: {lab: ['lab-collabora']}
 
   mt8173-elm-hana:
     mach: mediatek


### PR DESCRIPTION
This reverts commit 642c5d3fb715e57cad6816c874cd587645263c0c.

Enable minnowboard-turbot again in lab-collabora as other projects have stopped running tests on it so it has more capacity again.