### PR TITLE
CHROMEOS test-configs-chromeos.yaml: Remove chromeos suffix from fluster decoder tests

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -344,6 +344,7 @@ fragments:
       - 'CONFIG_VIDEO_OV02A10=m'
       - 'CONFIG_VIDEO_OV5695=m'
       - 'CONFIG_VIDEO_OV8856=m'
+      - 'CONFIG_VIDEO_ROCKCHIP_VDEC=m'
       - '# CONFIG_ARM_DSU_PMU is not set'
       - 'CONFIG_CROS_KBD_LED_BACKLIGHT=m'
       - 'CONFIG_SND_SOC_MT8195=m'
@@ -490,11 +491,6 @@ fragments:
   tinyconfig:
     path: "kernel/configs/tiny.config"
     defconfig: 'tinyconfig'
-
-  videodec:
-    path: "kernel/configs/videodec.config"
-    configs:
-      - 'CONFIG_VIDEO_ROCKCHIP_VDEC=m'
 
   virtualvideo:
     path: "kernel/configs/virtualvideo.config"
@@ -799,8 +795,7 @@ build_configs_defaults:
             - 'defconfig+arm64-chromebook+kselftest'
 # Disabling to reduce load
 #            - 'defconfig+CONFIG_RANDOMIZE_BASE=y'
-#            - 'defconfig+arm64-chromebook+videodec'
-#          fragments: [arm64-chromebook, crypto, ima, videodec]
+#          fragments: [arm64-chromebook, crypto, ima]
           fragments: [arm64-chromebook]
 
         i386: &i386_arch
@@ -1194,8 +1189,7 @@ build_configs:
               - 'allnoconfig'
               - 'defconfig+CONFIG_CPU_BIG_ENDIAN=y'
               - 'defconfig+arm64-chromebook+kselftest'
-              - 'defconfig+arm64-chromebook+videodec'
-            fragments: [arm64-chromebook, videodec]
+            fragments: [arm64-chromebook]
 
       # Minimum version
       clang-11:
@@ -1277,8 +1271,8 @@ build_configs:
               - 'allnoconfig'
               - 'defconfig+CONFIG_CPU_BIG_ENDIAN=y'
               - 'defconfig+arm64-chromebook+kselftest'
-              - 'defconfig+arm64-chromebook+videodec'
-            fragments: [arm64-chromebook, videodec]
+              - 'defconfig+arm64-chromebook'
+            fragments: [arm64-chromebook]
 
   net-next:
     tree: net-next
@@ -1310,8 +1304,7 @@ build_configs:
               - 'defconfig+CONFIG_CPU_BIG_ENDIAN=y'
               - 'defconfig+CONFIG_RANDOMIZE_BASE=y'
               - 'defconfig+arm64-chromebook+kselftest'
-              - 'defconfig+arm64-chromebook+videodec'
-            fragments: [arm64-chromebook, videodec]
+            fragments: [arm64-chromebook]
           arm:
             base_defconfig: 'multi_v7_defconfig'
             extra_configs:

--- a/config/core/test-configs-chromeos.yaml
+++ b/config/core/test-configs-chromeos.yaml
@@ -566,52 +566,6 @@ test_plans:
       <<: *cros-tast-base-qemu-params
       tests: *cros-tast-video-tests
 
-  v4l2-decoder-conformance-av1_chromeos: &v4l2-decoder-conformance_chromeos
-    rootfs: debian_bullseye-gst-fluster_nfs
-    pattern: 'v4l2-decoder-conformance/{category}-{method}-{protocol}-{rootfs}-v4l2-decoder-conformance-template.jinja2'
-    params: &v4l2-decoder-conformance-params_chromeos
-      job_timeout: '30'
-      testsuite: 'AV1-TEST-VECTORS'
-      decoders:
-        - 'GStreamer-AV1-V4L2SL-Gst1.0'
-      videodec_parallel_jobs: '1'
-      videodec_timeout: 90
-
-  v4l2-decoder-conformance-h264_chromeos:
-    <<: *v4l2-decoder-conformance_chromeos
-    params:
-      <<: *v4l2-decoder-conformance-params_chromeos
-      testsuite: 'JVT-AVC_V1'
-      decoders:
-        - 'GStreamer-H.264-V4L2-Gst1.0'
-        - 'GStreamer-H.264-V4L2SL-Gst1.0'
-
-  v4l2-decoder-conformance-h265_chromeos:
-    <<: *v4l2-decoder-conformance_chromeos
-    params:
-      <<: *v4l2-decoder-conformance-params_chromeos
-      testsuite: 'JCT-VC-HEVC_V1'
-      decoders:
-        - 'GStreamer-H.265-V4L2-Gst1.0'
-        - 'GStreamer-H.265-V4L2SL-Gst1.0'
-
-  v4l2-decoder-conformance-vp8_chromeos:
-    <<: *v4l2-decoder-conformance_chromeos
-    params:
-      <<: *v4l2-decoder-conformance-params_chromeos
-      testsuite: 'VP8-TEST-VECTORS'
-      decoders:
-        - 'GStreamer-VP8-V4L2-Gst1.0'
-        - 'GStreamer-VP8-V4L2SL-Gst1.0'
-
-  v4l2-decoder-conformance-vp9_chromeos:
-    <<: *v4l2-decoder-conformance_chromeos
-    params:
-      <<: *v4l2-decoder-conformance-params_chromeos
-      testsuite: 'VP9-TEST-VECTORS'
-      decoders:
-        - 'GStreamer-VP9-V4L2SL-Gst1.0'
-
 device_types:
 
   acer-R721T-grunt_chromeos: &chromebook-grunt-type
@@ -1243,7 +1197,7 @@ test_configs:
   - device_type: mt8183-kukui-jacuzzi-juniper-sku16_chromeos
     filters: *collabora-chromeos-kernel-filter
     test_plans:
-      - v4l2-decoder-conformance-h264_chromeos
+      - v4l2-decoder-conformance-h264
 
   - device_type: mt8183-kukui-jacuzzi-juniper-sku16_chromeos
     filters: *collabora-chromeos-kernel-filter
@@ -1263,9 +1217,9 @@ test_configs:
   - device_type: mt8186-corsola-steelix-sku131072_chromeos
     filters: *collabora-chromeos-kernel-filter
     test_plans:
-      - v4l2-decoder-conformance-h264_chromeos
-      - v4l2-decoder-conformance-vp8_chromeos
-      - v4l2-decoder-conformance-vp9_chromeos
+      - v4l2-decoder-conformance-h264
+      - v4l2-decoder-conformance-vp8
+      - v4l2-decoder-conformance-vp9
 
   - device_type: mt8192-asurada-spherion-r0_chromeos
     filters: *collabora-chromeos-kernel-filter
@@ -1289,9 +1243,9 @@ test_configs:
   - device_type: mt8192-asurada-spherion-r0_chromeos
     filters: *collabora-chromeos-kernel-filter
     test_plans:
-      - v4l2-decoder-conformance-h264_chromeos
-      - v4l2-decoder-conformance-vp8_chromeos
-      - v4l2-decoder-conformance-vp9_chromeos
+      - v4l2-decoder-conformance-h264
+      - v4l2-decoder-conformance-vp8
+      - v4l2-decoder-conformance-vp9
 
 # Test plans temporarily disabled as QEMU build doesnt work
 #  - device_type: qemu_x86_64-uefi-chromeos
@@ -1326,11 +1280,11 @@ test_configs:
   - device_type: mt8195-cherry-tomato-r2_chromeos
     filters: *collabora-chromeos-kernel-filter
     test_plans:
-      - v4l2-decoder-conformance-av1_chromeos
-      - v4l2-decoder-conformance-h264_chromeos
-      - v4l2-decoder-conformance-h265_chromeos
-      - v4l2-decoder-conformance-vp8_chromeos
-      - v4l2-decoder-conformance-vp9_chromeos
+      - v4l2-decoder-conformance-av1
+      - v4l2-decoder-conformance-h264
+      - v4l2-decoder-conformance-h265
+      - v4l2-decoder-conformance-vp8
+      - v4l2-decoder-conformance-vp9
 
   - device_type: sc7180-trogdor-kingoftown_chromeos
     test_plans: *chromebook-arm64-test-plans

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -691,8 +691,6 @@ test_plans:
         - 'GStreamer-AV1-V4L2SL-Gst1.0'
       videodec_parallel_jobs: '1'
       videodec_timeout: 90
-    filters:
-      - passlist: {defconfig: ['videodec']}
 
   v4l2-decoder-conformance-h264:
     <<: *v4l2-decoder-conformance
@@ -3174,7 +3172,6 @@ test_configs:
       - v4l2-decoder-conformance-vp8
       - v4l2-decoder-conformance-vp9
     filters: &chromebook-decoders-filter
-      - passlist: {defconfig: ['videodec']}
       - regex: {'tree': '(next|mainline|media)'}
 
   - device_type: mt8195-cherry-tomato-r2


### PR DESCRIPTION
The fluster+GStreamer decoder test plans running on the collabora-chromeos-kernel tree have a "chromeos" suffix. The suffix was added to distinguish these tests from the analogous ones running in the main instance. The suffix may cause confusion as the tests are running on Debian and not on ChromeOS; remove it and reuse the test plan definitions from test-configs.yaml.

This PR requires two changes in the main instance files (namely test-configs.yaml and build-configs.yaml). https://github.com/kernelci/kernelci-core/pull/2323 applies these changes to the main branch, while for this PR changes have been cherry-picked (commits prefixed with `CHROMEOS MAIN`).