### PR TITLE
config/runtime: base: reenable platform configs to override previously set values

### DIFF
--- a/kernelci/runtime/__init__.py
+++ b/kernelci/runtime/__init__.py
@@ -134,6 +134,7 @@ class Runtime(abc.ABC):
             'runtime_image': job.config.image,
         }
         params.update(job.config.params)
+        params.update(job.platform_config.params)
         return params
 
     @classmethod


### PR DESCRIPTION
Fixes: #2170