### PR TITLE
Add `kci event` commands for unicast list `push` and `pop`

### DIFF
--- a/kernelci/api/__init__.py
+++ b/kernelci/api/__init__.py
@@ -194,6 +194,14 @@ class API(abc.ABC, Base):  # pylint: disable=too-many-public-methods
     def receive_event(self, sub_id: int) -> CloudEvent:
         """Listen and receive an event from a given subscription id"""
 
+    @abc.abstractmethod
+    def push_event(self, list_name: str, data):
+        """Push an event to a given Redis List"""
+
+    @abc.abstractmethod
+    def pop_event(self, list_name: str) -> CloudEvent:
+        """Listen and pop an event from a given List"""
+
     # -----
     # Nodes
     # -----

--- a/kernelci/api/helper.py
+++ b/kernelci/api/helper.py
@@ -43,6 +43,10 @@ class APIHelper:
         """Receive CloudEvent from Pub/Sub and return its data payload"""
         return self.api.receive_event(sub_id).data
 
+    def pop_event_data(self, list_name):
+        """Receive CloudEvent from Redis list and return its data payload"""
+        return self.api.pop_event(list_name).data
+
     def get_node_from_event(self, event_data):
         """Listen for an event and get the matching node object from it"""
         return self.api.get_node(event_data['id'])

--- a/kernelci/api/latest.py
+++ b/kernelci/api/latest.py
@@ -6,6 +6,7 @@
 """KernelCI API bindings for the latest version"""
 
 import enum
+import json
 from typing import Optional, Sequence
 
 from cloudevents.http import from_json
@@ -70,6 +71,17 @@ class LatestAPI(API):  # pylint: disable=too-many-public-methods
             event = from_json(data)
             if event.data == 'BEEP':
                 continue
+            return event
+
+    def push_event(self, list_name: str, data):
+        self._post('/'.join(['push', list_name]), data)
+
+    def pop_event(self, list_name: str):
+        path = '/'.join(['pop', str(list_name)])
+        while True:
+            resp = self._get(path)
+            data = json.dumps(resp.json())
+            event = from_json(data)
             return event
 
     def get_node(self, node_id: str) -> dict:


### PR DESCRIPTION
Depends on https://github.com/kernelci/kernelci-api/pull/417 and https://github.com/kernelci/kernelci-core/pull/2203

Add `kci event push` command to push event to a given Redis unicast list. Add `kci event pop` command to pop event from the list for a single consumer.