### PR TITLE
kubernetes.jinja2: Increase timeout before container destroy

### DIFF
--- a/config/runtime/base/kubernetes.jinja2
+++ b/config/runtime/base/kubernetes.jinja2
@@ -8,7 +8,9 @@ metadata:
 
 spec:
   completions: 1
-  ttlSecondsAfterFinished: 30
+  # During development we keep logs a bit longer
+  # TODO: Reduce on production
+  ttlSecondsAfterFinished: 120
   template:
     spec:
       backoffLimit: 1


### PR DESCRIPTION
As we are in development process, we need to keep container a bit longer after failure or completion, so we can have enough time to catch logs on early failure.