### PR TITLE
kernelci.api.models: fix event payload data type

### DIFF
--- a/kernelci/api/models.py
+++ b/kernelci/api/models.py
@@ -25,6 +25,7 @@ from pydantic import (
     Field,
     FileUrl,
     StrictInt,
+    validator,
 )
 from .models_base import (
     PyObjectId,
@@ -612,6 +613,15 @@ class PublishEvent(BaseModel):
     attributes: Optional[Dict] = Field(
         description="Extra Cloudevents Extension Context Attributes"
     )
+
+    # suppress pylint error below
+    # It's a known issue: https://github.com/pylint-dev/pylint/issues/6900
+    @validator('data')
+    def validate_data(cls, val):  # pylint: disable=no-self-argument
+        """Do not allow 'None' as event payload data"""
+        if not val:
+            raise ValueError('None is not allowed as event payload')
+        return val
 
 
 def parse_node_obj(node: Node):


### PR DESCRIPTION
Fixes https://github.com/kernelci/kernelci-api/issues/451

When using `Any` for event payload `data` field allows all the values including `None`. Events with `None` payload will break pipeline services as per current design. Update the field to be mandatory and dictionary type to make it compatible with pipeline service usage.