### PR TITLE
kernelci.api.helper: fix `Node.data` trucation

### DIFF
--- a/config/runtime/base/python.jinja2
+++ b/config/runtime/base/python.jinja2
@@ -76,7 +76,8 @@ class BaseJob:
         raise NotImplementedError("_run() method required to run job")
 
     def _submit(self, result, node, api):
-        node = node.copy()
+        node_from_id = api.node.get(node['id'])
+        node = node_from_id.copy()
         node.update({
             'result': result,
             'state': 'done',

--- a/config/runtime/base/python.jinja2
+++ b/config/runtime/base/python.jinja2
@@ -110,7 +110,7 @@ class Job(BaseJob):
 def main(args):
     job = Job({% block python_job_constr %}workspace=WORKSPACE{% endblock %})
     try:
-        if 'debug' in NODE and NODE['debug'].get('dry_run'):
+        if NODE.get('debug') and NODE['debug'].get('dry_run'):
             results = job.dry_run(NODE['debug']['result'])
         else:
             tarball_url = NODE['artifacts'].get('tarball')

--- a/kernelci/api/helper.py
+++ b/kernelci/api/helper.py
@@ -140,7 +140,15 @@ class APIHelper:
 
     def _prepare_results(self, results, parent, base):
         node = results['node'].copy()
-        node.update(base)
+        # Merge `Node.data` instead of overwriting it
+        for key, value in base.items():
+            if isinstance(value, dict):
+                if node.get(key):
+                    node[key].update(value)
+                else:
+                    node.update({key: value})
+            else:
+                node[key] = value
         node['path'] = (parent['path'] if parent else []) + [node['name']]
         if 'kind' not in node:
             node['kind'] = parent['kind']
@@ -178,6 +186,8 @@ class APIHelper:
             ]
         }
         """
+        # Get latest node data added after node creation
+        root = self.api.node.get(root['id'])
         root_node = root.copy()
         root_node['result'] = results['node']['result']
         root_node['artifacts'].update(results['node']['artifacts'])


### PR DESCRIPTION
PUT `/nodes` request is truncation `Node.data` field and only preserve value of `Node.data.kernel_revision`. Fix `submit_results` helper function to resolve the issue.