### PR TITLE
test-configs.yaml: Enable more tests on verdin

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2844,10 +2844,10 @@ test_configs:
   - device_type: imx8mp-verdin-nonwifi-dahlia
     test_plans:
       - baseline
-# Disabling to reduce load
-#      - baseline-nfs
-#      - igt-gpu-etnaviv
-#      - kselftest-alsa
+      - baseline-nfs
+      - igt-gpu-etnaviv
+      - kselftest-alsa
+      - kselftest-clone3
 
   - device_type: imx8mq-zii-ultra-zest
     test_plans:


### PR DESCRIPTION
For some reason when reenabling the tests that were disabled due to load
issues those for verdin were skipped, enable everything now.

Also enable the clone3() selftests, they are not currently covered at all
on arm64 and the board is generally very lightly loaded.

Signed-off-by: Mark Brown <broonie@kernel.org>
