### PR TITLE
test-configs.yaml: Enable MM selftests on Avenger96

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -3638,6 +3638,7 @@ test_configs:
       - kselftest-landlock
       - kselftest-lib
       - kselftest-lkdtm
+      - kselftest-mm
       - kselftest-seccomp
 
   - device_type: stm32mp157c-dk2


### PR DESCRIPTION
The Avenger96 has a reasonable amount of memory so should be an
interesting candidate for the MM selftests.

Signed-off-by: Mark Brown <broonie@kernel.org>
