### PR TITLE
test-configs.yaml: Add LibreTech Solitude

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1579,6 +1579,12 @@ device_types:
     boot_method: uboot
     flags: ['big_endian']
 
+  meson-sm1-s905d3-libretech-cc:
+    mach: amlogic
+    class: arm64-dtb
+    boot_method: uboot
+    flags: ['big_endian']
+
   meson-sm1-sei610:
     mach: amlogic
     class: arm64-dtb
@@ -3045,6 +3051,16 @@ test_configs:
     test_plans:
       - baseline
       - preempt-rt
+
+  - device_type: meson-sm1-s905d3-libretech-cc
+    test_plans:
+      - baseline
+      - baseline-nfs
+      - igt-gpu-panfrost
+      - kselftest-alsa
+      - kselftest-dt
+      - kselftest-kvm
+      - kselftest-rtc
 
   - device_type: meson-sm1-sei610
     test_plans:


### PR DESCRIPTION
This is another Meson board from Libretech with some new audio hardware
to test that I have in my lab, enable baseline tests plus tests relevant for
the platform support and also KVM since the board has VHE which we don't
currently have good coverage for.

Signed-off-by: Mark Brown <broonie@kernel.org>
