### PR TITLE
rootfs: Add imagesize parameter

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -154,6 +154,8 @@ rootfs_configs:
       - wget
     script: "scripts/bullseye-gst-fluster.sh"
     test_overlay: "overlays/fluster"
+    imagesize: 2GB
+    debos_memory: 8G
 
   bullseye-igt:
     rootfs_type: debos

--- a/config/rootfs/debos/rootfs.yaml
+++ b/config/rootfs/debos/rootfs.yaml
@@ -12,6 +12,7 @@
 {{- $debian_mirror := or .debian_mirror "http://deb.debian.org/debian" -}}
 {{- $keyring_package := or .keyring_package "" -}}
 {{- $keyring_file := or .keyring_file "" -}}
+{{- $imagesize := or .imagesize "1GB" -}}
 
 architecture: {{ $architecture }}
 
@@ -132,7 +133,7 @@ actions:
 
   - action: image-partition
     imagename: rootfs.ext4
-    imagesize: 1GB
+    imagesize: {{ $imagesize }}
     partitiontype: msdos
     mountpoints:
       - mountpoint: /

--- a/kernelci/legacy/config/rootfs.py
+++ b/kernelci/legacy/config/rootfs.py
@@ -50,7 +50,7 @@ class RootFS_Debos(RootFS):
                  extra_files_remove=None, script="",
                  test_overlay="", crush_image_options=None, debian_mirror="",
                  keyring_package="", keyring_file="", debos_memory="",
-                 debos_cpus="", debos_scratchsize=""):
+                 debos_cpus="", debos_scratchsize="", imagesize=""):
         super().__init__(name, rootfs_type)
         self._debian_release = debian_release
         self._arch_list = arch_list or list()
@@ -65,6 +65,7 @@ class RootFS_Debos(RootFS):
         self._debian_mirror = debian_mirror
         self._keyring_package = keyring_package
         self._keyring_file = keyring_file
+        self._imagesize = imagesize
         self._debos_memory = debos_memory
         self._debos_cpus = debos_cpus
         self._debos_scratchsize = debos_scratchsize
@@ -83,6 +84,7 @@ class RootFS_Debos(RootFS):
             'debian_mirror',
             'keyring_package',
             'keyring_file',
+            'imagesize',
             'extra_packages',
             'extra_packages_remove',
             'extra_files_remove',
@@ -150,6 +152,10 @@ class RootFS_Debos(RootFS):
         return self._keyring_file
 
     @property
+    def imagesize(self):
+        return self._imagesize
+
+    @property
     def debos_memory(self):
         return self._debos_memory
 
@@ -170,6 +176,7 @@ class RootFS_Debos(RootFS):
             'debian_mirror',
             'keyring_package',
             'keyring_file',
+            'imagesize',
             'extra_packages',
             'extra_packages_remove',
             'extra_files_remove',
@@ -391,6 +398,7 @@ def _dump_config_debos(config_name, config):
     print('\tdebian_mirror: {}'.format(config.debian_mirror))
     print('\tkeyring_package: {}'.format(config.keyring_package))
     print('\tkeyring_file: {}'.format(config.keyring_file))
+    print('\timagesize: {}'.format(config.imagesize))
     print('\tdebos_memory: {}'.format(config.debos_memory))
     print('\tdebos_cpu: {}'.format(config.debos_cpu))
     print('\tdebos_scratchsize: {}'.format(config.debos_scratchsize))

--- a/kernelci/rootfs.py
+++ b/kernelci/rootfs.py
@@ -76,6 +76,7 @@ class DebosBuilder(RootfsBuilder):
             'debian_mirror': config.debian_mirror,
             'keyring_package': config.keyring_package,
             'keyring_file': config.keyring_file,
+            'imagesize': config.imagesize,
         }
 
         debos_opts += ' ' + ' '.join(


### PR DESCRIPTION
Some images might exceed 1GB default size, for example fluster tests that include a lot of test vectors.
We need configurable parameters to solve that.