### PR TITLE
test-configs.yaml: Block kselftest-dt in older kernels

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -317,7 +317,9 @@ test_plans:
     params:
       job_timeout: '10'
       kselftest_collections: "dt"
-    filters: *kselftest_no_fragment
+    filters:
+      - combination: *arch_defconfig_filter
+      - blocklist: { kernel: ['v3.', 'v4.', 'v5.', v6.0', 'v6.1$', 'v6.2$', 'v6.3', 'v6.4', 'v6.5', 'v6.6'] }
 
   kselftest-exec:
     <<: *kselftest


### PR DESCRIPTION
The DT selftests were only introduced in v6.7, don't try to run them on
stable kernels.  We should really block v6.1 as well but we're not doing
regexp matching here so the syntax is awkward, we can always improve
later.

Signed-off-by: Mark Brown <broonie@kernel.org>
