### PR TITLE
Allow listing multiple dtbs for a single platform

### DIFF
--- a/config/runtime/boot/depthcharge.jinja2
+++ b/config/runtime/boot/depthcharge.jinja2
@@ -4,7 +4,7 @@
 {%- if modules_url is not defined %}
 {%-   set modules_url = node.artifacts.modules %}
 {%- endif %}
-{%- if platform_config.dtb and dtb_url is not defined %}
+{%- if device_dtb and dtb_url is not defined %}
 {%-   set dtb_url = node.artifacts.dtb %}
 {%- endif %}
 {%- if boot_commands is not defined %}
@@ -20,7 +20,7 @@
     modules:
       compression: xz
       url: '{{ modules_url }}'
-{%- if platform_config.dtb %}
+{%- if device_dtb %}
     dtb:
       url: '{{ dtb_url }}'
 {%- endif %}

--- a/config/runtime/boot/grub.jinja2
+++ b/config/runtime/boot/grub.jinja2
@@ -7,7 +7,7 @@
       url: 'http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230421.0/{{ platform_config.arch }}/rootfs.cpio.gz'
       image_arg: -initrd {ramdisk}
       compression: gz
-{%- if platform_config.dtb %}
+{%- if device_dtb %}
     dtb:
       url: '{{ node.artifacts.dtb }}'
       image_arg: -dtb {dtb}

--- a/config/runtime/boot/qemu.jinja2
+++ b/config/runtime/boot/qemu.jinja2
@@ -7,7 +7,7 @@
       ramdisk:
         image_arg: -initrd {ramdisk}
         url: 'http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230421.0/{{ platform_config.arch }}/rootfs.cpio.gz'
-{%- if platform_config.dtb %}
+{%- if device_dtb %}
       dtb:
         url: '{{ node.artifacts.dtb }}'
         image_arg: -dtb {dtb}

--- a/config/runtime/boot/u-boot.jinja2
+++ b/config/runtime/boot/u-boot.jinja2
@@ -5,7 +5,7 @@
     modules:
       compression: xz
       url: '{{ node.artifacts.modules }}'
-{%- if platform_config.dtb %}
+{%- if device_dtb %}
     dtb:
       url: '{{ node.artifacts.dtb }}'
 {%- endif %}

--- a/config/runtime/chromeos/base.jinja2
+++ b/config/runtime/chromeos/base.jinja2
@@ -32,7 +32,7 @@
     to: tftp
     kernel:
       url: '{{ node.artifacts.kernel }}'
-{%- if platform_config.dtb %}
+{%- if device_dtb %}
     dtb:
       url: '{{ node.artifacts.dtb }}'
 {%- endif %}

--- a/kernelci/config/platform.py
+++ b/kernelci/config/platform.py
@@ -23,7 +23,12 @@ class Platform(YAMLConfigObject):
         self._base_name = base_name
         self._boot_method = boot_method
         self._context = context
-        self._dtb = dtb
+        self._dtb = None
+        if dtb:
+            if isinstance(dtb, list):
+                self._dtb = dtb
+            else:
+                self._dtb = [dtb]
         self._mach = mach
         self._params = self.format_params(params.copy(), params) if params else None
         self._rules = rules

--- a/kernelci/runtime/__init__.py
+++ b/kernelci/runtime/__init__.py
@@ -149,9 +149,9 @@ class Runtime(abc.ABC):
             'runtime': self.config.lab_type,
             'runtime_image': job.config.image,
         }
-        params.update(job.config.params)
         if job.platform_config.params:
             params.update(job.platform_config.params)
+        params.update(job.config.params)
         return params
 
     @classmethod


### PR DESCRIPTION
Device-tree files can be renamed upstream, like it happened for the `trogdor-kingoftown` Chromebook during the 6.4 developement cycle. In such cases, we have to provide several possible file names and select the appropriate one based on which files are present in the test kernel artifacts.

This PR makes it possible to store either a single string or a list of values in the platform config `dtb` field, and stores the selected value as a top-level `device_dtb` parameter to be used by templates. It also includes the corresponding rework of the existing templates.

To be merged in sync with https://github.com/kernelci/kernelci-pipeline/pull/495