### PR TITLE
Dynamically generate kernel "type"

### DIFF
--- a/config/runtime/boot/grub.jinja2
+++ b/config/runtime/boot/grub.jinja2
@@ -2,7 +2,7 @@
     kernel:
       url: {{ node.artifacts.kernel }}
       image_arg: -kernel {kernel} -serial stdio --append "console=ttyS0"
-      type: zimage
+      type: {{ node.data.kernel_type }}
     ramdisk:
       url: http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230421.0/{{ platform_config.arch }}/rootfs.cpio.gz
       image_arg: -initrd {ramdisk}

--- a/config/runtime/boot/u-boot.jinja2
+++ b/config/runtime/boot/u-boot.jinja2
@@ -1,6 +1,6 @@
 - deploy:
     kernel:
-      type: image
+      type: {{ node.data.kernel_type }}
       url: {{ node.artifacts.kernel }}
     modules:
       compression: xz


### PR DESCRIPTION
We currently hardcode the kernel "type" in job templates requiring it, but this parameter can change depending on the target architecture and/or make target used to build the kernel: it is actually the lowercase kernel image filename.

For example, it should be `image` for arm64 devices, but `zimage` for arm32 ones.

Fixes https://github.com/kernelci/kernelci-api/issues/472