### PR TITLE
T40464 config/docker/api.jinja2: use python 3.11

### DIFF
--- a/config/docker/api.jinja2
+++ b/config/docker/api.jinja2
@@ -5,5 +5,4 @@
 -#}
 
 {%- set fragments = ['fragment/api.jinja2'] + fragments %}
-{%- set is_api = true %}
 {%- include 'base/python.jinja2' %}

--- a/config/docker/base/python.jinja2
+++ b/config/docker/base/python.jinja2
@@ -4,11 +4,7 @@
  # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
 -#}
 
-{%- if is_api %}
-   FROM python:3.10
-{% else %}
-   FROM python:3.11
-{%- endif %}
+FROM python:3.11
 
 MAINTAINER "KernelCI TSC" <kernelci-tsc@groups.io>
 


### PR DESCRIPTION
Depends on https://github.com/kernelci/kernelci-api/pull/504

Fixes https://github.com/kernelci/kernelci-api/issues/479

Since Python 3.11 support has been enabled for API, use the same version for building `api` docker image.
Remove conditional block from `base/python.jinja2` that was used to decide Python version as a part of a temporary solution for API until it supports Python 3.11.