### PR TITLE
CHROMEOS: build-configs: remove DRM_VGEM from arm chromebook cfg

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -240,7 +240,6 @@ fragments:
       - 'CONFIG_SX9324=m'
       - 'CONFIG_TCG_TIS_I2C_CR50=y'
       - 'CONFIG_QCOM_OCMEM=y'
-      - 'CONFIG_DRM_VGEM=y'
       # Mediatek specific options start here
       - 'CONFIG_RTC_DRV_PM8XXX=y'
       - 'CONFIG_SND_SOC_MT8183=y'


### PR DESCRIPTION
    Both trogdors (qualcomm) and also the mediatek boards fail the
    graphics.KernelConfig because they expect DRM_VGEM = n.
    
    Example:
    https://chromeos.kernelci.org/test/case/id/656ca345e2496d30984c084f/
    
    Signed-off-by: Adrian Ratiu <adrian.ratiu@collabora.com>