### PR TITLE
kernelci.api: drop unused bindings after user rework

### DIFF
--- a/kernelci/api/__init__.py
+++ b/kernelci/api/__init__.py
@@ -48,11 +48,6 @@ class API(abc.ABC):  # pylint: disable=too-many-public-methods
     def node_states(self):
         """An enum with all the valid node state names"""
 
-    @property
-    @abc.abstractmethod
-    def security_scopes(self) -> Sequence[str]:
-        """All the user token security scope names"""
-
     @abc.abstractmethod
     def hello(self) -> dict:
         """Get the hello message"""
@@ -60,14 +55,6 @@ class API(abc.ABC):  # pylint: disable=too-many-public-methods
     @abc.abstractmethod
     def whoami(self) -> dict:
         """Get information about the current user"""
-
-    @abc.abstractmethod
-    def password_hash(self, password: str) -> dict:
-        """Get an encryption hash for a given password"""
-
-    @abc.abstractmethod
-    def change_password(self, username: str, current: str, new: str) -> dict:
-        """Change a password for a given user"""
 
     @abc.abstractmethod
     def create_token(self, username: str, password: str) -> dict:

--- a/kernelci/api/latest.py
+++ b/kernelci/api/latest.py
@@ -37,30 +37,11 @@ class LatestAPI(API):  # pylint: disable=too-many-public-methods
     def node_states(self):
         return NodeStates
 
-    @property
-    def security_scopes(self) -> Sequence[str]:
-        return ['users', 'admin']
-
     def hello(self) -> dict:
         return self._get('/').json()
 
     def whoami(self) -> dict:
         return self._get('/whoami').json()
-
-    def password_hash(self, password: str) -> dict:
-        return self._post('/hash', {'password': password}).json()
-
-    def change_password(self, username: str, current: str, new: str) -> dict:
-        return self._post(
-            '/password',
-            {
-                'current_password': {'password': current},
-                'new_password': {'password': new},
-            },
-            {
-                'username': username,
-            },
-        ).json()
 
     def create_token(self, username: str, password: str) -> dict:
         data = {


### PR DESCRIPTION
Drop the API bindings that aren't used any more now that the user management implementation has been replaced with fastapi-users:

* API.security_scopes
* API.password_hash
* API.change_password

Update kernelci.api.latest accordingly.  No unit tests need to be adjusted and the kernelci.cli tools are already using the new bindings.