### PR TITLE
test-configs.yaml: Enable additional preempt-rt tests

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -698,10 +698,20 @@ test_plans:
       - blocklist: *kselftest_defconfig_filter
       - passlist: *qemu_labs_filter
 
-  preempt-rt:
+  preempt-rt: &preempt-rt
     rootfs: debian_bookworm-rt_ramdisk
+    pattern: 'preempt-rt/{category}-{method}-{protocol}-{rootfs}-preempt-rt-template.jinja2'
     filters:
       - passlist: {defconfig: ['preempt_rt']}
+    params: &preempt-rt-params
+      job_timeout: '10'
+      duration: '300s'
+
+  preempt-rt-cyclictest:
+    <<: *preempt-rt
+    params:
+      <<: *preempt-rt-params
+      tst_cmd: 'cyclictest'
 
   sleep:
     rootfs: debian_bookworm_ramdisk
@@ -2552,7 +2562,7 @@ test_configs:
       - ltp-mm
       - ltp-pty
       - ltp-timers
-      - preempt-rt
+      - preempt-rt-cyclictest
       - sleep_mem
       - smc
 
@@ -2603,7 +2613,7 @@ test_configs:
       - ltp-fsx
       - ltp-smoketest
       - ltp-timers
-      - preempt-rt
+      - preempt-rt-cyclictest
 
   - device_type: bcm2835-rpi-b-rev2
     test_plans:
@@ -2657,7 +2667,7 @@ test_configs:
       - ltp-io
       - ltp-ipc
       - ltp-smoketest
-      - preempt-rt
+      - preempt-rt-cyclictest
       - vdso
 
   - device_type: cubietruck
@@ -2784,7 +2794,7 @@ test_configs:
       - ltp-mm
       - ltp-pty
       - ltp-timers
-      - preempt-rt
+      - preempt-rt-cyclictest
       - sleep
       - smc
 
@@ -3187,7 +3197,7 @@ test_configs:
   - device_type: meson-sm1-khadas-vim3l
     test_plans:
       - baseline
-      - preempt-rt
+      - preempt-rt-cyclictest
 
   - device_type: meson-sm1-s905d3-libretech-cc
     test_plans:
@@ -3244,7 +3254,7 @@ test_configs:
       - ltp-mm
       - ltp-pty
       - ltp-timers
-      - preempt-rt
+      - preempt-rt-cyclictest
       - sleep
       - v4l2-compliance-uvc
       - wifi-basic
@@ -3265,7 +3275,7 @@ test_configs:
       - kselftest-seccomp
       - kselftest-tpm2
       - lc-compliance
-      - preempt-rt
+      - preempt-rt-cyclictest
       - sleep
       - v4l2-compliance-uvc
       - wifi-basic
@@ -3286,7 +3296,7 @@ test_configs:
       - kselftest-seccomp
       - kselftest-tpm2
       - lc-compliance
-      - preempt-rt
+      - preempt-rt-cyclictest
       - sleep_mem
       - v4l2-compliance-mtk-vcodec-enc
       - v4l2-compliance-uvc
@@ -3490,7 +3500,7 @@ test_configs:
       - ltp-mm
       - ltp-pty
       - ltp-timers
-      - preempt-rt
+      - preempt-rt-cyclictest
       - smc
 
   - device_type: r8a774b1-hihope-rzg2n-ex
@@ -3727,7 +3737,7 @@ test_configs:
       - ltp-crypto
       - ltp-hugetlb
       - ltp-smoketest
-      - preempt-rt
+      - preempt-rt-cyclictest
 
   - device_type: sun50i-h5-nanopi-neo-plus2
     test_plans:

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -707,11 +707,73 @@ test_plans:
       job_timeout: '10'
       duration: '300s'
 
+  preempt-rt-cyclicdeadline:
+    <<: *preempt-rt
+    params:
+      <<: *preempt-rt-params
+      test_cmd: 'cyclicdeadline'
+
   preempt-rt-cyclictest:
     <<: *preempt-rt
     params:
       <<: *preempt-rt-params
       tst_cmd: 'cyclictest'
+
+  preempt-rt-pi-stress:
+    <<: *preempt-rt
+    params:
+      <<: *preempt-rt-params
+      tst_cmd: 'pi-stress'
+
+  preempt-rt-pmqtest:
+    <<: *preempt-rt
+    params:
+      <<: *preempt-rt-params
+      tst_cmd: 'pmqtest'
+
+  preempt-rt-ptsematest:
+    <<: *preempt-rt
+    params:
+      <<: *preempt-rt-params
+      tst_cmd: 'ptsematest'
+
+  preempt-rt-rt-migrate-test:
+    <<: *preempt-rt
+    params:
+      <<: *preempt-rt-params
+      tst_cmd: 'rt-migrate-test'
+
+  preempt-rt-rtla-osnoise:
+    <<: *preempt-rt
+    params:
+      <<: *preempt-rt-params
+      tst_cmd: 'rtla-osnoise'
+      tst_group: 'rtla'
+
+  preempt-rt-rtla-timerlat:
+    <<: *preempt-rt
+    params:
+      <<: *preempt-rt-params
+      tst_cmd: 'rtla-timerlat'
+      tst_group: 'rtla'
+
+  preempt-rt-signaltest:
+    <<: *preempt-rt
+    params:
+      <<: *preempt-rt-params
+      tst_cmd: 'signaltest'
+
+  preempt-rt-sigwaittest:
+    <<: *preempt-rt
+    params:
+      <<: *preempt-rt-params
+      tst_cmd: 'sigwaittest'
+
+  preempt-rt-svsematest:
+    <<: *preempt-rt
+    params:
+      <<: *preempt-rt-params
+      tst_cmd: 'svsematest'
 
   sleep:
     rootfs: debian_bookworm_ramdisk

--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -705,7 +705,7 @@ test_plans:
       - passlist: {defconfig: ['preempt_rt']}
     params: &preempt-rt-params
       job_timeout: '10'
-      duration: '300s'
+      duration: '60s'
 
   preempt-rt-cyclicdeadline:
     <<: *preempt-rt
@@ -2624,7 +2624,10 @@ test_configs:
       - ltp-mm
       - ltp-pty
       - ltp-timers
+      - preempt-rt-cyclicdeadline
       - preempt-rt-cyclictest
+      - preempt-rt-rtla-osnoise
+      - preempt-rt-rtla-timerlat
       - sleep_mem
       - smc
 
@@ -2675,7 +2678,10 @@ test_configs:
       - ltp-fsx
       - ltp-smoketest
       - ltp-timers
+      - preempt-rt-cyclicdeadline
       - preempt-rt-cyclictest
+      - preempt-rt-rtla-osnoise
+      - preempt-rt-rtla-timerlat
 
   - device_type: bcm2835-rpi-b-rev2
     test_plans:
@@ -2729,7 +2735,10 @@ test_configs:
       - ltp-io
       - ltp-ipc
       - ltp-smoketest
+      - preempt-rt-cyclicdeadline
       - preempt-rt-cyclictest
+      - preempt-rt-rtla-osnoise
+      - preempt-rt-rtla-timerlat
       - vdso
 
   - device_type: cubietruck
@@ -2856,7 +2865,10 @@ test_configs:
       - ltp-mm
       - ltp-pty
       - ltp-timers
+      - preempt-rt-cyclicdeadline
       - preempt-rt-cyclictest
+      - preempt-rt-rtla-osnoise
+      - preempt-rt-rtla-timerlat
       - sleep
       - smc
 
@@ -3259,7 +3271,10 @@ test_configs:
   - device_type: meson-sm1-khadas-vim3l
     test_plans:
       - baseline
+      - preempt-rt-cyclicdeadline
       - preempt-rt-cyclictest
+      - preempt-rt-rtla-osnoise
+      - preempt-rt-rtla-timerlat
 
   - device_type: meson-sm1-s905d3-libretech-cc
     test_plans:
@@ -3316,7 +3331,10 @@ test_configs:
       - ltp-mm
       - ltp-pty
       - ltp-timers
+      - preempt-rt-cyclicdeadline
       - preempt-rt-cyclictest
+      - preempt-rt-rtla-osnoise
+      - preempt-rt-rtla-timerlat
       - sleep
       - v4l2-compliance-uvc
       - wifi-basic
@@ -3337,7 +3355,10 @@ test_configs:
       - kselftest-seccomp
       - kselftest-tpm2
       - lc-compliance
+      - preempt-rt-cyclicdeadline
       - preempt-rt-cyclictest
+      - preempt-rt-rtla-osnoise
+      - preempt-rt-rtla-timerlat
       - sleep
       - v4l2-compliance-uvc
       - wifi-basic
@@ -3358,7 +3379,10 @@ test_configs:
       - kselftest-seccomp
       - kselftest-tpm2
       - lc-compliance
+      - preempt-rt-cyclicdeadline
       - preempt-rt-cyclictest
+      - preempt-rt-rtla-osnoise
+      - preempt-rt-rtla-timerlat
       - sleep_mem
       - v4l2-compliance-mtk-vcodec-enc
       - v4l2-compliance-uvc
@@ -3562,7 +3586,10 @@ test_configs:
       - ltp-mm
       - ltp-pty
       - ltp-timers
+      - preempt-rt-cyclicdeadline
       - preempt-rt-cyclictest
+      - preempt-rt-rtla-osnoise
+      - preempt-rt-rtla-timerlat
       - smc
 
   - device_type: r8a774b1-hihope-rzg2n-ex
@@ -3799,7 +3826,10 @@ test_configs:
       - ltp-crypto
       - ltp-hugetlb
       - ltp-smoketest
+      - preempt-rt-cyclicdeadline
       - preempt-rt-cyclictest
+      - preempt-rt-rtla-osnoise
+      - preempt-rt-rtla-timerlat
 
   - device_type: sun50i-h5-nanopi-neo-plus2
     test_plans:

--- a/config/lava/preempt-rt/preempt-rt.jinja2
+++ b/config/lava/preempt-rt/preempt-rt.jinja2
@@ -22,9 +22,14 @@
       path: automated/linux/{{ tst_cmd }}/{{ tst_cmd }}.yaml
       name: {{ plan }}
       parameters:
-        AFFINTIY: 0-1
-        BACKGROUND_CMD: {{ background|default('hackbench') }}
+        ARTIFACTORIAL_TOKEN: {{ artifactorial_token|default('') }}
+        ARTIFACTORIAL_URL: {{ artifactorial_url|default('') }}
+        AFFINTIY: {{ affinity|default('0-1') }}
         DURATION: {{ duration|default('300s') }}
-        INTERVAL: 1000
-        PRIORITY: 98
-        THREADS: 2
+        BACKGROUND_CMD: {{ background|default('hackbench') }}
+      {% if tst_cmd == 'cyclictest' %}
+        HISTOGRAM: {{ histogram|default('') }}
+        INTERVAL: {{ interval|default('1000') }}
+        PRIORITY: {{ priority|default('98') }}
+        THREADS: {{ threads|default('2') }}
+      {% endif %}

--- a/config/lava/preempt-rt/preempt-rt.jinja2
+++ b/config/lava/preempt-rt/preempt-rt.jinja2
@@ -1,6 +1,7 @@
 - test:
+    name: {{ plan }}
     timeout:
-      minutes: 10
+      minutes: {{ job_timeout }}
 
     definitions:
     - from: inline
@@ -18,13 +19,12 @@
     - repository: https://github.com/kernelci/test-definitions.git
       from: git
       revision: kernelci.org
-      path: automated/linux/cyclictest/cyclictest.yaml
-      name: cyclictest
+      path: automated/linux/{{ tst_cmd }}/{{ tst_cmd }}.yaml
+      name: {{ plan }}
       parameters:
         AFFINTIY: 0-1
-        BACKGROUND_CMD: hackbench
-        DURATION: 300s
+        BACKGROUND_CMD: {{ background|default('hackbench') }}
+        DURATION: {{ duration|default('300s') }}
         INTERVAL: 1000
-        MAX_LATENCY: 35
         PRIORITY: 98
         THREADS: 2

--- a/config/lava/preempt-rt/preempt-rt.jinja2
+++ b/config/lava/preempt-rt/preempt-rt.jinja2
@@ -19,7 +19,7 @@
     - repository: https://github.com/kernelci/test-definitions.git
       from: git
       revision: kernelci.org
-      path: automated/linux/{{ tst_cmd }}/{{ tst_cmd }}.yaml
+      path: automated/linux/{{ tst_group|default(tst_cmd) }}/{{ tst_cmd }}.yaml
       name: {{ plan }}
       parameters:
         ARTIFACTORIAL_TOKEN: {{ artifactorial_token|default('') }}
@@ -27,9 +27,18 @@
         AFFINTIY: {{ affinity|default('0-1') }}
         DURATION: {{ duration|default('300s') }}
         BACKGROUND_CMD: {{ background|default('hackbench') }}
-      {% if tst_cmd == 'cyclictest' %}
+      {% if tst_cmd == 'cyclicdeadline' %}
+        INTERVAL: {{ interval|default('1000') }}
+        STEP: {{ step|default('500') }}
+        THREADS: {{ threads|default('2') }}
+      {% elif tst_cmd == 'cyclictest' %}
         HISTOGRAM: {{ histogram|default('') }}
         INTERVAL: {{ interval|default('1000') }}
+        PRIORITY: {{ priority|default('98') }}
+        THREADS: {{ threads|default('2') }}
+      {% elif tst_cmd == 'pi-stress' %}
+        MLOCKALL: {{ mlockall|default('true') }}
+      {% elif tst_cmd == 'signaltest' %}
         PRIORITY: {{ priority|default('98') }}
         THREADS: {{ threads|default('2') }}
       {% endif %}


### PR DESCRIPTION
While cyclictest is the classic preempt-rt test, cyclicdeadline and the rtla tests are also interesting to run.

Since these are all smoke test there is no point in running them too long. Thus reduce the runtime per test to one minute. This should keep the total preempt-rt runtime roughly in the same time frame.