### PR TITLE
test-configs.yaml: Enable LKDTM selftests on Juno

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2932,6 +2932,7 @@ test_configs:
       - kselftest-cpufreq
       - kselftest-dt
       - kselftest-ftrace
+      - kselftest-lkdtm
       - ltp-crypto
       # ltp-mm - runs system out of memory
       - smc


### PR DESCRIPTION
We are not covering the LKDTM selftests on any arm64 platforms since
while it's enabled for some of them we're struggling to run the
kselftest kernel on any of them.  Since Juno does currently seem to be
booting the kselftest kernels fine and has some bandwidth let's schedule
the LKDTM tests there.

Signed-off-by: Mark Brown <broonie@kernel.org>
