### PR TITLE
CHROMEOS build-configs-chromeos: update 6.6 reference branch

### DIFF
--- a/config/core/build-configs-chromeos.yaml
+++ b/config/core/build-configs-chromeos.yaml
@@ -85,26 +85,26 @@ chromeos_6.6_variants: &chromeos_6_6_variants
     build_environment: clang-17
     architectures:
       arm:
-        base_defconfig: 'cros://chromeos-6.6-rc6-up/armel/chromiumos-arm.flavour.config'
+        base_defconfig: 'cros://chromeos-6.6/armel/chromiumos-arm.flavour.config'
         extra_configs:
-          - 'cros://chromeos-6.6-rc6-up/armel/chromiumos-rockchip.flavour.config'
+          - 'cros://chromeos-6.6/armel/chromiumos-rockchip.flavour.config'
         filters: *cros-filters
       arm64:
-        base_defconfig: 'cros://chromeos-6.6-rc6-up/arm64/chromiumos-arm64.flavour.config'
+        base_defconfig: 'cros://chromeos-6.6/arm64/chromiumos-arm64.flavour.config'
         fragments: [arm64-chromebook]
         extra_configs:
-          - 'cros://chromeos-6.6-rc6-up/arm64/chromiumos-mediatek.flavour.config+arm64-chromebook+CONFIG_MODULE_COMPRESS_GZIP=n'
-          - 'cros://chromeos-6.6-rc6-up/arm64/chromiumos-qualcomm.flavour.config+arm64-chromebook+CONFIG_MODULE_COMPRESS_GZIP=n'
-          - 'cros://chromeos-6.6-rc6-up/arm64/chromiumos-rockchip64.flavour.config+arm64-chromebook+CONFIG_MODULE_COMPRESS_GZIP=n'
+          - 'cros://chromeos-6.6/arm64/chromiumos-mediatek.flavour.config+arm64-chromebook+CONFIG_MODULE_COMPRESS_GZIP=n'
+          - 'cros://chromeos-6.6/arm64/chromiumos-qualcomm.flavour.config+arm64-chromebook+CONFIG_MODULE_COMPRESS_GZIP=n'
+          - 'cros://chromeos-6.6/arm64/chromiumos-rockchip64.flavour.config+arm64-chromebook+CONFIG_MODULE_COMPRESS_GZIP=n'
         filters: *cros-filters
       x86_64:
-        base_defconfig: 'cros://chromeos-6.6-rc6-up/x86_64/chromiumos-x86_64.flavour.config'
+        base_defconfig: 'cros://chromeos-6.6/x86_64/chromiumos-x86_64.flavour.config'
         fragments: [x86-chromebook]
         extra_configs:
-          - 'cros://chromeos-6.6-rc6-up/x86_64/chromeos-amd-stoneyridge.flavour.config+x86-chromebook+CONFIG_MODULE_COMPRESS_GZIP=n'
-          - 'cros://chromeos-6.6-rc6-up/x86_64/chromeos-intel-denverton.flavour.config+x86-chromebook+CONFIG_MODULE_COMPRESS_GZIP=n'
-          - 'cros://chromeos-6.6-rc6-up/x86_64/chromeos-intel-pineview.flavour.config+x86-chromebook+CONFIG_MODULE_COMPRESS_GZIP=n'
-          - 'cros://chromeos-6.6-rc6-up/x86_64/chromiumos-x86_64.flavour.config+x86-chromebook+CONFIG_MODULE_COMPRESS_GZIP=n'
+          - 'cros://chromeos-6.6/x86_64/chromeos-amd-stoneyridge.flavour.config+x86-chromebook+CONFIG_MODULE_COMPRESS_GZIP=n'
+          - 'cros://chromeos-6.6/x86_64/chromeos-intel-denverton.flavour.config+x86-chromebook+CONFIG_MODULE_COMPRESS_GZIP=n'
+          - 'cros://chromeos-6.6/x86_64/chromeos-intel-pineview.flavour.config+x86-chromebook+CONFIG_MODULE_COMPRESS_GZIP=n'
+          - 'cros://chromeos-6.6/x86_64/chromiumos-x86_64.flavour.config+x86-chromebook+CONFIG_MODULE_COMPRESS_GZIP=n'
         filters: *cros-filters
 
   clang-17: *clang-17


### PR DESCRIPTION
ChromiumOS' kernel repo now includes a `chromeos-6.6` branch, so let's use that one instead of the CI-generated one.