### PR TITLE
kernelci.api.helper: ignore non-node events in get_node_from_event()

### DIFF
--- a/kernelci/api/helper.py
+++ b/kernelci/api/helper.py
@@ -45,7 +45,9 @@ class APIHelper:
 
     def get_node_from_event(self, event_data):
         """Listen for an event and get the matching node object from it"""
-        return self.api.get_node(event_data['id'])
+        if 'id' in event_data:
+            return self.api.get_node(event_data['id'])
+        return None
 
     def pubsub_event_filter(self, sub_id, event):
         """Filter Pub/Sub events
@@ -87,6 +89,9 @@ class APIHelper:
         while True:
             event = self.receive_event_data(sub_id)
             node = self.get_node_from_event(event)
+            # Crude (provisional) filtering of non-node events
+            if not node:
+                continue
             if all(self.pubsub_event_filter(sub_id, obj)
                    for obj in [node, event]):
                 return node


### PR DESCRIPTION
This one shouldn't break anything, it's safe to merge but a review is appreciated.

Related to https://github.com/kernelci/kernelci-pipeline/pull/363

This is a provisional fix to prevent listeners from crashing when waiting for node events upon reception of a different type of event.