### PR TITLE
runtime: lava: generate job as it will be submitted

### DIFF
--- a/kernelci/runtime/lava.py
+++ b/kernelci/runtime/lava.py
@@ -187,7 +187,9 @@ class LAVA(Runtime):
 
     def generate(self, job, params):
         template = self._get_template(job.config)
-        return template.render(params)
+        rendered = template.render(params)
+        # yaml round-trip to process e.g. multi-line commands
+        return yaml.dump(yaml.load(rendered, Loader=yaml.CLoader))
 
     def submit(self, job_path):
         with open(job_path, 'r', encoding='utf-8') as job_file:
@@ -224,7 +226,7 @@ class LAVA(Runtime):
     def _submit(self, job):
         jobs_url = urljoin(self._server.url, 'jobs/')
         job_data = {
-            'definition': yaml.dump(yaml.load(job, Loader=yaml.CLoader)),
+            'definition': job,
         }
         resp = self._server.session.post(
             jobs_url, json=job_data, allow_redirects=False


### PR DESCRIPTION
Currently, the `submit()` method includes a round-trip through the `yaml` module, which is needed to ensure the job will be properly formatted for LAVA. This includes, for example, processing commands span over multiple lines.

However, this implies the submitted job is different from the output from `generate()`, which can cause issues, for example when using `kci job generate` which relies solely on the latter and doesn't reflect how the job data is processed in `submit()`. This can ultimately to a false sense of correctness when testing locally, while an actual pipeline run will cause errors due to the additional processing.

In order to avoid such cases, ensure the output from `generate()` is identical to the submitted job by moving the yaml round-trip earlier in the chain.