### PR TITLE
config/core/test-configs-cip: update isar-cip-core rootfs to 20231004 bookworm

### DIFF
--- a/config/core/test-configs-cip.yaml
+++ b/config/core/test-configs-cip.yaml
@@ -1,7 +1,7 @@
 file_system_types:
 
   cip:
-    url: 'https://storage.kernelci.org/images/rootfs/cip/20220920'
+    url: 'https://storage.kernelci.org/images/rootfs/cip/20231004'
     arch_map:
       amd64: [{arch: x86_64}]
 
@@ -10,8 +10,8 @@ file_systems:
 
   cip_nfs:
     type: cip
-    ramdisk: 'qemu-{arch}/cip-core-image-kernelci-cip-core-buster-qemu-{arch}-initrd.img.gz'
-    nfs: 'qemu-{arch}/cip-core-image-kernelci-cip-core-buster-qemu-{arch}.tar.gz'
+    ramdisk: 'qemu-{arch}/cip-core-image-kernelci-cip-core-bookworm-qemu-{arch}-initrd.img.gz'
+    nfs: 'qemu-{arch}/cip-core-image-kernelci-cip-core-bookworm-qemu-{arch}.tar.gz'
     root_type: nfs
 
 


### PR DESCRIPTION
updating isar-cip-core rootfs to currently the last one 20231004 this also update the image from buster to bookworm