### PR TITLE
CHROMEOS rootfs-images.yaml: Update fluster rootfs image

### DIFF
--- a/config/core/rootfs-images.yaml
+++ b/config/core/rootfs-images.yaml
@@ -41,10 +41,10 @@ file_systems:
     type: debian
   debian_bullseye-gst-fluster_nfs:
     boot_protocol: tftp
-    nfs: bullseye-gst-fluster/20230717.0/{arch}/full.rootfs.tar.xz
+    nfs: bullseye-gst-fluster/20231117.0/{arch}/full.rootfs.tar.xz
     params: {}
     prompt: '/ #'
-    ramdisk: bullseye-gst-fluster/20230717.0/{arch}/initrd.cpio.gz
+    ramdisk: bullseye-gst-fluster/20231117.0/{arch}/initrd.cpio.gz
     root_type: nfs
     type: debian
   debian_bullseye-igt_ramdisk:


### PR DESCRIPTION
This image built by new rootfs script, verify it in staging, and if no problem observed - merge.