### PR TITLE
kernelci.cli: fix `catch_error` for logging 422 HTTPError

### DIFF
--- a/kernelci/cli/__init__.py
+++ b/kernelci/cli/__init__.py
@@ -86,7 +86,7 @@ def catch_error(func):
                 else None
             )
             raise click.ClickException(
-                '\n'.join((str(ex), detail)) if detail else ex
+                '\n'.join((str(ex), str(detail))) if detail else ex
             ) from ex
         except KeyError as ex:
             raise click.ClickException(


### PR DESCRIPTION
Fixes https://github.com/kernelci/kernelci-core/issues/2368

Fix logging of HTTP exception when API returns `HTTP 422 Unprocessable entity` error.