### PR TITLE
Handle DTB for devices requiring it

### DIFF
--- a/config/runtime/boot/depthcharge.jinja2
+++ b/config/runtime/boot/depthcharge.jinja2
@@ -1,13 +1,17 @@
 - deploy:
     kernel:
-      url: {{ node.artifacts.bzImage }}
+      url: {{ node.artifacts.kernel }}
     modules:
       compression: xz
       url: {{ node.artifacts.modules }}
+{%- if platform_config.dtb %}
+    dtb:
+      url: {{ node.artifacts.dtb }}
+{%- endif %}
     os: oe
     ramdisk:
       compression: gz
-      url: http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230623.0/x86/rootfs.cpio.gz
+      url: http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230623.0/{{ platform_config.arch }}/rootfs.cpio.gz
     timeout:
       minutes: 10
     to: tftp

--- a/config/runtime/boot/grub.jinja2
+++ b/config/runtime/boot/grub.jinja2
@@ -1,12 +1,17 @@
 - deploy:
     kernel:
-      url: {{ node.artifacts.bzImage }}
+      url: {{ node.artifacts.kernel }}
       image_arg: -kernel {kernel} -serial stdio --append "console=ttyS0"
       type: zimage
     ramdisk:
-      url: http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230421.0/x86/rootfs.cpio.gz
+      url: http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230421.0/{{ platform_config.arch }}/rootfs.cpio.gz
       image_arg: -initrd {ramdisk}
       compression: gz
+{%- if platform_config.dtb %}
+    dtb:
+      url: {{ node.artifacts.dtb }}
+      image_arg: -dtb {dtb}
+{%- endif %}
     os: oe
     root_partition: 1
     to: tftp

--- a/config/runtime/boot/qemu.jinja2
+++ b/config/runtime/boot/qemu.jinja2
@@ -3,10 +3,15 @@
       kernel:
         image_arg: -kernel {kernel} -append "console=ttyS0,115200 root=/dev/ram0 debug
           verbose console_msg_format=syslog earlycon"
-        url: {{ node.artifacts.bzImage }}
+        url: {{ node.artifacts.kernel }}
       ramdisk:
         image_arg: -initrd {ramdisk}
-        url: http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230421.0/x86/rootfs.cpio.gz
+        url: http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230421.0/{{ platform_config.arch }}/rootfs.cpio.gz
+{%- if platform_config.dtb %}
+      dtb:
+        url: {{ node.artifacts.dtb }}
+        image_arg: -dtb {dtb}
+{%- endif %}
     os: oe
     timeout:
       minutes: 3
@@ -14,7 +19,7 @@
 
 - boot:
     docker:
-      binary: qemu-system-x86_64
+      binary: qemu-system-{{ platform_config.arch }}
       image: kernelci/qemu
     media: tmpfs
     method: qemu

--- a/kernelci/cli/job.py
+++ b/kernelci/cli/job.py
@@ -82,6 +82,8 @@ def generate(node_id,  # pylint: disable=too-many-arguments, too-many-locals
     runtime = kernelci.runtime.get_runtime(
         runtime_config, token=secrets.api.runtime_token)
     params = runtime.get_params(job, api.config)
+    if not params:
+        raise click.ClickException("Invalid job parameters, aborting...")
     job_data = runtime.generate(job, params)
     if output:
         output_file = runtime.save_file(job_data, output, params)

--- a/kernelci/runtime/lava.py
+++ b/kernelci/runtime/lava.py
@@ -176,7 +176,8 @@ class LAVA(Runtime):
 
     def get_params(self, job, api_config=None):
         params = super().get_params(job, api_config)
-        params['notify'] = self.config.notify
+        if params:
+            params['notify'] = self.config.notify
         return params
 
     def generate(self, job, params):


### PR DESCRIPTION
This PR allows to handle DTBs for arm64 devices by executing the following steps:
* download the `metadata.json` file from the `kbuild` job
* extract from this file the URL to the DTB as defined in the device type parameters
* add this to the node's artifacts list with the name `dtb`

The boot templates are modified accordingly and made device-agnostic in the process.