### PR TITLE
kernelci.cli: allow multiple values for .split_attributes()

### DIFF
--- a/kernelci/cli/__init__.py
+++ b/kernelci/cli/__init__.py
@@ -208,20 +208,14 @@ def split_attributes(attributes: typing.List[str]):
         if not match:
             raise click.ClickException(f"Invalid attribute: {attribute}")
         name, operator, value = match.groups()
-        ex_op, ex_value = parsed.get(name, (None, None))
-        if ex_value:
-            raise click.ClickException(
-                f"Conflicting values for {name}: \
-                {name}{value}, {ex_op}{ex_value}"
-            )
         opstr = operators.get(operator)
         if opstr is None:
             raise click.ClickException(f"Invalid operator: {operator}")
-        parsed[name] = (opstr, value)
+        parsed.setdefault(''.join((name, opstr)), []).append(value)
 
     return {
-        ''.join((key, opstr)): value
-        for key, (opstr, value) in parsed.items()
+        name: value[0] if len(value) == 1 else value
+        for name, value in parsed.items()
     }
 
 


### PR DESCRIPTION
Allow the same attribute to be provided several times in .split_attributes().  This is useful when looking for database entries that match one of a set of values e.g. name=foo?name=bar to find entries named 'foo' or 'bar'.

Update unit tests accordingly with an additional one to test the generated request URL with multiple values for the same parameter.