### PR TITLE
CHROMEOS add build definition for 6.6 kernel

### DIFF
--- a/config/core/build-configs-chromeos.yaml
+++ b/config/core/build-configs-chromeos.yaml
@@ -80,6 +80,35 @@ chromeos_6.1_variants: &chromeos_6_1_variants
   clang-17: *clang-17
 
 
+chromeos_6.6_variants: &chromeos_6_6_variants
+  chromeos-clang-17:
+    build_environment: clang-17
+    architectures:
+      arm:
+        base_defconfig: 'cros://merge%continuous%chromeos-kernelupstream-6.6-rc4/armel/chromiumos-arm.flavour.config'
+        extra_configs:
+          - 'cros://merge%continuous%chromeos-kernelupstream-6.6-rc4/armel/chromiumos-rockchip.flavour.config'
+        filters: *cros-filters
+      arm64:
+        base_defconfig: 'cros://merge%continuous%chromeos-kernelupstream-6.6-rc4/arm64/chromiumos-arm64.flavour.config'
+        fragments: [arm64-chromebook]
+        extra_configs:
+          - 'cros://merge%continuous%chromeos-kernelupstream-6.6-rc4/arm64/chromiumos-mediatek.flavour.config+arm64-chromebook+CONFIG_MODULE_COMPRESS_GZIP=n'
+          - 'cros://merge%continuous%chromeos-kernelupstream-6.6-rc4/arm64/chromiumos-qualcomm.flavour.config+arm64-chromebook+CONFIG_MODULE_COMPRESS_GZIP=n'
+          - 'cros://merge%continuous%chromeos-kernelupstream-6.6-rc4/arm64/chromiumos-rockchip64.flavour.config+arm64-chromebook+CONFIG_MODULE_COMPRESS_GZIP=n'
+        filters: *cros-filters
+      x86_64:
+        base_defconfig: 'cros://merge%continuous%chromeos-kernelupstream-6.6-rc4/x86_64/chromiumos-x86_64.flavour.config'
+        fragments: [x86-chromebook]
+        extra_configs:
+          - 'cros://merge%continuous%chromeos-kernelupstream-6.6-rc4/x86_64/chromeos-amd-stoneyridge.flavour.config+x86-chromebook+CONFIG_MODULE_COMPRESS_GZIP=n'
+          - 'cros://merge%continuous%chromeos-kernelupstream-6.6-rc4/x86_64/chromeos-intel-denverton.flavour.config+x86-chromebook+CONFIG_MODULE_COMPRESS_GZIP=n'
+          - 'cros://merge%continuous%chromeos-kernelupstream-6.6-rc4/x86_64/chromeos-intel-pineview.flavour.config+x86-chromebook+CONFIG_MODULE_COMPRESS_GZIP=n'
+          - 'cros://merge%continuous%chromeos-kernelupstream-6.6-rc4/x86_64/chromiumos-x86_64.flavour.config+x86-chromebook+CONFIG_MODULE_COMPRESS_GZIP=n'
+        filters: *cros-filters
+
+  clang-17: *clang-17
+
 
 build_configs:
 
@@ -102,6 +131,12 @@ build_configs:
     tree: kernelci
     branch: 'linux-6.1.y-arm64-chromeos'
     variants: *chromeos_6_1_variants
+
+  chromeos-stable_6.6:
+    tree: stable
+    # linux-6.6.y will only be created once 6.6 is released, for now track master
+    branch: 'master'
+    variants: *chromeos_6_6_variants
 
   collabora-chromeos-kernel:
     tree: collabora-chromeos-kernel

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -1073,9 +1073,9 @@ scripts/kconfig/merge_config.sh -O {output} '{base}' '{frag}' {redir}
             raise FileNotFoundError("Error reading {}".format(url))
 
     def _create_cros_config(self, config):
-        [(branch, config)] = re.findall(r"cros://([\w\-.]+)/(.*)", config)
+        [(branch, config)] = re.findall(r"cros://([\w\-%.]+)/(.*)", config)
         cros_config = os.path.join(self._output_path, "cros-config.tgz")
-        url = CROS_CONFIG_URL.format(branch=branch)
+        url = CROS_CONFIG_URL.format(branch=branch.replace("%", "/"))
         if not _download_file(url, cros_config):
             raise FileNotFoundError("Error reading {}".format(url))
         tar = tarfile.open(cros_config)


### PR DESCRIPTION
This PR includes the 6.6 build definition for ChromeOS, which itself relies on a (small) change to `kernelci/build.py` so we can use a ChromeOS branch name which includes the `/` character