### PR TITLE
kernelci.cli: storage: always print the artifact URL

### DIFF
--- a/kernelci/cli/storage.py
+++ b/kernelci/cli/storage.py
@@ -25,7 +25,6 @@ class cmd_upload(Command):  # pylint: disable=invalid-name
     opt_args = Command.opt_args + [
         Args.storage_cred,
         Args.upload_path,
-        Args.verbose,
     ]
 
     def __call__(self, configs, args):
@@ -38,8 +37,7 @@ class cmd_upload(Command):  # pylint: disable=invalid-name
                 (file_path, os.path.basename(file_path)),
                 args.upload_path or ''
             )
-            if args.verbose:
-                print(url)
+            print(url)
 
 
 def main(args=None):


### PR DESCRIPTION
Always print the URL of the uploaded artifact as otherwise there may not be any easy way to find it again later.

Fixes: c514b5884e44 ("kernelci.cli.storage: add command to upload files etc.")