### PR TITLE
CHROMEOS: build-configs: add skyrim amdgpu psp firmware

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -628,6 +628,7 @@ fragments:
       amdgpu/green_sardine_mec.bin
       amdgpu/green_sardine_mec2.bin
       amdgpu/green_sardine_rlc.bin
+      amdgpu/psp_13_0_8_toc.bin
       amdgpu/raven2_asd.bin
       amdgpu/raven2_ce.bin
       amdgpu/raven2_gpu_info.bin


### PR DESCRIPTION
Running tests revealed a firmware blob is required for GPU initialization:

[    3.576634] amdgpu 0000:04:00.0: Direct firmware load for amdgpu/psp_13_0_8_toc.bin failed with error -2
[    3.586367] amdgpu 0000:04:00.0: amdgpu: fail to request/validate toc microcode
[    3.593924] [drm:psp_sw_init] *ERROR* Failed to load psp firmware!
[    3.600359] [drm:amdgpu_device_ip_init] *ERROR* sw_init of IP block <psp> failed -2
[    3.608265] amdgpu 0000:04:00.0: amdgpu: amdgpu_device_ip_init failed
[    3.614955] amdgpu 0000:04:00.0: amdgpu: Fatal error during GPU init
