### PR TITLE
config/core: add back db_configs which were deleted with storage rework

### DIFF
--- a/config/core/db-configs.yaml
+++ b/config/core/db-configs.yaml
@@ -1,0 +1,17 @@
+db_configs:
+
+  chromeos.kernelci.org:
+    db_type: kernelci_backend
+    url: https://api.chromeos.kernelci.org/
+
+  kernelci.org:
+    db_type: kernelci_backend
+    url: https://api.kernelci.org/
+
+  localhost:
+    db_type: kernelci_backend
+    url: http://localhost:5001/
+
+  staging.kernelci.org:
+    db_type: kernelci_backend
+    url: https://api.staging.kernelci.org/


### PR DESCRIPTION
Add back the db_configs entries which got lost by mistake while reworking the storage configs.

Fixes: 68b04800c0f0 ("config/core: move storage_configs to storage in storage.yaml")