### PR TITLE
config/core: move storage_configs to storage in storage.yaml

### DIFF
--- a/config/core/storage.yaml
+++ b/config/core/storage.yaml
@@ -1,23 +1,4 @@
-db_configs:
-
-  chromeos.kernelci.org:
-    db_type: kernelci_backend
-    url: https://api.chromeos.kernelci.org/
-
-  kernelci.org:
-    db_type: kernelci_backend
-    url: https://api.kernelci.org/
-
-  localhost:
-    db_type: kernelci_backend
-    url: http://localhost:5001/
-
-  staging.kernelci.org:
-    db_type: kernelci_backend
-    url: https://api.staging.kernelci.org/
-
-
-storage_configs:
+storage:
 
   early-access-azure:
     storage_type: azure

--- a/kernelci/config/storage.py
+++ b/kernelci/config/storage.py
@@ -173,9 +173,15 @@ def from_yaml(data, _):
     """Load storage configuration from YAML data"""
     storage_configs = {
         name: StorageFactory.from_yaml(name, storage)
+        for name, storage in data.get('storage', {}).items()
+    }
+    legacy_storage_configs = {
+        name: StorageFactory.from_yaml(name, storage)
         for name, storage in data.get('storage_configs', {}).items()
     }
+    storage_configs.update(legacy_storage_configs)
 
     return {
-        'storage_configs': storage_configs,
+        'storage_configs': storage_configs,  # deprecated
+        'storage': storage_configs,
     }

--- a/tests/configs/storage-configs.yaml
+++ b/tests/configs/storage-configs.yaml
@@ -1,4 +1,4 @@
-storage_configs:
+storage:
 
   local:
     storage_type: ssh

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -240,8 +240,8 @@ class TestStorageConfigs(ConfigTest):
         ref_data, config = self._load_config(
             'tests/configs/storage-configs.yaml'
         )
-        ref_configs = ref_data['storage_configs']
-        storage_configs = self._reload(ref_data, config, 'storage_configs')
+        ref_configs = ref_data['storage']
+        storage_configs = self._reload(ref_data, config, 'storage')
         config_names = ['local', 'staging.kernelci.org', 'staging-backend']
         assert all(name in ref_configs for name in config_names)
         assert all(name in storage_configs for name in config_names)


### PR DESCRIPTION
Rename the top-level 'storage_configs' entry to 'storage' as per the GitHub discussion and move it from db-configs.yaml to storage.yaml. Keep a 'storage_configs' key in the configuration dictionary for backwards compatibility with legacy tools.

Update unit tests accordingly.

Link: https://github.com/kernelci/kernelci-core/discussions/1907