### PR TITLE
CHROMEOS: test-configs-chromeos: add some new tests in R118

### DIFF
--- a/config/core/test-configs-chromeos.yaml
+++ b/config/core/test-configs-chromeos.yaml
@@ -380,7 +380,6 @@ test_plans:
     params: &cros-tast-perf-params
       <<: *cros-tast-base-params
       tests: &cros-tast-perf-tests >
-        ui.IdlePerf
         ui.DesksAnimationPerf
         ui.DragTabInTabletPerf.touch
         ui.OverviewWithExpandedDesksBarPerf

--- a/config/core/test-configs-chromeos.yaml
+++ b/config/core/test-configs-chromeos.yaml
@@ -381,23 +381,29 @@ test_plans:
       <<: *cros-tast-base-params
       tests: &cros-tast-perf-tests >
         ui.IdlePerf
-        ui.WindowCyclePerf
-        ui.WindowResizePerf
-        ui.BubbleLauncherAnimationPerf
         ui.DesksAnimationPerf
-        ui.DragMaximizedWindowPerf
-        ui.DragTabInClamshellPerf
-        ui.DragTabInTabletPerf
         ui.DragTabInTabletPerf.touch
         filemanager.UIPerf.directory_list
         filemanager.UIPerf.list_apps
-        filemanager.ZipPerf
 
   cros-tast-perf-fixed:
     <<: *cros-tast-perf
     params:
       <<: *cros-tast-perf-params
       fixed_kernel: true
+
+  cros-tast-perf-long-duration:
+    <<: *cros-tast-base
+    params:
+      <<: *cros-tast-base-params
+      tests:
+        ui.WindowCyclePerf
+        ui.WindowResizePerf
+        ui.BubbleLauncherAnimationPerf
+        ui.DragMaximizedWindowPerf
+        ui.DragTabInClamshellPerf
+        ui.DragTabInTabletPerf
+        filemanager.ZipPerf
 
   cros-tast-perf_qemu:
     <<: *cros-tast-base-qemu
@@ -1068,6 +1074,7 @@ test_configs:
       - cros-tast-kernel-fixed
       - cros-tast-perf
       - cros-tast-perf-fixed
+      - cros-tast-perf-long-duration
       - cros-tast-platform
       - cros-tast-platform-fixed
       - cros-tast-power
@@ -1145,6 +1152,7 @@ test_configs:
       - cros-tast-mm-misc-fixed
       - cros-tast-perf
       - cros-tast-perf-fixed
+      - cros-tast-perf-long-duration
       - cros-tast-platform
       - cros-tast-platform-fixed
       - cros-tast-power

--- a/config/core/test-configs-chromeos.yaml
+++ b/config/core/test-configs-chromeos.yaml
@@ -383,8 +383,10 @@ test_plans:
         ui.IdlePerf
         ui.DesksAnimationPerf
         ui.DragTabInTabletPerf.touch
+        ui.OverviewWithExpandedDesksBarPerf
         filemanager.UIPerf.directory_list
         filemanager.UIPerf.list_apps
+        settings.DeviceMouseScrollAcceleration
 
   cros-tast-perf-fixed:
     <<: *cros-tast-perf
@@ -404,6 +406,7 @@ test_plans:
         ui.DragTabInClamshellPerf
         ui.DragTabInTabletPerf
         filemanager.ZipPerf
+        storage.WriteZeroPerf
 
   cros-tast-perf_qemu:
     <<: *cros-tast-base-qemu
@@ -437,10 +440,14 @@ test_plans:
         platform.Memd
         platform.Mtpd
         platform.TPMResponsive
+        platform.TPMStatus
         platform.CheckDiskSpace
         platform.CheckProcesses
         platform.DeviceHwid
         platform.SerialNumber
+        storage.HealthInfo
+        storage.InternalStorage
+        storage.LowPowerStateResidence
 
 
   cros-tast-platform-fixed:


### PR DESCRIPTION
These are new tests added in R118 which are known to work. We can extend coverage more, especially on the storage side but we need some bugs like b:311421846 fixed first.