### PR TITLE
build-configs: Update MediaTek SoC tree

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -73,11 +73,11 @@ trees:
   mainline:
     url: 'https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git'
 
-  matthiasbgg:
-    url: 'https://git.kernel.org/pub/scm/linux/kernel/git/matthias.bgg/linux.git'
-
   media:
     url: "https://git.linuxtv.org/media_tree.git"
+
+  mediatek:
+    url: 'https://git.kernel.org/pub/scm/linux/kernel/git/mediatek/linux.git'
 
   net-next:
     url: "https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net-next.git"
@@ -1218,20 +1218,6 @@ build_configs:
           x86_64:
             base_defconfig: 'x86_64_defconfig'
 
-  matthiasbgg-for-next:
-    tree: matthiasbgg
-    branch: 'for-next'
-    variants:
-      gcc-10:
-        build_environment: gcc-10
-        architectures:
-          arm64:
-            <<: *arm64_defconfig
-            fragments: [arm64-chromebook]
-          x86_64:
-            <<: *x86_64_defconfig
-            fragments: [x86-board]
-
   media:
     tree: media
     branch: 'master'
@@ -1251,6 +1237,20 @@ build_configs:
               - 'defconfig+arm64-chromebook+kselftest'
               - 'defconfig+arm64-chromebook+videodec'
             fragments: [arm64-chromebook, videodec]
+
+  mediatek-for-next:
+    tree: mediatek
+    branch: 'for-next'
+    variants:
+      gcc-10:
+        build_environment: gcc-10
+        architectures:
+          arm64:
+            <<: *arm64_defconfig
+            fragments: [arm64-chromebook]
+          x86_64:
+            <<: *x86_64_defconfig
+            fragments: [x86-board]
 
   net-next:
     tree: net-next


### PR DESCRIPTION
The MediaTek SoC tree was moved from git/matthias.bgg/linux.git to the collaborative git/mediatek/linux.git tree.