### PR TITLE
api.models: Add patchset field to node revision

### DIFF
--- a/kernelci/api/models.py
+++ b/kernelci/api/models.py
@@ -87,6 +87,9 @@ class Revision(BaseModel):
     version: Optional[KernelVersion] = Field(
         description="Kernel version"
     )
+    patchset: Optional[str] = Field(
+        description="Patchset hash"
+    )
 
 
 class DefaultTimeout:


### PR DESCRIPTION
This patch was initially submitted as kernelci/kernelci-api#380 but required moving after merging kernelci/kernelci-api#433.