### PR TITLE
kbuild: Make kselftest build non-critical

### DIFF
--- a/kernelci/kbuild.py
+++ b/kernelci/kbuild.py
@@ -602,7 +602,7 @@ class KBuild():
         self.startjob("package_kselftest")
         self.addcmd(f"cp {self._srcdir}/tools/testing/selftests/kselftest_install/" +
                     "kselftest-packages/kselftest.tar.gz " +
-                    f"{self._af_dir}/")
+                    f"{self._af_dir}/", False)
         self._artifacts.append("kselftest.tar.gz")
 
     def _package_dtbs(self):


### PR DESCRIPTION
Don't fail kernel build if kselftest failed to build, as it's normal for some old kernels like 4.19.