### PR TITLE
kbuild: Fix back dtbs_check "magic word"

### DIFF
--- a/kernelci/kbuild.py
+++ b/kernelci/kbuild.py
@@ -568,7 +568,8 @@ class KBuild():
         self.addcmd("cd " + self._srcdir)
         self.addcmd("make -j$(nproc) dtbs_check" + " --output-sync " +
                     REDIR.format(self._af_dir + "/build_dtbs_check.log",
-                                 self._af_dir + "/build_dtbs_check_stderr.log"))
+                                 self._af_dir + "/build_dtbs_check_stderr.log") +
+                    " && echo DTBS_CHECK_OK || echo DTBS_CHECK_FAILED $?", False)
         self.addcmd("cd ..")
 
     def _package_kimage(self):


### PR DESCRIPTION
After fixing stderr/stdout file we got lost DTBS_CHECK_OK/FAIL result trigger in build.log output, return it back.