### PR TITLE
test-configs.yaml: Add LibreTech Alta

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1523,6 +1523,11 @@ device_types:
     class: arm64-dtb
     boot_method: uboot
 
+  meson-g12b-a311d-libretech-cc:
+    mach: amlogic
+    class: arm64-dtb
+    boot_method: uboot
+
   meson-g12b-odroid-n2:
     mach: amlogic
     class: arm64-dtb
@@ -2999,6 +3004,15 @@ test_configs:
       - kselftest-filesystems
       - kselftest-futex
       - kselftest-lib
+
+  - device_type: meson-g12b-a311d-libretech-cc
+    test_plans:
+      - baseline
+      - baseline-nfs
+      - igt-gpu-panfrost
+      - kselftest-alsa
+      - kselftest-dt
+      - kselftest-rtc
 
   - device_type: meson-g12b-odroid-n2
     test_plans:


### PR DESCRIPTION
The Alta is another new board from LibreTech again based on an AMLogic
SoC, it uses the same PCB as Solitude but has a different lower end SoC
mounted.  Enable basic tests relevant to the hardware present on the
board.

Signed-off-by: Mark Brown <broonie@kernel.org>
