### PR TITLE
CHROMEOS test-configs-chromeos.yaml: Enable fluster tests on tomato for collabora-chromeos-kernel tree

### DIFF
--- a/config/core/test-configs-chromeos.yaml
+++ b/config/core/test-configs-chromeos.yaml
@@ -948,6 +948,31 @@ device_types:
         dtb: 'https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-asurada/20230825.0/arm64/dtbs/mediatek/mt8192-asurada-spherion-r0.dtb'
       block_device: detect
 
+  mt8195-cherry-tomato-r2_chromeos:
+    <<: *chromebook-arm64-type
+    base_name: mt8195-cherry-tomato-r2
+    mach: mediatek
+    dtb: 'mediatek/mt8195-cherry-tomato-r2.dtb'
+    filters: [blocklist: {}]
+    params:
+      <<: *chromebook-arm64-params
+      cros_flash_kernel:
+        base_url: 'https://storage.chromeos.kernelci.org/images/kernel/v6.1-mediatek/'
+        image: 'kernel/Image'
+        modules: 'modules.tar.xz'
+        modules_compression: 'xz'
+        dtb: 'dtbs/mediatek/mt8195-cherry-tomato-r2.dtb'
+      cros_image:
+        base_url: 'https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-cherry/20230825.0/arm64/'
+        flash_tarball: 'full-cros-flash.tar.gz'
+        flash_tarball_compression: 'gz'
+        tast_tarball: 'tast.tgz'
+      reference_kernel:
+        image: 'https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-cherry/20230825.0/arm64/Image'
+        modules: 'https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-cherry/20230825.0/arm64/modules.tar.xz'
+        dtb: 'https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-cherry/20230825.0/arm64/dtbs/mediatek/mt8192-asurada-spherion-r0.dtb'
+      block_device: detect
+
 # Test plans temporarily disabled as QEMU build doesnt work
 #  qemu_x86_64-uefi-chromeos:
 #    base_name: qemu

--- a/config/core/test-configs-chromeos.yaml
+++ b/config/core/test-configs-chromeos.yaml
@@ -1196,6 +1196,13 @@ test_configs:
 #      - cros-tast-platform_qemu
 #      - cros-tast-video_qemu
 
+  - device_type: mt8195-cherry-tomato-r2_chromeos
+    filters: *collabora-chromeos-kernel-filter
+    test_plans:
+      - v4l2-decoder-conformance-h264_chromeos
+      - v4l2-decoder-conformance-vp8_chromeos
+      - v4l2-decoder-conformance-vp9_chromeos
+
   - device_type: sc7180-trogdor-kingoftown_chromeos
     test_plans: *chromebook-arm64-test-plans
 


### PR DESCRIPTION
Enable V4L2 decoder conformance tests on `mt8195-cherry-tomato-r2_chromeos` for H264, VP8 and VP9 formats. Run the tests on the `for-kernelci` branch of the `collabora-chromeos-kernel` tree.