### PR TITLE
CHROMEOS test-configs-chromeos: drop failing/absent tests

### DIFF
--- a/config/core/test-configs-chromeos.yaml
+++ b/config/core/test-configs-chromeos.yaml
@@ -442,15 +442,10 @@ test_plans:
         platform.CrosDisksRename
         platform.CrosDisksSSHFS
         platform.CrosID
-        platform.DLCService
-        platform.DLCServiceCrosDeploy
-        platform.DLCServicePreloading
         platform.DMVerity
         platform.DumpVPDLog
         platform.Firewall
-        platform.Histograms
         platform.LocalPerfettoTBMTracedProbes
-        platform.Memd
         platform.Mtpd
         platform.TPMResponsive
         platform.TPMStatus


### PR DESCRIPTION
We experience a lot of failures due to `platform.Histograms` no longer existing. Moreover, recent investigations confirmed that `platform.Memd` and `platform.DLCService*` simply cannot run on mainline kernels, as they rely on downstream ChromeOS features.