### PR TITLE
Format config params using objet attributes

### DIFF
--- a/config/runtime/base/lava.jinja2
+++ b/config/runtime/base/lava.jinja2
@@ -17,7 +17,7 @@
 
 job_name: "[{{ instanceid|default('KernelCI AKS')}}] {{ node.id }} {{ node.name }} {{ node.data.kernel_revision.describe }}"
 
-device_type: {{ platform_config.base_name }}
+device_type: {{ platform_config.name }}
 
 visibility: public
 

--- a/kernelci/api/helper.py
+++ b/kernelci/api/helper.py
@@ -293,6 +293,13 @@ class APIHelper:
             if not self.should_create_node(platform.rules, job_node, input_node):
                 print(f"Not creating node due to platform rules for {platform.name}")
                 return None
+            # Process potential f-strings in node's data with platform attributes
+            kernel_revision = job_node['data']['kernel_revision']['version']
+            extra_args = {
+                'krev': f"{kernel_revision['version']}.{kernel_revision['patchlevel']}"
+            }
+            extra_args.update(job_config.params)
+            job_node['data'] = platform.format_params(job_node['data'], extra_args)
         try:
             return self._api.node.add(job_node)
         except requests.exceptions.HTTPError as error:

--- a/kernelci/cli/job.py
+++ b/kernelci/cli/job.py
@@ -101,6 +101,14 @@ def generate(node_id,  # pylint: disable=too-many-arguments, too-many-locals
     params = runtime.get_params(job, api.config)
     if not params:
         raise click.ClickException("Invalid job parameters, aborting...")
+    # Process potential f-strings in `params` with configured job params
+    # and platform attributes
+    kernel_revision = job_node['data']['kernel_revision']['version']
+    extra_args = {
+        'krev': f"{kernel_revision['version']}.{kernel_revision['patchlevel']}"
+    }
+    extra_args.update(job.config.params)
+    params = job.platform_config.format_params(params, extra_args)
     job_data = runtime.generate(job, params)
     if output:
         output_file = runtime.save_file(job_data, output, params)

--- a/kernelci/config/job.py
+++ b/kernelci/config/job.py
@@ -19,7 +19,7 @@ class Job(YAMLConfigObject):
         self._template = template
         self._kind = kind
         self._image = image
-        self._params = params or {}
+        self._params = self.format_params(params.copy(), params) if params else {}
         self._rules = rules
 
     @property

--- a/kernelci/config/platform.py
+++ b/kernelci/config/platform.py
@@ -25,7 +25,7 @@ class Platform(YAMLConfigObject):
         self._context = context
         self._dtb = dtb
         self._mach = mach
-        self._params = params
+        self._params = self.format_params(params.copy(), params) if params else None
         self._rules = rules
 
     @property

--- a/kernelci/kbuild.py
+++ b/kernelci/kbuild.py
@@ -358,27 +358,21 @@ class KBuild():
 
     def _getcrosfragment(self, fragment):
         """ Get ChromeOS specific configuration fragments """
-        # ChromeOS fragment name can be f-strings with placeholders
-        # for the kernel revision (major.minor) and target architecture
-        version = self._node['data']['kernel_revision']['version']
         # The ChromeOS kernel only has release branches for LTS kernels
         # so let's fall back to using the config for the latest LTS if
         # building a more recent version
+        version = self._node['data']['kernel_revision']['version']
         target_rev = f"{version['version']}.{version['patchlevel']}"
         lts_rev = f"{LATEST_LTS_MAJOR}.{LATEST_LTS_MINOR}"
-        krev = None
-        if ((version['version'] > LATEST_LTS_MAJOR) or
-            (version['version'] == LATEST_LTS_MAJOR and
-             version['patchlevel'] > LATEST_LTS_MINOR)):
+        if (target_rev in fragment and
+            ((version['version'] > LATEST_LTS_MAJOR) or
+             (version['version'] == LATEST_LTS_MAJOR and
+              version['patchlevel'] > LATEST_LTS_MINOR))):
             print(f"Falling back to latest LTS config ({lts_rev}) " +
                   f"for kernel {target_rev}")
-            krev = lts_rev
-        else:
-            krev = target_rev
-        arch = self._arch
-        real_frag = fragment.format(krev=krev, arch=arch)
+            fragment = fragment.replace(target_rev, lts_rev)
         buffer = ''
-        [(branch, config)] = re.findall(r"cros://([\w\-.]+)/(.*)", real_frag)
+        [(branch, config)] = re.findall(r"cros://([\w\-.]+)/(.*)", fragment)
         cros_config = "/tmp/cros-config.tgz"
         url = CROS_CONFIG_URL.format(branch=branch)
         if not _download_file(url, cros_config):
@@ -395,7 +389,7 @@ class KBuild():
 
         os.unlink(cros_config)
 
-        return (buffer, real_frag)
+        return (buffer, fragment)
 
     def extract_config(self, frag):
         """ Extract config fragments from legacy config file """


### PR DESCRIPTION
Our config files currently have to specify lots of nearly-identical parameters, especially for chromebooks. Those parameters usually depend on the device/job target architecture, name or family.

In order to make things more flexible and reduce config verbosity, this PR implements string formatting for job/platform params, substituting placeholders with the values of the corresponding object attributes.

A special `krev` placeholder is also handled: it doesn't match any object attribute, but it is constructed from the code as the kernel revision in the form `major.minor`, extracted from node data.

Example:
```yaml
  chromebook-device: &chromebook-device
    arch: arm64
    mach: mediatek
    params:
      myconfig: 'config-{arch}-{mach}-{base_name}.config'

  device-1: *chromebook-device

  device-2:
    <<: *chromebook-device
    base_name: dev2
    mach: qcom
```

This config will then be equivalent to:
```yaml
  device-1: *chromebook-device
    arch: arm64
    base_name: device-1
    mach: mediatek
    params:
      myconfig: 'config-arm64-mediatek-device-1.config'

  device-2:
    arch: arm64
    base_name: dev2
    mach: qcom
    params:
      myconfig: 'config-arm64-qcom-dev2.config'
```