### PR TITLE
runtime/kubernetes: store k8s cluster name

### DIFF
--- a/kernelci/api/models.py
+++ b/kernelci/api/models.py
@@ -319,6 +319,9 @@ class KbuildData(BaseModel):
     job_id: Optional[str] = Field(
         description="Runtime job ID"
     )
+    job_context: Optional[str] = Field(
+        description="Kubernetes cluster name the job submitted to"
+    )
 
 
 class Kbuild(Node):
@@ -355,6 +358,9 @@ class TestData(BaseModel):
     )
     job_id: Optional[str] = Field(
         description="Runtime job ID"
+    )
+    job_context: Optional[str] = Field(
+        description="Kubernetes cluster name the job submitted to"
     )
 
 


### PR DESCRIPTION
Introduce `kcontext` instance variable to store k8s cluster name that ran the job in k8s runtime.
Implement `Kubernetes.get_context` to get the cluster name.