### PR TITLE
test-configs.yaml: Use battery tag in kselftest-dt jobs for Chromebooks

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -317,6 +317,8 @@ test_plans:
     params:
       job_timeout: '10'
       kselftest_collections: "dt"
+      tags:
+        - battery
     filters:
       - combination: *arch_defconfig_filter
       - blocklist: { kernel: ['v3.', 'v4.', 'v5.', v6.0', 'v6.1$', 'v6.2$', 'v6.3', 'v6.4', 'v6.5', 'v6.6'] }

--- a/config/lava/kselftest/generic-depthcharge-tftp-nfs-kselftest-template.jinja2
+++ b/config/lava/kselftest/generic-depthcharge-tftp-nfs-kselftest-template.jinja2
@@ -1,5 +1,15 @@
 {% extends 'boot-nfs/generic-depthcharge-tftp-nfs-template.jinja2' %}
+{% block main %}
+{{ super () }}
 
+{%- if tags %}
+tags:
+  {%- for tag in tags %}
+  - {{ tag }}
+  {%- endfor -%}
+{% endif %}
+
+{% endblock %}
 {% block actions %}
 {{ super () }}
 


### PR DESCRIPTION
Chromebook/Chromebox devices might operate with or without a battery.

The `kselftest-dt` test checks whether drivers are probed correctly, including the battery gauge driver. 
Use the battery LAVA tag to target only Chromebooks where the battery is actually connected, to avoid reporting false regressions.

Signed-off-by: Laura Nao <laura.nao@collabora.com>