### PR TITLE
kernelci.cli: rework `kci job` commands with `Click`

### DIFF
--- a/kci
+++ b/kci
@@ -20,6 +20,7 @@ from kernelci.cli import (  # pylint: disable=unused-import
     config as kci_config,
     docker as kci_docker,
     event as kci_event,
+    job as kci_job,
     node as kci_node,
     storage as kci_storage,
     user as kci_user,

--- a/kernelci/api/helper.py
+++ b/kernelci/api/helper.py
@@ -7,6 +7,7 @@
 """KernelCI API helpers"""
 
 from typing import Dict
+import json
 
 from . import API
 
@@ -171,3 +172,9 @@ class APIHelper:
         node_id = data['node']['id']
         # pylint: disable=protected-access
         return self.api._put(f'nodes/{node_id}', data).json()
+
+    @classmethod
+    def load_json(cls, json_path, encoding='utf-8'):
+        """Read content from JSON file"""
+        with open(json_path, encoding=encoding) as json_file:
+            return json.load(json_file)

--- a/kernelci/cli/__init__.py
+++ b/kernelci/cli/__init__.py
@@ -58,6 +58,10 @@ class Args:  # pylint: disable=too-few-public-methods
         '-v', '--verbose/--no-verbose', default=None,
         help="Print more details output"
     )
+    runtime = click.option(
+        '--runtime',
+        help="Name of the Runtime environment config entry"
+    )
 
 
 def catch_http_error(func):

--- a/kernelci/cli/job.py
+++ b/kernelci/cli/job.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2023 Collabora Limited
+# Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+# Author: Jeny Sadadia <jeny.sadadia@collabora.com>
+
+"""Tool to generate and run KernelCI jobs"""
+
+import json
+
+import click
+
+import kernelci.api
+import kernelci.config
+import kernelci.api.helper
+import kernelci.runtime
+from . import Args, kci, catch_http_error
+
+
+@kci.group(name='job')
+def kci_job():
+    """Manage KernelCI jobs"""
+
+
+@kci_job.command(secrets=True)
+@click.argument('name')
+@click.option('--node-id')
+@click.option('--node-json')
+@Args.config
+@Args.api
+@Args.indent
+@catch_http_error
+def new(name, node_id, node_json, config,  # pylint: disable=too-many-arguments
+        api, indent, secrets):
+    """Create a new job node"""
+    configs = kernelci.config.load(config)
+    api_config = configs['api'][api]
+    api = kernelci.api.get_api(api_config, secrets.api.token)
+    helper = kernelci.api.helper.APIHelper(api)
+    if node_id:
+        input_node = api.get_node(node_id)
+    elif node_json:
+        input_node = helper.load_json(node_json)
+    else:
+        raise click.ClickException("Either --node-id or --node-json \
+is required.")
+    job_config = configs['jobs'][name]
+    job_node = helper.create_job_node(job_config, input_node)
+    click.echo(json.dumps(job_node, indent=indent))
+
+
+@kci_job.command(secrets=True)
+@click.argument('node-id')
+@click.option('--platform', help="Name of the platform to run the job",
+              required=True)
+@click.option('--output', help="Path of the directory where to generate \
+              the job data")
+@Args.runtime
+@Args.storage
+@Args.config
+@Args.api
+@catch_http_error
+def generate(node_id,  # pylint: disable=too-many-arguments, too-many-locals
+             runtime, storage, platform, output, config, api, secrets):
+    """Generate a job definition in a file"""
+    configs = kernelci.config.load(config)
+    api_config = configs['api'][api]
+    api = kernelci.api.get_api(api_config, secrets.api.token)
+    job_node = api.get_node(node_id)
+    job = kernelci.runtime.Job(job_node, configs['jobs'][job_node['name']])
+    job.platform_config = configs['device_types'][platform]
+    job.storage_config = (
+        configs['storage'][storage]
+        if storage else None
+    )
+    runtime_config = configs['runtimes'][runtime]
+    runtime = kernelci.runtime.get_runtime(
+        runtime_config, token=secrets.api.runtime_token)
+    params = runtime.get_params(job, api.config)
+    job_data = runtime.generate(job, params)
+    if output:
+        output_file = runtime.save_file(job_data, output, params)
+        click.echo(f"Job saved in {output_file}")
+    else:
+        click.echo(job_data)
+
+
+@kci_job.command(secrets=True)
+@click.argument('job-path')
+@click.option('--wait', is_flag=True)
+@Args.runtime
+@Args.config
+@catch_http_error
+def submit(runtime, job_path, wait, config, secrets):
+    """Submit a job definition to its designated runtime"""
+    configs = kernelci.config.load(config)
+    runtime_config = configs['runtimes'][runtime]
+    runtime = kernelci.runtime.get_runtime(
+        runtime_config, token=secrets.api.runtime_token
+    )
+    job = runtime.submit(job_path)
+    click.echo(runtime.get_job_id(job))
+    if wait:
+        ret = runtime.wait(job)
+        click.echo(f"Job completed with status: {ret}")


### PR DESCRIPTION
Rework `kci` commands to manage KernelCI jobs with `Click` framework.

Tested locally for `kver` job:
```
$ ./kci job new kver --node-id=6465cd3c73281d29430d3071
{"id": "656ad50f8cff329b0e4ad092", "kind": "node", "name": "kver", "path": ["checkout", "kver"], "group": "kver", "revision": {"tree": "kernelci", "url": "https://github.com/kernelci/linux.git", "branch": "staging-mainline", "commit": "ac37cbde135450309a2b6c3b66331912d744b4c9", "describe": "staging-mainline-20230517.0", "version": {"version": 6, "patchlevel": 4, "sublevel": null, "extra": "-rc2-1-gac37cbde1354", "name": null}}, "parent": "6465cd3c73281d29430d3071", "state": "running", "result": null, "artifacts": {"tarball": "http://172.17.0.1:8002/linux-kernelci-staging-mainline-staging-mainline-20230517.0.tar.gz"}, "data": null, "created": "2023-12-02T06:56:15.243717", "updated": "2023-12-02T06:56:15.243726", "timeout": "2023-12-02T12:56:15.243734", "holdoff": null, "owner": "admin", "user_groups": []}


$ ./kci job generate 656ad50f8cff329b0e4ad092 --platform=shell --yaml-config=config/pipeline.yaml  --output=.
Job saved in ./kver


$ ./kci job submit ./kver --wait
17202
Getting kernel source tree...
Source directory: /tmp/kci/linux-kernelci-staging-mainline-staging-mainline-20230517.0
Running job...
Checking kernel revision
Result: pass
Job completed with status: 0
```