### PR TITLE
kbuild: Remove stray break

### DIFF
--- a/kernelci/kbuild.py
+++ b/kernelci/kbuild.py
@@ -486,7 +486,6 @@ class KBuild():
             self.addcmd("cp arch/" + self._arch + "/boot/" + img + " ../artifacts", False)  # noqa
             # add image to artifacts relative to artifacts dir
             self._artifacts.append(img)
-            break
         self.addcmd("cd ..")
 
     def _package_modules(self):


### PR DESCRIPTION
This break will cause only first kernel to be added to artifacts.