### PR TITLE
build-configs-stable: add `stable-rc_6.6`

### DIFF
--- a/config/core/build-configs-stable.yaml
+++ b/config/core/build-configs-stable.yaml
@@ -331,6 +331,14 @@ build_configs:
       tree: stable
       branch: 'linux-6.3.y'
 
+  stable-rc_6.6:
+    tree: stable-rc
+    branch: 'linux-6.6.y'
+    variants: *stable_variants
+    reference:
+      tree: stable
+      branch: 'linux-6.6.y'
+
   stable-rc_queue-4.4:
     tree: stable-rc
     branch: 'queue/4.4'


### PR DESCRIPTION
Enable testing for `stable-rc` tree for Linux-6.6.y.