### PR TITLE
Add WiFi basic test

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -362,6 +362,11 @@ fragments:
       mediatek/mt8195/scp.img
       mediatek/WIFI_MT7961_patch_mcu_1_2_hdr.bin
       mediatek/WIFI_RAM_CODE_MT7961_1.bin
+      mrvl/sd8897_uapsta.bin
+      ath10k/QCA6174/hw3.0/firmware-sdio-6.bin
+      ath10k/QCA6174/hw3.0/board-2.bin
+      ath10k/WCN3990/hw1.0/firmware-5.bin
+      ath10k/WCN3990/hw1.0/board-2.bin
       "'
 
 
@@ -510,6 +515,8 @@ fragments:
   x86-board:
     path: "kernel/configs/x86-board.config"
     configs:
+      - 'CONFIG_ATH10K_PCI=m'
+      - 'CONFIG_ATH10K=m'
       - 'CONFIG_BLK_DEV_NVME=y'
       - 'CONFIG_CHARGER_CROS_USBPD=m'
       - 'CONFIG_CHARGER_WILCO=m'
@@ -545,6 +552,9 @@ fragments:
       - 'CONFIG_IIO_CROS_EC_SENSORS=m'
       - 'CONFIG_IIO=m'
       - 'CONFIG_INTEL_ISH_HID=m'
+      - 'CONFIG_IWLDVM=m'
+      - 'CONFIG_IWLMVM=m'
+      - 'CONFIG_IWLWIFI=m'
       - 'CONFIG_KEYBOARD_CROS_EC=m'
       - 'CONFIG_MEDIA_CAMERA_SUPPORT=y'
       - 'CONFIG_MEDIA_SUPPORT=y'
@@ -556,6 +566,7 @@ fragments:
       - 'CONFIG_MMC_SDHCI_PCI=y'
       - 'CONFIG_MMC_SDHCI=y'
       - 'CONFIG_MMC=y'
+      - 'CONFIG_MT7921E=m'
       - 'CONFIG_NFS_FS=y'
       - 'CONFIG_NFS_V2=y'
       - 'CONFIG_NFS_V3_ACL=y'
@@ -567,6 +578,10 @@ fragments:
       - 'CONFIG_PINCTRL_SX150X=y'
       - 'CONFIG_ROOT_NFS=y'
       - 'CONFIG_RTC_DRV_CROS_EC=m'
+      - 'CONFIG_RTW88_8822CE=m'
+      - 'CONFIG_RTW88=m'
+      - 'CONFIG_RTW89_8852AE=m'
+      - 'CONFIG_RTW89=m'
       - 'CONFIG_SERIAL_8250_DW=y'
       - 'CONFIG_SERIAL_8250=y'
       - 'CONFIG_SND_DESIGNWARE_I2S=m'
@@ -638,6 +653,19 @@ fragments:
       i915/kbl_dmc_ver1_04.bin
       rtl_nic/rtl8153a-4.fw
       rtl_nic/rtl8153b-2.fw
+      ath10k/QCA6174/hw3.0/firmware-6.bin
+      ath10k/QCA6174/hw3.0/board-2.bin
+      rtw88/rtw8822c_fw.bin
+      rtw88/rtw8822c_wow_fw.bin
+      rtw89/rtw8852a_fw.bin
+      iwlwifi-so-a0-gf-a0-86.ucode
+      iwlwifi-so-a0-gf-a0.pnvm
+      iwlwifi-QuZ-a0-hr-b0-77.ucode
+      iwlwifi-7265D-29.ucode
+      iwlwifi-cc-a0-77.ucode
+      mediatek/WIFI_RAM_CODE_MT7961_1.bin
+      mediatek/WIFI_MT7961_patch_mcu_1_2_hdr.bin
+      iwlwifi-9000-pu-b0-jf-b0-46.ucode
       "'
 
   x86_kvm_guest:

--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -355,6 +355,19 @@ rootfs_configs:
       - e2fsprogs
     script: "scripts/bullseye-vdso.sh"
 
+  bullseye-wifi:
+    rootfs_type: debos
+    debian_release: bullseye
+    arch_list:
+      - amd64
+      - arm64
+      - armhf
+    extra_packages:
+      - rfkill
+      - iw
+      - iproute2
+    test_overlay: "overlays/wifi"
+
   sid:
     rootfs_type: debos
     debian_release: sid

--- a/config/core/rootfs-images.yaml
+++ b/config/core/rootfs-images.yaml
@@ -159,6 +159,14 @@ file_systems:
     ramdisk: bullseye-vdso/20230623.0/{arch}/rootfs.cpio.gz
     root_type: ramdisk
     type: debian
+  debian_bullseye-wifi_nfs:
+    boot_protocol: tftp
+    nfs: bullseye-wifi/20240109.0/{arch}/full.rootfs.tar.xz
+    params: {}
+    prompt: '/ #'
+    ramdisk: bullseye-wifi/20240109.0/{arch}/initrd.cpio.gz
+    root_type: nfs
+    type: debian
   debian_bullseye_nfs:
     boot_protocol: tftp
     nfs: bullseye/20230623.0/{arch}/full.rootfs.tar.xz

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2347,6 +2347,7 @@ test_configs:
       - baseline
       - baseline-nfs
       - kselftest-cpufreq
+      - wifi-basic
 
   - device_type: acer-cb317-1h-c3z6-dedede
     test_plans:
@@ -2357,6 +2358,7 @@ test_configs:
     test_plans:
       - baseline
       - baseline-nfs
+      - wifi-basic
 
   - device_type: acer-chromebox-cxi4-puff
     test_plans:
@@ -2372,6 +2374,7 @@ test_configs:
     test_plans:
       - baseline
       - baseline-nfs
+      - wifi-basic
 
   - device_type: alpine-db
     test_plans:
@@ -2502,6 +2505,7 @@ test_configs:
       - baseline
       - baseline-nfs
       - kselftest-cpufreq
+      - wifi-basic
 
   - device_type: asus-cx9400-volteer
     test_plans:
@@ -2514,6 +2518,7 @@ test_configs:
       - kselftest-mm
       - kselftest-vm
       - ltp-ipc
+      - wifi-basic
 
   - device_type: at91-sama5d2_xplained
     test_plans:
@@ -2617,6 +2622,7 @@ test_configs:
       - baseline
       - baseline-nfs
       - kselftest-cpufreq
+      - wifi-basic
 
   - device_type: dove-cubox
     test_plans:
@@ -2730,6 +2736,7 @@ test_configs:
       - kselftest-alsa
       - kselftest-cpufreq
       - kselftest-landlock
+      - wifi-basic
 
   - device_type: hp-x360-12b-ca0500na-n4000-octopus
     test_plans:
@@ -2996,6 +3003,7 @@ test_configs:
       - baseline
       - baseline-nfs
       - kselftest-cpufreq
+      - wifi-basic
 
   - device_type: meson-g12a-sei510
     test_plans:
@@ -3151,6 +3159,7 @@ test_configs:
       - preempt-rt
       - sleep
       - v4l2-compliance-uvc
+      - wifi-basic
 
   - device_type: mt8183-kukui-jacuzzi-juniper-sku16
     test_plans:
@@ -3171,6 +3180,7 @@ test_configs:
       - preempt-rt
       - sleep
       - v4l2-compliance-uvc
+      - wifi-basic
 
   - device_type: mt8192-asurada-spherion-r0
     test_plans:
@@ -3206,6 +3216,7 @@ test_configs:
     test_plans:
       - baseline
       - kselftest-dt
+      - wifi-basic
 
   - device_type: mt8195-cherry-tomato-r2
     test_plans:

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -767,6 +767,12 @@ test_plans:
     params:
       job_timeout: '20'
 
+  wifi-basic: &wifi-basic
+    rootfs: debian_bullseye-wifi_nfs
+    pattern: 'wifi/{category}-{method}-{protocol}-{rootfs}-wifi-template.jinja2'
+    params: &wifi-basic-params
+      job_timeout: '10'
+
 device_types:
 
   acer-R721T-grunt:

--- a/config/lava/wifi/generic-depthcharge-tftp-nfs-wifi-template.jinja2
+++ b/config/lava/wifi/generic-depthcharge-tftp-nfs-wifi-template.jinja2
@@ -1,0 +1,8 @@
+{% extends 'boot-nfs/generic-depthcharge-tftp-nfs-template.jinja2' %}
+
+{% block actions %}
+{{ super () }}
+
+{% include 'wifi/wifi.jinja2' %}
+
+{% endblock %}

--- a/config/lava/wifi/generic-grub-tftp-nfs-wifi-template.jinja2
+++ b/config/lava/wifi/generic-grub-tftp-nfs-wifi-template.jinja2
@@ -1,0 +1,8 @@
+{% extends 'boot-nfs/generic-grub-tftp-nfs-template.jinja2' %}
+
+{% block actions %}
+{{ super () }}
+
+{% include 'wifi/wifi.jinja2' %}
+
+{% endblock %}

--- a/config/lava/wifi/generic-qemu-wifi-template.jinja2
+++ b/config/lava/wifi/generic-qemu-wifi-template.jinja2
@@ -1,0 +1,11 @@
+{% extends 'boot/generic-qemu-boot-template.jinja2' %}
+{% block actions %}
+{{ super () }}
+
+{% include 'wifi/wifi.jinja2' %}
+
+{% endblock %}
+
+{%- block image_arg %}
+        image_arg: '-kernel {kernel} -append "console={{ console_dev }},115200 root=/dev/ram0 debug verbose {{ extra_kernel_args }}"'
+{%- endblock %}

--- a/config/lava/wifi/generic-uboot-tftp-nfs-wifi-template.jinja2
+++ b/config/lava/wifi/generic-uboot-tftp-nfs-wifi-template.jinja2
@@ -1,0 +1,8 @@
+{% extends 'boot-nfs/generic-uboot-tftp-nfs-template.jinja2' %}
+
+{% block actions %}
+{{ super () }}
+
+{% include 'wifi/wifi.jinja2' %}
+
+{% endblock %}

--- a/config/lava/wifi/wifi.jinja2
+++ b/config/lava/wifi/wifi.jinja2
@@ -1,0 +1,19 @@
+- test:
+    timeout:
+      minutes: {{ job_timeout }}
+    definitions:
+    - repository:
+        metadata:
+          format: Lava-Test Test Definition 1.0
+          name: {{ plan }}
+          description: "WiFi test plan"
+          os:
+          - debian
+          scope:
+          - functional
+        run:
+          steps:
+          - KERNELCI_LAVA=y /usr/bin/wifi-basic-parser.sh
+      from: inline
+      name: {{ plan }}
+      path: inline/{{ plan }}.yaml

--- a/config/rootfs/debos/overlays/wifi/usr/bin/wifi-basic-parser.sh
+++ b/config/rootfs/debos/overlays/wifi/usr/bin/wifi-basic-parser.sh
@@ -1,0 +1,137 @@
+#!/bin/sh
+#
+# Copyright (C) 2024 Collabora Limited
+# Author: Laura Nao <laura.nao@collabora.com>
+#
+# This module is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+set -e
+
+if [ "$KERNELCI_LAVA" = "y" ]; then
+    alias test-result='lava-test-case'
+    alias test-exception='lava-test-raise'
+else
+    alias test-result='echo'
+    alias test-exception='echo'
+fi
+
+# Check if rfkill is available
+if ! command -v rfkill >/dev/null; then
+    echo "rfkill not found. Please install it to proceed."
+    exit 1
+fi
+
+# Check if iw is available
+if ! command -v iw >/dev/null; then
+    echo "iw could not be found. Please install it to proceed."
+    exit 1
+fi
+
+# Check if iproute2 is available
+if ! command -v ip >/dev/null; then
+    echo "iproute2 could not be found. Please install it to proceed."
+    exit 1
+fi
+
+# Find wlan interface name
+wlan_if=$(iw dev | grep Interface | awk '{print $2}')
+
+if [ -z "$wlan_if" ]; then
+    echo "No wlan interface found."
+    lava-test-case wlan-present --result fail
+    exit 1
+else
+    echo "wlan interfaces found:"
+    echo "$wlan_if"
+    lava-test-case wlan-present --result pass
+fi
+
+lava-test-set start wlan-rfkill
+
+# Check wlan rfkill presence
+if rfkill --noheadings --raw --output ID,TYPE | grep wlan; then
+    test-result rfkill-wlan-present --result pass
+    # Check for hard-block
+    if [ "$(rfkill --noheadings --raw --output ID,TYPE,SOFT,HARD | grep wlan | cut -d' ' -f4)" = "blocked" ]; then
+        test-exception "wlan is hard-blocked"
+        exit 1
+    fi
+    # Test soft block
+    rfkill block wlan
+    [ "$(rfkill --noheadings --raw --output ID,TYPE,SOFT | grep wlan | cut -d' ' -f3)" = "blocked" ] && res=pass || res=fail
+    test-result rfkill-wlan-soft-block --result "$res"
+    # Test soft unblock
+    rfkill unblock wlan
+    [ "$(rfkill --noheadings --raw --output ID,TYPE,SOFT | grep wlan | cut -d' ' -f3)" = "unblocked" ] && res=pass || res=fail
+    test-result rfkill-wlan-soft-unblock --result "$res"
+else
+    test-result rfkill-wlan-present --result fail
+    test-result rfkill-wlan-soft-block --result skip
+    test-result rfkill-wlan-soft-unblock --result skip
+fi
+
+lava-test-set stop wlan-rfkill
+lava-test-set start wlan-scan
+
+# Bring interface up
+ip link set "$wlan_if" up
+while ! ip link show up | grep -q "$wlan_if"; do
+    echo "Waiting for ${wlan_if} to come up"
+    sleep 1
+done
+
+# Perform scan; assuming networks within reach
+wlan_scan_results=$(iw dev "$wlan_if" scan)
+if [ -n "$wlan_scan_results" ]; then
+    wlan_scan_networks=$(echo "$wlan_scan_results" | grep -c 'ssid\|signal\|^bss')
+    test-result wlan-scan --result pass --measurement "$wlan_scan_networks" --units networks
+else
+    test-result wlan-scan --result fail
+fi
+
+lava-test-set stop wlan-scan
+lava-test-set start wlan-monitor
+
+# Check if monitor mode is supported
+if ! iw list | grep '\* monitor' >/dev/null; then
+    echo "Monitor mode not supported."
+    test-result wlan-monitor --result skip
+else
+    # Bring interface down
+    ip link set "$wlan_if" down
+    iw "$wlan_if" set monitor none
+    ip link set "$wlan_if" up
+
+    # Check monitor mode is active
+    wlan_mode=$(iw dev "$wlan_if" info | grep type | awk '{print $2}')
+    echo "${wlan_if} is in ${wlan_mode} mode"
+    [ "$wlan_mode" = "monitor" ] && res=pass || res=fail
+    test-result wlan-monitor-mode --result "$res"
+
+    # Restore managed mode
+    ip link set "$wlan_if" down
+    iw "$wlan_if" set type managed
+    ip link set "$wlan_if" up
+
+    # Check managed mode has been restored
+    wlan_mode=$(iw dev "$wlan_if" info | grep type | awk '{print $2}')
+    echo "${wlan_if} is in ${wlan_mode} mode"
+    [ "$wlan_mode" = "managed" ] && res=pass || res=fail
+    test-result wlan-managed-mode --result "$res"
+fi
+
+lava-test-set stop wlan-monitor
+
+exit 0


### PR DESCRIPTION
Add support for a basic WiFi test and run it on an initial set of target Chromebooks, based on the WiFi chip:
- Intel(R) Wi-Fi 6 AX201 160MHz - `asus-cx9400-volteer`
- Intel(R) Wi-Fi 6E AX211 160MHz -  	`acer-cbv514-1h-34uz-brya`
- Intel(R) Wi-Fi 6 AX200 160MHz - `lenovo-TPad-C13-Yoga-zork`
- Intel(R) Dual Band Wireless AC 7265 - `hp-x360-14-G1-sona`
- Intel(R) Wireless-AC 9560 160MHz - `dell-latitude-5400-8665U-sarien`
- Marvell SD8897-B0 - `mt8173-elm-hana`
- RTL8852AE - `acer-cp514-3wh-r0qs-guybrush`
- RTL8822CE - `asus-CM1400CXA-dalboz`
- QCA6174 - `acer-R721T-grunt` , `mt8183-kukui-jacuzzi-juniper-sku16`
- mt7921e - `mt8195-cherry-tomato-r2`