### PR TITLE
kernelci.api.models: add `job_id` field to Node data

### DIFF
--- a/kernelci/api/models.py
+++ b/kernelci/api/models.py
@@ -313,6 +313,9 @@ class KbuildData(BaseModel):
     runtime: Optional[str] = Field(
         description="Runtime that runs the build"
     )
+    job_id: Optional[str] = Field(
+        description="Runtime job ID"
+    )
 
 
 class Kbuild(Node):
@@ -346,6 +349,9 @@ class TestData(BaseModel):
     )
     runtime: Optional[str] = Field(
         description="Runtime that runs the test"
+    )
+    job_id: Optional[str] = Field(
+        description="Runtime job ID"
     )
 
 


### PR DESCRIPTION
Add field to store job ID received from runtime for `kbuild` and `test` nodes.