### PR TITLE
kbuild.py: Map artifact fields to proper key names

### DIFF
--- a/kernelci/kbuild.py
+++ b/kernelci/kbuild.py
@@ -578,6 +578,7 @@ class KBuild():
         }
 
         node = self._node.copy()
+        results['node']['data']['kernel_revision'] = node['data']['kernel_revision']  # noqa
         node.update(results['node'])
         api_helper = kernelci.api.helper.APIHelper(api)
         print(json.dumps(node, indent=2))


### PR DESCRIPTION
In MongoDB, when you need to query nested fields where the field name includes dots (.), such as artifacts.job.txt, you face a common issue. MongoDB interprets the dots as separators for nested documents. We should avoid using dots in field names.

Suppose we have:
```
{
    "artifacts": {
        "job.txt": "data"
    }
}
```
In this case, artifacts.job.txt is intended to be a single field name. However, MongoDB interprets artifacts.job.txt as artifacts -> job -> txt, assuming job is a nested document within artifacts, and txt is a field within job.

When you try to query this field directly, MongoDB will look for a nested structure rather than a field with dots in its name. This leads to confusion and errors in querying and manipulating data. To handle such field names, you typically need to use special syntax or workarounds.