### PR TITLE
Merge videodec and arm64-chromebook fragments

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -344,6 +344,7 @@ fragments:
       - 'CONFIG_VIDEO_OV02A10=m'
       - 'CONFIG_VIDEO_OV5695=m'
       - 'CONFIG_VIDEO_OV8856=m'
+      - 'CONFIG_VIDEO_ROCKCHIP_VDEC=m'
       - '# CONFIG_ARM_DSU_PMU is not set'
       - 'CONFIG_CROS_KBD_LED_BACKLIGHT=m'
       - 'CONFIG_SND_SOC_MT8195=m'
@@ -494,11 +495,6 @@ fragments:
   tinyconfig:
     path: "kernel/configs/tiny.config"
     defconfig: 'tinyconfig'
-
-  videodec:
-    path: "kernel/configs/videodec.config"
-    configs:
-      - 'CONFIG_VIDEO_ROCKCHIP_VDEC=m'
 
   virtualvideo:
     path: "kernel/configs/virtualvideo.config"
@@ -820,8 +816,7 @@ build_configs_defaults:
             - 'defconfig+arm64-chromebook+kselftest'
 # Disabling to reduce load
 #            - 'defconfig+CONFIG_RANDOMIZE_BASE=y'
-#            - 'defconfig+arm64-chromebook+videodec'
-#          fragments: [arm64-chromebook, crypto, ima, videodec]
+#          fragments: [arm64-chromebook, crypto, ima]
           fragments: [arm64-chromebook]
 
         i386: &i386_arch
@@ -1215,8 +1210,7 @@ build_configs:
               - 'allnoconfig'
               - 'defconfig+CONFIG_CPU_BIG_ENDIAN=y'
               - 'defconfig+arm64-chromebook+kselftest'
-              - 'defconfig+arm64-chromebook+videodec'
-            fragments: [arm64-chromebook, videodec]
+            fragments: [arm64-chromebook]
 
       # Minimum version
       clang-11:
@@ -1331,8 +1325,7 @@ build_configs:
               - 'defconfig+CONFIG_CPU_BIG_ENDIAN=y'
               - 'defconfig+CONFIG_RANDOMIZE_BASE=y'
               - 'defconfig+arm64-chromebook+kselftest'
-              - 'defconfig+arm64-chromebook+videodec'
-            fragments: [arm64-chromebook, videodec]
+            fragments: [arm64-chromebook]
           arm:
             base_defconfig: 'multi_v7_defconfig'
             extra_configs:

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -761,8 +761,6 @@ test_plans:
         - 'GStreamer-AV1-V4L2SL-Gst1.0'
       videodec_parallel_jobs: '1'
       videodec_timeout: 90
-    filters:
-      - passlist: {defconfig: ['videodec']}
 
   v4l2-decoder-conformance-av1-chromium-10bit:
     <<: *v4l2-decoder-conformance


### PR DESCRIPTION
The videodec fragment was created to hold configs for decoder support, required to run decoder conformance tests on Chromebooks. The fragment is currently holding only one config for the kevin Chromebook, while decoder specific configs for other platforms were added to the arm64-chromebook fragment instead. Add the CONFIG_VIDEO_ROCKCHIP_VDEC
option to the arm64-chromebook fragment and drop the videodec one.