### PR TITLE
python.jinja2: Retrieve fresh copy of node before updating it

### DIFF
--- a/config/runtime/base/python.jinja2
+++ b/config/runtime/base/python.jinja2
@@ -76,7 +76,8 @@ class BaseJob:
         raise NotImplementedError("_run() method required to run job")
 
     def _submit(self, result, node, api):
-        node = node.copy()
+        node_id = node.get('id')
+        node = self.api.node.get(node_id)
         node.update({
             'result': result,
             'state': 'done',


### PR DESCRIPTION
Node might be updated while test was running, we need to refresh it.