### PR TITLE
runtime: Add instance ID for LAVA runtime

### DIFF
--- a/config/runtime/base/lava.jinja2
+++ b/config/runtime/base/lava.jinja2
@@ -15,7 +15,7 @@
 # * rootfs URL
 # * Docker image for QEMU
 
-job_name: "[KernelCI AKS] {{ node.id }} {{ node.name }} {{ node.revision.describe }}"
+job_name: "[{{ instanceid|default('KernelCI AKS')}}] {{ node.id }} {{ node.name }} {{ node.revision.describe }}"
 
 device_type: {{ platform_config.base_name|default(platform_config.name) }}
 

--- a/kernelci/runtime/__init__.py
+++ b/kernelci/runtime/__init__.py
@@ -122,10 +122,12 @@ class Runtime(abc.ABC):
 
     def get_params(self, job, api_config=None):
         """Get job template parameters"""
+        instanceid = os.environ.get('KCI_INSTANCE')
         params = {
             'api_config': api_config or {},
             'storage_config': job.storage_config or {},
             'platform_config': job.platform_config.to_dict() or {},
+            'instanceid': instanceid,
             'name': job.name,
             'node': job.node,
             'runtime': self.config.lab_type,


### PR DESCRIPTION
Add environment variable KCI_INSTANCE that will adjust job name prefix for LAVA.
Probably in future similar way we can customize k8s and docker names as well.