### PR TITLE
build-configs.yaml: Add scp.img for mt8183/mt8186 to arm64-chromebook

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -356,6 +356,8 @@ fragments:
       rockchip/dptx.bin
       qcom/venus-5.4/venus.mdt
       qcom/venus-5.4/venus.mbn
+      mediatek/mt8183/scp.img
+      mediatek/mt8186/scp.img
       mediatek/mt8192/scp.img
       mediatek/mt8195/scp.img
       mediatek/WIFI_MT7961_patch_mcu_1_2_hdr.bin


### PR DESCRIPTION
Embed the scp.img firmware for mt8183 and mt8186 into the arm64-chromebook kernel, like was already done for other MediaTek chromebooks. This ensures the SCP can fully boot on those platforms independent of the rootfs used. In particular it makes the cros-ec-rpmsg check in the dt-kselftest pass.