### PR TITLE
config: runtime: tests: tast: use "for" loop to enumerate tests

### DIFF
--- a/config/runtime/tests/tast.jinja2
+++ b/config/runtime/tests/tast.jinja2
@@ -39,7 +39,9 @@
               cat /etc/os-release
             - >-
               ./tast_parser.py
-              {{ tests|wordwrap(1, False, "\n              ") }}
+{%- for test in tests %}
+              {{ test }}
+{%- endfor %}
             - >-
               ./ssh_retry.sh
               -o StrictHostKeyChecking=no


### PR DESCRIPTION
The legacy implementation relied on Tast tests being listed as a single string in the job config, then uses the `wordwrap()` jinja2 function to output one test per line in the job definition.

This is needlessly complex, storing the list of tests as a string array and using a classic `for` loop makes things more straightforward and understandable to external contributors.