### PR TITLE
api.models: new optional "debug" field for Nodes

### DIFF
--- a/kernelci/api/models.py
+++ b/kernelci/api/models.py
@@ -145,6 +145,9 @@ class Node(DatabaseModel):
     data: Optional[Dict[str, Any]] = Field(
         description="Arbitrary data stored in the node"
     )
+    debug: Optional[Dict[str, Any]] = Field(
+        description="Debug info fields (for development purposes)"
+    )
     created: datetime = Field(
         default_factory=datetime.utcnow,
         description="Timestamp of node creation"


### PR DESCRIPTION
Free-form dict of debug attributes that can be used to specify debug flags in a node. These flags can then be used by the pipeline services to enable debug features, log additional traces or perform debug-specific actions.

Examples:

It could be used to define a checkout node to test-run the pipeline services, bypassing most actions and directly assuming "pass" (or "fail") for all results:
 
```
"debug": {
    "dry_run": true,
    "force_result": "pass" / "fail"
    ...
```

To make certain pipeline services more verbose:

```
"debug": {
    "debug_log": ["scheduler", "tarball", "kbuild"]
```

To force certain artifacts instead of running actions to generate them:

```
"debug": {
    "tarball": "https://mydomain.com/tarball"
```

The use cases are defined by the individual pipeline services and by the runtimes.

All suggestions/ideas are welcome.