### PR TITLE
scheduler: Fix crash if event is str

### DIFF
--- a/kernelci/scheduler.py
+++ b/kernelci/scheduler.py
@@ -31,6 +31,11 @@ class Scheduler:
 
     def get_configs(self, event, channel='node'):
         """Get the scheduler configs matching a given event"""
+        # scheduler expects a dict, but in some cases someone
+        # might pass something else, this will prevent a crash
+        if not isinstance(event, dict):
+            print("Error: event type should be dict")
+            return
         for entry in self._scheduler:
             sched_event_channel = entry.event.get('channel')
             if sched_event_channel == channel:


### PR DESCRIPTION
```
today at 4:52:34 PM04/02/2024 01:52:34 PM UTC [ERROR] Traceback (most recent call last):
today at 4:52:34 PM  File "/home/kernelci/pipeline/base.py", line 69, in run
today at 4:52:34 PM    status = self._run(context)
today at 4:52:34 PM             ^^^^^^^^^^^^^^^^^^
today at 4:52:34 PM  File "/home/kernelci/./pipeline/scheduler.py", line 190, in _run
today at 4:52:34 PM    for job, runtime, platform, rules in self._sched.get_schedule(event):
today at 4:52:34 PM  File "/usr/local/lib/python3.11/site-packages/kernelci/scheduler.py", line 44, in get_schedule
today at 4:52:34 PM    for config in self.get_configs(event, channel):
today at 4:52:34 PM  File "/usr/local/lib/python3.11/site-packages/kernelci/scheduler.py", line 39, in get_configs
today at 4:52:34 PM    if sched_event.items() <= event.items():
today at 4:52:34 PM                              ^^^^^^^^^^^
today at 4:52:34 PMAttributeError: 'str' object has no attribute 'items'
```
Even incorrect event sent it will crash scheduler, add workaround for that.