### PR TITLE
rootfs-images.yaml: Update most of images to recent build

### DIFF
--- a/config/core/rootfs-images.yaml
+++ b/config/core/rootfs-images.yaml
@@ -9,11 +9,11 @@ file_systems:
     type: buildroot
   debian_bookworm-kselftest_nfs:
     boot_protocol: tftp
-    nfs: bookworm-kselftest/20231214.0/{arch}/full.rootfs.tar.xz
+    nfs: bookworm-kselftest/20240129.0/{arch}/full.rootfs.tar.xz
     params:
       os_config: debian
     prompt: '/ #'
-    ramdisk: bookworm-kselftest/20231214.0/{arch}/initrd.cpio.gz
+    ramdisk: bookworm-kselftest/20240129.0/{arch}/initrd.cpio.gz
     root_type: nfs
     type: debian
   debian_bookworm-kselftest_ramdisk:
@@ -21,7 +21,7 @@ file_systems:
     params:
       os_config: debian
     prompt: '/ #'
-    ramdisk: bookworm-kselftest/20231214.0/{arch}/rootfs.cpio.gz
+    ramdisk: bookworm-kselftest/20240129.0/{arch}/rootfs.cpio.gz
     root_type: ramdisk
     type: debian
   debian_bullseye-cros-ec_ramdisk:
@@ -33,18 +33,18 @@ file_systems:
     type: debian
   debian_bullseye-diskfile:
     boot_protocol: tftp
-    diskfile: bullseye/20230623.0/{arch}/rootfs.ext4.xz
+    diskfile: bullseye/20240129.0/{arch}/rootfs.ext4.xz
     params: {}
     prompt: '/ #'
-    ramdisk: bullseye/20230623.0/{arch}/initrd.cpio.gz
+    ramdisk: bullseye/20240129.0/{arch}/initrd.cpio.gz
     root_type: diskfile
     type: debian
   debian_bullseye-gst-fluster_nfs:
     boot_protocol: tftp
-    nfs: bullseye-gst-fluster/20240103.0/{arch}/full.rootfs.tar.xz
+    nfs: bullseye-gst-fluster/20240129.0/{arch}/full.rootfs.tar.xz
     params: {}
     prompt: '/ #'
-    ramdisk: bullseye-gst-fluster/20240103.0/{arch}/initrd.cpio.gz
+    ramdisk: bullseye-gst-fluster/20240129.0/{arch}/initrd.cpio.gz
     root_type: nfs
     type: debian
   debian_bookworm-igt_ramdisk:
@@ -56,20 +56,20 @@ file_systems:
     type: debian
   debian_bullseye-kselftest_diskfile:
     boot_protocol: tftp
-    diskfile: bullseye-kselftest/20230623.0/{arch}/rootfs.ext4.xz
+    diskfile: bullseye-kselftest/20240129.0/{arch}/rootfs.ext4.xz
     params:
       os_config: debian
     prompt: '/ #'
-    ramdisk: bullseye-kselftest/20230623.0/{arch}/initrd.cpio.gz
+    ramdisk: bullseye-kselftest/20240129.0/{arch}/initrd.cpio.gz
     root_type: diskfile
     type: debian
   debian_bullseye-kselftest_nfs:
     boot_protocol: tftp
-    nfs: bullseye-kselftest/20230623.0/{arch}/full.rootfs.tar.xz
+    nfs: bullseye-kselftest/20240129.0/{arch}/full.rootfs.tar.xz
     params:
       os_config: debian
     prompt: '/ #'
-    ramdisk: bullseye-kselftest/20230623.0/{arch}/initrd.cpio.gz
+    ramdisk: bullseye-kselftest/20240129.0/{arch}/initrd.cpio.gz
     root_type: nfs
     type: debian
   debian_bullseye-kselftest_ramdisk:
@@ -77,24 +77,24 @@ file_systems:
     params:
       os_config: debian
     prompt: '/ #'
-    ramdisk: bullseye-kselftest/20230623.0/{arch}/rootfs.cpio.gz
+    ramdisk: bullseye-kselftest/20240129.0/{arch}/rootfs.cpio.gz
     root_type: ramdisk
     type: debian
   debian_bullseye-libcamera_nfs:
     boot_protocol: tftp
-    nfs: bullseye-libcamera/20230623.0/{arch}/full.rootfs.tar.xz
+    nfs: bullseye-libcamera/20240129.0/{arch}/full.rootfs.tar.xz
     params: {}
     prompt: '/ #'
-    ramdisk: bullseye-libcamera/20230623.0/{arch}/initrd.cpio.gz
+    ramdisk: bullseye-libcamera/20240129.0/{arch}/initrd.cpio.gz
     root_type: nfs
     type: debian
   debian_bullseye-libhugetlbfs_nfs:
     boot_protocol: tftp
-    nfs: bullseye-libhugetlbfs/20230623.0/{arch}/full.rootfs.tar.xz
+    nfs: bullseye-libhugetlbfs/20240129.0/{arch}/full.rootfs.tar.xz
     params:
       os_config: debian
     prompt: '/ #'
-    ramdisk: bullseye-libhugetlbfs/20230623.0/{arch}/initrd.cpio.gz
+    ramdisk: bullseye-libhugetlbfs/20240129.0/{arch}/initrd.cpio.gz
     root_type: nfs
     type: debian
   debian_bullseye-libhugetlbfs_ramdisk:
@@ -102,37 +102,37 @@ file_systems:
     params:
       os_config: debian
     prompt: '/ #'
-    ramdisk: bullseye-libhugetlbfs/20230623.0/{arch}/rootfs.cpio.gz
+    ramdisk: bullseye-libhugetlbfs/20240129.0/{arch}/rootfs.cpio.gz
     root_type: ramdisk
     type: debian
   debian_bullseye-ltp_diskfile:
     boot_protocol: tftp
-    diskfile: bullseye-ltp/20230623.0/{arch}/rootfs.ext4.xz
+    diskfile: bullseye-ltp/20240129.0/{arch}/rootfs.ext4.xz
     params: {}
     prompt: '/ #'
-    ramdisk: bullseye-ltp/20230623.0/{arch}/initrd.cpio.gz
+    ramdisk: bullseye-ltp/20240129.0/{arch}/initrd.cpio.gz
     root_type: diskfile
     type: debian
   debian_bullseye-ltp_nfs:
     boot_protocol: tftp
-    nfs: bullseye-ltp/20230623.0/{arch}/full.rootfs.tar.xz
+    nfs: bullseye-ltp/20240129.0/{arch}/full.rootfs.tar.xz
     params: {}
     prompt: '/ #'
-    ramdisk: bullseye-ltp/20230623.0/{arch}/initrd.cpio.gz
+    ramdisk: bullseye-ltp/20240129.0/{arch}/initrd.cpio.gz
     root_type: nfs
     type: debian
   debian_bullseye-ltp_ramdisk:
     boot_protocol: tftp
     params: {}
     prompt: '/ #'
-    ramdisk: bullseye-ltp/20230623.0/{arch}/rootfs.cpio.gz
+    ramdisk: bullseye-ltp/20240129.0/{arch}/rootfs.cpio.gz
     root_type: ramdisk
     type: debian
   debian_bullseye-rt_ramdisk:
     boot_protocol: tftp
     params: {}
     prompt: '/ #'
-    ramdisk: bullseye-rt/20230623.0/{arch}/rootfs.cpio.gz
+    ramdisk: bullseye-rt/20240129.0/{arch}/rootfs.cpio.gz
     root_type: ramdisk
     type: debian
   debian_bullseye-v4l2_ramdisk:
@@ -144,11 +144,11 @@ file_systems:
     type: debian
   debian_bullseye-vdso_nfs:
     boot_protocol: tftp
-    nfs: bullseye-vdso/20230623.0/{arch}/full.rootfs.tar.xz
+    nfs: bullseye-vdso/20240129.0/{arch}/full.rootfs.tar.xz
     params:
       os_config: debian
     prompt: '/ #'
-    ramdisk: bullseye-vdso/20230623.0/{arch}/initrd.cpio.gz
+    ramdisk: bullseye-vdso/20240129.0/{arch}/initrd.cpio.gz
     root_type: nfs
     type: debian
   debian_bullseye-vdso_ramdisk:
@@ -156,22 +156,22 @@ file_systems:
     params:
       os_config: debian
     prompt: '/ #'
-    ramdisk: bullseye-vdso/20230623.0/{arch}/rootfs.cpio.gz
+    ramdisk: bullseye-vdso/20240129.0/{arch}/rootfs.cpio.gz
     root_type: ramdisk
     type: debian
   debian_bullseye_nfs:
     boot_protocol: tftp
-    nfs: bullseye/20230623.0/{arch}/full.rootfs.tar.xz
+    nfs: bullseye/20240129.0/{arch}/full.rootfs.tar.xz
     params: {}
     prompt: '/ #'
-    ramdisk: bullseye/20230623.0/{arch}/initrd.cpio.gz
+    ramdisk: bullseye/20240129.0/{arch}/initrd.cpio.gz
     root_type: nfs
     type: debian
   debian_bullseye_ramdisk:
     boot_protocol: tftp
     params: {}
     prompt: '/ #'
-    ramdisk: bullseye/20230623.0/{arch}/rootfs.cpio.gz
+    ramdisk: bullseye/20240129.0/{arch}/rootfs.cpio.gz
     root_type: ramdisk
     type: debian
   debian_sid-kselftest_nfs:


### PR DESCRIPTION
We will start gradually updating rootfs images.
First verification - newer build of bullseye and in some cases bookworm.