### PR TITLE
test-configs.yaml: Enable hardware relevant tests on Renegade Elite

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -3479,12 +3479,12 @@ test_configs:
     test_plans:
       - baseline
       - baseline-nfs
-      # wishlist for when this device becomes online in a lab that allows them to run
-      # - igt-gpu-panfrost
-      # - igt-kms-rockchip
-      # - kselftest-alsa
-      # - kselftest-cpufreq
-      # - kselftest-rtc
+      - igt-gpu-panfrost
+      - igt-kms-rockchip
+      - kselftest-alsa
+      - kselftest-cpufreq
+      - kselftest-dt
+      - kselftest-rtc
 
   - device_type: rk3399-rock-pi-4b
     test_plans:


### PR DESCRIPTION
I've added two Renegade Elites to my lab (and whichever lab used to have
them seems to have removed them) so let's enable all the hardware
relevant tests that had been commented out.  Also enable kselftest-dt
since it's a DT based platform.

Signed-off-by: Mark Brown <broonie@kernel.org>
