### PR TITLE
models: allow `kernel_type` field in kbuild/test node data

### DIFF
--- a/kernelci/api/models.py
+++ b/kernelci/api/models.py
@@ -339,6 +339,9 @@ class KbuildData(BaseModel):
     job_context: Optional[str] = Field(
         description="Kubernetes cluster name the job submitted to"
     )
+    kernel_type: Optional[str] = Field(
+        description="Kernel image type (zimage, bzimage...)"
+    )
 
 
 class Kbuild(Node):
@@ -362,6 +365,10 @@ class TestData(BaseModel):
     # [TODO] Can be fetched from parent checkout node
     kernel_revision: Optional[Revision] = Field(
         description="Kernel repo revision data"
+    )
+    # [TODO] Can be fetched from parent kbuild node
+    kernel_type: Optional[str] = Field(
+        description="Kernel image type (zimage, bzimage...)"
     )
     # [TODO] Specify the source code file/function too?
     test_source: Optional[AnyUrl] = Field(


### PR DESCRIPTION
According to my local cli-based tests, this could be the missing bit for actually propagating this field to test nodes.