### PR TITLE
models.py: Add node_timeout in errors

### DIFF
--- a/kernelci/api/models.py
+++ b/kernelci/api/models.py
@@ -57,6 +57,8 @@ class ErrorCodes(str, enum.Enum):
 
     INVALID_JOB_PARAMS = 'invalid_job_params'
     SUBMIT_ERROR = 'submit_error'
+    # Node reached timeout and timeout service forced it to be done
+    NODE_TIMEOUT = 'node_timeout'
 
 
 class KernelVersion(BaseModel):


### PR DESCRIPTION
We need to indicate when node reached timeout,
it is likely infrastructure issue, not real node failure.