### PR TITLE
PoC: kernelci.api.latest: parse `Redis List` message

### DIFF
--- a/kernelci/api/latest.py
+++ b/kernelci/api/latest.py
@@ -10,6 +10,7 @@ from typing import Optional, Sequence
 
 from cloudevents.http import from_json
 import requests
+import json
 
 from . import API
 
@@ -93,7 +94,8 @@ class LatestAPI(API):  # pylint: disable=too-many-public-methods
         path = '/'.join(['listen', str(sub_id)])
         while True:
             resp = self._get(path)
-            data = resp.json().get('data')
+            # data = resp.json().get('data')
+            data = json.dumps(resp.json())
             if not data:
                 continue
             event = from_json(data)


### PR DESCRIPTION
Update message parsing for GET `/listen` response.
Redis `Pubsub` returns broadcast messages in `pmessage` format while `redis.blpop` returns message in `CloudEvent` dictionary.
Update message parsing in `api.receive_event` accordingly.