### PR TITLE
test-configs.yaml: Enable AV1 and HEVC fluster tests on mt8195-cherry…

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -3121,7 +3121,9 @@ test_configs:
 
   - device_type: mt8195-cherry-tomato-r2
     test_plans:
+      - v4l2-decoder-conformance-av1
       - v4l2-decoder-conformance-h264
+      - v4l2-decoder-conformance-h265
       - v4l2-decoder-conformance-vp8
       - v4l2-decoder-conformance-vp9
     filters: *chromebook-decoders-filter


### PR DESCRIPTION
…-tomato-r2

Enable V4L2 decoder conformance tests on mt8195-cherry-tomato-r2 for AV1 and HEVC formats.