### PR TITLE
runtime/lava: Generate more info on exception

### DIFF
--- a/kernelci/api/models.py
+++ b/kernelci/api/models.py
@@ -73,6 +73,7 @@ class ErrorCodes(str, enum.Enum):
     MULTI_NODE_TIMEOUT = 'MultinodeTimeout'
     OBJECT_NOT_PERSISTED = 'ObjectNotPersisted'
     UNEXISTING_PERMISSION_CODENAME = 'Unexisting permission codename.'
+    JOB_GENERATION_ERROR = 'job_generation_error'
 
 
 class KernelVersion(BaseModel):

--- a/kernelci/runtime/lava.py
+++ b/kernelci/runtime/lava.py
@@ -195,7 +195,7 @@ class Callback:
 
     def to_file(self, filename):
         """Write the callback data to a JSON file"""
-        with open(filename, 'w') as file:
+        with open(filename, 'w', encoding='utf-8') as file:
             file.write(self._data)
 
 
@@ -229,9 +229,9 @@ class LAVA(Runtime):
         try:
             rendered = template.render(params)
         # jinja2.exceptions.UndefinedError
-        except Exception as exc:
+        except Exception as exc:  # pylint: disable=broad-except
             platform_params = params['platform_config'].params
-            print(f"Error rendering job template: {exc}, {params}"+
+            print(f"Error rendering job template: {exc}, {params}" +
                   f"{exc}, {params} {platform_params}")
             return None
 

--- a/kernelci/runtime/lava.py
+++ b/kernelci/runtime/lava.py
@@ -111,8 +111,14 @@ class Callback:
         login = (
             tests_map.get('auto-login-action') or tests_map.get('login-action')
         )
-        job_result = tests_map['job']['result']
-        result = login and login['result'] == 'pass' and job_result == 'pass'
+        result = login and login['result'] == 'pass'
+        return 'pass' if result else 'fail'
+
+    @classmethod
+    def _get_kernelmsg_case(cls, tests):
+        tests_map = {test['name']: test for test in tests}
+        kernelmsg = tests_map.get('kernel-messages')
+        result = kernelmsg and kernelmsg['result'] == 'pass'
         return 'pass' if result else 'fail'
 
     @classmethod
@@ -134,6 +140,7 @@ class Callback:
             tests = yaml.safe_load(suite_results)
             if suite_name == 'lava':
                 results['login'] = self._get_login_case(tests)
+                results['kernelmsg'] = self._get_kernelmsg_case(tests)
             else:
                 suite_name = suite_name.partition("_")[2]
                 results[suite_name] = self._get_suite_results(tests)
@@ -190,6 +197,7 @@ class Callback:
         """Write the callback data to a JSON file"""
         with open(filename, 'w') as file:
             file.write(self._data)
+
 
 class LAVA(Runtime):
     """Runtime implementation to run jobs in a LAVA lab

--- a/kernelci/runtime/lava.py
+++ b/kernelci/runtime/lava.py
@@ -186,6 +186,10 @@ class Callback:
         """Get a LogParser object from the callback data"""
         return LogParser(self._data['log'])
 
+    def to_file(self, filename):
+        """Write the callback data to a JSON file"""
+        with open(filename, 'w') as file:
+            file.write(self._data)
 
 class LAVA(Runtime):
     """Runtime implementation to run jobs in a LAVA lab

--- a/kernelci/runtime/lava.py
+++ b/kernelci/runtime/lava.py
@@ -214,7 +214,15 @@ class LAVA(Runtime):
 
     def generate(self, job, params):
         template = self._get_template(job.config)
-        rendered = template.render(params)
+        try:
+            rendered = template.render(params)
+        # jinja2.exceptions.UndefinedError
+        except Exception as exc:
+            platform_params = params['platform_config'].params
+            print(f"Error rendering job template: {exc}, {params}"+
+                  f"{exc}, {params} {platform_params}")
+            return None
+
         # yaml round-trip to process e.g. multi-line commands
         return yaml.dump(yaml.load(rendered, Loader=yaml.CLoader))
 


### PR DESCRIPTION
In case we experience problem during template rendering, we often cannot identify even task caused this exception.
Add some more debug to help with that.