### PR TITLE
Rust 1.75

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -723,6 +723,12 @@ build_environments:
     arch_params:
       x86_64: *x86_64_params
 
+  rustc-1.75:
+    cc: clang
+    cc_version: 17
+    arch_params:
+      x86_64: *x86_64_params
+
 # Default config with full build coverage
 build_configs_defaults:
   variants:

--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -1309,8 +1309,8 @@ build_configs:
         architectures:
           <<: *arch_clang_configs
 
-      rustc-1.74:
-        build_environment: rustc-1.74
+      rustc-1.75:
+        build_environment: rustc-1.75
         fragments: [rust, rust-samples, kselftest]
         architectures:
           x86_64:
@@ -1468,8 +1468,8 @@ build_configs:
     tree: rust-for-linux
     branch: 'rust-next'
     variants:
-      rustc-1.74:
-        build_environment: rustc-1.74
+      rustc-1.75:
+        build_environment: rustc-1.75
         fragments: [rust, rust-for-linux-samples, rust-samples, kselftest]
         architectures:
           x86_64:

--- a/config/docker/rustc-1.75-x86.jinja2
+++ b/config/docker/rustc-1.75-x86.jinja2
@@ -1,0 +1,9 @@
+{%- set sub_arch = 'amd64' %}
+{% extends 'rustc-1.75.jinja2' %}
+
+{% block packages %}
+{{ super() }}
+
+RUN dpkg --add-architecture amd64
+
+{%- endblock %}

--- a/config/docker/rustc-1.75.jinja2
+++ b/config/docker/rustc-1.75.jinja2
@@ -1,0 +1,43 @@
+{% extends 'clang-17.jinja2' %}
+
+{% block packages %}
+{{ super() }}
+
+ARG RUST_VER=1.75.0
+ARG BINDGEN_VER=0.65.1
+
+ARG RUST_TRIPLE=rust-${RUST_VER}-x86_64-unknown-linux-gnu
+
+ENV CARGO_HOME=/home/kernelci/.cargo
+ENV PATH=/usr/${RUST_TRIPLE}/bin:${CARGO_HOME}/bin:${PATH}
+
+ARG SHA256SUM=473978b6f8ff216389f9e89315211c6b683cf95a966196e7914b46e8cf0d74f6
+
+# fetch, verify the toolchain
+RUN wget https://static.rust-lang.org/dist/${RUST_TRIPLE}.tar.gz && \
+    echo "${SHA256SUM} ${RUST_TRIPLE}.tar.gz" | sha256sum --check --quiet
+
+# install & cleanup tmp files
+RUN tar -xf ${RUST_TRIPLE}.tar.gz  -C /tmp/ && \
+    /tmp/${RUST_TRIPLE}/install.sh --prefix=/usr/${RUST_TRIPLE} \
+        --components=rustc,cargo,rust-std-x86_64-unknown-linux-gnu && \
+    rm -rf /tmp/${RUST_TRIPLE} && \
+    rm /${RUST_TRIPLE}*
+
+# This image is based on clang-*jinja2 which only has clang installed, but rustc
+# defaults to linker "cc" which usually points to the GNU/GCC stack. Pointing cc
+# to clang ensures both cargo and kernel build rustc invocations use llvm/clang.
+RUN update-alternatives --install /usr/bin/cc cc $(which clang) 30 && \
+    update-alternatives --set cc $(which clang)
+
+RUN git clone --recurse-submodules --branch $RUST_VER \
+        https://github.com/rust-lang/rust \
+        $(rustc --print sysroot)/lib/rustlib/src/rust
+
+RUN cargo install --locked --version ${BINDGEN_VER} bindgen-cli
+
+# kernel build generates some rust code and tries to format it, if rustfmt is
+# missing it will print non-fatal error noise
+RUN cargo install rustfmt
+
+{%- endblock %}


### PR DESCRIPTION
Rust 1.75.0 will likely be the next version supported by the kernel. Therefore, add it as a new build environment.

@gctucker @aliceinwire @nuclearcat This time around, if possible, I would like to keep both the latest and previous latest build environments, so that we can upgrade only `linux-next` and so on, before `mainline`, and so on. Please let me know if this somehow breaks some assumptions -- it is the first time we are doing this. Thanks!

Upgrade PRs:
  - https://github.com/kernelci/kernelci-core/pull/2321.
  - https://github.com/kernelci/kernelci-deploy/pull/121.
  - https://github.com/kernelci/kernelci-deploy/pull/122.