### PR TITLE
build-configs.yaml: Add rust-for-linux-samples to rust-next

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -1460,7 +1460,7 @@ build_configs:
     variants:
       rustc-1.73:
         build_environment: rustc-1.73
-        fragments: [rust, rust-samples, kselftest]
+        fragments: [rust, rust-for-linux-samples, rust-samples, kselftest]
         architectures:
           x86_64:
             base_defconfig: 'x86_64_defconfig'

--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -1463,7 +1463,7 @@ build_configs:
         fragments: [rust, rust-for-linux-samples, rust-samples, kselftest]
         architectures:
           x86_64:
-            base_defconfig: 'x86_64_defconfig'
+            base_defconfig: 'x86_64_defconfig+rust'
 
   samsung:
     tree: samsung


### PR DESCRIPTION
rust-for-linux-samples was used for building rust test modules, recently unused.
enable it for rust-next as it have substitute the previous rust branch.