### PR TITLE
kernelci.cli: use catch_http_error in all API calls

### DIFF
--- a/kernelci/cli/api.py
+++ b/kernelci/cli/api.py
@@ -7,6 +7,7 @@
 
 from . import (
     Args,
+    catch_http_error,
     echo_json,
     get_api,
     kci,
@@ -22,6 +23,7 @@ def kci_api():
 @Args.config
 @Args.api
 @Args.indent
+@catch_http_error
 def hello(config, api, indent):
     """Query the API root endpoint"""
     api = get_api(config, api)

--- a/kernelci/cli/event.py
+++ b/kernelci/cli/event.py
@@ -12,6 +12,7 @@ import click
 
 from . import (
     Args,
+    catch_http_error,
     echo_json,
     get_api,
     get_api_helper,
@@ -28,6 +29,7 @@ def kci_event():
 @click.argument('channel')
 @Args.config
 @Args.api
+@catch_http_error
 def subscribe(config, api, channel, secrets):
     """Subscribe to a Pub/Sub channel"""
     api = get_api(config, api, secrets)
@@ -39,6 +41,7 @@ def subscribe(config, api, channel, secrets):
 @click.argument('sub_id')
 @Args.config
 @Args.api
+@catch_http_error
 def unsubscribe(config, api, sub_id, secrets):
     """Unsubscribe from a Pub/Sub channel"""
     api = get_api(config, api, secrets)
@@ -47,12 +50,13 @@ def unsubscribe(config, api, sub_id, secrets):
 
 @kci_event.command(secrets=True)
 @click.argument('input_file', type=click.File('r'))
+@click.argument('channel')
 @click.option('--is-json', help="Parse input data as JSON", is_flag=True)
 @Args.config
 @Args.api
-@click.argument('channel')
+@catch_http_error
 # pylint: disable=too-many-arguments
-def send(input_file, is_json, config, api, channel, secrets):
+def send(input_file, channel, is_json, config, api, secrets):
     """Read some data and send it as an event on a channel"""
     api = get_api(config, api, secrets)
     data = json.load(input_file) if is_json else input_file.read()
@@ -64,7 +68,8 @@ def send(input_file, is_json, config, api, channel, secrets):
 @Args.config
 @Args.api
 @Args.indent
-def receive(config, api, indent, sub_id, secrets):
+@catch_http_error
+def receive(sub_id, config, api, indent, secrets):
     """Wait and receive an event from a subscription and print on stdout"""
     helper = get_api_helper(config, api, secrets)
     event = helper.receive_event_data(sub_id)
@@ -82,6 +87,7 @@ def receive(config, api, indent, sub_id, secrets):
 @click.option('--is-json', help="Parse input data as JSON", is_flag=True)
 @Args.config
 @Args.api
+@catch_http_error
 # pylint: disable=too-many-arguments
 def push(input_file, list_name, is_json, config, api, secrets):
     """Read some data and push it as an event on a list"""
@@ -95,7 +101,8 @@ def push(input_file, list_name, is_json, config, api, secrets):
 @Args.config
 @Args.api
 @Args.indent
-def pop(config, api, indent, list_name, secrets):
+@catch_http_error
+def pop(list_name, config, api, indent, secrets):
     """Wait and pop an event from a List when received print on stdout"""
     helper = get_api_helper(config, api, secrets)
     event = helper.pop_event_data(list_name)

--- a/kernelci/cli/node.py
+++ b/kernelci/cli/node.py
@@ -12,6 +12,7 @@ import click
 
 from . import (
     Args,
+    catch_http_error,
     echo_json,
     get_api,
     get_pagination,
@@ -30,6 +31,7 @@ def kci_node():
 @Args.config
 @Args.api
 @Args.indent
+@catch_http_error
 def get(node_id, config, api, indent):
     """Get a node with a given ID"""
     api = get_api(config, api)
@@ -44,6 +46,7 @@ def get(node_id, config, api, indent):
 @Args.indent
 @Args.page_length
 @Args.page_number
+@catch_http_error
 # pylint: disable=too-many-arguments
 def find(attributes, config, api, indent, page_length, page_number):
     """Find nodes with arbitrary attributes"""
@@ -60,6 +63,7 @@ def find(attributes, config, api, indent, page_length, page_number):
 @click.argument('attributes', nargs=-1)
 @Args.config
 @Args.api
+@catch_http_error
 def count(attributes, config, api):
     """Count nodes with arbitrary attributes"""
     api = get_api(config, api)
@@ -72,6 +76,7 @@ def count(attributes, config, api):
 @Args.config
 @Args.api
 @Args.indent
+@catch_http_error
 def submit(input_file, config, api, indent, secrets):
     """Submit a new node or update an existing one"""
     api = get_api(config, api, secrets)


### PR DESCRIPTION
    Add the catch_http_error decorator to all the commands that make some
    API calls.  This improves the user experience noticeably as it avoids
    having a noisy exception trace and also adds any the details provided
    by the API from the HTTP error data.
    
    For example:
    
        $ ./kci node get --api=staging abcd
        Error: 400 Client Error: Bad Request for url: https://staging.kernelci.org:9000/latest/node/abcd
        'abcd' is not a valid ObjectId, it must be a 12-byte input or a 24-character hex string
    
    The last line there is not part of the standard exception handling,
    and it's needed in order for the user to understand what the actual
    problem was (rather than there was just an HTTP error).

Fixes #2223