### PR TITLE
igt: Update IGT rootfs to bookworm

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -1,4 +1,61 @@
 rootfs_configs:
+  bookworm-igt:
+    rootfs_type: debos
+    debian_release: bookworm
+    arch_list:
+        - amd64
+        - arm64
+        - armhf
+    extra_packages:
+        - libcairo2
+        - libdw1
+        - libglib2.0-0
+        - libpciaccess0
+        - libproc2-0
+        - libudev1
+        - libunwind8
+    extra_packages_remove:
+        - bash
+        - e2fslibs
+        - e2fsprogs
+        - fonts-dejavu-core
+        - klibc-utils
+        - libext2fs2
+        - libgio3.0-cil
+        - libgnutls30
+        - libklibc
+        - libncursesw6
+        - libp11-kit0
+        - libunistring2
+        - libx11-data
+        - sensible-utils
+    extra_files_remove:
+        - '*networkd*'
+        - '*resolved*'
+        - tar
+        - patch
+        - diff
+        - dir
+        - partx
+        - find
+    extra_firmware:
+        - amdgpu/stoney_ce.bin
+        - amdgpu/stoney_me.bin
+        - amdgpu/stoney_mec.bin
+        - amdgpu/stoney_pfp.bin
+        - amdgpu/stoney_rlc.bin
+        - amdgpu/stoney_sdma.bin
+        - amdgpu/stoney_uvd.bin
+        - amdgpu/stoney_vce.bin
+        - i915/bxt_dmc_ver1_07.bin
+        - i915/kbl_dmc_ver1_04.bin
+        - i915/glk_dmc_ver1_04.bin
+        - qcom/a630_gmu.bin
+        - qcom/a630_sqe.fw
+    linux_fw_version: d526e044bddaa2c2ad855c7296147e49be0ab03c
+    script: "scripts/debian-igt.sh"
+    test_overlay: "overlays/igt"
+
   bookworm-kselftest:
     rootfs_type: debos
     debian_release: bookworm
@@ -161,62 +218,6 @@ rootfs_configs:
     imagesize: 2GB
     debos_memory: 8G
 
-  bullseye-igt:
-    rootfs_type: debos
-    debian_release: bullseye
-    arch_list:
-        - amd64
-        - arm64
-        - armhf
-    extra_packages:
-        - libcairo2
-        - libdw1
-        - libglib2.0-0
-        - libpciaccess0
-        - libprocps8
-        - libudev1
-        - libunwind8
-    extra_packages_remove:
-        - bash
-        - e2fslibs
-        - e2fsprogs
-        - fonts-dejavu-core
-        - klibc-utils
-        - libext2fs2
-        - libgio3.0-cil
-        - libgnutls30
-        - libklibc
-        - libncursesw6
-        - libp11-kit0
-        - libunistring2
-        - libx11-data
-        - sensible-utils
-    extra_files_remove:
-        - '*networkd*'
-        - '*resolved*'
-        - tar
-        - patch
-        - diff
-        - dir
-        - partx
-        - find
-    extra_firmware:
-        - amdgpu/stoney_ce.bin
-        - amdgpu/stoney_me.bin
-        - amdgpu/stoney_mec.bin
-        - amdgpu/stoney_pfp.bin
-        - amdgpu/stoney_rlc.bin
-        - amdgpu/stoney_sdma.bin
-        - amdgpu/stoney_uvd.bin
-        - amdgpu/stoney_vce.bin
-        - i915/bxt_dmc_ver1_07.bin
-        - i915/kbl_dmc_ver1_04.bin
-        - i915/glk_dmc_ver1_04.bin
-        - qcom/a630_gmu.bin
-        - qcom/a630_sqe.fw
-    linux_fw_version: d526e044bddaa2c2ad855c7296147e49be0ab03c
-    script: "scripts/bullseye-igt.sh"
-    test_overlay: "overlays/igt"
 
   bullseye-kselftest:
     rootfs_type: debos

--- a/config/core/rootfs-images.yaml
+++ b/config/core/rootfs-images.yaml
@@ -47,11 +47,11 @@ file_systems:
     ramdisk: bullseye-gst-fluster/20240103.0/{arch}/initrd.cpio.gz
     root_type: nfs
     type: debian
-  debian_bullseye-igt_ramdisk:
+  debian_bookworm-igt_ramdisk:
     boot_protocol: tftp
     params: {}
     prompt: '/ #'
-    ramdisk: bullseye-igt/20230623.0/{arch}/rootfs.cpio.gz
+    ramdisk: bookworm-igt/20240129.0/{arch}/rootfs.cpio.gz
     root_type: ramdisk
     type: debian
   debian_bullseye-kselftest_diskfile:

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -112,7 +112,7 @@ test_plans:
     rootfs: debian_bullseye-cros-ec_ramdisk
 
   igt: &igt
-    rootfs: debian_bullseye-igt_ramdisk
+    rootfs: debian_bookworm-igt_ramdisk
     pattern: 'igt/{category}-{method}-{protocol}-{rootfs}-igt.jinja2'
 
   igt-gpu-amd:

--- a/config/rootfs/debos/scripts/debian-igt.sh
+++ b/config/rootfs/debos/scripts/debian-igt.sh
@@ -19,7 +19,7 @@ BUILD_DEPS="\
     libkmod-dev \
     liblzma-dev \
     libpciaccess-dev \
-    libprocps-dev \
+    libproc2-dev \
     libtool \
     libudev-dev  \
     libunwind-dev  \


### PR DESCRIPTION
Old rootfs fails to build as one of subsystems require newer Meson.