### PR TITLE
CHROMEOS test.py: Shorten some kernel names

### DIFF
--- a/kernelci/test.py
+++ b/kernelci/test.py
@@ -34,6 +34,8 @@ SHORTEN_KEYWORDS = {
     'cros---chromeos-5.15': 'cros-5.15',
     'cros---chromeos-6.1': 'cros-6.1',
     'CONFIG_MODULE_COMPRESS_GZIP=n': 'no-gz',
+    'linux-6.6.y-arm64-chromeos': 'arm-6.6-cros',
+    'linux-6.1.y-arm64-chromeos': 'arm-6.1-cros',
 }
 
 

--- a/kernelci/test.py
+++ b/kernelci/test.py
@@ -34,8 +34,8 @@ SHORTEN_KEYWORDS = {
     'cros---chromeos-5.15': 'cros-5.15',
     'cros---chromeos-6.1': 'cros-6.1',
     'CONFIG_MODULE_COMPRESS_GZIP=n': 'no-gz',
-    'linux-6.6.y-arm64-chromeos': 'arm-6.6-cros',
-    'linux-6.1.y-arm64-chromeos': 'arm-6.1-cros',
+    'linux-6.6.y-arm64-chromeos': 'arm64-6.6-cros',
+    'linux-6.1.y-arm64-chromeos': 'arm64-6.1-cros',
 }
 
 


### PR DESCRIPTION
As always we hit LAVA job name limits, trying to shorten some of names.

```
12242517 /data/workspace/bot.staging.kernelci.org/test-runner/workspace/chromeos/test-runner/jobs/lab-collabora/kernelci-linux-6.6.y-arm64-chromeos-linux-6.6.y-arm64-chromeos-20231211.0-arm64-arm64-qcom-6.6-arm64-chromebook-clang-17-sc7180-trogdor-lazor-limozeen_chromeos-cros-tast-kernel.yaml
HTTPError: 400 Client Error: Bad Request for url: https://lava.collabora.dev/api/v0.2/jobs/?format=json&limit=256
```