### PR TITLE
Add API.User abstract class

### DIFF
--- a/kernelci/api/__init__.py
+++ b/kernelci/api/__init__.py
@@ -144,7 +144,7 @@ class Base:
         return resp
 
 
-class API(abc.ABC, Base):  # pylint: disable=too-many-public-methods
+class API(abc.ABC, Base):
     """KernelCI API Python bindings abstraction"""
 
     # pylint: disable=abstract-class-instantiated

--- a/kernelci/api/latest.py
+++ b/kernelci/api/latest.py
@@ -37,15 +37,64 @@ class LatestAPI(API):  # pylint: disable=too-many-public-methods
     def hello(self) -> dict:
         return self._get('/').json()
 
-    def whoami(self) -> dict:
-        return self._get('/whoami').json()
+    class User(API.User):
+        """User bindings for the latest API version"""
 
-    def create_token(self, username: str, password: str) -> dict:
-        data = {
-            'username': username,
-            'password': password,
-        }
-        return self._post('/user/login', data, json_data=False).json()
+        def whoami(self) -> dict:
+            return self._get('/whoami').json()
+
+        def create_token(self, username: str, password: str) -> dict:
+            data = {
+                'username': username,
+                'password': password,
+            }
+            return self._post('/user/login', data, json_data=False).json()
+
+        def get(self, user_id: str) -> dict:
+            return self._get(f'user/{user_id}').json()
+
+        def find(
+            self, attributes: Dict[str, str],
+            offset: Optional[int] = None, limit: Optional[int] = None
+        ) -> Sequence[dict]:
+            params = attributes.copy() if attributes else {}
+            return self._get_paginated(params, 'users', offset, limit)
+
+        def add(self, user: dict) -> dict:
+            return self._post('user/register', user).json()
+
+        def update(self, fields: dict, user_id: Optional[str] = None) -> dict:
+            return self._patch(f'user/{user_id or "me"}', fields).json()
+
+        def request_verification_token(self, email: str):
+            return self._post('user/request-verify-token', {
+                "email": email
+            })
+
+        def verify_email(self, token: str):
+            return self._post('user/verify', {
+                "token": token
+            })
+
+        def request_password_reset_token(self, email: str):
+            return self._post('user/forgot-password', {
+                "email": email
+            })
+
+        def reset_password(self, token: str, password: str):
+            return self._post('user/reset-password', {
+                "token": token,
+                "password": password
+            })
+
+        def update_password(self, username: str, current_password: str,
+                            new_password: str):
+            data = {
+                "username": username,
+                "password": current_password,
+                "new_password": new_password
+            }
+            return self._post('user/update-password', data, json_data=False)
 
     class Node(API.Node):
         """Node bindings for the latest API version"""
@@ -115,52 +164,6 @@ class LatestAPI(API):  # pylint: disable=too-many-public-methods
     ) -> Sequence[dict]:
         params = attributes.copy() if attributes else {}
         return self._get_paginated(params, 'groups', offset, limit)
-
-    def get_users(
-        self, attributes: dict,
-        offset: Optional[int] = None, limit: Optional[int] = None
-    ) -> Sequence[dict]:
-        params = attributes.copy() if attributes else {}
-        return self._get_paginated(params, 'users', offset, limit)
-
-    def create_user(self, user: dict) -> dict:
-        return self._post('user/register', user).json()
-
-    def update_user(self, fields: dict, user_id: Optional[str] = None) -> dict:
-        return self._patch(f'user/{user_id or "me"}', fields).json()
-
-    def request_verification_token(self, email: str):
-        return self._post('user/request-verify-token', {
-            "email": email
-        })
-
-    def verify_user(self, token: str):
-        return self._post('user/verify', {
-            "token": token
-        })
-
-    def request_password_reset_token(self, email: str):
-        return self._post('user/forgot-password', {
-            "email": email
-        })
-
-    def reset_password(self, token: str, password: str):
-        return self._post('user/reset-password', {
-            "token": token,
-            "password": password
-        })
-
-    def get_user(self, user_id: str) -> dict:
-        return self._get(f'user/{user_id}').json()
-
-    def update_password(self, username: str, current_password: str,
-                        new_password: str):
-        data = {
-            "username": username,
-            "password": current_password,
-            "new_password": new_password
-        }
-        return self._post('user/update-password', data, json_data=False)
 
     def create_group(self, name: str) -> dict:
         return self._post('group', {"name": name}).json()

--- a/kernelci/cli/user.py
+++ b/kernelci/cli/user.py
@@ -35,7 +35,7 @@ def kci_user():
 def whoami(config, api, indent, secrets):
     """Get the current user's details with API authentication"""
     api = get_api(config, api, secrets)
-    data = api.whoami()
+    data = api.user.whoami()
     echo_json(data, indent)
 
 
@@ -49,7 +49,7 @@ def find(attributes, config, api, indent, secrets):
     """Find user profiles with arbitrary attributes"""
     api = get_api(config, api, secrets)
     attributes = split_attributes(attributes)
-    users = api.get_users(attributes)
+    users = api.user.find(attributes)
     data = json.dumps(users, indent=indent or None)
     echo = click.echo_via_pager if len(users) > 1 else click.echo
     echo(data)
@@ -64,7 +64,7 @@ def token(username, config, api):
     """Create a new API token using a user name and password"""
     api = get_api(config, api)
     password = getpass.getpass()
-    api_token = api.create_token(username, password)
+    api_token = api.user.create_token(username, password)
     click.echo(api_token['access_token'])
 
 
@@ -83,13 +83,13 @@ def update(attributes, username, config, api, secrets):
 
     api = get_api(config, api, secrets)
     if username:
-        users = api.get_users({"username": username})
+        users = api.user.find({"username": username})
         if not users:
             raise click.ClickException(f"User not found: {username}")
         user_id = users[0]['id']
     else:
         user_id = None
-    api.update_user(fields, user_id)
+    api.user.update(fields, user_id)
 
 
 @kci_user.command(secrets=True)
@@ -110,7 +110,7 @@ def add(username, email, config, api, secrets):
         'password': password,
     }
     api = get_api(config, api, secrets)
-    api.create_user(user)
+    api.user.add(user)
 
 
 @kci_user.command
@@ -121,15 +121,15 @@ def add(username, email, config, api, secrets):
 def verify(username, config, api):
     """Verify the user's email address"""
     api = get_api(config, api)
-    users = api.get_users({"username": username})
+    users = api.user.find({"username": username})
     if not users:
         raise click.ClickException(f"User not found: {username}")
     user = users[0]
     email = user['email']
     click.echo(f"Sending verification token to {email}")
-    api.request_verification_token(email)
+    api.user.request_verification_token(email)
     verification_token = click.prompt("Verification token")
-    api.verify_user(verification_token)
+    api.user.verify_email(verification_token)
     click.echo("Email verification successful!")
 
 
@@ -142,7 +142,7 @@ def verify(username, config, api):
 def get(user_id, config, api, indent, secrets):
     """Get a user with a given ID"""
     api = get_api(config, api, secrets)
-    user = api.get_user(user_id)
+    user = api.user.get(user_id)
     echo_json(user, indent)
 
 
@@ -154,11 +154,11 @@ def get(user_id, config, api, indent, secrets):
 def activate(username, config, api, secrets):
     """Activate user account (admin only)"""
     api = get_api(config, api, secrets)
-    users = api.get_users({"username": username})
+    users = api.user.find({"username": username})
     if not users:
         raise click.ClickException(f"User not found: {username}")
     user = users[0]
-    api.update_user({"is_active": 1}, user['id'])
+    api.user.update({"is_active": 1}, user['id'])
 
 
 @kci_user.command(secrets=True)
@@ -169,11 +169,11 @@ def activate(username, config, api, secrets):
 def deactivate(username, config, api, secrets):
     """Deactivate a user account (admin only)"""
     api = get_api(config, api, secrets)
-    users = api.get_users({"username": username})
+    users = api.user.find({"username": username})
     if not users:
         raise click.ClickException(f"User not found: {username}")
     user = users[0]
-    api.update_user({"is_active": 0}, user['id'])
+    api.user.update({"is_active": 0}, user['id'])
 
 
 @kci_user.group(name='password')
@@ -194,7 +194,7 @@ def password_update(username, config, api):
     retyped = getpass.getpass("Retype new password: ")
     if new_password != retyped:
         raise click.ClickException("Sorry, passwords do not match")
-    api.update_password(username, current_password, new_password)
+    api.user.update_password(username, current_password, new_password)
 
 
 @user_password.command(name='reset')
@@ -205,19 +205,19 @@ def password_update(username, config, api):
 def password_reset(username, config, api):
     """Reset password for a user account"""
     api = get_api(config, api)
-    users = api.get_users({"username": username})
+    users = api.user.find({"username": username})
     if not users:
         raise click.ClickException(f"User not found: {username}")
     user = users[0]
     email = user['email']
     click.echo(f"Sending reset token to {email}")
-    api.request_password_reset_token(email)
+    api.user.request_password_reset_token(email)
     reset_token = click.prompt("Reset token")
     password = getpass.getpass("New password: ")
     retyped = getpass.getpass("Retype new password: ")
     if password != retyped:
         raise click.ClickException("Sorry, passwords do not match")
-    api.reset_password(reset_token, password)
+    api.user.reset_password(reset_token, password)
 
 
 @kci_user.group(name='group')
@@ -261,14 +261,14 @@ def group_add(name, config, api, secrets):
 def join(name, username, config, api, secrets):
     """Add a user to a group (admin only)"""
     api = get_api(config, api, secrets)
-    users = api.get_users({"username": username})
+    users = api.user.find({"username": username})
     if not users:
         raise click.ClickException(f"User not found: {username}")
     user = users[0]
     groups = [name]
     for group in users[0]['groups']:
         groups.append(group['name'])
-    api.update_user({"groups": groups}, user['id'])
+    api.user.update({"groups": groups}, user['id'])
 
 
 @user_group.command(secrets=True)
@@ -279,13 +279,13 @@ def join(name, username, config, api, secrets):
 def leave(name, config, api, secrets):
     """Leave a user group"""
     api = get_api(config, api, secrets)
-    user = api.whoami()
+    user = api.user.whoami()
     groups = []
     for group in user['groups']:
         groups.append(group['name'])
     if name in groups:
         groups.remove(name)
-        api.update_user({"groups": groups}, None)
+        api.user.update({"groups": groups}, None)
 
 
 @user_group.command(secrets=True)


### PR DESCRIPTION
Similarly to API.Node, refactor the user API endpoint bindings with a new API.User abstract class.  Update the LatestAPI implementation and `kernelci.cli.user` accordingly.  There doesn't appear to be any unit tests for this part of the API.

As a side-effect, the Pylint check for too many public methods can be enabled again as the base API abstract class has now fewer of them since each nested class is taking care of a specific part of the API.

The user groups are still in the API class and should be moved to API.User or a new API.Group class.  This can be done as a follow-up, it wasn't very clearly defined initially so I've left it out for now.

Similarly, there should be API.Event or API.PubSub etc. for the other parts of the API.