### PR TITLE
Add pre-commit validation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.4.0
+  hooks:
+    - id: check-executables-have-shebangs
+    - id: check-merge-conflict
+    - id: check-yaml
+      exclude: config/rootfs/debos/rootfs.yaml
+    - id: check-toml
+    - id: end-of-file-fixer
+    - id: trailing-whitespace
+


### PR DESCRIPTION
Basically kernelci/kernelci-core#2072 without `black`.  Add and apply following `pre-commit` checks:
- check-executables-have-shebangs
- check-merge-conflict
- check-yaml
- check-toml
- end-of-file-fixer
- trailing-whitespace