### PR TITLE
test-configs.yaml: Add Avenger96

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2083,6 +2083,13 @@ device_types:
     filters:
       - blocklist: *device_config_filter
 
+  stm32mp157a-dhcor-avenger96:
+    mach: stm32
+    class: arm-dtb
+    boot_method: uboot
+    filters:
+      - blocklist: {defconfig: ['stm32_defconfig']}
+
   stm32mp157c-dk2:
     mach: stm32
     class: arm-dtb
@@ -3539,6 +3546,14 @@ test_configs:
       - baseline
       - baseline-nfs
       - sleep
+
+  - device_type: stm32mp157a-dhcor-avenger96
+    test_plans:
+      - baseline
+      - baseline-nfs
+      - igt-gpu-etnaviv
+      - kselftest-alsa
+      - kselftest-dt
 
   - device_type: stm32mp157c-dk2
     test_plans:


### PR DESCRIPTION
This is a STM32MP157A based board, including ethernet support. Enable
basic boot tests plus suites that cover specific features found on the
board.

Signed-off-by: Mark Brown <broonie@kernel.org>
