### PR TITLE
kernelci.api.models: node_sequence field in regressions data

### DIFF
--- a/kernelci/api/models.py
+++ b/kernelci/api/models.py
@@ -385,6 +385,9 @@ class KbuildData(BaseModel):
     kernel_type: Optional[str] = Field(
         description="Kernel image type (zimage, bzimage...)"
     )
+    regression: Optional[PyObjectId] = Field(
+        description="Regression node related to this build instance"
+    )
 
 
 class Kbuild(Node):
@@ -398,6 +401,10 @@ class Kbuild(Node):
     data: KbuildData = Field(
         description="Kbuild details"
     )
+
+    _OBJECT_ID_FIELDS = Node._OBJECT_ID_FIELDS + [
+        'data.regression',
+    ]
 
 
 class TestData(BaseModel):
@@ -426,6 +433,9 @@ class TestData(BaseModel):
     )
     job_context: Optional[str] = Field(
         description="Kubernetes cluster name the job submitted to"
+    )
+    regression: Optional[PyObjectId] = Field(
+        description="Regression node related to this test run"
     )
 
     # Fields inherited from the parent kbuild or test case node
@@ -463,6 +473,10 @@ class Test(Node):
         description="Test details"
     )
 
+    _OBJECT_ID_FIELDS = Node._OBJECT_ID_FIELDS + [
+        'data.regression',
+    ]
+
 
 class RegressionData(BaseModel):
     """Model for the data field of a Regression node"""
@@ -473,6 +487,7 @@ class RegressionData(BaseModel):
         description="Previous passing Node"
     )
     node_sequence: Optional[List[PyObjectId]] = Field(
+        default=[],
         description=("Instances of this same job ran after the initial "
                      "failure. The last run in the sequence may be a "
                      "passed run, which means the regression is no longer"
@@ -516,6 +531,7 @@ class Regression(Node):
         const=True
     )
     result: Optional[ResultValues] = Field(
+        default=ResultValues.FAIL.value,
         description=("PASS if the regression is 'inactive', that is, if the "
                      "test has ever passed after the regression was created. "
                      "FAIL if the regression is still 'active', ie. the test "

--- a/kernelci/api/models.py
+++ b/kernelci/api/models.py
@@ -472,6 +472,14 @@ class RegressionData(BaseModel):
     pass_node: Optional[PyObjectId] = Field(
         description="Previous passing Node"
     )
+    node_sequence: Optional[List[PyObjectId]] = Field(
+        description=("Instances of this same job ran after the initial "
+                     "failure. The last run in the sequence may be a "
+                     "passed run, which means the regression is no longer"
+                     "active. If the sequence is empty or if all the runs "
+                     "in the sequence failed, that means the job is still "
+                     "failing and the regression is active")
+    )
     error_code: Optional[ErrorCodes] = Field(
         description="Error code of the failed job"
     )
@@ -506,6 +514,12 @@ class Regression(Node):
         default='regression',
         description='Type of the object',
         const=True
+    )
+    result: Optional[ResultValues] = Field(
+        description=("PASS if the regression is 'inactive', that is, if the "
+                     "test has ever passed after the regression was created. "
+                     "FAIL if the regression is still 'active', ie. the test "
+                     "is still failing")
     )
     data: RegressionData = Field(
         description="Regression details"


### PR DESCRIPTION
Encode the concept of "active" and "inactive" regressions. A regression is "active" if the test is still failing after the failure was introduced. The regression has "fail" as a result. A regression is "inactive" if the test has passed after the regression was created. The regression result in this case is "pass".

A new "node_sequence" field to stores the list of failed test runs after the first failure for active regressions. For inactive regressions it stores up to the first passing test run. 