### PR TITLE
Build `kernelci` package with developer requirements

### DIFF
--- a/config/docker/fragment/kernelci.jinja2
+++ b/config/docker/fragment/kernelci.jinja2
@@ -12,7 +12,7 @@ RUN git clone --depth=1 $core_url /tmp/kernelci-core
 WORKDIR /tmp/kernelci-core
 RUN git fetch origin $core_rev
 RUN git checkout FETCH_HEAD
-RUN python3 -m pip install .
+RUN python3 -m pip install '.[dev]'
 RUN cp -R config /etc/kernelci/
 WORKDIR /root
 RUN rm -rf /tmp/kernelci-core


### PR DESCRIPTION
Before `pyproject.toml` support, when `setup.py` was being used for package building, developer requirements were also installed in the package. Keep it the same while using `pyproject.toml` by adding `[dev]` option to the installation command.