### PR TITLE
config: runtime: lab-baylibre: switch to regex for tree

### DIFF
--- a/config/core/runtime-configs.yaml
+++ b/config/core/runtime-configs.yaml
@@ -11,17 +11,8 @@ runtimes:
     queue_timeout:
       days: 1
     filters:
+      - regex: {'tree': '^(kernelci|mainline|next|stable|arm64|riscv|soc|amlogic|matthiasbgg)$'}
       - passlist:
-          tree:
-            - staging
-            - mainline
-            - next
-            - stable
-            - arm64
-            - riscv
-            - soc
-            - amlogic
-            - matthiasbgg
           plan:
             - baseline
             - kselftest


### PR DESCRIPTION
Switch the tree filter to a regex with the primary goal of running tests for "stable", but not stable* (e.g. stable-rc-queue) due the number of jobs currently being too much for lab-baylibre.