### PR TITLE
CHROMEOS build-configs-chromeos: add new 6.6-based branch

### DIFF
--- a/config/core/build-configs-chromeos.yaml
+++ b/config/core/build-configs-chromeos.yaml
@@ -137,6 +137,11 @@ build_configs:
     branch: 'linux-6.6.y'
     variants: *chromeos_6_6_variants
 
+  chromeos-stable_6.6-backported-arm64:
+    tree: kernelci
+    branch: 'linux-6.6.y-arm64-chromeos'
+    variants: *chromeos_6_6_variants
+
   collabora-chromeos-kernel:
     tree: collabora-chromeos-kernel
     branch: 'for-kernelci'


### PR DESCRIPTION
Although most devices can use upstream 6.6 as-is, `cherry` still requires a few additional patches. Therefore, we create a new `chromeos-stable_6.6-backported-arm64` build config similar to the existing 6.1-based one.