### PR TITLE
build-configs.yaml: Build sc7180 display clock controller driver as m…

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -169,7 +169,7 @@ fragments:
       # This is required for sc7180-trogdor-lazor-limozeen and it hasn't been
       # merged upstream yet.
       - 'CONFIG_INTERCONNECT_QCOM_SC7180=y'
-      - 'CONFIG_SC_DISPCC_7180=y'
+      - 'CONFIG_SC_DISPCC_7180=m'
       - 'CONFIG_SC_GPUCC_7180=y'
       - 'CONFIG_SC_LPASS_CORECC_7180=y'
       - 'CONFIG_SC_VIDEOCC_7180=y'


### PR DESCRIPTION
…odule

Configure the display clock controller for trogdor Chromebooks to be built as a module, by modifying the arm64-chromebook fragment. This fixes a kernel hang observed on lazor and kingoftown Chromebooks when disabling the display clocks while they might still be in use.

See also: https://lore.kernel.org/linux-arm-msm/20231218091806.7155-1-laura.nao@collabora.com/