### PR TITLE
rootfs-images.yaml: Fix buildroot image

### DIFF
--- a/config/core/rootfs-images.yaml
+++ b/config/core/rootfs-images.yaml
@@ -4,7 +4,7 @@ file_systems:
     boot_protocol: tftp
     params: {}
     prompt: '/ #'
-    ramdisk: buildroot-baseline/20240313.0/{arch}/rootfs.cpio.gz
+    ramdisk: buildroot-baseline/20230703.0/{arch}/rootfs.cpio.gz
     root_type: ramdisk
     type: buildroot
   debian_bookworm-cros-ec_ramdisk:


### PR DESCRIPTION
By mistake it was updated, while not buildable for now.