### PR TITLE
kbuild: improve cros defconfig handling

### DIFF
--- a/kernelci/kbuild.py
+++ b/kernelci/kbuild.py
@@ -313,10 +313,11 @@ class KBuild():
     def _getcrosfragment(self, fragment):
         """ Get ChromeOS specific configuration fragments """
         # ChromeOS fragment name can be f-strings with placeholders
-        # for the kernel revision (major.minor)
+        # for the kernel revision (major.minor) and target architecture
         version = self._node['data']['kernel_revision']['version']
         krev = f"{version['version']}.{version['patchlevel']}"
-        real_frag = fragment.format(krev=krev)
+        arch = self._arch
+        real_frag = fragment.format(krev=krev, arch=arch)
         buffer = ''
         [(branch, config)] = re.findall(r"cros://([\w\-.]+)/(.*)", real_frag)
         cros_config = "/tmp/cros-config.tgz"

--- a/kernelci/kbuild.py
+++ b/kernelci/kbuild.py
@@ -35,6 +35,10 @@ CROS_CONFIG_URL = \
 LEGACY_CONFIG = '/etc/kernelci/core/build-configs.yaml'
 FW_GIT = "https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git"  # noqa
 
+# TODO: find a way to automatically fetch this information
+LATEST_LTS_MAJOR = 6
+LATEST_LTS_MINOR = 6
+
 # Hard-coded make targets for each CPU architecture
 MAKE_TARGETS = {
     'arm': 'zImage',
@@ -315,7 +319,20 @@ class KBuild():
         # ChromeOS fragment name can be f-strings with placeholders
         # for the kernel revision (major.minor) and target architecture
         version = self._node['data']['kernel_revision']['version']
-        krev = f"{version['version']}.{version['patchlevel']}"
+        # The ChromeOS kernel only has release branches for LTS kernels
+        # so let's fall back to using the config for the latest LTS if
+        # building a more recent version
+        target_rev = f"{version['version']}.{version['patchlevel']}"
+        lts_rev = f"{LATEST_LTS_MAJOR}.{LATEST_LTS_MINOR}"
+        krev = None
+        if ((version['version'] > LATEST_LTS_MAJOR) or
+            (version['version'] == LATEST_LTS_MAJOR and
+             version['patchlevel'] > LATEST_LTS_MINOR)):
+            print(f"Falling back to latest LTS config ({lts_rev}) " +
+                  f"for kernel {target_rev}")
+            krev = lts_rev
+        else:
+            krev = target_rev
         arch = self._arch
         real_frag = fragment.format(krev=krev, arch=arch)
         buffer = ''


### PR DESCRIPTION
Currently, `cros://` fragments used as a defconfig are special-cased so the defconfig node data is updated with the actual branch. However, this is done after `config_full` is updated, resulting in the latter still containing the `{kver}` placeholder.

This PR reworks this logic so we update all variables properly, and adds the ability to also use the `{arch}` placeholder in fragment names.