### PR TITLE
lava.jinja2: Hardcode priority as 10, lower than medium

### DIFF
--- a/config/runtime/base/lava.jinja2
+++ b/config/runtime/base/lava.jinja2
@@ -21,7 +21,7 @@ device_type: {{ platform_config.base_name }}
 
 visibility: public
 
-priority: medium
+priority: 10
 
 {% if platform_config.context %}
 context:{% for key, value in platform_config.context | items %}


### PR DESCRIPTION
As noted by Mark, priority should be low, to not interfere with other lab jobs. We need to open issue also to make this value configurable at least per lab.