### PR TITLE
test-configs.yaml: Increase timeout for kselftest-ftrace

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -336,7 +336,7 @@ test_plans:
   kselftest-ftrace:
     <<: *kselftest
     params:
-      job_timeout: '20'
+      job_timeout: '25'
       kselftest_collections: "ftrace"
 
   kselftest-futex:


### PR DESCRIPTION
The timeout for kselftest-ftrace is a little tight, at least on the
Avenger96 (which while fairly modern is still a 32 bit arm board), bump
the timeout up a bit so we don't get spurious timeouts - we were seeing
timeouts while getting the results off the board so don't need much.

Signed-off-by: Mark Brown <broonie@kernel.org>
