### PR TITLE
kernelci.api.model: fix version translation

### DIFF
--- a/kernelci/api/models.py
+++ b/kernelci/api/models.py
@@ -88,7 +88,7 @@ class KernelVersion(BaseModel):
     def translate_version_fields(cls, params):
         """Translate `StrictInt` field values into `int`"""
         for key, value in params.items():
-            if key in cls._STRICT_INT_FIELDS:
+            if key in cls._STRICT_INT_FIELDS and value:
                 params[key] = int(value)
         return params
 


### PR DESCRIPTION
Do not translate version fields with `None` value. Fix below error:
```
TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'
```