### PR TITLE
config/docker/fragment/api.jinja2: use `kernelci` fragment

### DIFF
--- a/config/docker/fragment/api.jinja2
+++ b/config/docker/fragment/api.jinja2
@@ -1,16 +1,3 @@
-# Install kernelci Python package from kernelci-core
-ARG core_url=https://github.com/kernelci/kernelci-core.git
-ARG core_rev=main
-RUN apt-get update && apt-get install --no-install-recommends -y git
-RUN git clone --depth=1 $core_url /tmp/kernelci-core
-WORKDIR /tmp/kernelci-core
-RUN git fetch origin $core_rev
-RUN git checkout FETCH_HEAD
-RUN python3 -m pip install '.[dev]'
-RUN cp -R config /etc/kernelci/
-WORKDIR /root
-RUN rm -rf /tmp/kernelci-core
-
 # Install kernelci-api Python package from kernelci-api
 ARG api_url=https://github.com/kernelci/kernelci-api.git
 ARG api_rev=main
@@ -21,11 +8,3 @@ RUN git checkout FETCH_HEAD
 RUN python3 -m pip install '.[dev]'
 WORKDIR /root
 RUN rm -rf /tmp/kernelci-api
-
-# Set up kernelci user
-RUN useradd kernelci -u 1000 -d /home/kernelci -s /bin/bash
-RUN mkdir -p /home/kernelci
-RUN chown kernelci: /home/kernelci
-USER kernelci
-ENV PATH=$PATH:/home/kernelci/.local/bin
-WORKDIR /home/kernelci

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,12 +16,12 @@ requires-python = ">=3.9"
 license = {text = "LGPL-2.1-or-later"}
 dependencies = [
   "azure-storage-file-share==12.13.0",
-  "bson==0.5.10",
   "click==8.1.3",
   "cloudevents==1.9.0",
   "docker==6.1.2",
   "jinja2==3.1.3",
   "kubernetes==26.1.0",
+  "motor==3.3.2",
   "paramiko==3.4.0",
   "pydantic==1.10.5",
   "pyelftools==0.29",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 azure-storage-file-share==12.13.0
-bson==0.5.10
 click==8.1.3
 cloudevents==1.9.0
 docker==6.1.2
 jinja2==3.1.3
 kubernetes==26.1.0
+motor==3.3.2
 paramiko==3.4.0
 pydantic==1.10.5
 pyelftools==0.29


### PR DESCRIPTION
Atm we are building and installing `kernelci` python package from `api.jinja2` template to avoid python package version conficts while building `api` with `kernelci` fragment.
Since the support for Python 3.11 has been enabled for API, that issue has been resolved. Now, we can use `kernelci` fragment to build `api` docker image as per the normal practice for all `core` docker images.