### PR TITLE
kernelci.config: rename 'api_configs' to 'api'

### DIFF
--- a/config/core/api-configs.yaml
+++ b/config/core/api-configs.yaml
@@ -1,4 +1,4 @@
-api_configs:
+api:
 
   docker-host:
     url: http://172.17.0.1:8001

--- a/kernelci/config/api.py
+++ b/kernelci/config/api.py
@@ -50,9 +50,9 @@ def from_yaml(data, _):
     """Create the API configs using data loaded from YAML"""
     api_configs = {
         name: API.load_from_yaml(config, name=name)
-        for name, config in data.get('api_configs', {}).items()
+        for name, config in data.get('api', {}).items()
     }
 
     return {
-        'api_configs': api_configs,
+        'api': api_configs,
     }

--- a/kernelci/legacy/cli/base_api.py
+++ b/kernelci/legacy/cli/base_api.py
@@ -28,7 +28,7 @@ class APICommand(Command):  # pylint: disable=too-few-public-methods
 
     @classmethod
     def _get_api(cls, configs, args):
-        config = configs['api_configs'][args.api_config]
+        config = configs['api'][args.api_config]
         return kernelci.api.get_api(config, args.api_token)
 
     @classmethod

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -237,7 +237,7 @@ class APIHelperTestData:
 def get_api_config():
     """Fixture to get API configurations"""
     config = kernelci.config.load('tests/configs/api-configs.yaml')
-    api_configs = config['api_configs']
+    api_configs = config['api']
     return api_configs
 
 

--- a/tests/configs/api-configs.yaml
+++ b/tests/configs/api-configs.yaml
@@ -1,4 +1,4 @@
-api_configs:
+api:
 
   docker-host:
     url: http://172.17.0.1:8001

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -184,11 +184,11 @@ class TestAPIConfigs(ConfigTest):
     """Tests for configs related to the KernelCI API"""
 
     def test_apis(self):
-        """Test the api_configs"""
+        """Test the api configs"""
         ref_data, config = self._load_config('tests/configs/api-configs.yaml')
-        api_config = self._reload(ref_data, config, 'api_configs')
+        api_config = self._reload(ref_data, config, 'api')
         api_names = ['docker-host']
-        assert all(name in ref_data['api_configs'] for name in api_names)
+        assert all(name in ref_data['api'] for name in api_names)
         assert all(name in api_config for name in api_names)
         assert (
             api_config['docker-host']['url'] == 'http://172.17.0.1:8001'


### PR DESCRIPTION
Rename the YAML entry 'api_configs' to 'api' as per the GitHub discussion.  The new kci command line tool will also have an --api option to specify the API config to use.

Update standard YAML configuration and unit tests accordingly.

Link: https://github.com/kernelci/kernelci-core/discussions/1907#discussioncomment-5718754