### PR TITLE
kernelci.cli: handle no attributes in split_attributes()

### DIFF
--- a/kernelci/cli/__init__.py
+++ b/kernelci/cli/__init__.py
@@ -168,6 +168,7 @@ def split_attributes(attributes: typing.List[str]):
     }
     pattern = re.compile(r'^([.a-zA-Z0-9_-]+) *([<>!=]+) *(.*)')
 
+    attributes = attributes or []
     parsed = {}
     for attribute in attributes:
         match = pattern.match(attribute)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -73,6 +73,8 @@ def test_kci_command_with_secrets():
 def test_split_valid_attributes():
     """Test the logic to split valid attribute with operators"""
     attributes = [
+        (None, {}),
+        ([], {}),
         (['name=value'], {'name': 'value'}),
         (['name>value'], {'name__gt': 'value'}),
         (['name>=value'], {'name__gte': 'value'}),


### PR DESCRIPTION
As a convenience, since when no attributes are passed on the command line Click gives a None rather than an empty list, deal with the case where attributes are None in split_attributes() as if it was an empty list.

Update unit tests accordingly to take this use-case into account.

Fixes: 0a62fb90d404 ("kernelci.cli: rewrite split_attributes() method")