### PR TITLE
rootfs-configs.yaml: Add liburing for mm selftests

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -84,6 +84,7 @@ rootfs_configs:
       - libpcre2-8-0
       - libperl5.36
       - libpsl5
+      - liburing2
       - libxtables12
       - netbase
       - openssl
@@ -245,6 +246,7 @@ rootfs_configs:
       - libpcre2-8-0
       - libperl5.32
       - libpsl5
+      - liburing1
       - libxtables12
       - netbase
       - openssl
@@ -403,6 +405,7 @@ rootfs_configs:
       - libpcre2-8-0
       - libperl5.36
       - libpsl5
+      - liburing2
       - libxtables12
       - netbase
       - openssl


### PR DESCRIPTION
The mm selftests require liburing. The binaries error out if liburing
isn't found at runtime. This will fix the following class of errors:

error while loading shared libraries: liburing.so.1: cannot open
shared object file: No such file or directory
https://lava.collabora.dev/scheduler/job/12674655#L3643

Signed-off-by: Muhammad Usama Anjum <usama.anjum@collabora.com>