### PR TITLE
rootfs-configs.yaml: Add runtime dependencies for net selftests

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -11,7 +11,9 @@ rootfs_configs:
       - bc
       - ca-certificates
       - iproute2
+      - iputils-ping
       - jdim
+      - jq
       - libasound2
       - libatm1
       - libcap2-bin
@@ -34,6 +36,8 @@ rootfs_configs:
       - publicsuffix
       - python3-minimal
       - python3-unittest2
+      - socat
+      - tcpdump
       - tpm2-tools
       - wget
       - xz-utils


### PR DESCRIPTION
The net kselftests require a number of userspace utilities which we
don't currently include in the kselftest rootfs, add them to the
bookworm-kselftest image so we can run more of the suite.

Signed-off-by: Mark Brown <broonie@kernel.org>
