### PR TITLE
kci.test: Fix generation of URLs for DTBs on 32 bit Arm

### DIFF
--- a/kernelci/test.py
+++ b/kernelci/test.py
@@ -111,9 +111,17 @@ def get_params(meta, target, plan_config, storage, device_id):
     variant = target.variant
     dtb = dtb_full = target.dtb
     if dtb:
+        # Find which subidrectory (if any) of the kernel output the DTB is in
+        dtb_list = meta.get_single_artifact('dtbs', attr='contents')
+        for d in dtb_list:
+            (p, f) = os.path.split(d)
+            if f == target.dtb:
+                dtb = dtb_full = d
+
+        # Add the prefix we installed the DTBs into
         dtb_dir = meta.get_single_artifact('dtbs', attr='path')
         if dtb_dir:
-            dtb = dtb_full = os.path.join(dtb_dir, target.dtb)
+            dtb = dtb_full = os.path.join(dtb_dir, dtb)
             dtb = os.path.basename(dtb)  # hack for dtbs in subfolders
     publish_path = kernel['publish_path']
     job_px = publish_path.replace('/', '-')


### PR DESCRIPTION
Following a reorganisation of the DTBs into subdirectories for 32 bit Arm
we have had issues generating jobs for that architecture. We fixed
generation of jobs with 970c1982f3cb8561a9 ("kernelci.test: match configs
by dtb basename") but we are still generating jobs with URLs to DTBs that
omit the subdirectories the DTBs have been installed into, resulting in
none of the jobs actually running.

Fix this by substituting in the full path of the DTB from the contents list
in the metadata for the build. If a full path is already specified (eg, for
architectures like arm64 which always used subdirectories) then this will
do nothing.

Signed-off-by: Mark Brown <broonie@kernel.org>
