### PR TITLE
kernelci.legacy: move legacy config implementation

### DIFF
--- a/kci_data
+++ b/kci_data
@@ -23,7 +23,7 @@ import sys
 
 from kernelci.legacy.cli import Args, Command, parse_opts
 import kernelci.build
-import kernelci.config.db
+import kernelci.legacy.config.db
 import kernelci.db
 
 

--- a/kci_test
+++ b/kci_test
@@ -28,7 +28,7 @@ import yaml
 
 from kernelci.legacy.cli import Args, Command, parse_opts
 import kernelci
-import kernelci.config.test
+import kernelci.legacy.config.test
 import kernelci.build
 import kernelci.runtime
 import kernelci.legacy

--- a/kernelci/config/__init__.py
+++ b/kernelci/config/__init__.py
@@ -16,20 +16,12 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 import glob
+import importlib
 import os
 import yaml
 
 import kernelci
-import kernelci.config
-import kernelci.config.api
-import kernelci.config.build
-import kernelci.config.db
-import kernelci.config.job
-import kernelci.config.runtime
-import kernelci.config.rootfs
-import kernelci.config.scheduler
-import kernelci.config.storage
-import kernelci.config.test
+from .base import default_filters_from_yaml
 
 
 def iterate_yaml_files(config_path):
@@ -167,16 +159,17 @@ def load_data(data):
     *data* is the configuration dictionary loaded from YAML
     """
     config = dict()
-    filters = kernelci.config.base.default_filters_from_yaml(data)
-    config.update(kernelci.config.api.from_yaml(data, filters))
-    config.update(kernelci.config.build.from_yaml(data, filters))
-    config.update(kernelci.config.db.from_yaml(data, filters))
-    config.update(kernelci.config.job.from_yaml(data, filters))
-    config.update(kernelci.config.runtime.from_yaml(data, filters))
-    config.update(kernelci.config.scheduler.from_yaml(data, filters))
-    config.update(kernelci.config.rootfs.from_yaml(data, filters))
-    config.update(kernelci.config.storage.from_yaml(data, filters))
-    config.update(kernelci.config.test.from_yaml(data, filters))
+    filters = default_filters_from_yaml(data)
+    for module in [
+        'kernelci.config.api',
+        'kernelci.config.job',
+        'kernelci.config.runtime',
+        'kernelci.config.scheduler',
+        'kernelci.config.storage',
+        'kernelci.legacy.config',
+    ]:
+        mod = importlib.import_module(module)
+        config.update(mod.from_yaml(data, filters))
     return config
 
 

--- a/kernelci/config/api.py
+++ b/kernelci/config/api.py
@@ -5,7 +5,7 @@
 
 """KernelCI API object configuration"""
 
-from kernelci.config.base import YAMLConfigObject
+from .base import YAMLConfigObject
 
 
 class API(YAMLConfigObject):

--- a/kernelci/config/job.py
+++ b/kernelci/config/job.py
@@ -5,7 +5,7 @@
 
 """KernelCI pipeline job configuration"""
 
-from kernelci.config.base import YAMLConfigObject
+from .base import YAMLConfigObject
 
 
 class Job(YAMLConfigObject):

--- a/kernelci/config/runtime.py
+++ b/kernelci/config/runtime.py
@@ -5,7 +5,7 @@
 
 """KernelCI Runtime environment configuration"""
 
-from kernelci.config.base import FilterFactory, YAMLConfigObject
+from .base import FilterFactory, YAMLConfigObject
 
 
 class Runtime(YAMLConfigObject):

--- a/kernelci/config/scheduler.py
+++ b/kernelci/config/scheduler.py
@@ -5,7 +5,7 @@
 
 """KernelCI scheduler configuration"""
 
-from kernelci.config.base import YAMLConfigObject
+from .base import YAMLConfigObject
 
 
 class SchedulerEntry(YAMLConfigObject):

--- a/kernelci/config/storage.py
+++ b/kernelci/config/storage.py
@@ -5,7 +5,7 @@
 
 """KernelCI API object configuration"""
 
-from kernelci.config.base import YAMLConfigObject
+from .base import YAMLConfigObject
 
 
 class Storage(YAMLConfigObject):

--- a/kernelci/legacy/config/__init__.py
+++ b/kernelci/legacy/config/__init__.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2023 Collabora Limited
+
+import glob
+import os
+import yaml
+
+from . import (
+    build as build_config,
+    db as db_config,
+    rootfs as rootfs_config,
+    test as test_config,
+)
+
+
+def from_yaml(data, filters):
+    """Load legacy YAML configuration data"""
+    config = dict()
+    config.update(build_config.from_yaml(data, filters))
+    config.update(db_config.from_yaml(data, filters))
+    config.update(rootfs_config.from_yaml(data, filters))
+    config.update(test_config.from_yaml(data, filters))
+    return config

--- a/kernelci/legacy/config/base.py
+++ b/kernelci/legacy/config/base.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2022-2023 Collabora Limited
+# Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+
+from kernelci.config.base import FilterFactory, _YAMLObject, YAMLConfigObject

--- a/kernelci/legacy/config/build.py
+++ b/kernelci/legacy/config/build.py
@@ -17,7 +17,7 @@
 
 import yaml
 
-from kernelci.config.base import FilterFactory, _YAMLObject, YAMLConfigObject
+from .base import FilterFactory, _YAMLObject, YAMLConfigObject
 
 
 class Tree(YAMLConfigObject):

--- a/kernelci/legacy/config/db.py
+++ b/kernelci/legacy/config/db.py
@@ -16,7 +16,7 @@
 # along with this library; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-from kernelci.config.base import _YAMLObject
+from .base import _YAMLObject
 
 
 class Database(_YAMLObject):

--- a/kernelci/legacy/config/rootfs.py
+++ b/kernelci/legacy/config/rootfs.py
@@ -19,7 +19,7 @@ import sys
 import yaml
 
 from kernelci import sort_check
-from kernelci.config.base import _YAMLObject
+from .base import _YAMLObject
 
 
 class RootFS(_YAMLObject):

--- a/kernelci/legacy/config/test.py
+++ b/kernelci/legacy/config/test.py
@@ -17,7 +17,7 @@
 
 import yaml
 
-from kernelci.config.base import FilterFactory, _YAMLObject, YAMLConfigObject
+from .base import FilterFactory, _YAMLObject, YAMLConfigObject
 
 
 class DeviceType(_YAMLObject):

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setuptools.setup(
         "kernelci.db",
         "kernelci.legacy",
         "kernelci.legacy.cli",
+        "kernelci.legacy.config",
         "kernelci.legacy.lava",
         "kernelci.runtime",
         "kernelci.runtime.legacy",

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -18,13 +18,17 @@
 import yaml
 
 import kernelci.config
-import kernelci.config.build
+import kernelci.legacy.config.build
+
+# -----------------------------------------------------------------------------
+# Legacy
+#
 
 
 def test_build_configs_parsing():
     """Verify build configs from YAML"""
     data = kernelci.config.load_yaml("config/core")
-    configs = kernelci.config.build.from_yaml(data, {})
+    configs = kernelci.legacy.config.build.from_yaml(data, {})
     assert len(configs) == 4
     for key in ['build_configs', 'build_environments', 'fragments', 'trees']:
         assert key in configs
@@ -34,7 +38,7 @@ def test_build_configs_parsing():
 def test_build_configs_parsing_minimal():
     """Test that minimal build configs can be parsed from YAML"""
     data = kernelci.config.load_yaml("tests/configs/builds-minimal.yaml")
-    configs = kernelci.config.build.from_yaml(data, {})
+    configs = kernelci.legacy.config.build.from_yaml(data, {})
     assert 'agross' in configs['build_configs']
     assert 'agross' in configs['trees']
     assert 'gcc-7' in configs['build_environments']
@@ -44,13 +48,13 @@ def test_build_configs_parsing_minimal():
 def test_build_configs_parsing_empty_architecture():
     """Test that build configs with empty architectures can be parsed"""
     data = kernelci.config.load_yaml("tests/configs/builds-empty-arch.yaml")
-    configs = kernelci.config.build.from_yaml(data, {})
+    configs = kernelci.legacy.config.build.from_yaml(data, {})
     assert len(configs) == 4
 
 
 def test_architecture_init_name_only():
     """Test that build config objects can be created with just a name"""
-    architecture = kernelci.config.build.Architecture("arm")
+    architecture = kernelci.legacy.config.build.Architecture("arm")
     assert architecture.name == 'arm'
     assert architecture.base_defconfig == 'defconfig'
     assert len(architecture.extra_configs) == 0
@@ -163,6 +167,10 @@ class TestTestConfigs(ConfigTest):
             'http://storage.kernelci.org/images/rootfs/debian'
         )
 
+
+# -----------------------------------------------------------------------------
+# API & Pipeline
+#
 
 class TestJobConfigs(ConfigTest):
     """Tests for pipeline job definitions"""


### PR DESCRIPTION
Move the modules that relate to the legacy YAML implementation to kernelci.legacy.config.  This is still loaded as part of the main configuration to provide backwards-compatibility until support is eventually dropped.

Update unit tests, imports and setup.py accordingly.