### PR TITLE
Add recipe for kernelci/api-production image

### DIFF
--- a/config/docker/api.jinja2
+++ b/config/docker/api.jinja2
@@ -1,0 +1,8 @@
+{# SPDX-License-Identifier: LGPL-2.1-or-later
+ #
+ # Copyright (C) 2024 Collabora Limited
+ # Author: Paweł Wieczorek <pawiecz@collabora.com>
+-#}
+
+{%- set fragments = ['fragment/api.jinja2'] + fragments %}
+{%- include 'base/python-fixed.jinja2' %}

--- a/config/docker/base/python-fixed.jinja2
+++ b/config/docker/base/python-fixed.jinja2
@@ -1,0 +1,21 @@
+{# SPDX-License-Identifier: LGPL-2.1-or-later
+ #
+ # Copyright (C) 2024 Collabora Limited
+ # Author: Paweł Wieczorek <pawiecz@collabora.com>
+-#}
+
+FROM python:3.10
+MAINTAINER "KernelCI TSC" <kernelci-tsc@groups.io>
+
+# Upgrade pip3 - never mind the warning about running this as root
+RUN pip3 install --upgrade "pip==23.2.1"
+
+# Upgrade setuptools for full pyproject.toml support
+RUN pip3 install "setuptools==68.1.2"
+
+{%- block fragments %}
+{%- for fragment in fragments %}
+
+{% include fragment %}
+{%- endfor %}
+{%- endblock %}

--- a/config/docker/fragment/api.jinja2
+++ b/config/docker/fragment/api.jinja2
@@ -1,0 +1,12 @@
+# Set up kernelci user
+RUN useradd kernelci -u 1000 -d /home/kernelci -s /bin/bash
+RUN mkdir -p /home/kernelci
+RUN chown kernelci: /home/kernelci
+USER kernelci
+ENV PATH=$PATH:/home/kernelci/.local/bin
+WORKDIR /home/kernelci
+
+# Install kernelci Python package from kernelci-api
+ARG api_url=https://github.com/kernelci/kernelci-api.git
+ARG api_rev=main
+RUN pip install git+$api_url@$api_rev


### PR DESCRIPTION
Verification (on the assumption environment for `kci` tool is set and there is `kernelci-api` repo in the CWD parent):
```
diff <(./kci docker generate api) ../kernelci-api/docker/api/Dockerfile.production
```
Difference should only include:
- stripped license header (moved to a relevant fragment from which Dockerfile is generated)
- cosmetic changes in comments

Then build the image with: `./kci docker build --prefix=kernelci/ api`

Fixes: https://github.com/kernelci/kernelci-core/issues/2331