### PR TITLE
Get suspend/resume tests passing on the MT8192-Spherion Chromebook

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -358,6 +358,8 @@ fragments:
       qcom/venus-5.4/venus.mbn
       mediatek/mt8192/scp.img
       mediatek/mt8195/scp.img
+      mediatek/WIFI_MT7961_patch_mcu_1_2_hdr.bin
+      mediatek/WIFI_RAM_CODE_MT7961_1.bin
       "'
 
 

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -3121,7 +3121,7 @@ test_configs:
       - kselftest-tpm2
       - lc-compliance
       - preempt-rt
-      - sleep
+      - sleep_mem
       - v4l2-compliance-mtk-vcodec-enc
       - v4l2-compliance-uvc
 


### PR DESCRIPTION
Add missing Wifi firmwares and reduce the suspend modes tested to the ones supported to get the suspend/resume tests passing on the MT8192-Spherion Chromebook.

Results went from 3/23 (passing/total) to 13/13. LAVA log: https://lava.collabora.dev/scheduler/job/12152307

This will make suspend regressions on Spherion detectable.