### PR TITLE
TOML settings rework

### DIFF
--- a/kernelci.toml.sample
+++ b/kernelci.toml.sample
@@ -1,61 +1,36 @@
+# -*- mode: Conf[TOML] -*- -#
+#
 # Sample kernelci.toml settings file with arbitrary values.
 #
 # These value are only for illustration purposes, they should be manually set
-# by any user to match a particular installation.  The options mentioned here
-# are typical ones that shouldn't change in every command line call when used
-# manually for local development purposes.  Any command line argument can have
-# a default value stored in this file.  Components such as databases and runtimes
-# have their own section too, with a naming convention of the form [db.db-name]
-# or [runtime.runtime-name]. Make sure to surround sub-section name with "" (double-quotes)
-# if it contains "." (dot) in the name e.g [db."staging.kernelci.org"].
-
-[DEFAULT]
+# by every user as required.
+#
+# The settings provided here are typical ones that shouldn't change in every
+# command line call when used manually for local development purposes.  Any
+# argument can have a default value stored in this file.  Each subcommand can
+# have its own setction, for example [kci.docker] for 'kci docker'.
+#
+# A special section [kci.secrets] is used to provide secrets with configuration
+# names, for example API secrets are stored in [kci.secrets.api.<api-name>].
+#
+# Since this relies on the TOML dotted keys syntax, make sure to enclose
+# sub-section names in "" (double-quotes) if they contain "."  (dot) in their
+# name e.g api."staging.kernelci.org".token.
 
 # -- Sample global defaults ---
 #
-# storage = "http://localhost:5002"
-# db_config = "localhost"
-
-# -- Sample runtime --
-#
-# [runtime.my-lava-lab]
-#
-# user = "user-name"
-# runtime_token = "1234-5678"
-
-# -- Sample database --
-#
-[db.localhost]
-#
-# db_token = "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
-# api = "http://192.168.122.1:5001"
-# callback_id = "kernelci-callback-local"
-# callback_url = "http://localhost:5001"
-
-# [db."staging.kernelci.org"]
-
-# db_token = "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
-
-# -- Sample command line defaults --
-
-[kci_build]
-
-# mirror = "linux-mirror.git"
-# kdir = "linux"
-# build_env = "gcc-10"
-# j = 3
-
-[kci_test]
-
-# runtime_config = "localhost"
-# bmeta_json = "linux/_install_/bmeta.json"
-# dtbs_json = "linux/_install_/dtbs.json"
-
-[kci_data]
-
-# db_config = "localhost"
+# [kci]
 # verbose = true
+# indent = 2
+# api = 'docker-host'
+# storage = 'docker-host'
 
-[kci_rootfs]
+# -- Sample docker command config --
+#
+# [kci.docker]
+# prefix = 'username/'
 
-# arc = "arm64"
+# -- Sample secrets --
+#
+# [kci.secrets]
+# api.docker-host.token = 'my-secret-token'

--- a/kernelci/settings.py
+++ b/kernelci/settings.py
@@ -71,6 +71,35 @@ class Settings:
             data = data.get(arg)
         return data
 
+    def get(self, *args):
+        """Get a settings value using inheritance
+
+        Unlike .get_raw() which directly returns what is found from the TOML
+        settings, the .get() method will try and find a key within the path as
+        a default value.  For example, if kci.api is defined in TOML but not
+        kci.node.api, when trying to retrieve ('kci', 'node', 'api') it will
+        return the value found in ('kci', 'api') as a default value.  This
+        allows setting values across all the sub-commands.
+
+        This method will also always return a final value and never a group
+        dictionary like .get_raw().  If the requested value is not found and no
+        parent section with the same final key has been found, then this method
+        returns None.
+        """
+        if len(args) < 1:
+            return None
+        key = args[-1]
+        data = self._settings
+        value = data.get(key)
+        for arg in args:
+            if not isinstance(data, dict):
+                data = None
+            if data is None:
+                break
+            value = data.get(key, value)
+            data = data.get(arg)
+        return value
+
 
 class Secrets:
     """Helper class to find the secrets section in the settings

--- a/kernelci/settings.py
+++ b/kernelci/settings.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2023 Collabora Limited
+# Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+
+"""KernelCI TOML Settings
+
+KernelCI relies on TOML Settings to provide a way to store secrets and default
+values for command line arguments.  Each user typically has their own TOML
+settings file for particular use-cases.
+"""
+
+import os
+
+import toml
+
+
+class Settings:
+    """KernelCI TOML Settings
+
+    This class loads settings from a TOML file and provides utilities to
+    retrieve values from it.  The `path` argument passed when creating the
+    object can be used to load an arbitrary TOML file.  Otherwise, the default
+    paths are:
+
+        kernelci.toml in the current directory
+        ~/.config/kernelci/kernelci.toml
+        /etc/kernelci/kernelci.toml
+    """
+
+    def __init__(self, path: str = None):
+        if path is not None:
+            if not os.path.exists(path):
+                raise FileNotFoundError(path)
+        else:
+            default_paths = [
+                'kernelci.toml',
+                os.path.expanduser('~/.config/kernelci/kernelci.toml'),
+                '/etc/kernelci/kernelci.toml',
+            ]
+            for default_path in default_paths:
+                if os.path.exists(default_path):
+                    path = default_path
+                    break
+        self._path = path
+        self._settings = toml.load(path) if path else {}
+
+    @property
+    def path(self):
+        """Path to the loaded TOML settings file"""
+        return self._path
+
+    def get_raw(self, *args):
+        """Get a settings value from an arbitrary series of keys
+
+        The *args are a tuple of strings for the path, e.g. ('foo', 'bar',
+        'baz') will look for a foo.bar.baz value or baz within [foo.bar] etc.
+
+        This method returns None if the value or any element of the path
+        doesn't exist.  If the last element is not a single value but a group
+        then it will return a dictionary with the settings for that group.
+        """
+        data = self._settings
+        for arg in args:
+            if not isinstance(data, dict):
+                data = None
+            if data is None:
+                break
+            data = data.get(arg)
+        return data

--- a/tests/kernelci-settings.toml
+++ b/tests/kernelci-settings.toml
@@ -1,0 +1,15 @@
+something = 'hello'
+
+[kci]
+hello = 123
+flag = false
+name = "bingo"
+
+[kci.foo]
+bar = 456
+a.b.c = 'ABC'
+a.b.z = 'XYZ'
+
+[alternative]
+foo.bar = 'baz'
+hello = 456

--- a/tests/kernelci-settings.toml
+++ b/tests/kernelci-settings.toml
@@ -13,3 +13,12 @@ a.b.z = 'XYZ'
 [alternative]
 foo.bar = 'baz'
 hello = 456
+
+[kci.secrets]
+storage.foo.password = "abracadabra"
+storage.bar.password = "mickeymouse"
+api.local.token = "my-local-api-token"
+api.main.token = "my-main-api-token"
+
+[secret.bits]
+foo.bar.baz = 'FooBarBaz'

--- a/tests/kernelci-settings.toml
+++ b/tests/kernelci-settings.toml
@@ -14,6 +14,9 @@ a.b.z = 'XYZ'
 foo.bar = 'baz'
 hello = 456
 
+[alternative.hey]
+abc = 'def'
+
 [kci.secrets]
 storage.foo.password = "abracadabra"
 storage.bar.password = "mickeymouse"

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2023 Collabora Limited
+# Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+
+"""Unit test for the KernelCI TOML settings"""
+
+import kernelci.settings
+
+
+def test_load_toml():
+    """Verify that the settings can be loaded from the local TOML file"""
+    settings = kernelci.settings.Settings('tests/kernelci-settings.toml')
+    assert settings.path == 'tests/kernelci-settings.toml'
+
+
+def test_get_raw():
+    """Test the Settings.get_raw() method with various use-cases"""
+    settings = kernelci.settings.Settings('tests/kernelci-settings.toml')
+    something = settings.get_raw('something')
+    assert something == 'hello'
+    value_int = settings.get_raw('kci', 'hello')
+    assert value_int == 123
+    value_bool = settings.get_raw('kci', 'flag')
+    assert value_bool is False
+    value_str = settings.get_raw('kci', 'name')
+    assert value_str == 'bingo'
+    value_sub_command = settings.get_raw('kci', 'foo', 'bar')
+    assert value_sub_command == 456
+    value_not_found = settings.get_raw('kci', 'foo', 'baz')
+    assert value_not_found is None
+    abc = settings.get_raw('kci', 'foo', 'a', 'b', 'c')
+    assert abc == 'ABC'
+    xyz = settings.get_raw('kci', 'foo', 'a', 'b', 'z')
+    assert xyz == 'XYZ'
+    ab_group = settings.get_raw('kci', 'foo', 'a', 'b')
+    assert ab_group == {'c': 'ABC', 'z': 'XYZ'}
+    alt = settings.get_raw('alternative', 'foo', 'bar')
+    assert alt == 'baz'

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -27,8 +27,6 @@ def test_get_raw():
     assert value_str == 'bingo'
     value_sub_command = settings.get_raw('kci', 'foo', 'bar')
     assert value_sub_command == 456
-    value_not_found = settings.get_raw('kci', 'foo', 'baz')
-    assert value_not_found is None
     abc = settings.get_raw('kci', 'foo', 'a', 'b', 'c')
     assert abc == 'ABC'
     xyz = settings.get_raw('kci', 'foo', 'a', 'b', 'z')
@@ -58,6 +56,19 @@ def test_get():
     assert abc == 'def'
     hello = settings.get('alternative', 'hey', 'hello')
     assert hello == 456
+
+
+def test_not_found():
+    """Test all the Settings methods with values that don't exist"""
+    settings = kernelci.settings.Settings('tests/kernelci-settings.toml')
+    assert settings.get_raw('kci', 'foo', 'baz') is None
+    assert settings.get_raw('kci', 'foo', 'baz', 'bingo') is None
+    assert settings.get_raw('kci', 'what') is None
+    assert settings.get_raw('something', 'else') is None
+    assert settings.get('kci', 'what') is None
+    assert settings.get('what') is None
+    assert settings.get('something', 'else') is None
+    assert settings.get() is None
 
 
 def test_secrets_init():

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -39,6 +39,27 @@ def test_get_raw():
     assert alt == 'baz'
 
 
+def test_get():
+    """Test the Settings.get() method with various use-cases"""
+    settings = kernelci.settings.Settings('tests/kernelci-settings.toml')
+    raw_flag = settings.get_raw('kci', 'foo', 'flag')
+    assert raw_flag is None
+    parent_flag = settings.get('kci', 'foo', 'flag')
+    assert parent_flag is False
+    raw_name = settings.get_raw('kci', 'foo', 'name')
+    assert raw_name is None
+    parent_name = settings.get('kci', 'foo', 'name')
+    assert parent_name == 'bingo'
+    alt_bar = settings.get('alternative', 'foo', 'bar')
+    assert alt_bar == 'baz'
+    alt_hello = settings.get('alternative', 'hello')
+    assert alt_hello == 456
+    abc = settings.get('alternative', 'hey', 'abc')
+    assert abc == 'def'
+    hello = settings.get('alternative', 'hey', 'hello')
+    assert hello == 456
+
+
 def test_secrets_init():
     """Verify that secrets can be initialised from the TOML settings"""
     settings = kernelci.settings.Settings('tests/kernelci-settings.toml')

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -37,3 +37,41 @@ def test_get_raw():
     assert ab_group == {'c': 'ABC', 'z': 'XYZ'}
     alt = settings.get_raw('alternative', 'foo', 'bar')
     assert alt == 'baz'
+
+
+def test_secrets_init():
+    """Verify that secrets can be initialised from the TOML settings"""
+    settings = kernelci.settings.Settings('tests/kernelci-settings.toml')
+    secrets = kernelci.settings.Secrets(settings)
+    assert secrets.root == ()
+    assert secrets.ding.dong is None
+
+
+def test_secrets():
+    """Test that secrets can be retrieved from the TOML settings"""
+    settings = kernelci.settings.Settings('tests/kernelci-settings.toml')
+
+    args = {
+        'storage': 'foo',
+        'api': 'main',
+    }
+    secrets = kernelci.settings.Secrets(settings, args, ('kci', 'secrets'))
+    assert secrets.storage.password == 'abracadabra'
+    assert secrets.api.token == 'my-main-api-token'
+
+    args = {
+        'storage': 'bar',
+        'api': 'local',
+    }
+    secrets = kernelci.settings.Secrets(settings, args, ('kci', 'secrets'))
+    assert secrets.storage.password == 'mickeymouse'
+    assert secrets.api.token == 'my-local-api-token'
+    assert secrets.storage.nothing is None
+    assert secrets.wrong.path is None
+
+    args = {
+        'foo': 'bar',
+    }
+    secrets = kernelci.settings.Secrets(settings, args, ('secret', 'bits'))
+    assert secrets.foo.baz == 'FooBarBaz'
+    assert secrets.bar.baz is None


### PR DESCRIPTION
Implement the TOML settings handling again in a new `kenrelci.settings` module.  This is based on the legacy one but also takes into account new features required for the `kci` command line tool as per https://github.com/kernelci/kernelci-project/discussions/261