### PR TITLE
test-configs.yaml: Enable V4L decoder tests on Le Potato

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -3074,6 +3074,9 @@ test_configs:
       # ltp-mm - Runs board out of memory
       - ltp-pty
       - ltp-timers
+      - v4l2-decoder-conformance-h264
+      - v4l2-decoder-conformance-h265
+      - v4l2-decoder-conformance-vp9
 
   - device_type: meson-gxm-khadas-vim2
     test_plans:


### PR DESCRIPTION
There is a video CODEC block with upstream support on the Le Potato,
enable the V4L2 decoder tests for the CODECs it supports.  It also
supports MJPEG but that doesn't seem to be a suite we cover.

Signed-off-by: Mark Brown <broonie@kernel.org>
