### PR TITLE
setup.py: add missing kernelci.cli package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setuptools.setup(
     packages=[
         "kernelci",
         "kernelci.api",
+        "kernelci.cli",
         "kernelci.config",
         "kernelci.db",
         "kernelci.legacy",


### PR DESCRIPTION
Add the missing kernelci.cli package to the list of packages to install.

This was missing when adding the new kernelci.cli implementation and went unnoticed when using the code from the Git checkout.

Fixes: ec7f5c61ae53 ("kernelci.cli: rewrite with Click framework")