### PR TITLE
test-configs.yaml: Enable bookworm rootfs on kselftest-net_qemu

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -416,6 +416,7 @@ test_plans:
 
   kselftest-net_qemu:
     <<: *kselftest_qemu
+    rootfs: debian_bookworm-kselftest_ramdisk
     params:
       job_timeout: '90'
       kselftest_collections: "net"


### PR DESCRIPTION
We use yaml alias which hide that kselftest by default uses bullseye. So we need to change this parameter to bookworm.