### PR TITLE
Add data fields to Test and Regression models

### DIFF
--- a/kernelci/api/helper.py
+++ b/kernelci/api/helper.py
@@ -116,10 +116,13 @@ class APIHelper:
                 'kernel_revision': input_node['data']['kernel_revision'],
             },
         }
-        # for test kind, if node.data.kernel_type - copy to test node
-        # it is required for LAVA templates
-        if 'kernel_type' in input_node['data'] and job_config.kind == 'test':
-            job_node['data']['kernel_type'] = input_node['data']['kernel_type']
+        # Test-specific fields inherited from parent node (kbuild or
+        # test) if available
+        if job_config.kind == 'test':
+            job_node['data']['kernel_type'] = input_node['data'].get('kernel_type')  # noqa
+            job_node['data']['arch'] = input_node['data'].get('arch')
+            job_node['data']['defconfig'] = input_node['data'].get('defconfig')
+            job_node['data']['compiler'] = input_node['data'].get('compiler')
         # This information is highly useful, as we might
         # extract from it the following, for example:
         # in case of lab: lab-name, device-name

--- a/kernelci/api/models.py
+++ b/kernelci/api/models.py
@@ -422,6 +422,21 @@ class RegressionData(BaseModel):
     pass_node: Optional[PyObjectId] = Field(
         description="Previous passing Node"
     )
+    failed_kernel_revision: Optional[Revision] = Field(
+        description="Kernel repo revision data of the failed test run"
+    )
+    arch: Optional[str] = Field(
+        description="CPU architecture family"
+    )
+    defconfig: Optional[str] = Field(
+        description="Kernel defconfig identifier"
+    )
+    compiler: Optional[str] = Field(
+        description="Compiler used for the build"
+    )
+    platform: Optional[str] = Field(
+        description="Test platform"
+    )
 
 
 class Regression(Node):

--- a/kernelci/api/models.py
+++ b/kernelci/api/models.py
@@ -362,14 +362,6 @@ class TestData(BaseModel):
     error_code: Optional[ErrorCodes] = Field(
         description="Details of the failure state"
     )
-    # [TODO] Can be fetched from parent checkout node
-    kernel_revision: Optional[Revision] = Field(
-        description="Kernel repo revision data"
-    )
-    # [TODO] Can be fetched from parent kbuild node
-    kernel_type: Optional[str] = Field(
-        description="Kernel image type (zimage, bzimage...)"
-    )
     # [TODO] Specify the source code file/function too?
     test_source: Optional[AnyUrl] = Field(
         description="Repository containing the test source code"
@@ -388,6 +380,24 @@ class TestData(BaseModel):
     )
     job_context: Optional[str] = Field(
         description="Kubernetes cluster name the job submitted to"
+    )
+
+    # Fields inherited from the parent kbuild or test case node
+
+    kernel_revision: Optional[Revision] = Field(
+        description="Kernel repo revision data"
+    )
+    arch: Optional[str] = Field(
+        description="CPU architecture family"
+    )
+    defconfig: Optional[str] = Field(
+        description="Kernel defconfig identifier"
+    )
+    compiler: Optional[str] = Field(
+        description="Compiler used for the build"
+    )
+    kernel_type: Optional[str] = Field(
+        description="Kernel image type (zimage, bzimage...)"
     )
 
 


### PR DESCRIPTION
In order to perform effective api queries to search for regressions and test results we need to have these new fields in the models. In the case of tests, these will be populated from the parent node (either a kbuild or a test case node). In the case of regressions, they'll be taken from the associated test runs.

**WARNING:** Not tested locally.