### PR TITLE
build-configs.yaml: Add missing firmware for sound on MT8195-Tomato

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -361,6 +361,8 @@ fragments:
       mediatek/mt8186/scp.img
       mediatek/mt8192/scp.img
       mediatek/mt8195/scp.img
+      mediatek/sof-tplg/sof-mt8195-mt6359-rt1019-rt5682-dts.tplg
+      mediatek/sof/sof-mt8195.ri
       mediatek/WIFI_MT7961_patch_mcu_1_2_hdr.bin
       mediatek/WIFI_RAM_CODE_MT7961_1.bin
       mrvl/sd8897_uapsta.bin


### PR DESCRIPTION
Add in the arm64-chromebook config fragment the firmware required by MT8195-Cherry-Tomato to successfully probe the sound card. This change can be verified by checking that the '/mt8195-sound' test case in the kselftest-dt test now passes.

LAVA run before: https://lava.collabora.dev/scheduler/job/12640584
LAVA run after: https://lava.collabora.dev/scheduler/job/12640545