### PR TITLE
kernelci.cli: add storage subcommand

### DIFF
--- a/kci
+++ b/kci
@@ -17,6 +17,7 @@ https://kernelci.org/docs/api/.
 from kernelci.cli import kci
 from kernelci.cli import (  # pylint: disable=unused-import
     docker as kci_docker,
+    storage as kci_storage,
     user as kci_user,
 )
 

--- a/kernelci/cli/__init__.py
+++ b/kernelci/cli/__init__.py
@@ -39,6 +39,10 @@ class Args:  # pylint: disable=too-few-public-methods
         '-s', '--toml-settings', 'settings',
         help="Path to the TOML user settings"
     )
+    storage = click.option(
+        '--storage',
+        help="Name of the storage config entry"
+    )
     verbose = click.option(
         '-v', '--verbose/--no-verbose', default=None,
         help="Print more details output"

--- a/kernelci/cli/storage.py
+++ b/kernelci/cli/storage.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2023 Collabora Limited
+# Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+
+"""Tool to interact with storage services supported by KernelCI"""
+
+import os
+
+import click
+
+import kernelci.config
+import kernelci.storage
+from . import Args, kci
+
+
+@kci.group(name='storage')
+def kci_storage():
+    """Interact with KernelCI storage services"""
+
+
+@kci_storage.command(secrets=True)
+@click.argument('filename', type=click.Path(exists=True))
+@click.argument('path', required=False)
+@Args.config
+@Args.storage
+def upload(filename, path, config, storage, secrets):
+    """Upload FILENAME to the designated storage service in PATH"""
+    configs = kernelci.config.load(config)
+    storage_config = configs['storage'][storage]
+    storage = kernelci.storage.get_storage(
+        storage_config, secrets.storage.credentials
+    )
+    url = storage.upload_single(
+        file_path=(filename, os.path.basename(filename)),
+        dest_path=(path or '')
+    )
+    click.echo(url)


### PR DESCRIPTION
Add implementation for `kci storage upload` subcommand using the new framework with Click.

Fixes #2158