### PR TITLE
Improve results reporting for Tast tests

### DIFF
--- a/config/runtime/tests/tast.jinja2
+++ b/config/runtime/tests/tast.jinja2
@@ -30,13 +30,16 @@
               && cp cros /usr/libexec/tast/bundles/remote/
             - while ! ping -c 1 -w 1 $(lava-target-ip); do sleep 1; done
             - >-
-              lava-test-case os-release --shell
               ./ssh_retry.sh
               -o StrictHostKeyChecking=no
               -o UserKnownHostsFile=/dev/null
               -i /home/cros/.ssh/id_rsa
               root@$(lava-target-ip)
-              cat /etc/os-release
+              cat /etc/os-release > /tmp/osrel.tmp
+            - cat /tmp/osrel.tmp
+            - >-
+              lava-test-case os-release --result pass
+              --measurement $(sed -e '/VERSION_ID/!d' -e 's/.*=//' /tmp/osrel.tmp)
             - >-
               ./tast_parser.py
 {%- for test in tests %}

--- a/config/runtime/tests/tast.jinja2
+++ b/config/runtime/tests/tast.jinja2
@@ -41,7 +41,7 @@
               lava-test-case os-release --result pass
               --measurement $(sed -e '/VERSION_ID/!d' -e 's/.*=//' /tmp/osrel.tmp)
             - >-
-              ./tast_parser.py
+              ./tast_parser.py --run
 {%- for test in tests %}
               {{ test }}
 {%- endfor %}
@@ -52,3 +52,4 @@
               -i /home/cros/.ssh/id_rsa
               root@$(lava-target-ip)
               sync && poweroff && exit 0
+            - ./tast_parser.py --results


### PR DESCRIPTION
This PR adds the OS version as a "measurement" for the `os-release` test case, so it can be stored as part of the test results and provide valuable information when investigating a regression.

It also ensures the whole test suite is marked as failed if at least one of the Tast tests fail, making it easier to determine the actual status of a test run.

Depends on the docker images to be re-generated/published after #2478 is merged.