### PR TITLE
kbuild: wget retry on DNS error

### DIFF
--- a/kernelci/kbuild.py
+++ b/kernelci/kbuild.py
@@ -296,7 +296,7 @@ class KBuild():
         # download tarball
         self.addcomment("Download tarball")
         self.addcmd("cd " + self._workspace)
-        self.addcmd("wget -c -t 10 \"" + self._srctarball + "\" -O linux.tgz")
+        self.addcmd("wget -c -t 10 --retry-on-host-error \"" + self._srctarball + "\" -O linux.tgz")
         self.addcmd("tar -xzf linux.tgz -C " + self._srcdir + " --strip-components=1")
 
     def addspacer(self):


### PR DESCRIPTION
It often happens k8s containers have unreliable DNS, retry download on DNS error