### PR TITLE
api: Fix incorrect headers

### DIFF
--- a/kernelci/api/__init__.py
+++ b/kernelci/api/__init__.py
@@ -111,8 +111,11 @@ class Base:
                     params=params, timeout=self.data.timeout
                 )
             else:
+                headers = self.data.headers | {
+                    'Content-Type': 'application/x-www-form-urlencoded'
+                }
                 resp = requests.post(
-                    url, data, headers=self.data.headers,
+                    url, data, headers=headers,
                     params=params, timeout=self.data.timeout
                 )
             resp.raise_for_status()


### PR DESCRIPTION
PR https://github.com/kernelci/kernelci-core/pull/2406 assume headers will be set correct, but seems they are not, and on kci user token by some reason it set headers as json. This PR fixes that.