### PR TITLE
kernelci.cli.user: fix password reset

### DIFF
--- a/kernelci/cli/user.py
+++ b/kernelci/cli/user.py
@@ -198,18 +198,13 @@ def password_update(username, config, api):
 
 
 @user_password.command(name='reset')
-@click.argument('username')
+@click.argument('email')
 @Args.config
 @Args.api
 @catch_http_error
-def password_reset(username, config, api):
+def password_reset(email, config, api):
     """Reset password for a user account"""
     api = get_api(config, api)
-    users = api.user.find({"username": username})
-    if not users:
-        raise click.ClickException(f"User not found: {username}")
-    user = users[0]
-    email = user['email']
     click.echo(f"Sending reset token to {email}")
     api.user.request_password_reset_token(email)
     reset_token = click.prompt("Reset token")


### PR DESCRIPTION
Since GET `/users` request is now restricted to authorized users only, it is not possible to retrieve user information in password reset request to get email address. Instead of getting username, directly ask for email address in the
command argument to fix the issue.