### PR TITLE
Revert "test-configs.yaml: reduce coverage to bare minimal"

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2288,26 +2288,22 @@ test_configs:
   - device_type: acer-cb317-1h-c3z6-dedede
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
+      - baseline-nfs
 
   - device_type: acer-cbv514-1h-34uz-brya
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
+      - baseline-nfs
 
   - device_type: acer-chromebox-cxi4-puff
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
+      - baseline-nfs
 
   - device_type: acer-cp514-3wh-r0qs-guybrush
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
+      - baseline-nfs
 
   - device_type: alpine-db
     test_plans:
@@ -2389,30 +2385,25 @@ test_configs:
       - baseline
       - baseline-nfs
       - kselftest-alsa
-# Disabling to reduce load
-#      - kselftest-cpufreq
-#      - kselftest-lkdtm
-#      - kselftest-seccomp
+      - kselftest-cpufreq
+      - kselftest-lkdtm
+      - kselftest-seccomp
       - ltp-fcntl-locktests
-# Disabling to reduce load
-#      - ltp-pty
-#      - ltp-timers
+      - ltp-pty
+      - ltp-timers
 
   - device_type: asus-C436FA-Flip-hatch
     test_plans:
       - baseline
       - baseline-nfs
-# Disabling to reduce load
-#      - kselftest-alsa
-#      - kselftest-cpufreq
+      - kselftest-alsa
+      - kselftest-cpufreq
       - kselftest-filesystems
-# Disabling to reduce load
-#      - kselftest-futex
-#      - kselftest-rtc
+      - kselftest-futex
+      - kselftest-rtc
       - ltp-ipc
-# Disabling to reduce load
-#      - ltp-mm
-#      - ltp-timers
+      - ltp-mm
+      - ltp-timers
 
   - device_type: asus-C523NA-A20057-coral
     test_plans:
@@ -2420,23 +2411,20 @@ test_configs:
       - baseline-nfs
       - cros-ec
       - igt-gpu-i915
-# Disabling to reduce load
-#      - kselftest-alsa
+      - kselftest-alsa
       - kselftest-cpufreq
-# Disabling to reduce load
-#      - kselftest-filesystems
-#      - kselftest-futex
-#      - kselftest-lib
-#      - kselftest-lkdtm
-#      - kselftest-seccomp
+      - kselftest-filesystems
+      - kselftest-futex
+      - kselftest-lib
+      - kselftest-lkdtm
+      - kselftest-seccomp
       - ltp-crypto
-# Disabling to reduce load
-#      - ltp-fcntl-locktests
-#      - ltp-ima
-#      - ltp-ipc
-#      - ltp-mm
-#      - ltp-pty
-#      - ltp-timers
+      - ltp-fcntl-locktests
+      - ltp-ima
+      - ltp-ipc
+      - ltp-mm
+      - ltp-pty
+      - ltp-timers
       - preempt-rt
       - sleep_mem
       - smc
@@ -2444,23 +2432,20 @@ test_configs:
   - device_type: asus-CM1400CXA-dalboz
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
-#      - kselftest-cpufreq
+      - baseline-nfs
+      - kselftest-cpufreq
 
   - device_type: asus-cx9400-volteer
     test_plans:
       - baseline
       - baseline-nfs
       - cros-ec
-# Disabling to reduce load
-#      - kselftest-alsa
-#      - kselftest-cpufreq
+      - kselftest-alsa
+      - kselftest-cpufreq
       - kselftest-lib
-# Disabling to reduce load
-#      - kselftest-mm
-#      - kselftest-vm
-#      - ltp-ipc
+      - kselftest-mm
+      - kselftest-vm
+      - ltp-ipc
 
   - device_type: at91-sama5d2_xplained
     test_plans:
@@ -2473,8 +2458,7 @@ test_configs:
   - device_type: at91sam9g20ek
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
+      - baseline-nfs
 
   - device_type: bcm2711-rpi-4-b
     test_plans:
@@ -2485,14 +2469,12 @@ test_configs:
   - device_type: bcm2835-rpi-b-rev2
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
+      - baseline-nfs
 
   - device_type: bcm2836-rpi-2-b
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - ltp-crypto
+      - ltp-crypto
       - sleep
       - usb
 
@@ -2513,37 +2495,33 @@ test_configs:
     test_plans:
       - baseline
       - baseline-nfs
-# Disabling to reduce load
-#      - kselftest-alsa
+      - kselftest-alsa
       - kselftest-capabilities
-# Disabling to reduce load
-#      - kselftest-cgroup
-#      - kselftest-clone3
-#      - kselftest-exec
-#      - kselftest-filesystems
-#      - kselftest-futex
-#      - kselftest-kcmp
-#      - kselftest-lib
-#      - kselftest-membarrier
-#      - kselftest-mincore
-#      - kselftest-openat2
-#      - kselftest-seccomp
-#      - kselftest-sigaltstack
-#      - kselftest-timers
-#      - ltp-crypto
+      - kselftest-cgroup
+      - kselftest-clone3
+      - kselftest-exec
+      - kselftest-filesystems
+      - kselftest-futex
+      - kselftest-kcmp
+      - kselftest-lib
+      - kselftest-membarrier
+      - kselftest-mincore
+      - kselftest-openat2
+      - kselftest-seccomp
+      - kselftest-sigaltstack
+      - kselftest-timers
+      - ltp-crypto
       - ltp-dio
-# Disabling to reduce load
-#      - ltp-fsx
-#      - ltp-io
-#      - ltp-ipc
-#      - ltp-smoketest
+      - ltp-fsx
+      - ltp-io
+      - ltp-ipc
+      - ltp-smoketest
       - preempt-rt
       - vdso
 
   - device_type: cubietruck
     test_plans:
       - baseline
-# Disabling to reduce load
       - baseline-nfs
 
   - device_type: d03
@@ -2561,22 +2539,19 @@ test_configs:
   - device_type: dell-latitude-5400-4305U-sarien
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
-#      - kselftest-cpufreq
+      - baseline-nfs
+      - kselftest-cpufreq
 
   - device_type: dell-latitude-5400-8665U-sarien
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
-#      - kselftest-cpufreq
+      - baseline-nfs
+      - kselftest-cpufreq
 
   - device_type: dove-cubox
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
+      - baseline-nfs
       - sleep
 
   - device_type: dra7-evm
@@ -2620,8 +2595,7 @@ test_configs:
   - device_type: hi6220-hikey
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
+      - baseline-nfs
 
   - device_type: hifive-unleashed-a00
     test_plans:
@@ -2651,45 +2625,40 @@ test_configs:
       - baseline-nfs
       - cros-ec
       - igt-gpu-amd
-# Disabling to reduce load
-#      - kselftest-alsa
-#      - kselftest-filesystems
-#      - kselftest-futex
+      - kselftest-alsa
+      - kselftest-filesystems
+      - kselftest-futex
       - kselftest-lib
-# Disabling to reduce load
-#      - kselftest-livepatch
-#      - kselftest-lkdtm
-#      - kselftest-mm
-#      - kselftest-rtc
-#      - kselftest-seccomp
-#      - kselftest-tpm2
-#      - kselftest-vm
-#      - ltp-crypto
-#      - ltp-fcntl-locktests
-#      - ltp-ipc
+      - kselftest-livepatch
+      - kselftest-lkdtm
+      - kselftest-mm
+      - kselftest-rtc
+      - kselftest-seccomp
+      - kselftest-tpm2
+      - kselftest-vm
+      - ltp-crypto
+      - ltp-fcntl-locktests
+      - ltp-ipc
       - ltp-mm
-# Disabling to reduce load
-#      - ltp-pty
-#      - ltp-timers
-#      - preempt-rt
+      - ltp-pty
+      - ltp-timers
+      - preempt-rt
       - sleep
       - smc
 
   - device_type: hp-14-db0003na-grunt
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
-#      - kselftest-cpufreq
+      - baseline-nfs
+      - kselftest-cpufreq
 
   - device_type: hp-x360-14-G1-sona
     test_plans:
       - baseline
       - baseline-nfs
       - cros-ec
-# Disabling to reduce load
-#      - kselftest-alsa
-#      - kselftest-cpufreq
+      - kselftest-alsa
+      - kselftest-cpufreq
       - kselftest-landlock
 
   - device_type: hp-x360-12b-ca0500na-n4000-octopus
@@ -2698,31 +2667,28 @@ test_configs:
       - baseline-nfs
       - cros-ec
       - igt-gpu-i915
-# Disabling to reduce load
-#      - kselftest-lib
+      - kselftest-lib
 
   - device_type: hp-x360-12b-ca0010nr-n4020-octopus
     test_plans:
       - baseline
       - baseline-nfs
       - cros-ec
-# Disabling to reduce load
-#      - igt-gpu-i915
-#      - kselftest-filesystems
-#      - kselftest-futex
-#      - kselftest-lib
-#      - ltp-crypto
-#      - ltp-ipc
-#      - ltp-mm
+      - igt-gpu-i915
+      - kselftest-filesystems
+      - kselftest-futex
+      - kselftest-lib
+      - ltp-crypto
+      - ltp-ipc
+      - ltp-mm
       - sleep_mem
       - smc
 
   - device_type: hp-x360-14a-cb0001xx-zork
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
-#      - kselftest-cpufreq
+      - baseline-nfs
+      - kselftest-cpufreq
 
   - device_type: hsdk
     test_plans:
@@ -2735,47 +2701,40 @@ test_configs:
   - device_type: imx23-olinuxino
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
+      - baseline-nfs
       - sleep
 
   - device_type: imx27-phytec-phycard-s-rdk
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
+      - baseline-nfs
       - sleep
 
   - device_type: imx28-duckbill
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
+      - baseline-nfs
       - sleep
 
   - device_type: imx53-qsrb
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
+      - baseline-nfs
       - sleep
 
   - device_type: imx6dl-riotboard
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
+      - baseline-nfs
       - sleep
 
   - device_type: imx6dl-udoo
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
+      - baseline-nfs
       - igt-gpu-etnaviv
-# Disabling to reduce load
-#      - kselftest-alsa
-#      - ltp-crypto
+      - kselftest-alsa
+      - ltp-crypto
 
   - device_type: imx6q-nitrogen6x
     test_plans:
@@ -2785,13 +2744,11 @@ test_configs:
     test_plans:
       - baseline
       - baseline-nfs
-# Disabling to reduce load
-#      - kselftest-filesystems
-#      - kselftest-lib
+      - kselftest-filesystems
+      - kselftest-lib
       - kselftest-livepatch
-# Disabling to reduce load
-#      - kselftest-lkdtm
-#      - kselftest-seccomp
+      - kselftest-lkdtm
+      - kselftest-seccomp
 
   - device_type: imx6q-sabrelite
     test_plans:
@@ -2809,9 +2766,8 @@ test_configs:
       - baseline
       - baseline-nfs
       - igt-gpu-etnaviv
-# Disabling to reduce load
-#      - kselftest-alsa
-#      - ltp-crypto
+      - kselftest-alsa
+      - ltp-crypto
 
   - device_type: imx6q-var-dt6customboard
     test_plans:
@@ -2840,8 +2796,7 @@ test_configs:
   - device_type: imx6ul-pico-hobbit
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
+      - baseline-nfs
       - sleep
 
   - device_type: imx6ull-14x14-evk
@@ -2871,10 +2826,9 @@ test_configs:
   - device_type: imx8mp-evk
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
-#      - igt-gpu-etnaviv
-#      - kselftest-alsa
+      - baseline-nfs
+      - igt-gpu-etnaviv
+      - kselftest-alsa
 
   - device_type: imx8mp-verdin-nonwifi-dahlia
     test_plans:
@@ -2891,8 +2845,7 @@ test_configs:
   - device_type: jetson-tk1
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
+      - baseline-nfs
 
   - device_type: jh7100-starfive-visionfive-v1
     test_plans:
@@ -2901,12 +2854,11 @@ test_configs:
   - device_type: juno-uboot
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
-#      - kselftest-cpufreq
-#      - ltp-crypto
+      - baseline-nfs
+      - kselftest-cpufreq
+      - ltp-crypto
       # ltp-mm - runs system out of memory
-#      - smc
+      - smc
 
   - device_type: k3-am625-sk
     test_plans:
@@ -2923,50 +2875,42 @@ test_configs:
   - device_type: kirkwood-db-88f6282
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
+      - baseline-nfs
 
   - device_type: kirkwood-openblocks_a7
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
+      - baseline-nfs
 
   - device_type: kontron-bl-imx8mm
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
+      - baseline-nfs
 
   - device_type: kontron-kbox-a-230-ls
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
+      - baseline-nfs
 
   - device_type: kontron-kswitch-d10-mmt-6g-2gs
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
+      - baseline-nfs
 
   - device_type: kontron-kswitch-d10-mmt-8g
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
+      - baseline-nfs
 
   - device_type: kontron-pitx-imx8m
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
+      - baseline-nfs
 
   - device_type: kontron-sl28-var3-ads2
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
+      - baseline-nfs
 
   - device_type: lenovo-hr330a-7x33cto1ww-emag
     test_plans:
@@ -2975,9 +2919,8 @@ test_configs:
   - device_type: lenovo-TPad-C13-Yoga-zork
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
-#      - kselftest-cpufreq
+      - baseline-nfs
+      - kselftest-cpufreq
 
   - device_type: meson-g12a-sei510
     test_plans:
@@ -2995,20 +2938,17 @@ test_configs:
     test_plans:
       - baseline
       - baseline-nfs
-# Disabling to reduce load
-#      - kselftest-cpufreq
-#      - kselftest-filesystems
+      - kselftest-cpufreq
+      - kselftest-filesystems
       - kselftest-futex
-# Disabling to reduce load
-#      - kselftest-lib
+      - kselftest-lib
 
   - device_type: meson-g12b-odroid-n2
     test_plans:
       - baseline
       - baseline-nfs
       - kselftest-arm64
-# Disabling to reduce load
-#      - kselftest-lib
+      - kselftest-lib
 
   - device_type: meson-gxbb-nanopi-k2
     test_plans:
@@ -3042,34 +2982,29 @@ test_configs:
     test_plans:
       - baseline
       - baseline-nfs
-# Disabling to reduce load
-#      - kselftest-alsa
-#      - kselftest-arm64
-#      - kselftest-cpufreq
-#      - kselftest-futex
+      - kselftest-alsa
+      - kselftest-arm64
+      - kselftest-cpufreq
+      - kselftest-futex
       - kselftest-kvm
-# Disabling to reduce load
-#      - kselftest-lib
-#      - kselftest-seccomp
-#      - ltp-crypto
-#      - ltp-fcntl-locktests
-#      - ltp-ipc
+      - kselftest-lib
+      - kselftest-seccomp
+      - ltp-crypto
+      - ltp-fcntl-locktests
+      - ltp-ipc
       # ltp-mm - Runs board out of memory
       - ltp-pty
-# Disabling to reduce load
-#      - ltp-timers
+      - ltp-timers
 
   - device_type: meson-gxm-khadas-vim2
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
+      - baseline-nfs
 
   - device_type: meson-gxm-q200
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
+      - baseline-nfs
 
   - device_type: meson-sm1-khadas-vim3l
     test_plans:
@@ -3087,9 +3022,8 @@ test_configs:
   - device_type: minnowboard-max-E3825
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
-#      - kselftest-alsa
+      - baseline-nfs
+      - kselftest-alsa
 
   - device_type: minnowboard-turbot-E3826
     test_plans:
@@ -3101,28 +3035,25 @@ test_configs:
       - baseline-nfs
       - cros-ec
       - igt-kms-mediatek
-# Disabling to reduce load
-#      - kselftest-arm64
-#      - kselftest-cpufreq
-#      - kselftest-filesystems
-#      - kselftest-futex
-#      - kselftest-lib
-#      - kselftest-livepatch
-#      - kselftest-lkdtm
-#      - kselftest-rtc
+      - kselftest-arm64
+      - kselftest-cpufreq
+      - kselftest-filesystems
+      - kselftest-futex
+      - kselftest-lib
+      - kselftest-livepatch
+      - kselftest-lkdtm
+      - kselftest-rtc
       - kselftest-seccomp
-# Disabling to reduce load
-#      - kselftest-tpm2
+      - kselftest-tpm2
       - lc-compliance
-# Disabling to reduce load
-#      - ltp-crypto
-#      - ltp-fcntl-locktests
-#      - ltp-ipc
-#      - ltp-mm
-#      - ltp-pty
-#      - ltp-timers
-#      - preempt-rt
-#      - sleep
+      - ltp-crypto
+      - ltp-fcntl-locktests
+      - ltp-ipc
+      - ltp-mm
+      - ltp-pty
+      - ltp-timers
+      - preempt-rt
+      - sleep
       - v4l2-compliance-uvc
 
   - device_type: mt8183-kukui-jacuzzi-juniper-sku16
@@ -3132,13 +3063,12 @@ test_configs:
       - cros-ec
       - igt-gpu-panfrost
       - igt-kms-mediatek
-# Disabling to reduce load
-#      - kselftest-alsa
-#      - kselftest-arm64
-#      - kselftest-cpufreq
-#      - kselftest-lkdtm
-#      - kselftest-rtc
-#      - kselftest-seccomp
+      - kselftest-alsa
+      - kselftest-arm64
+      - kselftest-cpufreq
+      - kselftest-lkdtm
+      - kselftest-rtc
+      - kselftest-seccomp
       - kselftest-tpm2
       - lc-compliance
       - preempt-rt
@@ -3150,23 +3080,20 @@ test_configs:
       - baseline
       - baseline-nfs
       - cros-ec
-# Disabling to reduce load
-#      - igt-gpu-panfrost
-#      - igt-kms-mediatek
-#      - kselftest-alsa
-#      - kselftest-arm64
-#      - kselftest-cpufreq
-#      - kselftest-lkdtm
-#      - kselftest-rtc
+      - igt-gpu-panfrost
+      - igt-kms-mediatek
+      - kselftest-alsa
+      - kselftest-arm64
+      - kselftest-cpufreq
+      - kselftest-lkdtm
+      - kselftest-rtc
       - kselftest-seccomp
-# Disabling to reduce load
-#      - kselftest-tpm2
-#      - lc-compliance
+      - kselftest-tpm2
+      - lc-compliance
       - preempt-rt
       - sleep
       - v4l2-compliance-mtk-vcodec-enc
-# Disabling to reduce load
-#      - v4l2-compliance-uvc
+      - v4l2-compliance-uvc
 
   - device_type: mt8192-asurada-spherion-r0
     test_plans:
@@ -3188,8 +3115,7 @@ test_configs:
   - device_type: mustang
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
+      - baseline-nfs
 
   - device_type: odroid-x2
     test_plans:
@@ -3209,8 +3135,7 @@ test_configs:
   - device_type: orion5x-rd88f5182-nas
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
+      - baseline-nfs
 
   - device_type: panda
     test_plans:
@@ -3230,20 +3155,19 @@ test_configs:
   - device_type: qcom-qdf2400
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - kselftest-filesystems
-#      - kselftest-futex
-#      - kselftest-kvm
-#      - kselftest-lib
-#      - kselftest-lkdtm
-#      - kselftest-seccomp
-#      - ltp-crypto
-#      - ltp-fcntl-locktests
-#      - ltp-ima
-#      - ltp-ipc
-#      - ltp-mm
-#      - ltp-pty
-#      - ltp-timers
+      - kselftest-filesystems
+      - kselftest-futex
+      - kselftest-kvm
+      - kselftest-lib
+      - kselftest-lkdtm
+      - kselftest-seccomp
+      - ltp-crypto
+      - ltp-fcntl-locktests
+      - ltp-ima
+      - ltp-ipc
+      - ltp-mm
+      - ltp-pty
+      - ltp-timers
 
   - device_type: qemu_arm-versatilepb
     test_plans:
@@ -3344,23 +3268,20 @@ test_configs:
     test_plans:
       - baseline
       - baseline-nfs
-# Disabling to reduce load
-#      - kselftest-filesystems
-#      - kselftest-futex
-#      - kselftest-lib
-#      - kselftest-lkdtm
-#      - kselftest-seccomp
-#      - ltp-crypto
-#      - ltp-fcntl-locktests
+      - kselftest-filesystems
+      - kselftest-futex
+      - kselftest-lib
+      - kselftest-lkdtm
+      - kselftest-seccomp
+      - ltp-crypto
+      - ltp-fcntl-locktests
       - ltp-ima
-# Disabling to reduce load
-#      - ltp-ipc
-#      - ltp-mm
-#      - ltp-pty
-#      - ltp-timers
+      - ltp-ipc
+      - ltp-mm
+      - ltp-pty
+      - ltp-timers
       - preempt-rt
-# Disabling to reduce load
-#      - smc
+      - smc
 
   - device_type: r8a774b1-hihope-rzg2n-ex
     test_plans:
@@ -3377,8 +3298,7 @@ test_configs:
   - device_type: r8a7795-salvator-x
     test_plans: &r8a7795-salvator-x_test-plans
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
+      - baseline-nfs
       # kselftest-alsa - Lab networking issue
 
   - device_type: r8a77950-salvator-x  # same as r8a7795-salvator-x
@@ -3394,8 +3314,7 @@ test_configs:
   - device_type: r8a779m1-ulcb
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
+      - baseline-nfs
 
   - device_type: rk3288-rock2-square
     test_plans:
@@ -3408,8 +3327,7 @@ test_configs:
   - device_type: rk3328-rock64
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
+      - baseline-nfs
       # kselftest-alsa - lab stability/availability issue
 
   - device_type: rk3399-gru-kevin
@@ -3417,15 +3335,14 @@ test_configs:
       - baseline
       - baseline-nfs
       - cros-ec
-# Disabling to reduce load
-#      - kselftest-alsa
-#      - kselftest-rtc
-#      - ltp-fcntl-locktests
-#      - ltp-pty
-#      - ltp-timers
-#      - sleep
-#      - smc
-#      - v4l2-compliance-uvc
+      - kselftest-alsa
+      - kselftest-rtc
+      - ltp-fcntl-locktests
+      - ltp-pty
+      - ltp-timers
+      - sleep
+      - smc
+      - v4l2-compliance-uvc
 
   - device_type: rk3399-gru-kevin
     test_plans:
@@ -3448,8 +3365,7 @@ test_configs:
   - device_type: rk3399-roc-pc
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
+      - baseline-nfs
       # wishlist for when this device becomes online in a lab that allows them to run
       # - igt-gpu-panfrost
       # - igt-kms-rockchip
@@ -3460,8 +3376,7 @@ test_configs:
   - device_type: rk3399-rock-pi-4b
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
+      - baseline-nfs
 
   - device_type: rk3588-rock-5b
     test_plans:
@@ -3470,12 +3385,10 @@ test_configs:
   - device_type: sc7180-trogdor-kingoftown
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
+      - baseline-nfs
       - cros-ec
-# Disabling to reduce load
-#      - kselftest-alsa
-#      - kselftest-tpm2
+      - kselftest-alsa
+      - kselftest-tpm2
       - v4l2-decoder-conformance-h264
       - v4l2-decoder-conformance-h265
       - v4l2-decoder-conformance-vp8
@@ -3484,11 +3397,10 @@ test_configs:
   - device_type: sc7180-trogdor-kingoftown-r1
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
-#      - cros-ec
-#      - kselftest-alsa
-#      - kselftest-tpm2
+      - baseline-nfs
+      - cros-ec
+      - kselftest-alsa
+      - kselftest-tpm2
       - v4l2-decoder-conformance-h264
       - v4l2-decoder-conformance-h265
       - v4l2-decoder-conformance-vp8
@@ -3497,19 +3409,18 @@ test_configs:
   - device_type: sc7180-trogdor-lazor-limozeen
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
-#      - cros-ec
-#      - igt-gpu-msm
-#      - igt-kms-msm
-#      - kselftest-alsa
-#      - kselftest-arm64
-#      - kselftest-cpufreq
-#      - kselftest-rtc
-#      - kselftest-timens
-#      - kselftest-timers
-#      - kselftest-tpm2
-#      - usb
+      - baseline-nfs
+      - cros-ec
+      - igt-gpu-msm
+      - igt-kms-msm
+      - kselftest-alsa
+      - kselftest-arm64
+      - kselftest-cpufreq
+      - kselftest-rtc
+      - kselftest-timens
+      - kselftest-timers
+      - kselftest-tpm2
+      - usb
       - v4l2-decoder-conformance-h264
       - v4l2-decoder-conformance-h265
       - v4l2-decoder-conformance-vp8
@@ -3518,14 +3429,12 @@ test_configs:
   - device_type: snow
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
+      - baseline-nfs
 
   - device_type: socfpga-cyclone5-socrates
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
+      - baseline-nfs
       - sleep
 
   - device_type: stm32mp157c-dk2
@@ -3539,8 +3448,7 @@ test_configs:
   - device_type: sun4i-a10-olinuxino-lime
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
+      - baseline-nfs
 
   - device_type: sun50i-a64-bananapi-m64
     test_plans:
@@ -3549,39 +3457,33 @@ test_configs:
   - device_type: sun50i-a64-pine64-plus
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
+      - baseline-nfs
       - igt-gpu-lima
-# Disabling to reduce load
-#      - kselftest-arm64
-#      - kselftest-cpufreq
-#      - kselftest-rtc
-#      - ltp-crypto
+      - kselftest-arm64
+      - kselftest-cpufreq
+      - kselftest-rtc
+      - ltp-crypto
       # ltp-mm - runs system out of memory
 
   - device_type: sun50i-h5-libretech-all-h3-cc
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
+      - baseline-nfs
       - igt-gpu-lima
-# Disabling to reduce load
-#      - kselftest-alsa
-#      - kselftest-arm64
-#      - kselftest-capabilities
-#      - kselftest-cpufreq
-#      - kselftest-kvm
-#      - kselftest-rseq
+      - kselftest-alsa
+      - kselftest-arm64
+      - kselftest-capabilities
+      - kselftest-cpufreq
+      - kselftest-kvm
+      - kselftest-rseq
       - kselftest-sigaltstack
-# Disabling to reduce load
-#      - kselftest-timers
+      - kselftest-timers
       - libhugetlbfs
       - ltp-cpuhotplug
-# Disabling to reduce load
-#      - ltp-crypto
-#      - ltp-hugetlb
-#      - ltp-smoketest
-#      - preempt-rt
+      - ltp-crypto
+      - ltp-hugetlb
+      - ltp-smoketest
+      - preempt-rt
 
   - device_type: sun50i-h5-nanopi-neo-plus2
     test_plans:
@@ -3626,8 +3528,7 @@ test_configs:
   - device_type: sun7i-a20-olinuxino-lime2
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
+      - baseline-nfs
 
   - device_type: sun8i-a23-evb
     test_plans:
@@ -3705,20 +3606,17 @@ test_configs:
   - device_type: x86-celeron
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
+      - baseline-nfs
 
   - device_type: x86-pentium4
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
+      - baseline-nfs
 
   - device_type: x86-x5-z8350
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
+      - baseline-nfs
 
   - device_type: zynq-zc702
     test_plans:


### PR DESCRIPTION
This reverts commit 491a3dba7b3b2c433fc1f6518600ac0eb33492ab.

Enable all the test configurations again to measure the added load and related costs in the infrastructure.