### PR TITLE
debos: Ask for maximal compression of the rootfs images

### DIFF
--- a/config/rootfs/debos/rootfs.yaml
+++ b/config/rootfs/debos/rootfs.yaml
@@ -129,7 +129,7 @@ actions:
   - action: run
     description: Create full cpio archive
     chroot: false
-    command: cd ${ROOTDIR} ; find -H  |  cpio -H newc -v -o | gzip -c - > ${ARTIFACTDIR}/{{ $basename -}}/full.rootfs.cpio.gz
+    command: cd ${ROOTDIR} ; find -H  |  cpio -H newc -v -o | gzip -9 -c - > ${ARTIFACTDIR}/{{ $basename -}}/full.rootfs.cpio.gz
 
   - action: image-partition
     imagename: rootfs.ext4
@@ -154,7 +154,7 @@ actions:
     postprocess: true
 
   - action: run
-    command: xz -f ${ARTIFACTDIR}/{{ $basename -}}/rootfs.ext4
+    command: xz -9 -T0 -f ${ARTIFACTDIR}/{{ $basename -}}/rootfs.ext4
     postprocess: true
 
   - action: run


### PR DESCRIPTION
The rootfs images are quite large and get sent over the network a lot so
it's probably worth spending some CPU cycles trying to make them
smaller, ask xz and gzip to use maximum compression.  While we're at it
also allow xz to use all the available CPUs for compression to speed
things up a bit.

Signed-off-by: Mark Brown <broonie@kernel.org>
