### PR TITLE
CHROMEOS Small fixes for build_board.sh

### DIFF
--- a/config/rootfs/chromiumos/scripts/build_board.sh
+++ b/config/rootfs/chromiumos/scripts/build_board.sh
@@ -148,13 +148,13 @@ sudo cp ./chroot/build/${BOARD}/boot/config* "${DATA_DIR}/${BOARD}/kernel.config
 sudo mv ./chroot/build/${BOARD}/opt/google/{cr,ti}50/firmware/* "${DATA_DIR}/${BOARD}/" > /dev/null 2>&1 || true
 
 # Identify baseboard and chipset
-BASEBOARD="$(grep baseboard ./src/overlays/overlay-${BOARD}/profiles/base/parent | sed 's/:.*//')"
+BASEBOARD="$(grep -m1 baseboard ./src/overlays/overlay-${BOARD}/profiles/base/parent | sed 's/:.*//')"
 if [ -z "${BASEBOARD}" ]; then
     # Some overlays (e.g. skyrim) directly refer to the chipset overlay,
     # not to an intermediate baseboard
     BASEBOARD="overlay-${BOARD}"
 fi
-CHIPSET="$(grep chipset ./src/overlays/${BASEBOARD}/profiles/base/parent | sed 's/:.*//')"
+CHIPSET="$(grep -m1 chipset ./src/overlays/${BASEBOARD}/profiles/base/parent | sed 's/:.*//')"
 # Source chipset config for $CHROMEOS_KERNEL_ARCH
 . ./src/overlays/${CHIPSET}/profiles/base/make.defaults
 

--- a/config/rootfs/chromiumos/scripts/build_board.sh
+++ b/config/rootfs/chromiumos/scripts/build_board.sh
@@ -66,6 +66,9 @@ if [ -n "${VANILLA_MANIFEST}" ]; then
   echo "Fetching vanilla manifest ${VANILLA_MANIFEST}"
   repo init --repo-url https://chromium.googlesource.com/external/repo --manifest-url https://chromium.googlesource.com/chromiumos/manifest --manifest-name default.xml --manifest-branch ${VANILLA_MANIFEST}
 else
+  # Ensure file ownership issues won't get in the way
+  git config --global safe.directory /kernelci-core
+
   if [ -z "${KCICORE_BRANCH}" ]; then
     KCICORE_BRANCH="$(git -C /kernelci-core branch --show-current 2>/dev/null || true)"
   fi

--- a/config/rootfs/chromiumos/scripts/build_board.sh
+++ b/config/rootfs/chromiumos/scripts/build_board.sh
@@ -139,7 +139,7 @@ echo "Updating ownership"
 sudo chown -R "${USERNAME}" "${DATA_DIR}/${BOARD}"
 
 echo "Compressing image"
-gzip -1 "${DATA_DIR}/${BOARD}/chromiumos_test_image.bin"
+gzip -1 --force "${DATA_DIR}/${BOARD}/chromiumos_test_image.bin"
 
 echo "Extracting additional artifacts"
 sudo tar -cJf "${DATA_DIR}/${BOARD}/modules.tar.xz" -C ./chroot/build/${BOARD} lib/modules


### PR DESCRIPTION
This PR packs multiple small improvement and fixes to the `build_board.sh` script we use to build CrOS images:
* fixes a build failure when a single board/baseboard has multiple `chipset-*` parents (affects `baseboard-brya`)
* fixes script error when the compressed CrOS image already exists (e.g. when restarting the build after it previously failed at a later stage)
* ensure the repo remote and branch are properly determined even in cases where the repo owner is different from the user executing the script (e.g. a normal user and root, respectively)