### PR TITLE
kernelci.cli: add api module with hello command

### DIFF
--- a/kci
+++ b/kci
@@ -16,6 +16,7 @@ https://kernelci.org/docs/api/.
 
 from kernelci.cli import kci
 from kernelci.cli import (  # pylint: disable=unused-import
+    api as kci_api,
     docker as kci_docker,
     user as kci_user,
 )

--- a/kernelci/cli/api.py
+++ b/kernelci/cli/api.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2023 Collabora Limited
+# Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+
+"""Tool to run generic queries with KernelCI API instances"""
+
+import json
+
+import click
+
+import kernelci.api
+import kernelci.config
+from . import Args, kci
+
+
+@kci.group(name='api')
+def kci_api():
+    """Run generic queries with API instances"""
+
+
+@kci_api.command
+@Args.config
+@Args.api
+@Args.indent
+def hello(config, indent, api):
+    """Query the API root endpoint"""
+    configs = kernelci.config.load(config)
+    api_config = configs['api'][api]
+    api = kernelci.api.get_api(api_config)
+    data = api.hello()
+    click.echo(json.dumps(data, indent=indent or None))


### PR DESCRIPTION
Add back the 'kci api hello' command as it's required as part of the Early Access setup documentation page.  This is also a placeholder for implementing other generic API commands to get the API instance version, URLs and other details.

Fixes #2158