### PR TITLE
CHROMEOS test-configs-chromeos.yaml: Enable decoder tests on juniper …

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -357,6 +357,7 @@ fragments:
       rockchip/dptx.bin
       qcom/venus-5.4/venus.mdt
       qcom/venus-5.4/venus.mbn
+      mediatek/mt8183/scp.img
       mediatek/mt8192/scp.img
       mediatek/mt8195/scp.img
       "'

--- a/config/core/test-configs-chromeos.yaml
+++ b/config/core/test-configs-chromeos.yaml
@@ -1161,6 +1161,16 @@ test_configs:
       - passlist: {tree: ['collabora-chromeos-kernel'], branch: ['for-kernelci']}
     test_plans: *chromebook-arm64-test-plans
 
+  - device_type: mt8183-kukui-jacuzzi-juniper-sku16_chromeos
+    filters: *collabora-chromeos-kernel-filter
+    test_plans:
+      - v4l2-decoder-conformance-h264_chromeos
+
+  - device_type: mt8183-kukui-jacuzzi-juniper-sku16_chromeos
+    filters: *collabora-chromeos-kernel-filter
+    test_plans:
+      - cros-tast-mm-decode-v4l2-stateless-h264
+
   - device_type: mt8192-asurada-spherion-r0_chromeos
     filters: *collabora-chromeos-kernel-filter
     test_plans:


### PR DESCRIPTION
…for collabora-chromeos-kernel tree

Enable fluster and tast decoder tests on mt8183-kukui-jacuzzi-juniper-sku16 for the H264 format.
Run the tests on the for-kernelci branch of the collabora-chromeos-kernel tree.