### PR TITLE
kernelci.cli.user: send API token to GET user matching ID

### DIFF
--- a/kernelci/cli/user.py
+++ b/kernelci/cli/user.py
@@ -132,15 +132,15 @@ def verify(username, config, api):
     click.echo("Email verification successful!")
 
 
-@kci_user.command
+@kci_user.command(secrets=True)
 @click.argument('user_id')
 @Args.config
 @Args.api
 @Args.indent
 @catch_http_error
-def get(user_id, config, api, indent):
+def get(user_id, config, api, indent, secrets):
     """Get a user with a given ID"""
-    api = get_api(config, api)
+    api = get_api(config, api, secrets)
     user = api.get_user(user_id)
     click.echo(json.dumps(user, indent=indent))
 


### PR DESCRIPTION
Depends on https://github.com/kernelci/kernelci-api/pull/431

Send API token for getting user matching given ID as the endpoint has made accessible to only authorized users.