### PR TITLE
test-configs.yaml: Enable more test coverage for Raspberry Pi 4

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -2538,6 +2538,11 @@ test_configs:
       - kselftest-alsa
       - kselftest-arm64
       - kselftest-dt
+      - ltp-dio
+      - ltp-fsx
+      - ltp-smoketest
+      - ltp-timers
+      - preempt-rt
 
   - device_type: bcm2835-rpi-b-rev2
     test_plans:


### PR DESCRIPTION
The labs which have Raspberry Pi 4s (including mine) seem to have quite
a bit of free capacity with multiple devices available and frequently
idle so let's use the capacity to fill in some of our coverage, add some
LTP suites which we don't currently cover on arm64 together with the
core LTP smoke tests.  Since we currently only run the preempt RT tests
on systems with in order cores also add them here to ensure coverage
with out of order cores.

Signed-off-by: Mark Brown <broonie@kernel.org>
