### PR TITLE
test-configs.yaml: Basic coverage for video decode on Udoo

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2800,6 +2800,7 @@ test_configs:
       - kselftest-alsa
       - kselftest-dt
       - ltp-crypto
+      - v4l2-decoder-conformance-h264
 
   - device_type: imx6q-nitrogen6x
     test_plans:
@@ -2834,6 +2835,7 @@ test_configs:
       - kselftest-alsa
       - kselftest-dt
       - ltp-crypto
+      - v4l2-decoder-conformance-h264
 
   - device_type: imx6q-var-dt6customboard
     test_plans:


### PR DESCRIPTION
The i.MX6 SoCs on the UDOO boards have a video decoder, enable coverage
of H.264.  There are a number of other CODECs supported and there is
encoding support but we don't have testsuite stanzas for them.

Signed-off-by: Mark Brown <broonie@kernel.org>
