### PR TITLE
kernelci.cli: fix split_attributes() docstring

### DIFF
--- a/kernelci/cli/__init__.py
+++ b/kernelci/cli/__init__.py
@@ -137,14 +137,17 @@ def kci(ctx, settings):
 def split_attributes(attributes: typing.List[str]):
     """Split attributes into a dictionary.
 
-    Split the attributes string into a dictionary using space as a delimiter
-    between key/value pairs and `=` between the key and the value.  The API
-    operators are expected to be part of the key e.g. score__gte=100 to find
-    objects with a 'score' attribute of 100 or more.
+    Split the attribute strings into a dictionary using `=` as a delimiter
+    between the key and the value e.g. key=value.  The API operators are
+    expected to be part of the key, for example score__gte=100 to find objects
+    with a 'score' attribute with a value greater or equal to 100.
 
     As a syntactic convenience, if the operator matches one of >, <, >=, <=, !=
     then the corresponding API operator '__gt', '__lt', '__gte', '__lte',
-    '__ne' is added to the key name automatically.
+    '__ne' is added to the key name automatically.  Spaces can also be used
+    around the operators, although this typically means adding double quotes on
+    the command line around each attribute.  As such, the example used
+    previously is equivalent to "score >= 100".
     """
     operators = {
         '>': '__gt',


### PR DESCRIPTION
Fix the split_attributes() docstring as the attributes are meant to be a list of key=value strings rather than a single string with all the attributes.  The command line parser should already split each attribute into a separate string.  Also mention that spaces can be used around operators with examples using double quotes.

Fixes: 0a62fb90d404 ("kernelci.cli: rewrite split_attributes() method")