### PR TITLE
test-configs.yaml: Run basic tests for mt8186-corsola-steelix-sku131072

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -1689,6 +1689,12 @@ device_types:
     boot_method: depthcharge
     filters: *arm64-chromebook-filters
 
+  mt8186-corsola-steelix-sku131072:
+    mach: mediatek
+    class: arm64-dtb
+    boot_method: depthcharge
+    filters: *arm64-chromebook-filters
+
   mt8192-asurada-spherion-r0:
     mach: mediatek
     class: arm64-dtb
@@ -3231,6 +3237,11 @@ test_configs:
       - preempt-rt
       - sleep
       - v4l2-compliance-uvc
+
+  - device_type: mt8186-corsola-steelix-sku131072
+    test_plans:
+      - baseline
+      - kselftest-dt
 
   - device_type: mt8192-asurada-spherion-r0
     test_plans:


### PR DESCRIPTION
Starting with next-20240215, the mt8186-corsola-steelix-sku131072 machine is able to boot. Enable the baseline and kselftest-dt tests on it so we can track the base support: booting and device probing.

Baseline LAVA run: https://lava.collabora.dev/scheduler/job/12769714
DT kselftest LAVA run: https://lava.collabora.dev/scheduler/job/12769689

(Not all tests currently pass but that's fine, will be addressed upstream over time, the important thing is that it boots and the tests run).