### PR TITLE
fragment/kernelci.jinja2: drop requirements installation using `pip`

### DIFF
--- a/config/docker/fragment/kernelci.jinja2
+++ b/config/docker/fragment/kernelci.jinja2
@@ -12,7 +12,6 @@ RUN git clone --depth=1 $core_url /tmp/kernelci-core
 WORKDIR /tmp/kernelci-core
 RUN git fetch origin $core_rev
 RUN git checkout FETCH_HEAD
-RUN pip3 install -r requirements-dev.txt
 RUN python3 -m pip install .
 RUN cp -R config /etc/kernelci/
 WORKDIR /root


### PR DESCRIPTION
As the support of building and installing `kernelci-core` package using `pyproject.toml` has been in place, delete a line to explicitly install requirements as the TOML would take care of it internally.

Fixes: cc937787 ("config/docker/fragment: update `kernelci.jinja2`")