### PR TITLE
cli/base.py: Implement KCI_SETTINGS env variable handling

### DIFF
--- a/kernelci/cli/base.py
+++ b/kernelci/cli/base.py
@@ -554,6 +554,15 @@ class Options:
                     path = default_path
                     break
 
+        # If path is set, means it is either retrieved from KCI_SETTINGS
+        # environment variable or set by --settings option. In both cases,
+        # check if the file exists. If not, raise FileNotFoundError, so we are
+        # aware file is missing.
+        # If path is not set, this means "default" - it is permitted that
+        # settings file does not exist, it will appear as empty dict.
+        if path and not os.path.exists(path):
+            raise FileNotFoundError(f"Settings file not found: {path}")
+
         if path and path.endswith('.conf'):
             self._deprecated_settings = True
 

--- a/kernelci/cli/base.py
+++ b/kernelci/cli/base.py
@@ -519,10 +519,14 @@ class Options:
         a section called `db:<db-config-name>` with `db-config-name` the value
         passed in `db_config`, or in the `--db-config` command line argument.
 
-        *path* is the path to the config file, which by default is
-                `kernelci.conf` or
-               `~/.config/kernelci/kernelci.conf` or
-               `/etc/kernelci/kernelci.conf`
+        *path* is the path to the config file, if not provided it will be
+                looked up in the following order:
+                1) from the `KCI_SETTINGS` environment variable
+                2) look for following files in order:
+                     kernelci.toml, ~/.config/kernelci/kernelci.toml,
+                     /etc/kernelci/kernelci.toml, kernelci.conf,
+                     ~/.config/kernelci/kernelci.conf,
+                     /etc/kernelci/kernelci.conf
 
         *command* is a `Command` object for the command being run
 
@@ -533,6 +537,9 @@ class Options:
                   way to have default values for each CLI tool
         """
         self._deprecated_settings = False
+        if path is None:
+            path = os.environ.get('KCI_SETTINGS')
+
         if path is None:
             default_paths = [
                 'kernelci.toml',


### PR DESCRIPTION
By default we can specify config file by --api-config, if not, kci will search config at predefined places.
Now we can also set config file path by environment variable KCI_SETTINGS.