### PR TITLE
Dry run support for python runtime and kbuild

### DIFF
--- a/config/runtime/base/python.jinja2
+++ b/config/runtime/base/python.jinja2
@@ -91,6 +91,10 @@ class BaseJob:
         print("Running job...")
         return self._run(src_path)
 
+    def dry_run(self, result):
+        print(f"Dry-running job (result: {result})...")
+        return result
+
     def submit(self, result, node, api_config_yaml):
         api = self._get_api(api_config_yaml)
         self._submit(result, node, api)
@@ -105,8 +109,11 @@ class Job(BaseJob):
 def main(args):
     job = Job({% block python_job_constr %}workspace=WORKSPACE{% endblock %})
     try:
-        tarball_url = NODE['artifacts'].get('tarball')
-        results = job.run(tarball_url)
+        if 'debug' in NODE and NODE['debug'].get('dry_run'):
+            results = job.dry_run(NODE['debug']['result'])
+        else:
+            tarball_url = NODE['artifacts'].get('tarball')
+            results = job.run(tarball_url)
         if NODE and API_CONFIG_YAML:
             job.submit(results, NODE, API_CONFIG_YAML)
     except requests.exceptions.HTTPError as ex:

--- a/kernelci/kbuild.py
+++ b/kernelci/kbuild.py
@@ -121,7 +121,12 @@ class KBuild():
             self._artifacts = []
             self._current_job = None
             self._config_full = ''
-            self._srctarball = node['artifacts']['tarball']
+            if node.get('artifacts') and 'tarball' in node['artifacts']:
+                self._srctarball = node['artifacts']['tarball']
+            elif node.get('debug') and 'tarball' in node['debug']:
+                self._srctarball = node['debug']['tarball']
+            else:
+                raise ValueError("No tarball artifact in input node")
             self._srcdir = None
             self._firmware_dir = None
             self._af_dir = None
@@ -632,10 +637,17 @@ class KBuild():
         with open(metadata_file, 'w') as f:
             json.dump(metadata, f, indent=4)
 
-    def submit(self, retcode):
+    def submit(self, retcode, dry_run=False):
         '''
         Submit results to API and artifacts to storage
         '''
+        if dry_run:
+            if self._node.get('artifacts'):
+                af_uri = self._node['artifacts']
+            else:
+                af_uri = {'tarball': 'http://dry-run.test/tarball'}
+        else:
+            af_uri = self.upload_artifacts()
         print("[_submit] Submitting results to API")
         af_uri = self.upload_artifacts()
         api_token = os.environ.get('KCI_API_TOKEN')

--- a/kernelci/kbuild.py
+++ b/kernelci/kbuild.py
@@ -121,10 +121,10 @@ class KBuild():
             self._artifacts = []
             self._current_job = None
             self._config_full = ''
-            if node.get('artifacts') and 'tarball' in node['artifacts']:
-                self._srctarball = node['artifacts']['tarball']
-            elif node.get('debug') and 'tarball' in node['debug']:
+            if node.get('debug') and 'tarball' in node['debug']:
                 self._srctarball = node['debug']['tarball']
+            elif node.get('artifacts') and 'tarball' in node['artifacts']:
+                self._srctarball = node['artifacts']['tarball']
             else:
                 raise ValueError("No tarball artifact in input node")
             self._srcdir = None


### PR DESCRIPTION
Requirement: https://github.com/kernelci/kernelci-core/pull/2326

If the input node specifies a "dry_run" result in its debug parameters, bypass all the script running, artifacts upload, etc. and simply return the fake result.