### PR TITLE
Enable AV1 chromium 10-bit and H264 fr-ext tests

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -701,11 +701,28 @@ test_plans:
     filters:
       - passlist: {defconfig: ['videodec']}
 
+  v4l2-decoder-conformance-av1-chromium-10bit:
+    <<: *v4l2-decoder-conformance
+    params:
+      <<: *v4l2-decoder-conformance-params
+      testsuite: 'CHROMIUM-10bit-AV1-TEST-VECTORS'
+      decoders:
+        - 'GStreamer-AV1-V4L2SL-Gst1.0'
+
   v4l2-decoder-conformance-h264:
     <<: *v4l2-decoder-conformance
     params:
       <<: *v4l2-decoder-conformance-params
       testsuite: 'JVT-AVC_V1'
+      decoders:
+        - 'GStreamer-H.264-V4L2-Gst1.0'
+        - 'GStreamer-H.264-V4L2SL-Gst1.0'
+
+  v4l2-decoder-conformance-h264-frext:
+    <<: *v4l2-decoder-conformance
+    params:
+      <<: *v4l2-decoder-conformance-params
+      testsuite: 'JVT-FR-EXT'
       decoders:
         - 'GStreamer-H.264-V4L2-Gst1.0'
         - 'GStreamer-H.264-V4L2SL-Gst1.0'
@@ -3128,6 +3145,7 @@ test_configs:
   - device_type: mt8192-asurada-spherion-r0
     test_plans:
       - v4l2-decoder-conformance-h264
+      - v4l2-decoder-conformance-h264-frext
       - v4l2-decoder-conformance-vp8
       - v4l2-decoder-conformance-vp9
     filters: &chromebook-decoders-filter
@@ -3141,7 +3159,9 @@ test_configs:
   - device_type: mt8195-cherry-tomato-r2
     test_plans:
       - v4l2-decoder-conformance-av1
+      - v4l2-decoder-conformance-av1-chromium-10bit
       - v4l2-decoder-conformance-h264
+      - v4l2-decoder-conformance-h264-frext
       - v4l2-decoder-conformance-h265
       - v4l2-decoder-conformance-vp8
       - v4l2-decoder-conformance-vp9
@@ -3393,6 +3413,7 @@ test_configs:
   - device_type: rk3399-gru-kevin
     test_plans:
       - v4l2-decoder-conformance-h264
+      - v4l2-decoder-conformance-h264-frext
       - v4l2-decoder-conformance-vp8
       - v4l2-decoder-conformance-vp9
     filters: *chromebook-decoders-filter
@@ -3433,6 +3454,7 @@ test_configs:
   - device_type: sc7180-trogdor-kingoftown
     test_plans:
       - v4l2-decoder-conformance-h264
+      - v4l2-decoder-conformance-h264-frext
       - v4l2-decoder-conformance-h265
       - v4l2-decoder-conformance-vp8
       - v4l2-decoder-conformance-vp9
@@ -3450,6 +3472,7 @@ test_configs:
   - device_type: sc7180-trogdor-kingoftown-r1
     test_plans:
       - v4l2-decoder-conformance-h264
+      - v4l2-decoder-conformance-h264-frext
       - v4l2-decoder-conformance-h265
       - v4l2-decoder-conformance-vp8
       - v4l2-decoder-conformance-vp9
@@ -3475,6 +3498,7 @@ test_configs:
   - device_type: sc7180-trogdor-lazor-limozeen
     test_plans:
       - v4l2-decoder-conformance-h264
+      - v4l2-decoder-conformance-h264-frext
       - v4l2-decoder-conformance-h265
       - v4l2-decoder-conformance-vp8
       - v4l2-decoder-conformance-vp9

--- a/config/rootfs/debos/scripts/bullseye-gst-fluster.sh
+++ b/config/rootfs/debos/scripts/bullseye-gst-fluster.sh
@@ -192,7 +192,9 @@ mkdir -p /opt/fluster && cd /opt/fluster
 git clone $FLUSTER_URL .
 
 download_fluster_testsuite ./test_suites/av1/AV1-TEST-VECTORS.json
+download_fluster_testsuite ./test_suites/av1/CHROMIUM-10bit-AV1-TEST-VECTORS.json
 download_fluster_testsuite ./test_suites/h264/JVT-AVC_V1.json
+download_fluster_testsuite ./test_suites/h264/JVT-FR-EXT.json
 download_fluster_testsuite ./test_suites/h265/JCT-VC-HEVC-V1.json
 download_fluster_testsuite ./test_suites/vp8/VP8-TEST-VECTORS.json
 download_fluster_testsuite ./test_suites/vp9/VP9-TEST-VECTORS.json


### PR DESCRIPTION
Run the fluster Chromium 10-bit AV1 test suite on cherry and the H.264 fidelity range extension test suite on asurada, cherry, lazor, kingoftown and kevin Chromebooks.