### PR TITLE
runtime/kubernetes.jinja2: Add safe defaults

### DIFF
--- a/config/runtime/base/kubernetes.jinja2
+++ b/config/runtime/base/kubernetes.jinja2
@@ -66,6 +66,15 @@ spec:
           name: ssh-key
           readOnly: true
 
+        # FIXME: Request safe defaults to not overload node with
+        # parallel pods
+        resources:
+          limits:
+            cpu: 8
+          requests:
+            cpu: 7.1
+            memory: 8
+
         env:
         - name: KCI_API_TOKEN
           valueFrom:


### PR DESCRIPTION
Add safe defaults, so in case too many jobs scheduled they will not crash cluster with parallel builds.