### PR TITLE
Rework `kernelci.api.API` class internals to have only abstract bindings

### DIFF
--- a/kernelci/api/__init__.py
+++ b/kernelci/api/__init__.py
@@ -108,6 +108,30 @@ class Base:
         resp.raise_for_status()
         return resp
 
+    def _get_paginated(self, input_params, path, offset=None, limit=None):
+        params = input_params.copy()
+
+        if any((offset, limit)):
+            params.update({
+                'offset': offset or None,
+                'limit': limit or None,
+            })
+            return self._get(path, params=params)
+
+        objs = []
+        offset = 0
+        limit = 100
+        params['limit'] = limit
+        while True:
+            params['offset'] = offset
+            resp = self._get(path, params=params)
+            items = resp.json()['items']
+            objs.extend(items)
+            if len(items) < limit:
+                break
+            offset += limit
+        return objs
+
 
 class API(abc.ABC, Base):  # pylint: disable=too-many-public-methods
     """KernelCI API Python bindings abstraction"""

--- a/kernelci/api/latest.py
+++ b/kernelci/api/latest.py
@@ -72,33 +72,6 @@ class LatestAPI(API):  # pylint: disable=too-many-public-methods
                 continue
             return event
 
-    def _get_api_objs(self, params: dict, path: str,
-                      limit: Optional[int] = None,
-                      offset: Optional[int] = None) -> list:
-        """Helper function for getting objects from API with pagination
-        parameters"""
-        objs = []
-        if any((offset, limit)):
-            params.update({
-                'offset': offset or None,
-                'limit': limit or None,
-            })
-            resp = self._get(path, params=params)
-            objs = resp.json()['items']
-        else:
-            offset = 0
-            limit = 100
-            params['limit'] = limit
-            while True:
-                params['offset'] = offset
-                resp = self._get(path, params=params)
-                items = resp.json()['items']
-                objs.extend(items)
-                if len(items) < limit:
-                    break
-                offset += limit
-        return objs
-
     def get_node(self, node_id: str) -> dict:
         return self._get(f'node/{node_id}').json()
 
@@ -107,8 +80,7 @@ class LatestAPI(API):  # pylint: disable=too-many-public-methods
         offset: Optional[int] = None, limit: Optional[int] = None
     ) -> Sequence[dict]:
         params = attributes.copy() if attributes else {}
-        return self._get_api_objs(params=params, path='nodes',
-                                  limit=limit, offset=offset)
+        return self._get_paginated(params, 'nodes', offset, limit)
 
     def count_nodes(self, attributes: dict) -> int:
         return self._get('count', params=attributes).json()
@@ -127,16 +99,14 @@ class LatestAPI(API):  # pylint: disable=too-many-public-methods
         offset: Optional[int] = None, limit: Optional[int] = None
     ) -> Sequence[dict]:
         params = attributes.copy() if attributes else {}
-        return self._get_api_objs(params=params, path='groups',
-                                  limit=limit, offset=offset)
+        return self._get_paginated(params, 'groups', offset, limit)
 
     def get_users(
         self, attributes: dict,
         offset: Optional[int] = None, limit: Optional[int] = None
     ) -> Sequence[dict]:
         params = attributes.copy() if attributes else {}
-        return self._get_api_objs(params=params, path='users',
-                                  limit=limit, offset=offset)
+        return self._get_paginated(params, 'users', offset, limit)
 
     def create_user(self, user: dict) -> dict:
         return self._post('user/register', user).json()


### PR DESCRIPTION
Move the helper methods out of the API() abstract class to make the actual bindings clearer.  This will also make it possible to have nested classes for different parts of the API e.g. `api.node.find()` and `api.node.find()` rather than all the methods in a single ever-growing class.