### PR TITLE
python.jinja2: Handle failure on json decode properly

### DIFF
--- a/config/runtime/base/python.jinja2
+++ b/config/runtime/base/python.jinja2
@@ -111,7 +111,10 @@ def main(args):
             job.submit(results, NODE, API_CONFIG_YAML)
     except requests.exceptions.HTTPError as ex:
         print(ex, file=sys.stderr)
-        detail = ex.response.json().get('detail')
+        try:
+            detail = ex.response.json().get('detail')
+        except requests.exceptions.JSONDecodeError:
+            print(f"Non-JSON response, body: {ex.response.text}", file=sys.stderr)
         if detail:
             print(detail, file=sys.stderr)
         results = None


### PR DESCRIPTION
Sometimes we have non-json response during kbuild, for example
```
[_upload_artifacts] Uploading artifacts to kbuild-gcc-10-x86-board-654b70f8c054242fbccbd592
    return complexjson.loads(self.text, **kwargs)
  File "/usr/lib/python3.9/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.9/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.9/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/kernelci/data/output/tmplcp0maoa/kbuild-gcc-10-x86-board", line 383, in <module>
    results = main(sys.argv)
  File "/home/kernelci/data/output/tmplcp0maoa/kbuild-gcc-10-x86-board", line 371, in main
    detail = ex.response.json().get('detail')
  File "/usr/local/lib/python3.9/dist-packages/requests/models.py", line 975, in json
    raise RequestsJSONDecodeError(e.msg, e.doc, e.pos)
requests.exceptions.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```
We need to handle it better for easier troubleshooting.