### PR TITLE
Add recipe for kernelci/pipeline image

### DIFF
--- a/config/docker/fragment/pipeline.jinja2
+++ b/config/docker/fragment/pipeline.jinja2
@@ -1,0 +1,6 @@
+ARG pipeline_url=https://github.com/kernelci/kernelci-pipeline.git
+ARG pipeline_rev=main
+RUN git clone --depth=1 $pipeline_url pipeline
+WORKDIR pipeline
+RUN git fetch origin $pipeline_rev
+RUN git checkout FETCH_HEAD

--- a/config/docker/pipeline.jinja2
+++ b/config/docker/pipeline.jinja2
@@ -1,0 +1,24 @@
+{# SPDX-License-Identifier: LGPL-2.1-or-later
+ #
+ # Copyright (C) 2024 Collabora Limited
+ # Author: Paweł Wieczorek <pawiecz@collabora.com>
+-#}
+
+{%- set fragments = [
+  'fragment/kubernetes.jinja2',
+  'fragment/helm.jinja2',
+  'fragment/gcloud.jinja2',
+  'fragment/azure-cli.jinja2',
+  'fragment/kernelci.jinja2',
+  'fragment/pipeline.jinja2']
+  + fragments
+-%}
+
+{% extends 'base/debian.jinja2' %}
+
+{% block packages %}
+{{ super() }}
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    curl \
+    wget
+{%- endblock %}


### PR DESCRIPTION
This patch duplicates the whole `kernelci/k8s:kernelci` image recipe so that it can be built without depending on it as a base image.

The same result could be achieved by:

```
kci build --prefix=kernelci/ k8s kernelci pipeline
```

Resulting image would be `kernelci/k8s:kernelci-pipeline`. To get `kernelci/pipeline` image out of it, retagging image would be required (which could result in more confusion in staging/production deployment scripts) or alternatively providing a custom name at build (which would require rewriting name handling in `kci docker` tool).

This duplication will probably require revisiting in the future but for now the key deliverable is to provide versioned production images using `kci docker` tool.

Fixes: #2350