### PR TITLE
test-configs.yaml: Enable V4L decoder coverage on Solitude

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -3099,6 +3099,9 @@ test_configs:
       - kselftest-dt
       - kselftest-kvm
       - kselftest-rtc
+      - v4l2-decoder-conformance-h264
+      - v4l2-decoder-conformance-h265
+      - v4l2-decoder-conformance-vp9
 
   - device_type: meson-sm1-sei610
     test_plans:


### PR DESCRIPTION
The SoC on the Solitude has an upstream supported video decoder IP,
enable coverage for the CODECs it supports.

Signed-off-by: Mark Brown <broonie@kernel.org>
