### PR TITLE
runtime/kubernetes: Add trivial context load-balancing

### DIFF
--- a/config/runtime/base/kubernetes.jinja2
+++ b/config/runtime/base/kubernetes.jinja2
@@ -24,12 +24,6 @@ spec:
       - name: compile-volume
         emptyDir: { }
 
-      # FIXME: add template conditional based on storage type
-      - name: ssh-key
-        secret:
-          # FIXME: convert to template parameter
-          secretName: {{ "kci-storage-ssh-staging" }}
-
       tolerations:
       - key: "kubernetes.azure.com/scalesetpriority"
         operator: "Equal"
@@ -46,10 +40,6 @@ spec:
           name: compile-volume
         - mountPath: "/dev/shm"
           name: dev-shm
-        # FIXME: add template conditional based on storage type
-        - mountPath: "/home/kernelci/.ssh"
-          name: ssh-key
-          readOnly: true
 
         # FIXME: Request safe defaults to not overload node with
         # parallel pods

--- a/kernelci/runtime/kubernetes.py
+++ b/kernelci/runtime/kubernetes.py
@@ -36,7 +36,15 @@ class Kubernetes(Runtime):
         return template.render(params)
 
     def submit(self, job_path):
-        kubernetes.config.load_kube_config(context=self.config.context)
+        # if context is array, pick any random context to load-balance
+        if isinstance(self.config.context, list):
+            kcontext = random.choice(self.config.context)
+        else:
+            kcontext = self.config.context
+        # TODO: Add temporary logging to debug
+        # We must add context name to jobid
+        print(f"Submitting job to context: ", kcontext)
+        kubernetes.config.load_kube_config(context=kcontext)
         client = kubernetes.client.ApiClient()
         return kubernetes.utils.create_from_yaml(client, job_path)
 

--- a/kernelci/runtime/kubernetes.py
+++ b/kernelci/runtime/kubernetes.py
@@ -41,9 +41,6 @@ class Kubernetes(Runtime):
             kcontext = random.choice(self.config.context)
         else:
             kcontext = self.config.context
-        # TODO: Add temporary logging to debug
-        # We must add context name to jobid
-        print(f"Submitting job to context: ", kcontext)
         kubernetes.config.load_kube_config(context=kcontext)
         client = kubernetes.client.ApiClient()
         return kubernetes.utils.create_from_yaml(client, job_path)


### PR DESCRIPTION
If we have multiple clusters defined in config - pick random one. This is enough for now.