### PR TITLE
Implement initial filtering capabilities

### DIFF
--- a/kernelci/cli/job.py
+++ b/kernelci/cli/job.py
@@ -58,7 +58,8 @@ def new(name, input_node_id, platform,  # pylint: disable=too-many-arguments
             configs['runtimes'][runtime], token=secrets.api.runtime_token)
     job_node = helper.create_job_node(job_config, input_node,
                                       platform=platform_config, runtime=runtime)
-    echo_json(job_node, indent)
+    if job_node:
+        echo_json(job_node, indent)
 
 
 @kci_job.command(secrets=True)

--- a/kernelci/config/job.py
+++ b/kernelci/config/job.py
@@ -14,12 +14,13 @@ class Job(YAMLConfigObject):
     yaml_tag = '!Job'
 
     # pylint: disable=too-many-arguments
-    def __init__(self, name, template, kind="node", image=None, params=None):
+    def __init__(self, name, template, kind="node", image=None, params=None, rules=None):
         self._name = name
         self._template = template
         self._kind = kind
         self._image = image
         self._params = params or {}
+        self._rules = rules
 
     @property
     def name(self):
@@ -46,10 +47,15 @@ class Job(YAMLConfigObject):
         """Arbitrary parameters passed to the template"""
         return dict(self._params)
 
+    @property
+    def rules(self):
+        """Kernel requirements (tree, branch, version...)"""
+        return self._rules
+
     @classmethod
     def _get_yaml_attributes(cls):
         attrs = super()._get_yaml_attributes()
-        attrs.update({'template', 'kind', 'image', 'params'})
+        attrs.update({'template', 'kind', 'image', 'params', 'rules'})
         return attrs
 
 

--- a/kernelci/config/platform.py
+++ b/kernelci/config/platform.py
@@ -16,8 +16,8 @@ class Platform(YAMLConfigObject):
 
     # pylint: disable=too-many-arguments
     def __init__(self, name, arch="x86_64", base_name=None,
-                 boot_method="grub", context=None, dtb=None, mach="x86",
-                 params=None):
+                 boot_method="grub", context=None, dtb=None,
+                 mach="x86", params=None, rules=None):
         self._name = name
         self._arch = arch
         self._base_name = base_name
@@ -26,6 +26,7 @@ class Platform(YAMLConfigObject):
         self._dtb = dtb
         self._mach = mach
         self._params = params
+        self._rules = rules
 
     @property
     def name(self):
@@ -67,6 +68,11 @@ class Platform(YAMLConfigObject):
         """Arbitrary parameters passed to the template"""
         return dict(self._params) if self._params else None
 
+    @property
+    def rules(self):
+        """Kernel requirements (tree, branch, version...)"""
+        return self._rules
+
     @classmethod
     def _get_yaml_attributes(cls):
         attrs = super()._get_yaml_attributes()
@@ -78,6 +84,7 @@ class Platform(YAMLConfigObject):
             'dtb',
             'mach',
             'params',
+            'rules',
         })
         return attrs
 

--- a/kernelci/config/runtime.py
+++ b/kernelci/config/runtime.py
@@ -13,7 +13,7 @@ class Runtime(YAMLConfigObject):
 
     yaml_tag = '!Runtime'
 
-    def __init__(self, name, lab_type, filters=None):
+    def __init__(self, name, lab_type, filters=None, rules=None):
         """A runtime environment configuration object
 
         *name* is the name used to refer to the lab in meta-data.
@@ -24,6 +24,7 @@ class Runtime(YAMLConfigObject):
         self._name = name
         self._lab_type = lab_type
         self._filters = filters or []
+        self._rules = rules
 
     @property
     def name(self):
@@ -35,10 +36,15 @@ class Runtime(YAMLConfigObject):
         """Runtime environment name"""
         return self._lab_type
 
+    @property
+    def rules(self):
+        """Kernel requirements (tree, branch, version...)"""
+        return self._rules
+
     @classmethod
     def _get_yaml_attributes(cls):
         attrs = super()._get_yaml_attributes()
-        attrs.update({'lab_type'})
+        attrs.update({'lab_type', 'rules'})
         return attrs
 
     @classmethod

--- a/tests/configs/jobs.yaml
+++ b/tests/configs/jobs.yaml
@@ -6,21 +6,25 @@ jobs:
     image: 'gcc-10:{arch}{fragments}'
     params:
       config: x86_64_defconfig
+    rules:
 
   kunit: &kunit-job
     template: 'kunit.jinja2'
     kind: 'test'
     image: 'gcc-10:x86-kunit-kernelci'
     params: {}
+    rules:
 
   kunit-x86_64:
     <<: *kunit-job
     image: 'kernelci/staging-gcc-10:x86-kunit-qemu-kernelci'
     params:
       arch: x86_64
+    rules:
 
   kver:
     template: 'kver.jinja2'
     kind: 'test'
     image: 'kernelci'
     params: {}
+    rules:

--- a/tests/configs/lava-runtimes.yaml
+++ b/tests/configs/lava-runtimes.yaml
@@ -16,6 +16,7 @@ runtimes:
             - kselftest
             - preempt-rt
             - ltp
+    rules:
 
   lab-broonie:
     lab_type: legacy.lava_xmlrpc
@@ -26,6 +27,7 @@ runtimes:
       days: 1
     filters:
       - blocklist: {tree: [android]}
+    rules:
 
   lab-collabora-staging:
     lab_type: legacy.lava_rest
@@ -36,18 +38,21 @@ runtimes:
     filters:
       - blocklist:
           tree: [android]
+    rules:
 
   lab-min-12-max-40:
     lab_type: legacy.lava_xmlrpc
     url: 'https://fake.kernelci.org/RPC2/'
     priority_min: 12
     priority_max: 40
+    rules:
 
   lab-min-12-max-40-new-runtime:
     lab_type: lava
     url: 'https://fake.kernelci.org/RPC2/'
     priority_min: 12
     priority_max: 40
+    rules:
 
 
 file_system_types:

--- a/tests/configs/runtimes.yaml
+++ b/tests/configs/runtimes.yaml
@@ -8,11 +8,13 @@ runtimes:
     timeout: 123
     volumes:
       - 'data:/home/kernelci/data'
+    rules:
 
   k8s-gke-eu-west4:
     lab_type: kubernetes
     filters: []
     context: 'gke_android-kernelci-external_europe-west4-c_kci-eu-west4'
+    rules:
 
   lab-baylibre:
     lab_type: legacy.lava_xmlrpc
@@ -34,6 +36,7 @@ runtimes:
             - kselftest
             - preempt-rt
             - ltp
+    rules:
 
   lab-collabora-staging:
     lab_type: legacy.lava_rest
@@ -50,7 +53,9 @@ runtimes:
     filters:
       - blocklist:
           tree: [android]
+    rules:
 
   shell:
     lab_type: shell
     filters: []
+    rules:


### PR DESCRIPTION
As all devices might not be equally supported by all kernel trees and versions, this PR implements filtering based on rules defined per job, platform and/or runtime. This is achieved by setting rules affecting any field present in the node structure, with the ability to provide both allowed and forbidden values.

If one of those items include at least one such rule, checks will be conducted during node creation, which will be aborted if one of the rules isn't satisfied.

For example, a job can be configured to run only on arm64 devices, with a kernel version >= 6.6, built with any defconfig except `allnoconfig`, and using the `kselftest` fragment but not the `arm64-chromebook` one, by adding the following to the job definition:

```yaml
  rules:
    min_version:
      version: 6
      patchlevel: 6
    arch:
      - 'arm64'
    defconfig:
      - '!allnoconfig'
    fragments:
      - 'kselftest'
      - '!arm64-chromebook'
```

Requires https://github.com/kernelci/kernelci-pipeline/pull/443 to avoid breaking the pipeline.

Note: the term "rules" has been preferred to "filters" in order to avoid confusion: the latter is used in the legacy config using different syntax and semantics, so providing a different implementation with the same name in the new system would likely lead to unexpected weird issues.

Fixes #2121 