### PR TITLE
CHROMEOS: test-configs-chromeos: fix reference cherry dtb name

### DIFF
--- a/config/core/test-configs-chromeos.yaml
+++ b/config/core/test-configs-chromeos.yaml
@@ -969,7 +969,7 @@ device_types:
       reference_kernel:
         image: 'https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-cherry/20231106.0/arm64/Image'
         modules: 'https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-cherry/20231106.0/arm64/modules.tar.xz'
-        dtb: 'https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-cherry/20231106.0/arm64/dtbs/mediatek/mt8192-asurada-spherion-r0.dtb'
+        dtb: 'https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-cherry/20231106.0/arm64/dtbs/mediatek/mt8195-cherry-tomato-r2.dtb'
       block_device: detect
 
 # Test plans temporarily disabled as QEMU build doesnt work


### PR DESCRIPTION
When this entry got added back in august, a copy+paste error resulted in the asurada dtb being used for cherry, leading to boot failures while flashing R118.