### PR TITLE
test-configs: Additional kselftests for Avenger96

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -3574,6 +3574,11 @@ test_configs:
       - igt-gpu-etnaviv
       - kselftest-alsa
       - kselftest-dt
+      - kselftest-ftrace
+      - kselftest-landlock
+      - kselftest-lib
+      - kselftest-lkdtm
+      - kselftest-seccomp
 
   - device_type: stm32mp157c-dk2
     test_plans:

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -333,6 +333,12 @@ test_plans:
       kselftest_collections: "filesystems"
     filters: *kselftest_no_fragment
 
+  kselftest-ftrace:
+    <<: *kselftest
+    params:
+      job_timeout: '20'
+      kselftest_collections: "ftrace"
+
   kselftest-futex:
     <<: *kselftest
     params:


### PR DESCRIPTION
Let's take advantage of the ability of Avenger96 to boot the full
kselftest configuration, including adding the config fragment for the
ftrace tests which has been blocked by the issues with finding something
that can boot the kernel with all the kselftest options enabled.
