### PR TITLE
api/__init__.py: Fix _get_paginated logic

### DIFF
--- a/kernelci/api/__init__.py
+++ b/kernelci/api/__init__.py
@@ -116,7 +116,9 @@ class Base:
                 'offset': offset or None,
                 'limit': limit or None,
             })
-            return self._get(path, params=params)
+            resp = self._get(path, params=params)
+            items = resp.json()['items']
+            return items
 
         objs = []
         offset = 0


### PR DESCRIPTION
On 'node find' with --limit we are failing because _get return different object type.