### PR TITLE
config/runtime: base: import kernelci.config.storage

### DIFF
--- a/config/runtime/base/python.jinja2
+++ b/config/runtime/base/python.jinja2
@@ -21,6 +21,7 @@ import yaml
 {%- block python_local_imports %}
 import kernelci.api
 import kernelci.config
+import kernelci.config.storage
 import kernelci.storage
 {%- endblock %}
 


### PR DESCRIPTION
As the kernelci.config module is being rewritten, it no longer implicitly import other submodules.  Explicitly import kernelci.config.storage in python.jinja2 to avoid missing import errors.