### PR TITLE
debos: Don't remove extra_packages

### DIFF
--- a/config/rootfs/debos/rootfs.yaml
+++ b/config/rootfs/debos/rootfs.yaml
@@ -168,7 +168,7 @@ actions:
 
   - action: run
     chroot: true
-    script: scripts/strip.sh "{{ $extra_packages }}"
+    script: scripts/strip.sh
 
 {{ if $extra_packages_remove }}
   - action: run

--- a/config/rootfs/debos/scripts/strip.sh
+++ b/config/rootfs/debos/scripts/strip.sh
@@ -9,25 +9,12 @@ set -e
 rm -rf /etc/localtime
 cp /usr/share/zoneinfo/Etc/UTC /etc/localtime
 
-EXTRA_PACKAGES=$(echo "${1}" | xargs -n1)
-EXTRA_TEMP_FILE=$(mktemp strip_extra_packages.XXXXXX)
-exec 3>"$EXTRA_TEMP_FILE"
-echo "$EXTRA_PACKAGES" | sort | uniq >&3
-
-UNNEEDED_PACKAGES="tzdata"
-UNNEEDED_TEMP_FILE=$(mktemp strip_unneeded_packages.XXXXXX)
-exec 4>"$UNNEEDED_TEMP_FILE"
-echo "$UNNEEDED_PACKAGES" | xargs -n1 | sort | uniq >&4
-
-PACKAGES_TO_REMOVE=$(comm  -23  "$UNNEEDED_TEMP_FILE" "$EXTRA_TEMP_FILE")
+PACKAGES_TO_REMOVE="tzdata"
 
 export DEBIAN_FRONTEND=noninteractive
 
 exec 3>&-
 exec 4>&-
-
-rm "$UNNEEDED_TEMP_FILE"
-rm "$EXTRA_TEMP_FILE"
 
 # Removing unused packages
 for PACKAGE in ${PACKAGES_TO_REMOVE}


### PR DESCRIPTION
The strip.sh script is passed a list of packages to remove.  For very
unclear reasons the list that is passed by debos is the extra_packages
list but this is a list of packages we want in the shipped image, there
is a separate extra_packages_remove which is intended for removal which
we already handle with a separate debos step.  Just remove the argument
and it's handling from strip.sh, ensuring that we don't remove
extra_packages.

This hasn't been apparent because strip.sh only takes effect for ext4
images, we don't use those images for many platforms.  That is a
separate issue which should also be addressed.

Signed-off-by: Mark Brown <broonie@kernel.org>
