### PR TITLE
Revert "Encode a Node path using a regular slash-separated string instead of a string list"

### DIFF
--- a/kernelci/api/helper.py
+++ b/kernelci/api/helper.py
@@ -34,17 +34,6 @@ def merge(primary: dict, secondary: dict):
     return result
 
 
-def node_path_join(paths_list):
-    """Joins a list of path components for the Node `path` field and
-    returns the complete path string.
-
-    TODO: Refactor Node path handling logic into the Node model in
-    models.py
-
-    """
-    return '/'.join(path.rstrip('/') for path in paths_list)
-
-
 class APIHelper:
     """API helper base class
 
@@ -287,7 +276,7 @@ class APIHelper:
             'kind': job_config.kind,
             'parent': input_node['id'],
             'name': job_config.name,
-            'path': node_path_join([input_node['path'], job_config.name]),
+            'path': input_node['path'] + [job_config.name],
             'group': job_config.name,
             'artifacts': {},
             'data': {
@@ -354,18 +343,12 @@ class APIHelper:
                     node.update({key: value})
             else:
                 node[key] = value
-        path_elems = [node['name']]
-        if parent:
-            path_elems.insert(0, parent['path'])
-        node['path'] = node_path_join(path_elems)
+        node['path'] = (parent['path'] if parent else []) + [node['name']]
         if 'kind' not in node:
             node['kind'] = parent['kind']
         child_nodes = []
         for child_node in results['child_nodes']:
             child_nodes.append(self._prepare_results(child_node, node, base))
-        if child_nodes:
-            # Trailing slash in path: the node contains child nodes
-            node['path'] += '/'
         return {
             'node': node,
             'child_nodes': child_nodes,

--- a/kernelci/api/models.py
+++ b/kernelci/api/models.py
@@ -162,10 +162,8 @@ class Node(DatabaseModel):
     name: str = Field(
         description="Name of the node object"
     )
-    path: str = Field(
-        description=("Slash-separated path to the node from the top-level"
-                     "node. For non-final nodes this should end with a "
-                     "trailing slash")
+    path: List[str] = Field(
+        description="Full path with node names from the top-level node"
     )
     group: Optional[str] = Field(
         description="Name of a group this node belongs to"

--- a/kernelci/legacy/cli/show.py
+++ b/kernelci/legacy/cli/show.py
@@ -101,7 +101,7 @@ class cmd_results(APICommand):  # pylint: disable=invalid-name
 
         print(f"""\
 {self._color('Node', 'bold')}
-  {self._color('path', 'blue')}      {node['path']}
+  {self._color('path', 'blue')}      {'.'.join(node['path'])}
   {self._color('id', 'blue')}        {args.id}
   {self._color('parent', 'blue')}    {parent_id}
   {self._color('owner', 'blue')}     {owner}

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -22,7 +22,9 @@ class APIHelperTestData:
             "id": "6332d8f51a45d41c279e7a01",
             "kind": "checkout",
             "name": "checkout",
-            "path": "checkout/",
+            "path": [
+                "checkout"
+            ],
             "group": None,
             "data": {
                 "kernel_revision": {
@@ -55,7 +57,10 @@ class APIHelperTestData:
         self._regression_node = {
             "kind": "regression",
             "name": "kver",
-            "path": "checkout/kver",
+            "path": [
+                "checkout",
+                "kver"
+            ],
             "group": "kver",
             "data": {
                 "fail_node": "636143c38f94e20c6826b0b6",
@@ -77,7 +82,10 @@ class APIHelperTestData:
             "id": "6332d92f1a45d41c279e7a06",
             "kind": "node",
             "name": "kunit",
-            "path": "checkout/kunit/",
+            "path": [
+                "checkout",
+                "kunit"
+            ],
             "group": "kunit",
             "data": {
                 "kernel_revision": {
@@ -161,7 +169,9 @@ class APIHelperTestData:
             "group": self._kunit_node["group"],
             "holdoff": None,
             "kind": self._kunit_node["kind"],
-            "path": f"{self._kunit_node['path']}/{self._kunit_child_node['name']}",
+            "path": (
+                self._kunit_node["path"] + [self._kunit_child_node["name"]]
+            ),
             "state": self._kunit_node["state"],
             "timeout": "2022-11-02T16:06:39.509000",
             "updated": "2022-11-01T16:07:09.633000",


### PR DESCRIPTION
Reverts kernelci/kernelci-core#2466