### PR TITLE
test-configs.yaml: Enable video decoder coverage on Alta

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -3020,6 +3020,9 @@ test_configs:
       - kselftest-alsa
       - kselftest-dt
       - kselftest-rtc
+      - v4l2-decoder-conformance-h264
+      - v4l2-decoder-conformance-h265
+      - v4l2-decoder-conformance-vp9
 
   - device_type: meson-g12b-odroid-n2
     test_plans:


### PR DESCRIPTION
The SoC on the LibreTech Alta has a video decoder IP which is supported
upstream, enable coverage of the CODECs it supports.

Signed-off-by: Mark Brown <broonie@kernel.org>
