### PR TITLE
kernelci.api: remove manual json data handling in requests

### DIFF
--- a/kernelci/api/__init__.py
+++ b/kernelci/api/__init__.py
@@ -24,7 +24,7 @@ class Data:
     def __init__(self, config: kernelci.config.api.API, token: str):
         self._config = config
         self._token = token
-        self._headers = {'Content-Type': 'application/json'}
+        self._headers = {}
         if self._token:
             self._headers['Authorization'] = f'Bearer {self._token}'
         self._timeout = float(config.timeout)
@@ -111,11 +111,8 @@ class Base:
                     params=params, timeout=self.data.timeout
                 )
             else:
-                headers = self.data.headers | {
-                    'Content-Type': 'application/x-www-form-urlencoded'
-                }
                 resp = requests.post(
-                    url, data, headers=headers,
+                    url, data, headers=self.data.headers,
                     params=params, timeout=self.data.timeout
                 )
             resp.raise_for_status()
@@ -123,9 +120,8 @@ class Base:
 
     def _put(self, path, data=None, params=None):
         url = self.make_url(path)
-        jdata = json.dumps(data)
         resp = requests.put(
-            url, jdata, headers=self.data.headers,
+            url, json=data, headers=self.data.headers,
             params=params, timeout=self.data.timeout
         )
         resp.raise_for_status()
@@ -133,9 +129,8 @@ class Base:
 
     def _patch(self, path, data=None, params=None):
         url = self.make_url(path)
-        jdata = json.dumps(data)
         resp = requests.patch(
-            url, jdata, headers=self.data.headers,
+            url, json=data, headers=self.data.headers,
             params=params, timeout=self.data.timeout
         )
         resp.raise_for_status()


### PR DESCRIPTION
Fixes 6e8d6c5b8dec943431c1f9d305cba1fd11d0f34d, see also a6df5594ca6508869fd3438310da4b902aa0c785.

The requests library can automatically encode data as json and set the proper Content-Type header. Remove the default header hardcoding in the requests and use the `json` option of the requests calls.

In the `_post` method, this is selectable and it accepts json data (by default) or a www-form-urlencoded string payload.