### PR TITLE
Define config_full in models and propagate it to test and regression nodes

### DIFF
--- a/kernelci/api/helper.py
+++ b/kernelci/api/helper.py
@@ -143,6 +143,7 @@ class APIHelper:
             job_node['data']['kernel_type'] = input_node['data'].get('kernel_type')
             job_node['data']['arch'] = input_node['data'].get('arch')
             job_node['data']['defconfig'] = input_node['data'].get('defconfig')
+            job_node['data']['config_full'] = input_node['data'].get('config_full')
             job_node['data']['compiler'] = input_node['data'].get('compiler')
         # This information is highly useful, as we might
         # extract from it the following, for example:
@@ -235,6 +236,7 @@ class APIHelper:
                 'kernel_type': root['data'].get('kernel_type'),
                 'arch': root['data'].get('arch'),
                 'defconfig': root['data'].get('defconfig'),
+                'config_full': root['data'].get('config_full'),
                 'compiler': root['data'].get('compiler'),
                 'platform': root['data'].get('platform'),
                 'runtime': root['data'].get('runtime'),

--- a/kernelci/api/models.py
+++ b/kernelci/api/models.py
@@ -340,6 +340,10 @@ class KbuildData(BaseModel):
     fragments: Optional[List[str]] = Field(
         description="List of additional configuration fragments used"
     )
+    config_full: Optional[str] = Field(
+        description=("Single-string specification of the kernel "
+                     "configuration including defconfig and fragments")
+    )
     platform: Optional[str] = Field(
         description="Build platform"
     )
@@ -406,6 +410,10 @@ class TestData(BaseModel):
     defconfig: Optional[str] = Field(
         description="Kernel defconfig identifier"
     )
+    config_full: Optional[str] = Field(
+        description=("Single-string specification of the kernel "
+                     "configuration including defconfig and fragments")
+    )
     compiler: Optional[str] = Field(
         description="Compiler used for the build"
     )
@@ -443,6 +451,10 @@ class RegressionData(BaseModel):
     )
     defconfig: Optional[str] = Field(
         description="Kernel defconfig identifier"
+    )
+    config_full: Optional[str] = Field(
+        description=("Single-string specification of the kernel "
+                     "configuration including defconfig and fragments")
     )
     compiler: Optional[str] = Field(
         description="Compiler used for the build"
@@ -511,6 +523,7 @@ class Regression(Node):
                       'data.kernel_revision',
                       'data.arch',
                       'data.defconfig',
+                      'data.config_full',
                       'data.compiler',
                       'data.platform',]
         for field in cmp_fields:
@@ -533,6 +546,7 @@ class Regression(Node):
         data_field = {
             'arch': fail_node.data.arch,
             'defconfig': fail_node.data.defconfig,
+            'config_full': fail_node.data.config_full,
             'compiler': fail_node.data.compiler,
             'platform': fail_node.data.platform,
             'failed_kernel_revision': fail_node.data.kernel_revision,


### PR DESCRIPTION
Currently, tests and regressions only contain the defconfig info from the kbuild but not the config fragment info. The easiest way to do it is to pass the complete 'config_full' field downwards.

Remember that in KernelCI, knowing the "defconfig" of a kernel build may be only a partial picture of the whole config, since the complete config applied to the kernel may include any number of additional KernelCI-defined config fragments.