### PR TITLE
config: runtime: tests: temporarily switch kselftest revision to staging

### DIFF
--- a/config/runtime/tests/kselftest.jinja2
+++ b/config/runtime/tests/kselftest.jinja2
@@ -16,7 +16,7 @@
 
     - repository: https://github.com/kernelci/test-definitions.git
       from: git
-      revision: kernelci.org
+      revision: staging.kernelci.org
       path: automated/linux/kselftest/kselftest.yaml
       name: '{{ node.name }}'
       parameters:


### PR DESCRIPTION
This patch temporarily changes the source revision of test-definitions for running kselftests to staging.kernelci.org branch. This change will be reverted once [0] is merged (preferably in the upstream repository).

[0] https://github.com/kernelci/test-definitions/pull/20