### PR TITLE
CHROMEOS: Fix linux-firmware dependencies

### DIFF
--- a/config/docker/base/host-tools.jinja2
+++ b/config/docker/base/host-tools.jinja2
@@ -68,6 +68,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     make \
     python \
     python3 \
+    rdfind \
     rsync \
     tar \
     u-boot-tools \

--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -1207,7 +1207,7 @@ firmware/linux-firmware.git'
         clone_git(repourl, fwdir, 'main')
         # We need to extract files and symlinks using copy-firmware.sh
         shell_cmd(f"rm -rf {fwfiles} && mkdir {fwfiles}")
-        shell_cmd(f"cd {fwdir};./copy-firmware.sh {fwfiles};cd -")
+        shell_cmd(f"cd {fwdir} && ./copy-firmware.sh {fwfiles} && cd -")
         # We need to override directory where firmware stored
         self._kernel_config_setkey('CONFIG_EXTRA_FIRMWARE_DIR',
                                    f'"{fwfiles}"')


### PR DESCRIPTION
Add rdfind to packages as it is required now by linux-firmware and make execution of copy-firmware fails on errors.