### PR TITLE
kernelci.cli: tidy up job command

### DIFF
--- a/kernelci/cli/__init__.py
+++ b/kernelci/cli/__init__.py
@@ -46,6 +46,10 @@ class Args:  # pylint: disable=too-few-public-methods
         '-n', '--page-number', type=int,
         help="Page number in paginated data"
     )
+    runtime = click.option(
+        '--runtime',
+        help="Name of the runtime config entry"
+    )
     settings = click.option(
         '-s', '--toml-settings', 'settings',
         help="Path to the TOML user settings"
@@ -57,10 +61,6 @@ class Args:  # pylint: disable=too-few-public-methods
     verbose = click.option(
         '-v', '--verbose/--no-verbose', default=None,
         help="Print more details output"
-    )
-    runtime = click.option(
-        '--runtime',
-        help="Name of the Runtime environment config entry"
     )
 
 

--- a/kernelci/cli/job.py
+++ b/kernelci/cli/job.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 #
-# Copyright (C) 2023 Collabora Limited
+# Copyright (C) 2022-2023 Collabora Limited
 # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
 # Author: Jeny Sadadia <jeny.sadadia@collabora.com>
 
@@ -42,8 +42,9 @@ def new(name, node_id, node_json, config,  # pylint: disable=too-many-arguments
     elif node_json:
         input_node = helper.load_json(node_json)
     else:
-        raise click.ClickException("Either --node-id or --node-json \
-is required.")
+        raise click.ClickException(
+            "Either --node-id or --node-json is required."
+        )
     job_config = configs['jobs'][name]
     job_node = helper.create_job_node(job_config, input_node)
     click.echo(json.dumps(job_node, indent=indent))
@@ -51,10 +52,14 @@ is required.")
 
 @kci_job.command(secrets=True)
 @click.argument('node-id')
-@click.option('--platform', help="Name of the platform to run the job",
-              required=True)
-@click.option('--output', help="Path of the directory where to generate \
-              the job data")
+@click.option(
+    '--platform', required=True,
+    help="Name of the platform to run the job"
+)
+@click.option(
+    '--output',
+    help="Path of the directory where to generate the job data"
+)
 @Args.runtime
 @Args.storage
 @Args.config


### PR DESCRIPTION
Fix a few cosmetic issues in the kernelci.cli.job implementation:

* fix alphabetical order in kernelci.cli.Args with runtime arg
* avoid breaking long strings by moving them to their on line
* fix copyright years as this was originally written in 2022

Fixes: 9ef18ea92d3c ("kernelci.cli: rework `kci job` commands")