### PR TITLE
kernelci.cli: add echo_json() function

### DIFF
--- a/kernelci/cli/__init__.py
+++ b/kernelci/cli/__init__.py
@@ -15,6 +15,7 @@ from TOML settings.
 
 import email.policy
 import functools
+import json
 import re
 import typing
 
@@ -264,3 +265,14 @@ def get_api_helper(*args, **kwargs):
     """Wrapper around get_api() to get an APIHelper object"""
     api = get_api(*args, **kwargs)
     return kernelci.api.helper.APIHelper(api)
+
+
+def echo_json(data, indent):
+    """Dump the JSON data with the provided indent on stdout
+
+    This is a convenience function for a very common use-case where some JSON
+    data received from the API needs to be dumped on stdout.  If indent is 0
+    then no identation is applied rather than indentation with 0 spaces (line
+    returns).
+    """
+    click.echo(json.dumps(data, indent=indent or None))

--- a/kernelci/cli/api.py
+++ b/kernelci/cli/api.py
@@ -5,12 +5,9 @@
 
 """Tool to run generic queries with KernelCI API instances"""
 
-import json
-
-import click
-
 from . import (
     Args,
+    echo_json,
     get_api,
     kci,
 )
@@ -29,4 +26,4 @@ def hello(config, api, indent):
     """Query the API root endpoint"""
     api = get_api(config, api)
     data = api.hello()
-    click.echo(json.dumps(data, indent=indent or None))
+    echo_json(data, indent)

--- a/kernelci/cli/event.py
+++ b/kernelci/cli/event.py
@@ -13,6 +13,7 @@ import click
 
 from . import (
     Args,
+    echo_json,
     get_api,
     get_api_helper,
     kci,
@@ -71,7 +72,7 @@ def receive(config, api, indent, sub_id, secrets):
     if isinstance(event, str):
         click.echo(event.strip())
     elif isinstance(event, dict):
-        click.echo(json.dumps(event, indent=indent))
+        echo_json(event, indent)
     else:
         click.echo(event)
 
@@ -102,6 +103,6 @@ def pop(config, api, indent, list_name, secrets):
     if isinstance(event, str):
         click.echo(event.strip())
     elif isinstance(event, dict):
-        click.echo(json.dumps(event, indent=indent))
+        echo_json(event, indent)
     else:
         click.echo(event)

--- a/kernelci/cli/job.py
+++ b/kernelci/cli/job.py
@@ -6,8 +6,6 @@
 
 """Tool to generate and run KernelCI jobs"""
 
-import json
-
 import click
 
 import kernelci.config
@@ -15,6 +13,7 @@ import kernelci.runtime
 from . import (
     Args,
     catch_http_error,
+    echo_json,
     get_api,
     get_api_helper,
     kci,
@@ -49,7 +48,7 @@ def new(name, node_id, node_json, config,  # pylint: disable=too-many-arguments
         )
     job_config = configs['jobs'][name]
     job_node = helper.create_job_node(job_config, input_node)
-    click.echo(json.dumps(job_node, indent=indent))
+    echo_json(job_node, indent)
 
 
 @kci_job.command(secrets=True)

--- a/kernelci/cli/node.py
+++ b/kernelci/cli/node.py
@@ -13,6 +13,7 @@ import click
 
 from . import (
     Args,
+    echo_json,
     get_api,
     kci,
     split_attributes,
@@ -33,7 +34,7 @@ def get(node_id, config, api, indent):
     """Get a node with a given ID"""
     api = get_api(config, api)
     node = api.get_node(node_id)
-    click.echo(json.dumps(node, indent=indent))
+    echo_json(node, indent)
 
 
 @kci_node.command
@@ -52,7 +53,7 @@ def find(attributes, config, api,   # pylint: disable=too-many-arguments
     api = get_api(config, api)
     attributes = split_attributes(attributes)
     nodes = api.get_nodes(attributes, offset, limit)
-    data = json.dumps(nodes, indent=indent)
+    data = json.dumps(nodes, indent=indent or None)
     echo = click.echo_via_pager if len(nodes) > 1 else click.echo
     echo(data)
 
@@ -80,4 +81,4 @@ def submit(config, api, secrets, indent):
         node = api.update_node(data)
     else:
         node = api.create_node(data)
-    click.echo(json.dumps(node, indent=indent))
+    echo_json(node, indent)

--- a/kernelci/cli/user.py
+++ b/kernelci/cli/user.py
@@ -15,6 +15,7 @@ import click
 from . import (
     Args,
     catch_http_error,
+    echo_json,
     get_api,
     kci,
     split_attributes,
@@ -35,7 +36,7 @@ def whoami(config, api, indent, secrets):
     """Get the current user's details with API authentication"""
     api = get_api(config, api, secrets)
     data = api.whoami()
-    click.echo(json.dumps(data, indent=indent))
+    echo_json(data, indent)
 
 
 @kci_user.command(secrets=True)
@@ -49,7 +50,7 @@ def find(attributes, config, api, indent, secrets):
     api = get_api(config, api, secrets)
     attributes = split_attributes(attributes)
     users = api.get_users(attributes)
-    data = json.dumps(users, indent=indent)
+    data = json.dumps(users, indent=indent or None)
     echo = click.echo_via_pager if len(users) > 1 else click.echo
     echo(data)
 
@@ -142,7 +143,7 @@ def get(user_id, config, api, indent):
     """Get a user with a given ID"""
     api = get_api(config, api)
     user = api.get_user(user_id)
-    click.echo(json.dumps(user, indent=indent))
+    echo_json(user, indent)
 
 
 @kci_user.command(secrets=True)
@@ -235,7 +236,7 @@ def find_groups(attributes, config, api, indent):
     api = get_api(config, api)
     attributes = split_attributes(attributes)
     users = api.get_groups(attributes)
-    data = json.dumps(users, indent=indent)
+    data = json.dumps(users, indent=indent or None)
     echo = click.echo_via_pager if len(users) > 1 else click.echo
     echo(data)
 


### PR DESCRIPTION
    Add kernelci.cli.echo_json() function as a convenience for the common
    use-case where some JSON data needs to be dumped on stdout.  Update
    all subcommands accordingly to use it.  This takes into account that
    indent=0 should mean no formatting, rather than indentation with only
    line returns and no spaces.
