### PR TITLE
test-configs.yaml: Enable DT selftests for Raspberry Pi

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2536,11 +2536,13 @@ test_configs:
       - baseline
       - baseline-nfs
       - kselftest-arm64
+      - kselftest-dt
 
   - device_type: bcm2835-rpi-b-rev2
     test_plans:
       - baseline
       - baseline-nfs
+      - kselftest-dt
 
   - device_type: bcm2836-rpi-2-b
     test_plans:


### PR DESCRIPTION
The Raspberry Pi platforms are DT based, enable the DT selftests for
those boards where we have NFS baseline tests enabled.

Signed-off-by: Mark Brown <broonie@kernel.org>
