### PR TITLE
Rework templates and add Tast tests

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -536,7 +536,6 @@ fragments:
       - 'CONFIG_I2C_DESIGNWARE_PCI=y'
       - 'CONFIG_I2C_DESIGNWARE_PLATFORM=y'
       - 'CONFIG_I2C_HID=m'
-      - 'CONFIG_IGB=y'
       - 'CONFIG_IIO_CROS_EC_ACCEL_LEGACY=m'
       - 'CONFIG_IIO_CROS_EC_BARO=m'
       - 'CONFIG_IIO_CROS_EC_LIGHT_PROX=m'
@@ -569,6 +568,7 @@ fragments:
       - 'CONFIG_RTC_DRV_CROS_EC=m'
       - 'CONFIG_SERIAL_8250_DW=y'
       - 'CONFIG_SERIAL_8250=y'
+      - 'CONFIG_SERIAL_8250_CONSOLE=y'
       - 'CONFIG_SND_DESIGNWARE_I2S=m'
       - 'CONFIG_SND_DESIGNWARE_PCM=y'
       - 'CONFIG_SND_HDA_CODEC_HDMI=m'
@@ -602,6 +602,13 @@ fragments:
       - 'CONFIG_X86_AMD_PLATFORM_DEVICE=y'
       - 'CONFIG_X86_INTEL_LPSS=y'
       - 'CONFIG_EXTRA_FIRMWARE="
+      amdgpu/dcn_3_1_6_dmcub.bin
+      amdgpu/gc_10_3_7_ce.bin
+      amdgpu/gc_10_3_7_me.bin
+      amdgpu/gc_10_3_7_mec2.bin
+      amdgpu/gc_10_3_7_mec.bin
+      amdgpu/gc_10_3_7_pfp.bin
+      amdgpu/gc_10_3_7_rlc.bin
       amdgpu/green_sardine_asd.bin
       amdgpu/green_sardine_ce.bin
       amdgpu/green_sardine_sdma.bin
@@ -614,6 +621,9 @@ fragments:
       amdgpu/green_sardine_mec.bin
       amdgpu/green_sardine_mec2.bin
       amdgpu/green_sardine_rlc.bin
+      amdgpu/psp_13_0_8_asd.bin
+      amdgpu/psp_13_0_8_ta.bin
+      amdgpu/psp_13_0_8_toc.bin
       amdgpu/raven2_asd.bin
       amdgpu/raven2_ce.bin
       amdgpu/raven2_gpu_info.bin
@@ -626,6 +636,7 @@ fragments:
       amdgpu/raven2_ta.bin
       amdgpu/raven2_vcn.bin
       amdgpu/raven_kicker_rlc.bin
+      amdgpu/sdma_5_2_7.bin
       amdgpu/stoney_ce.bin
       amdgpu/stoney_me.bin
       amdgpu/stoney_mec.bin
@@ -634,6 +645,7 @@ fragments:
       amdgpu/stoney_sdma.bin
       amdgpu/stoney_uvd.bin
       amdgpu/stoney_vce.bin
+      amdgpu/yellow_carp_vcn.bin
       i915/glk_dmc_ver1_04.bin
       i915/kbl_dmc_ver1_04.bin
       rtl_nic/rtl8153a-4.fw

--- a/config/rootfs/debos/overlays/cros-flash/opt/chromeos/install-modules
+++ b/config/rootfs/debos/overlays/cros-flash/opt/chromeos/install-modules
@@ -32,12 +32,13 @@ install_modules()
 
     local mount_dir=$(basename "$image_mountpoint")
     local root_path=$(dirname "$image_mountpoint")
-    local modules_tarball=$(basename "$modules_url")
+    # $modules_url may contain GET parameters, let's get rid of those
+    local modules_tarball=$(basename "$modules_url" | sed 's/?.*//')
 
-    echo "Downloading modules from $modules_url..."
+    echo "Downloading modules from $modules_url as $modules_tarball..."
     mkdir -p "$image_mountpoint"
     cd "$root_path"
-    wget "$modules_url"
+    wget -O "$modules_tarball" "$modules_url"
     mount /dev/${block_device}p3 "$mount_dir"
 
     echo "Installing modules..."

--- a/config/runtime/base/lava.jinja2
+++ b/config/runtime/base/lava.jinja2
@@ -35,7 +35,7 @@ timeouts:
     power-off:
       seconds: 30
   job:
-    minutes: 10
+    minutes: 30
   queue:
     days: 2
 

--- a/config/runtime/base/lava.jinja2
+++ b/config/runtime/base/lava.jinja2
@@ -67,29 +67,5 @@ actions:
 {% set boot_template = 'boot/' + platform_config.boot_method + '.jinja2' %}
 {% include boot_template %}
 
-- test:
-    definitions:
-    - from: inline
-      lava-signal: kmsg
-      name: dmesg
-      path: inline/dmesg.yaml
-      repository:
-        metadata:
-          description: baseline test plan
-          environment:
-            - lava-test-shell
-          format: Lava-Test Test Definition 1.0
-          name: baseline
-          os:
-            - debian
-          scope:
-            - functional
-        run:
-          steps:
-            - |
-{%- filter indent(width=16) -%}
-{% block commands %}{% endblock %}
-{%- endfilter %}
-
-    timeout:
-      minutes: 1
+{% set test_template = 'tests/' + test_method + '.jinja2' %}
+{% extends test_template %}

--- a/config/runtime/boot/depthcharge.jinja2
+++ b/config/runtime/boot/depthcharge.jinja2
@@ -16,25 +16,25 @@
     namespace: {{ boot_namespace }}
 {%- endif %}
     kernel:
-      url: {{ kernel_url }}
+      url: '{{ kernel_url }}'
     modules:
       compression: xz
-      url: {{ modules_url }}
+      url: '{{ modules_url }}'
 {%- if platform_config.dtb %}
     dtb:
-      url: {{ dtb_url }}
+      url: '{{ dtb_url }}'
 {%- endif %}
 {%- if boot_commands == 'nfs' and nfsroot %}
     nfsrootfs:
       compression: xz
-      url: {{ nfsroot }}/full.rootfs.tar.xz
+      url: '{{ nfsroot }}/full.rootfs.tar.xz'
     ramdisk:
       compression: gz
-      url: {{ nfsroot }}/initrd.cpio.gz
+      url: '{{ nfsroot }}/initrd.cpio.gz'
 {%- else %}
     ramdisk:
       compression: gz
-      url: http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230623.0/{{ platform_config.arch }}/rootfs.cpio.gz
+      url: 'http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230623.0/{{ platform_config.arch }}/rootfs.cpio.gz'
 {%- endif %}
     os: oe
     timeout:

--- a/config/runtime/boot/depthcharge.jinja2
+++ b/config/runtime/boot/depthcharge.jinja2
@@ -1,22 +1,50 @@
+{%- if kernel_url is not defined %}
+{%-   set kernel_url = node.artifacts.kernel %}
+{%- endif %}
+{%- if modules_url is not defined %}
+{%-   set modules_url = node.artifacts.modules %}
+{%- endif %}
+{%- if platform_config.dtb and dtb_url is not defined %}
+{%-   set dtb_url = node.artifacts.dtb %}
+{%- endif %}
+{%- if boot_commands is not defined %}
+{%-   set boot_commands = 'ramdisk' %}
+{%- endif %}
+
 - deploy:
+{%- if boot_namespace %}
+    namespace: {{ boot_namespace }}
+{%- endif %}
     kernel:
-      url: {{ node.artifacts.kernel }}
+      url: {{ kernel_url }}
     modules:
       compression: xz
-      url: {{ node.artifacts.modules }}
+      url: {{ modules_url }}
 {%- if platform_config.dtb %}
     dtb:
-      url: {{ node.artifacts.dtb }}
+      url: {{ dtb_url }}
 {%- endif %}
-    os: oe
+{%- if boot_commands == 'nfs' and nfsroot %}
+    nfsrootfs:
+      compression: xz
+      url: {{ nfsroot }}/full.rootfs.tar.xz
+    ramdisk:
+      compression: gz
+      url: {{ nfsroot }}/initrd.cpio.gz
+{%- else %}
     ramdisk:
       compression: gz
       url: http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230623.0/{{ platform_config.arch }}/rootfs.cpio.gz
+{%- endif %}
+    os: oe
     timeout:
       minutes: 10
     to: tftp
 - boot:
-    commands: ramdisk
+    commands: {{ boot_commands }}
+{%- if boot_namespace %}
+    namespace: {{ boot_namespace }}
+{%- endif %}
     method: depthcharge
     prompts:
     - '/ #'

--- a/config/runtime/boot/grub.jinja2
+++ b/config/runtime/boot/grub.jinja2
@@ -1,15 +1,15 @@
 - deploy:
     kernel:
-      url: {{ node.artifacts.kernel }}
+      url: '{{ node.artifacts.kernel }}'
       image_arg: -kernel {kernel} -serial stdio --append "console=ttyS0"
       type: {{ node.data.kernel_type }}
     ramdisk:
-      url: http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230421.0/{{ platform_config.arch }}/rootfs.cpio.gz
+      url: 'http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230421.0/{{ platform_config.arch }}/rootfs.cpio.gz'
       image_arg: -initrd {ramdisk}
       compression: gz
 {%- if platform_config.dtb %}
     dtb:
-      url: {{ node.artifacts.dtb }}
+      url: '{{ node.artifacts.dtb }}'
       image_arg: -dtb {dtb}
 {%- endif %}
     os: oe

--- a/config/runtime/boot/qemu.jinja2
+++ b/config/runtime/boot/qemu.jinja2
@@ -3,13 +3,13 @@
       kernel:
         image_arg: -kernel {kernel} -append "console=ttyS0,115200 root=/dev/ram0 debug
           verbose console_msg_format=syslog earlycon"
-        url: {{ node.artifacts.kernel }}
+        url: '{{ node.artifacts.kernel }}'
       ramdisk:
         image_arg: -initrd {ramdisk}
-        url: http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230421.0/{{ platform_config.arch }}/rootfs.cpio.gz
+        url: 'http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230421.0/{{ platform_config.arch }}/rootfs.cpio.gz'
 {%- if platform_config.dtb %}
       dtb:
-        url: {{ node.artifacts.dtb }}
+        url: '{{ node.artifacts.dtb }}'
         image_arg: -dtb {dtb}
 {%- endif %}
     os: oe

--- a/config/runtime/boot/u-boot.jinja2
+++ b/config/runtime/boot/u-boot.jinja2
@@ -1,16 +1,16 @@
 - deploy:
     kernel:
       type: {{ node.data.kernel_type }}
-      url: {{ node.artifacts.kernel }}
+      url: '{{ node.artifacts.kernel }}'
     modules:
       compression: xz
-      url: {{ node.artifacts.modules }}
+      url: '{{ node.artifacts.modules }}'
 {%- if platform_config.dtb %}
     dtb:
-      url: {{ node.artifacts.dtb }}
+      url: '{{ node.artifacts.dtb }}'
 {%- endif %}
     ramdisk:
-      url: http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230421.0/{{ platform_config.arch }}/rootfs.cpio.gz
+      url: 'http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230421.0/{{ platform_config.arch }}/rootfs.cpio.gz'
       compression: gz
     os: oe
     timeout:

--- a/config/runtime/chromeos/base.jinja2
+++ b/config/runtime/chromeos/base.jinja2
@@ -1,0 +1,54 @@
+- test:
+    namespace: modules
+    timeout:
+      minutes: 5
+    definitions:
+    - repository:
+        metadata:
+          format: Lava-Test Test Definition 1.0
+          name: modules
+          description: modules
+          os:
+            - oe
+          scope:
+            - functional
+          environment:
+            - lava-test-shell
+        run:
+          steps:
+            - >-
+              /opt/chromeos/install-modules
+              '{{ node.artifacts.modules }}'
+              || lava-test-raise "modules-install"
+      from: inline
+      name: modules
+      path: inline/modules.yaml
+
+# Chrome OS
+- deploy:
+    namespace: chromeos
+    timeout:
+      minutes: 10
+    to: tftp
+    kernel:
+      url: '{{ node.artifacts.kernel }}'
+{%- if platform_config.dtb %}
+    dtb:
+      url: '{{ node.artifacts.dtb }}'
+{%- endif %}
+    os: oe
+
+- boot:
+    namespace: chromeos
+    timeout:
+      minutes: 5
+    method: depthcharge
+    commands: emmc
+    extra_kernel_args: cros_secure cros_debug root=PARTUUID=566f7961-6765-7220-746f-20756e697665 rootwait ro
+    prompts:
+      - 'localhost(.*)~(.*)#'
+    auto_login:
+      login_prompt: "login:"
+      username: "root"
+      password_prompt: "Password:"
+      password: "test0000"

--- a/config/runtime/tests/baseline.jinja2
+++ b/config/runtime/tests/baseline.jinja2
@@ -1,0 +1,26 @@
+- test:
+    definitions:
+    - from: inline
+      lava-signal: kmsg
+      name: dmesg
+      path: inline/dmesg.yaml
+      repository:
+        metadata:
+          description: baseline test plan
+          environment:
+            - lava-test-shell
+          format: Lava-Test Test Definition 1.0
+          name: baseline
+          os:
+            - debian
+          scope:
+            - functional
+        run:
+          steps:
+            - |
+{%- filter indent(width=16) -%}
+{% block commands %}{% endblock %}
+{%- endfilter %}
+
+    timeout:
+      minutes: 1

--- a/config/runtime/tests/tast.jinja2
+++ b/config/runtime/tests/tast.jinja2
@@ -1,0 +1,49 @@
+{%- include 'chromeos/base.jinja2' %}
+
+- test:
+    namespace: chromeos
+    timeout:
+      minutes: 30
+    docker:
+      image: kernelci/cros-tast
+      wait:
+        device: true
+    results:
+      location: /home/cros/lava
+    definitions:
+    - from: inline
+      name: tast
+      path: inline/cros-tast.yaml
+      repository:
+        metadata:
+          format: Lava-Test Test Definition 1.0
+          name: cros-tast
+        run:
+          steps:
+            - cd /home/cros
+            - >-
+              lava-test-case tast-tarball --shell
+              curl -s '{{ platform_config.params.tast_tarball }}'
+              \| tar xzvf -
+              && cp remote_test_runner /usr/bin/remote_test_runner
+              && mkdir -p /usr/libexec/tast/bundles/remote/
+              && cp cros /usr/libexec/tast/bundles/remote/
+            - while ! ping -c 1 -w 1 $(lava-target-ip); do sleep 1; done
+            - >-
+              lava-test-case os-release --shell
+              ./ssh_retry.sh
+              -o StrictHostKeyChecking=no
+              -o UserKnownHostsFile=/dev/null
+              -i /home/cros/.ssh/id_rsa
+              root@$(lava-target-ip)
+              cat /etc/os-release
+            - >-
+              ./tast_parser.py
+              {{ tests|wordwrap(1, False, "\n              ") }}
+            - >-
+              ./ssh_retry.sh
+              -o StrictHostKeyChecking=no
+              -o UserKnownHostsFile=/dev/null
+              -i /home/cros/.ssh/id_rsa
+              root@$(lava-target-ip)
+              sync && poweroff && exit 0


### PR DESCRIPTION
Chromebooks use a ChromeOS-specific test suite called "Tast", requiring a different workflow than baseline tests:
* those tests run under ChromeOS, requiring an altered boot process
* they involve more that just running a set of shell commands