### PR TITLE
rootfs: Don't ship .deb files we installed

### DIFF
--- a/config/rootfs/debos/rootfs.yaml
+++ b/config/rootfs/debos/rootfs.yaml
@@ -122,6 +122,11 @@ actions:
     command: ln -s /usr/bin/systemd /init
 
   - action: run
+    description: Clean installed package files
+    chroot: true
+    command: apt-get clean
+
+  - action: run
     description: Create full archive
     chroot: false
     command: cd ${ROOTDIR} ; tar cvfJ  ${ARTIFACTDIR}/{{ $basename -}}/full.rootfs.tar.xz .


### PR DESCRIPTION
When we install Debian packages with apt these will be placed in
/var/cache/apt/archives, there is no need for them at runtime so we can
just remove them and reduce the size of the images.

Signed-off-by: Mark Brown <broonie@kernel.org>
