### PR TITLE
api.models: make Fields of KbuildData Optional

### DIFF
--- a/kernelci/api/models.py
+++ b/kernelci/api/models.py
@@ -301,13 +301,14 @@ class KbuildData(BaseModel):
     kernel_revision: Revision = Field(
         description="Kernel repo revision data"
     )
-    arch: str = Field(
+    # [TODO]: review which of these Fields should be optional or mandatory
+    arch: Optional[str] = Field(
         description="CPU architecture family"
     )
-    defconfig: str = Field(
+    defconfig: Optional[str] = Field(
         description="Kernel defconfig identifier"
     )
-    compiler: str = Field(
+    compiler: Optional[str] = Field(
         description="Compiler used for the build"
     )
     fragments: Optional[List[str]] = Field(


### PR DESCRIPTION
This is a workaround for a current error condition in staging. I don't think this is the appropriate solution for the problem, but until we find the root cause, this might be helpful to unblock other work.

See also https://github.com/kernelci/kernelci-core/pull/2304 as a companion to this.