### PR TITLE
test-configs.yaml: Enable ALSA selftests for Raspberry Pi 4B

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2535,6 +2535,7 @@ test_configs:
     test_plans:
       - baseline
       - baseline-nfs
+      - kselftest-alsa
       - kselftest-arm64
 
   - device_type: bcm2835-rpi-b-rev2


### PR DESCRIPTION
The Raspberry Pis have audio devices, enable the ALSA selftests to
provide some coverage of them.

Signed-off-by: Mark Brown <broonie@kernel.org>
