### PR TITLE
Add stable 6.7 trees

### DIFF
--- a/config/core/build-configs-stable.yaml
+++ b/config/core/build-configs-stable.yaml
@@ -339,6 +339,14 @@ build_configs:
       tree: stable
       branch: 'linux-6.6.y'
 
+  stable-rc_6.7:
+    tree: stable-rc
+    branch: 'linux-6.7.y'
+    variants: *stable_variants
+    reference:
+      tree: stable
+      branch: 'linux-6.7.y'
+
   stable-rc_queue-4.4:
     tree: stable-rc
     branch: 'queue/4.4'
@@ -458,3 +466,11 @@ build_configs:
     reference:
       tree: stable
       branch: 'linux-6.6.y'
+
+stable-rc_queue-6.7:
+    tree: stable-rc
+    branch: 'queue/6.7'
+    variants: *stable_variants
+    reference:
+      tree: stable
+      branch: 'linux-6.7.y'


### PR DESCRIPTION
As per https://github.com/kernelci/kernelci-core/issues/2346 Adding two more trees to monitor