### PR TITLE
Revert "docker/fragment/api.jinja2: install kernelci-api using pyproject.toml

### DIFF
--- a/config/docker/fragment/api.jinja2
+++ b/config/docker/fragment/api.jinja2
@@ -1,33 +1,18 @@
-# Install kernelci Python package from kernelci-core
-ARG core_url=https://github.com/kernelci/kernelci-core.git
-ARG core_rev=main
-RUN apt-get update && apt-get install --no-install-recommends -y git
-RUN git clone --depth=1 $core_url /tmp/kernelci-core
-WORKDIR /tmp/kernelci-core
-RUN git fetch origin $core_rev
-RUN git checkout FETCH_HEAD
-RUN python3 -m pip install .
-RUN cp -R config /etc/kernelci/
-WORKDIR /root
-RUN rm -rf /tmp/kernelci-core
+{% include 'fragment/kernelci.jinja2' %}
 
-# Install kernelci-api Python package from kernelci-api
-# ARG api_url=https://github.com/kernelci/kernelci-api.git
-ARG api_url=https://github.com/JenySadadia/kernelci-api.git
-# ARG api_rev=main
-ARG api_rev=update-pyproject-toml
-RUN git clone --depth=1 $api_url /tmp/kernelci-api
+# Install kernelci-api
+ARG api_url=https://github.com/kernelci/kernelci-api.git
+ARG api_rev=main
+RUN git clone $api_url /tmp/kernelci-api
+# Install requirements
 WORKDIR /tmp/kernelci-api
-RUN git fetch origin $api_rev
-RUN git checkout FETCH_HEAD
-RUN python3 -m pip install .
-WORKDIR /root
-RUN rm -rf /tmp/kernelci-api
-
-# Set up kernelci user
-RUN useradd kernelci -u 1000 -d /home/kernelci -s /bin/bash
-RUN mkdir -p /home/kernelci
-RUN chown kernelci: /home/kernelci
-USER kernelci
-ENV PATH=$PATH:/home/kernelci/.local/bin
+RUN git checkout $api_rev
+RUN pip install --requirement docker/api/requirements.txt
+# Move api,tests,migrations,templates to /home/kernelci
+RUN mv api /home/kernelci
+RUN mv tests /home/kernelci
+RUN mv migrations /home/kernelci
+RUN mv templates /home/kernelci
+# Clean up
 WORKDIR /home/kernelci
+RUN rm -rf /tmp/kernelci-api


### PR DESCRIPTION
This commit breaking api image, at least templates directory are missing.

This reverts commit f030e886dc2a357836c7e5c5a76424d55b38a0f7.