### PR TITLE
build-configs-stable.yaml: Some fixes and an update for v6.8

### DIFF
--- a/config/core/build-configs-stable.yaml
+++ b/config/core/build-configs-stable.yaml
@@ -472,7 +472,7 @@ build_configs:
       tree: stable
       branch: 'linux-6.6.y'
 
-stable-rc_queue-6.7:
+  stable-rc_queue-6.7:
     tree: stable-rc
     branch: 'queue/6.7'
     variants: *stable_variants

--- a/config/core/build-configs-stable.yaml
+++ b/config/core/build-configs-stable.yaml
@@ -216,6 +216,11 @@ build_configs:
     branch: 'linux-6.7.y'
     variants: *stable_variants
 
+  stable_6.8:
+    tree: stable
+    branch: 'linux-6.8.y'
+    variants: *stable_variants
+
   stable-rc_3.16:
     tree: stable-rc
     branch: 'linux-3.16.y'
@@ -352,6 +357,14 @@ build_configs:
       tree: stable
       branch: 'linux-6.7.y'
 
+  stable-rc_6.8:
+    tree: stable-rc
+    branch: 'linux-6.8.y'
+    variants: *stable_variants
+    reference:
+      tree: stable
+      branch: 'linux-6.8.y'
+
   stable-rc_queue-4.4:
     tree: stable-rc
     branch: 'queue/4.4'
@@ -479,3 +492,11 @@ build_configs:
     reference:
       tree: stable
       branch: 'linux-6.7.y'
+
+  stable-rc_queue-6.8:
+    tree: stable-rc
+    branch: 'queue/6.8'
+    variants: *stable_variants
+    reference:
+      tree: stable
+      branch: 'linux-6.8.y'

--- a/config/core/build-configs-stable.yaml
+++ b/config/core/build-configs-stable.yaml
@@ -211,6 +211,11 @@ build_configs:
     branch: 'linux-6.6.y'
     variants: *stable_variants
 
+  stable_6.7:
+    tree: stable
+    branch: 'linux-6.7.y'
+    variants: *stable_variants
+
   stable-rc_3.16:
     tree: stable-rc
     branch: 'linux-3.16.y'


### PR DESCRIPTION
- build-config-stable.yaml: Add coverage for v6.7 stables
- build-configs-stable.yaml: Correct indentation for v6.7 queue entry
- build-configs-stable.yaml: Add v6.8 stable coverage
