### PR TITLE
CHROMEOS test.py: Truncate very long cross:// repo name

### DIFF
--- a/config/core/build-configs-chromeos.yaml
+++ b/config/core/build-configs-chromeos.yaml
@@ -85,26 +85,26 @@ chromeos_6.6_variants: &chromeos_6_6_variants
     build_environment: clang-17
     architectures:
       arm:
-        base_defconfig: 'cros://merge%continuous%chromeos-kernelupstream-6.6-rc6/armel/chromiumos-arm.flavour.config'
+        base_defconfig: 'cros://chromeos-6.6-rc6-up/armel/chromiumos-arm.flavour.config'
         extra_configs:
-          - 'cros://merge%continuous%chromeos-kernelupstream-6.6-rc6/armel/chromiumos-rockchip.flavour.config'
+          - 'cros://chromeos-6.6-rc6-up/armel/chromiumos-rockchip.flavour.config'
         filters: *cros-filters
       arm64:
-        base_defconfig: 'cros://merge%continuous%chromeos-kernelupstream-6.6-rc6/arm64/chromiumos-arm64.flavour.config'
+        base_defconfig: 'cros://chromeos-6.6-rc6-up/arm64/chromiumos-arm64.flavour.config'
         fragments: [arm64-chromebook]
         extra_configs:
-          - 'cros://merge%continuous%chromeos-kernelupstream-6.6-rc6/arm64/chromiumos-mediatek.flavour.config+arm64-chromebook+CONFIG_MODULE_COMPRESS_GZIP=n'
-          - 'cros://merge%continuous%chromeos-kernelupstream-6.6-rc6/arm64/chromiumos-qualcomm.flavour.config+arm64-chromebook+CONFIG_MODULE_COMPRESS_GZIP=n'
-          - 'cros://merge%continuous%chromeos-kernelupstream-6.6-rc6/arm64/chromiumos-rockchip64.flavour.config+arm64-chromebook+CONFIG_MODULE_COMPRESS_GZIP=n'
+          - 'cros://chromeos-6.6-rc6-up/arm64/chromiumos-mediatek.flavour.config+arm64-chromebook+CONFIG_MODULE_COMPRESS_GZIP=n'
+          - 'cros://chromeos-6.6-rc6-up/arm64/chromiumos-qualcomm.flavour.config+arm64-chromebook+CONFIG_MODULE_COMPRESS_GZIP=n'
+          - 'cros://chromeos-6.6-rc6-up/arm64/chromiumos-rockchip64.flavour.config+arm64-chromebook+CONFIG_MODULE_COMPRESS_GZIP=n'
         filters: *cros-filters
       x86_64:
-        base_defconfig: 'cros://merge%continuous%chromeos-kernelupstream-6.6-rc6/x86_64/chromiumos-x86_64.flavour.config'
+        base_defconfig: 'cros://chromeos-6.6-rc6-up/x86_64/chromiumos-x86_64.flavour.config'
         fragments: [x86-chromebook]
         extra_configs:
-          - 'cros://merge%continuous%chromeos-kernelupstream-6.6-rc6/x86_64/chromeos-amd-stoneyridge.flavour.config+x86-chromebook+CONFIG_MODULE_COMPRESS_GZIP=n'
-          - 'cros://merge%continuous%chromeos-kernelupstream-6.6-rc6/x86_64/chromeos-intel-denverton.flavour.config+x86-chromebook+CONFIG_MODULE_COMPRESS_GZIP=n'
-          - 'cros://merge%continuous%chromeos-kernelupstream-6.6-rc6/x86_64/chromeos-intel-pineview.flavour.config+x86-chromebook+CONFIG_MODULE_COMPRESS_GZIP=n'
-          - 'cros://merge%continuous%chromeos-kernelupstream-6.6-rc6/x86_64/chromiumos-x86_64.flavour.config+x86-chromebook+CONFIG_MODULE_COMPRESS_GZIP=n'
+          - 'cros://chromeos-6.6-rc6-up/x86_64/chromeos-amd-stoneyridge.flavour.config+x86-chromebook+CONFIG_MODULE_COMPRESS_GZIP=n'
+          - 'cros://chromeos-6.6-rc6-up/x86_64/chromeos-intel-denverton.flavour.config+x86-chromebook+CONFIG_MODULE_COMPRESS_GZIP=n'
+          - 'cros://chromeos-6.6-rc6-up/x86_64/chromeos-intel-pineview.flavour.config+x86-chromebook+CONFIG_MODULE_COMPRESS_GZIP=n'
+          - 'cros://chromeos-6.6-rc6-up/x86_64/chromiumos-x86_64.flavour.config+x86-chromebook+CONFIG_MODULE_COMPRESS_GZIP=n'
         filters: *cros-filters
 
   clang-17: *clang-17

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -1074,6 +1074,14 @@ scripts/kconfig/merge_config.sh -O {output} '{base}' '{frag}' {redir}
 
     def _create_cros_config(self, config):
         [(branch, config)] = re.findall(r"cros://([\w\-%.]+)/(.*)", config)
+        # Map branch names to the actual branch
+        # We cannot use original branchname due to length, special characters,
+        # length, naming conventions.
+        branch_map = {
+            'chromeos-6.6-rc6-up': 'merge%continuous%chromeos-kernelupstream-6.6-rc6'  # noqa
+        }
+        if branch in branch_map:
+            branch = branch_map[branch]
         cros_config = os.path.join(self._output_path, "cros-config.tgz")
         url = CROS_CONFIG_URL.format(branch=branch.replace("%", "/"))
         if not _download_file(url, cros_config):

--- a/kernelci/legacy/lava/__init__.py
+++ b/kernelci/legacy/lava/__init__.py
@@ -13,7 +13,7 @@ import os
 import re
 import sys
 
-CROS_CONFIG_RE = re.compile(r'cros://chromeos-([0-9.]+)/([a-z0-9_]+)/([a-z0-9-._]+).flavour.config(\+[a-z0-9-+]+)?')  # noqa
+CROS_CONFIG_RE = re.compile(r'cros://chromeos-([0-9.a-z\-]+)/([a-z0-9_]+)/([a-z0-9-._]+).flavour.config(\+[a-z0-9-+]+)?')  # noqa
 
 CROS_FLAVOURS = {
     'chromeos-amd-stoneyridge': 'ston',


### PR DESCRIPTION
Use shortening service to reduce job length, as it is excessively long.