### PR TITLE
kernelci.api.models: use `StrictInt` for version fields

### DIFF
--- a/kernelci/api/models.py
+++ b/kernelci/api/models.py
@@ -22,6 +22,7 @@ from pydantic import (
     BaseModel,
     Field,
     FileUrl,
+    StrictInt,
 )
 from .models_base import (
     PyObjectId,
@@ -63,13 +64,13 @@ class ErrorCodes(str, enum.Enum):
 
 class KernelVersion(BaseModel):
     """Linux kernel version model"""
-    version: int = Field(
+    version: StrictInt = Field(
         description="Major version number e.g. 4 in 'v4.19'"
     )
-    patchlevel: int = Field(
+    patchlevel: StrictInt = Field(
         description="Minor version number or 'patch level' e.g. 19 in 'v4.19'"
     )
-    sublevel: Optional[int] = Field(
+    sublevel: Optional[StrictInt] = Field(
         description="Stable version or 'sub-level' e.g. 123 in 'v4.19.123'"
     )
     extra: Optional[str] = Field(

--- a/kernelci/api/models.py
+++ b/kernelci/api/models.py
@@ -80,6 +80,16 @@ class KernelVersion(BaseModel):
         description="Version name e.g. People's Front for v4.19"
     )
 
+    _STRICT_INT_FIELDS = ['version', 'patchlevel', 'sublevel']
+
+    @classmethod
+    def translate_version_fields(cls, params):
+        """Translate `StrictInt` field values into `int`"""
+        for key, value in params.items():
+            if key in cls._STRICT_INT_FIELDS:
+                params[key] = int(value)
+        return params
+
 
 class Revision(BaseModel):
     """Linux kernel Git revision model"""


### PR DESCRIPTION
For `int` fields, pydantic internally converts fields to integer if possible e.g. request field value `"2"` is converted to `2` in the FastAPI request handler for model parsing. That's why `KernelVersion.version` is converted to `int` when received by API.
Instead of relying on implicit data type conversion for `int` field, use `StrictInt` to enforce defined data type in the request itself.