### PR TITLE
config: runtime: boot: Use latest kselftest rootfs to avoid tap issue

### DIFF
--- a/config/runtime/boot/u-boot.jinja2
+++ b/config/runtime/boot/u-boot.jinja2
@@ -11,10 +11,10 @@
 {%- endif %}
 {%- if boot_commands == 'nfs' %}
     nfsrootfs:
-      url: 'http://storage.kernelci.org/images/rootfs/debian/bullseye-kselftest/20240129.0/{{ platform_config.arch }}/full.rootfs.tar.xz'
+      url: 'http://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20240221.0/{{ platform_config.arch }}/full.rootfs.tar.xz'
       compression: xz
     ramdisk:
-      url: 'http://storage.kernelci.org/images/rootfs/debian/bullseye-kselftest/20240129.0/{{ platform_config.arch }}/initrd.cpio.gz'
+      url: 'http://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20240221.0/{{ platform_config.arch }}/initrd.cpio.gz'
       compression: gz
     os: debian
 {%- else %}


### PR DESCRIPTION
Update the kselftest rootfs URL to the latest one which includes tappy, and is thus able to parse the kselftest results without throwing an error:

ModuleNotFoundError: No module named 'tap'