### PR TITLE
config/docker/fragment/api.jinja2: modify `WORKDIR`

### DIFF
--- a/config/docker/api.jinja2
+++ b/config/docker/api.jinja2
@@ -1,8 +1,0 @@
-{# SPDX-License-Identifier: LGPL-2.1-or-later
- #
- # Copyright (C) 2024 Collabora Limited
- # Author: Paweł Wieczorek <pawiecz@collabora.com>
--#}
-
-{%- set fragments = ['fragment/api.jinja2'] + fragments %}
-{%- include 'base/python.jinja2' %}

--- a/config/docker/fragment/api.jinja2
+++ b/config/docker/fragment/api.jinja2
@@ -1,16 +1,3 @@
-# Install kernelci Python package from kernelci-core
-ARG core_url=https://github.com/kernelci/kernelci-core.git
-ARG core_rev=main
-RUN apt-get update && apt-get install --no-install-recommends -y git
-RUN git clone --depth=1 $core_url /tmp/kernelci-core
-WORKDIR /tmp/kernelci-core
-RUN git fetch origin $core_rev
-RUN git checkout FETCH_HEAD
-RUN python3 -m pip install '.[dev]'
-RUN cp -R config /etc/kernelci/
-WORKDIR /root
-RUN rm -rf /tmp/kernelci-core
-
 # Install kernelci-api Python package from kernelci-api
 ARG api_url=https://github.com/kernelci/kernelci-api.git
 ARG api_rev=main
@@ -19,13 +6,5 @@ WORKDIR /tmp/kernelci-api
 RUN git fetch origin $api_rev
 RUN git checkout FETCH_HEAD
 RUN python3 -m pip install '.[dev]'
-WORKDIR /root
-RUN rm -rf /tmp/kernelci-api
-
-# Set up kernelci user
-RUN useradd kernelci -u 1000 -d /home/kernelci -s /bin/bash
-RUN mkdir -p /home/kernelci
-RUN chown kernelci: /home/kernelci
-USER kernelci
-ENV PATH=$PATH:/home/kernelci/.local/bin
 WORKDIR /home/kernelci
+RUN rm -rf /tmp/kernelci-api


### PR DESCRIPTION
Atm we are building and installing `kernelci` python package from `api.jinja2` template to avoid python package version conficts while building `api` with `kernelci` fragment.

Since the support for Python 3.11 has been enabled for API, that issue has been resolved. Now, we should be able to use `kernelci` fragment to build `api` docker image as per the normal practice for all `core` docker images. An attempt has already been done to create `api` docker image with `kernelci` fragment and that requires `pymongo` related package adjustment for underlying `bson`.
Details can be found here: https://github.com/kernelci/kernelci-core/pull/2485#issuecomment-2029743842

To avoid these adjustments, use `api` as fragment for `kernelci` image. Fix `WORKDIR` in the `api` fragment template as `api` will now be built with `kernelci` user and will not be able to access `/root` directory. Change it to use `/home/kernelci` directory instead.