### PR TITLE
kernelci.cli: add command for getting PubSub subscribers stats

### DIFF
--- a/kernelci/api/__init__.py
+++ b/kernelci/api/__init__.py
@@ -301,6 +301,10 @@ class API(abc.ABC, Base):
     def pop_event(self, list_name: str) -> CloudEvent:
         """Listen and pop an event from a given List"""
 
+    @abc.abstractmethod
+    def subscription_stats(self):
+        """Get Pub/Sub scribscription statistics"""
+
     # -----------
     # User groups
     # -----------

--- a/kernelci/api/latest.py
+++ b/kernelci/api/latest.py
@@ -155,6 +155,9 @@ class LatestAPI(API):  # pylint: disable=too-many-public-methods
             event = from_json(data)
             return event
 
+    def subscription_stats(self):
+        return self._get('stats/subscriptions').json()
+
     def get_group(self, group_id: str) -> dict:
         return self._get(f'group/{group_id}').json()
 

--- a/kernelci/cli/event.py
+++ b/kernelci/cli/event.py
@@ -112,3 +112,14 @@ def pop(list_name, config, api, indent, secrets):
         echo_json(event, indent)
     else:
         click.echo(event)
+
+
+@kci_event.command(secrets=True)
+@Args.config
+@Args.api
+@Args.indent
+@catch_http_error
+def stats(config, api, indent, secrets):
+    """Get Pub/Sub subscribers statistics (admin only)"""
+    api = get_api(config, api, secrets)
+    echo_json(api.subscription_stats(), indent)


### PR DESCRIPTION
Implement `kci event stats` command to get details of existing Pub/Sub subscribers.

```
$ ./kci event stats --indent=2
[
  {
    "id": 773,
    "channel": "test",
    "user": "admin",
    "created": "2023-12-22T07:03:53.335397",
    "last_poll": null
  }
]
```