### PR TITLE
Apply rules to scheduler entries as well

### DIFF
--- a/kernelci/config/scheduler.py
+++ b/kernelci/config/scheduler.py
@@ -13,11 +13,13 @@ class SchedulerEntry(YAMLConfigObject):
 
     yaml_tag = '!SchedulerEntry'
 
-    def __init__(self, job, runtime, event, platforms=None):
+    # pylint: disable=too-many-arguments
+    def __init__(self, job, runtime, event, platforms=None, rules=None):
         self._job = job
         self._runtime = runtime
         self._event = event
         self._platforms = platforms or []
+        self._rules = rules
 
     @property
     def job(self):
@@ -39,10 +41,15 @@ class SchedulerEntry(YAMLConfigObject):
         """List of platform names"""
         return list(self._platforms)
 
+    @property
+    def rules(self):
+        """Kernel requirements (tree, branch, version...)"""
+        return self._rules
+
     @classmethod
     def _get_yaml_attributes(cls):
         attrs = super()._get_yaml_attributes()
-        attrs.update({'job', 'runtime', 'event', 'platforms'})
+        attrs.update({'job', 'runtime', 'event', 'platforms', 'rules'})
         return attrs
 
 

--- a/kernelci/legacy/cli/sched.py
+++ b/kernelci/legacy/cli/sched.py
@@ -29,7 +29,7 @@ class cmd_get_schedule(Command):  # pylint: disable=invalid-name
         sched = kernelci.scheduler.Scheduler(configs, runtimes)
         event = json.loads(sys.stdin.read())
         channel = args.channel or 'node'
-        for job, runtime, platform in sched.get_schedule(event, channel):
+        for job, runtime, platform, _rules in sched.get_schedule(event, channel):
             print(f"{job.name:32} {runtime.config.name:32} {platform.name}")
         return True
 

--- a/kernelci/scheduler.py
+++ b/kernelci/scheduler.py
@@ -57,4 +57,4 @@ class Scheduler:
             for platform_name in platforms:
                 platform = self._platforms.get(platform_name)
                 if platform:
-                    yield job, runtime, platform
+                    yield job, runtime, platform, config.rules

--- a/tests/configs/scheduler.yaml
+++ b/tests/configs/scheduler.yaml
@@ -16,15 +16,21 @@ scheduler:
     runtime:
       type: lava
     platforms: [qemu-x86]
+    rules:
+      tree:
+        - 'mainline'
+        - '!next'
 
   - job: kunit
     event: *checkout
     runtime:
       name: k8s-gke-eu-west4
     platforms: []
+    rules:
 
   - job: kbuild-gcc-10-x86
     event: *checkout
     runtime:
       type: kubernetes
     platforms: []
+    rules:


### PR DESCRIPTION
The filtering capabilities implemented in #2413 only apply to job and platform entries. It could, however, be useful to add such capabilities to scheduler entries as well.

This PR ensures the generic mechanisms for doing so are in place, but the actual filtering will be executed within [kernelci-pipeline](https://github.com/kernelci/kernelci-pipeline)