### PR TITLE
kernelci.api.helper: don't inherit parent node artifacts

### DIFF
--- a/kernelci/api/helper.py
+++ b/kernelci/api/helper.py
@@ -263,7 +263,7 @@ class APIHelper:
             'name': job_config.name,
             'path': input_node['path'] + [job_config.name],
             'group': job_config.name,
-            'artifacts': input_node['artifacts'],
+            'artifacts': {},
             'data': {
                 'kernel_revision': input_node['data']['kernel_revision'],
             },


### PR DESCRIPTION
When creating a new job node, we don't want it to automatically inherit the parent node artifacts. This leads to nodes carrying irrelevant information in most cases, such as test nodes including the build artifacts of the parent kbuild node.

@nuclearcat let's see how this works in staging first and then we can decide whether it's worth it or not.