### PR TITLE
kernelci: runtime: ensure job params take precedence

### DIFF
--- a/kernelci/runtime/__init__.py
+++ b/kernelci/runtime/__init__.py
@@ -149,9 +149,9 @@ class Runtime(abc.ABC):
             'runtime': self.config.lab_type,
             'runtime_image': job.config.image,
         }
-        params.update(job.config.params)
         if job.platform_config.params:
             params.update(job.platform_config.params)
+        params.update(job.config.params)
         return params
 
     @classmethod


### PR DESCRIPTION
`params` are a free-form set of parameters which can be defined on a per-job or per-platform basis. However, the platform-defined params are always accessible through `platform_config.params`, while those can override job-defined params with the same name. In such cases, said job-defined params are lost forever.

Fix this by ensuring we import job-defined params last. Templates should therefore refer to `platform_config.params.<param_name>` wherever needed.