### PR TITLE
kernelci.cli: support multiple values with default in TOML

### DIFF
--- a/kernelci/cli/__init__.py
+++ b/kernelci/cli/__init__.py
@@ -89,12 +89,17 @@ class Kci(click.Command):
 
     def invoke(self, ctx):
         path = self._walk_name(ctx)
+        params = {}
         for key, value in ctx.params.items():
-            if value is None:
-                ctx.params[key] = ctx.obj.get(*path, key)
+            if isinstance(value, (tuple, set)):
+                value = list(value)
+            if value is None or value == []:
+                value = ctx.obj.get(*path, key)
+            params[key] = value
         if self._kci_secrets:
             root = (path[0], 'secrets')
-            ctx.params['secrets'] = ctx.obj.get_secrets(ctx.params, root)
+            params['secrets'] = ctx.obj.get_secrets(params, root)
+        ctx.params = params
         super().invoke(ctx)
 
 

--- a/tests/kernelci-cli.toml
+++ b/tests/kernelci-cli.toml
@@ -1,5 +1,6 @@
 ["python -m pytest".hey]
 hello = 123
+many = ['a', 'bcd', 'xzy']
 
 ["python -m pytest".secrets]
 foo.bar.baz = 'FooBarBaz'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -28,16 +28,22 @@ def test_kci_command():
     @kernelci.cli.kci.command(cls=kernelci.cli.Kci, help="Unit test")
     @click.option('--hello', type=int)
     @click.option('--hack', type=str)
-    def hey(hello, hack):
+    @click.option('--many', type=str, multiple=True)
+    @click.option('--more', type=str, multiple=True)
+    def hey(hello, hack, many, more):
         assert isinstance(hello, int)
         assert hello == 123
         assert isinstance(hack, str)
         assert hack == 'Hack'
+        assert isinstance(many, list)
+        assert many == ['a', 'bcd', 'xzy']
+        assert isinstance(more, list)
+        assert more == ['xyz', 'abc']
 
     try:
         kernelci.cli.kci(args=[  # pylint: disable=no-value-for-parameter
             '--toml-settings', 'tests/kernelci-cli.toml',
-            'hey', '--hack', 'Hack'
+            'hey', '--hack', 'Hack', '--more=xyz', '--more=abc'
         ])
     except SystemExit as exc:
         if exc.code != 0:


### PR DESCRIPTION
Deal with cases where an option can have multiple values by converting it always to a list and loading the default list value from TOML when it's not supplied on the command line.

Update unit tests accordingly.

Fixes #2158