### PR TITLE
kernelci.api.helper: make node hierarchies inherit parameters from parent

### DIFF
--- a/kernelci/api/helper.py
+++ b/kernelci/api/helper.py
@@ -231,7 +231,13 @@ class APIHelper:
         parent = self.api.node.get(root['parent'])
         base = {
             'data': {
-                'kernel_revision': root['data']['kernel_revision'],
+                'kernel_revision': root['data'].get('kernel_revision'),
+                'kernel_type': root['data'].get('kernel_type'),
+                'arch': root['data'].get('arch'),
+                'defconfig': root['data'].get('defconfig'),
+                'compiler': root['data'].get('compiler'),
+                'platform': root['data'].get('platform'),
+                'runtime': root['data'].get('runtime'),
             },
             'group': root['name'],
             'state': 'done',


### PR DESCRIPTION
When submitting test results via `submit_results()`, a tree of nodes is created hanging from a root node. These nodes aren't created in the same way as nodes built with `create_job_node`, where certain node types will inherit specific parameters from the parent node. Fix submit_results() so that the child nodes will inherit additional data parameters if they're defined in the parent node.