### PR TITLE
kbuild.py: Inherit kernel revision data

### DIFF
--- a/kernelci/kbuild.py
+++ b/kernelci/kbuild.py
@@ -551,6 +551,7 @@ class KBuild():
                         'config_full': self._config_full,
                         'src_tarball': self._srctarball,
                     },
+                    'kernel_revision': self._node['data']['kernel_revision'],
                 },
             },
             'child_nodes': [],


### PR DESCRIPTION
As required by PRs to migrate data model https://github.com/kernelci/kernelci-core/pull/2224