### PR TITLE
test-configs.yaml: Add video decoder coverage for i.MX8MP

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2896,6 +2896,10 @@ test_configs:
       - igt-gpu-etnaviv
       - kselftest-alsa
       - kselftest-dt
+      - v4l2-decoder-conformance-h264
+      - v4l2-decoder-conformance-h265
+      - v4l2-decoder-conformance-vp8
+      - v4l2-decoder-conformance-vp9
 
   - device_type: imx8mp-verdin-nonwifi-dahlia
     test_plans:
@@ -2905,6 +2909,11 @@ test_configs:
       - kselftest-alsa
       - kselftest-clone3
       - kselftest-dt
+      - v4l2-decoder-conformance-h264
+      - v4l2-decoder-conformance-h265
+      - v4l2-decoder-conformance-vp8
+      - v4l2-decoder-conformance-vp9
+
 
   - device_type: imx8mq-zii-ultra-zest
     test_plans:


### PR DESCRIPTION
The i.MX8MP has a video decoder IP, add coverage of the CODECs it
supports on the i.MX8MP boards we cover (all of them already have
stanzas).

Signed-off-by: Mark Brown <broonie@kernel.org>
