### PR TITLE
kernelci.cli: Allow multiple values for --yaml-config

### DIFF
--- a/kernelci/cli/__init__.py
+++ b/kernelci/cli/__init__.py
@@ -28,7 +28,7 @@ class Args:  # pylint: disable=too-few-public-methods
         help="Name of the API config entry"
     )
     config = click.option(
-        '-c', '--yaml-config', 'config',
+        '-c', '--yaml-config', 'config', multiple=True,
         help="Path to the YAML pipeline configuration"
     )
     indent = click.option(


### PR DESCRIPTION
Allow multiple values for the --yaml-config option so that the YAML configuration can be stored in different directories and files in various locations.  The code to merge them all is already in place.

Fixes #2158 