### PR TITLE
kernelci.api.helper: fix node data retrieval in job result submission

### DIFF
--- a/kernelci/api/helper.py
+++ b/kernelci/api/helper.py
@@ -144,6 +144,9 @@ class APIHelper:
         node['path'] = (parent['path'] if parent else []) + [node['name']]
         if 'kind' not in node:
             node['kind'] = parent['kind']
+        if 'data' not in node:
+            node['data'] = parent['data']
+
         child_nodes = []
         for child_node in results['child_nodes']:
             child_nodes.append(self._prepare_results(child_node, node, base))
@@ -187,9 +190,6 @@ class APIHelper:
         }
         parent = self.api.node.get(root['parent'])
         base = {
-            'data': {
-                'kernel_revision': root['data']['kernel_revision'],
-            },
             'group': root['name'],
             'state': 'done',
         }


### PR DESCRIPTION
For each node result, take the node data (including the kernel revision) from its parent.

**NOTE:** I think this should fix the issue of disappearing data info after lava callbacks, but I couldn't test it and I don't really know exactly how these results look like in a real lava callback scenario. I guess the only way to be sure is to run it on staging and checking the results live, if there's a way to do that.

**NOTE 2:** This should make all child nodes inherit _all_ the data contents from its parent. Is that the intended behavior you want?