### PR TITLE
rootfs-configs.yaml: Add tappy to the kselftest images

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -94,6 +94,7 @@ rootfs_configs:
       - python3-minimal
       - python3-unittest2
       - socat
+      - tappy
       - tcpdump
       - tpm2-tools
       - wget


### PR DESCRIPTION
A recent change[1] to test-definitons has added use of the Python tappy
package when parsing the kselftest output in order to deal better with
nested KTAP output, especially useful with the MM selftests.  Add the
tappy package to our ksselftest rootfs images so that it's there when we
update to the latest test-definitions version.

[1] https://github.com/Linaro/test-definitions/commit/6e2cfcd26c4c805c4a3061dc22cf46c1b9b47f4b

Signed-off-by: Mark Brown <broonie@kernel.org>
