### PR TITLE
Get platforms/device types from pipeline configuration for the new system

### DIFF
--- a/kernelci/cli/job.py
+++ b/kernelci/cli/job.py
@@ -73,7 +73,7 @@ def generate(node_id,  # pylint: disable=too-many-arguments, too-many-locals
     api = get_api(configs, api, secrets)
     job_node = api.node.get(node_id)
     job = kernelci.runtime.Job(job_node, configs['jobs'][job_node['name']])
-    job.platform_config = configs['device_types'][platform]
+    job.platform_config = configs['platforms'][platform]
     job.storage_config = (
         configs['storage'][storage]
         if storage else None

--- a/kernelci/config/__init__.py
+++ b/kernelci/config/__init__.py
@@ -164,6 +164,7 @@ def load_data(data):
     for module in [
         'kernelci.config.api',
         'kernelci.config.job',
+        'kernelci.config.platform',
         'kernelci.config.runtime',
         'kernelci.config.scheduler',
         'kernelci.config.storage',

--- a/kernelci/config/platform.py
+++ b/kernelci/config/platform.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2024 Collabora Limited
+# Author: Arnaud Ferraris <arnaud.ferraris@collabora.com>
+
+"""KernelCI platform configuration"""
+
+from .base import YAMLConfigObject
+
+
+# pylint: disable=too-many-instance-attributes
+class Platform(YAMLConfigObject):
+    """Platform configuration definition"""
+
+    yaml_tag = '!Platform'
+
+    # pylint: disable=too-many-arguments
+    def __init__(self, name, arch="x86_64", base_name=None,
+                 boot_method="grub", context=None, dtb=None, mach="x86",
+                 params=None):
+        self._name = name
+        self._arch = arch
+        self._base_name = base_name
+        self._boot_method = boot_method
+        self._context = context
+        self._dtb = dtb
+        self._mach = mach
+        self._params = params
+
+    @property
+    def name(self):
+        """Platform name"""
+        return self._name
+
+    @property
+    def arch(self):
+        """Platform architecture"""
+        return self._arch
+
+    @property
+    def base_name(self):
+        """Platform base name"""
+        return self._base_name if self._base_name else self._name
+
+    @property
+    def boot_method(self):
+        """Platform boot method"""
+        return self._boot_method
+
+    @property
+    def context(self):
+        """Context variables used for platform boot"""
+        return dict(self._context) if self._context else None
+
+    @property
+    def dtb(self):
+        """Platform dtb file name"""
+        return self._dtb
+
+    @property
+    def mach(self):
+        """Platform sub-architecture"""
+        return self._mach
+
+    @property
+    def params(self):
+        """Arbitrary parameters passed to the template"""
+        return dict(self._params) if self._params else None
+
+    @classmethod
+    def _get_yaml_attributes(cls):
+        attrs = super()._get_yaml_attributes()
+        attrs.update({
+            'arch',
+            'base_name',
+            'boot_method',
+            'context',
+            'dtb',
+            'mach',
+            'params',
+        })
+        return attrs
+
+
+def from_yaml(data, _):
+    """Create the platforms configurations using data loaded from YAML"""
+    platforms = {
+        name: Platform.load_from_yaml(config, name=name)
+        for name, config in data.get('platforms', {}).items()
+    }
+
+    return {
+        'platforms': platforms,
+    }

--- a/kernelci/runtime/__init__.py
+++ b/kernelci/runtime/__init__.py
@@ -138,7 +138,7 @@ class Runtime(abc.ABC):
         params = {
             'api_config': api_config or {},
             'storage_config': job.storage_config or {},
-            'platform_config': job.platform_config.to_dict() or {},
+            'platform_config': job.platform_config or {},
             'instanceid': instanceid,
             'name': job.name,
             'node': job.node,
@@ -146,7 +146,8 @@ class Runtime(abc.ABC):
             'runtime_image': job.config.image,
         }
         params.update(job.config.params)
-        params.update(job.platform_config.params)
+        if job.platform_config.params:
+            params.update(job.platform_config.params)
         return params
 
     @classmethod

--- a/kernelci/scheduler.py
+++ b/kernelci/scheduler.py
@@ -27,7 +27,7 @@ class Scheduler:
                 runtime.config.lab_type, []
             )
             runtime_type.append(runtime)
-        self._platforms = configs['device_types']
+        self._platforms = configs['platforms']
 
     def get_configs(self, event, channel='node'):
         """Get the scheduler configs matching a given event"""


### PR DESCRIPTION
The current platform config is taken exclusively from the legacy `device_types` configuration. We have to parse similar parameters for the new system, avoiding collisions with legacy config.

This PR creates a new class for parsing the new system's config and makes use of it instead of the legacy config.