### PR TITLE
Improve the reliability of Tast tests and detect corrupt devices

### DIFF
--- a/config/docker/data/tast_parser.py
+++ b/config/docker/data/tast_parser.py
@@ -167,7 +167,7 @@ if __name__ == '__main__':
         # Legacy system expects only a list of tests to run, let's not
         # disrupt that
         else:
-            main(argv[1:])
+            main(sys.argv[1:])
     else:
         print("No tests provided")
         sys.exit(1)

--- a/config/runtime/chromeos/base.jinja2
+++ b/config/runtime/chromeos/base.jinja2
@@ -47,6 +47,7 @@
     extra_kernel_args: cros_secure cros_debug root=PARTUUID=566f7961-6765-7220-746f-20756e697665 rootwait ro
     prompts:
       - 'localhost(.*)~(.*)#'
+    failure_message: 'chromeos-boot-alert: self_repair'
     auto_login:
       login_prompt: "login:"
       username: "root"

--- a/config/runtime/tests/tast.jinja2
+++ b/config/runtime/tests/tast.jinja2
@@ -44,7 +44,7 @@
 {%- endfor %}
 {%- endif %}
             - >-
-              ./tast_parser.py
+              ./tast_parser.py --run
 {%- for test in tests %}
               {{ test }}
 {%- endfor %}
@@ -54,4 +54,13 @@
               -o UserKnownHostsFile=/dev/null
               -i /home/cros/.ssh/id_rsa
               root@$(lava-target-ip)
-              sync && poweroff && exit 0
+              sync
+            # Wait for DUT to shut down, or keep going if unreachable (e.g. crashed)
+            - >-
+              ./ssh_retry.sh
+              -o StrictHostKeyChecking=no
+              -o UserKnownHostsFile=/dev/null
+              -i /home/cros/.ssh/id_rsa
+              root@$(lava-target-ip)
+              poweroff && sleep 30 || true
+            - ./tast_parser.py --results

--- a/config/runtime/tests/tast.jinja2
+++ b/config/runtime/tests/tast.jinja2
@@ -30,13 +30,16 @@
               && cp cros /usr/libexec/tast/bundles/remote/
             - while ! ping -c 1 -w 1 $(lava-target-ip); do sleep 1; done
             - >-
-              lava-test-case os-release --shell
               ./ssh_retry.sh
               -o StrictHostKeyChecking=no
               -o UserKnownHostsFile=/dev/null
               -i /home/cros/.ssh/id_rsa
               root@$(lava-target-ip)
-              cat /etc/os-release
+              cat /etc/os-release > /tmp/osrel.tmp
+            - cat /tmp/osrel.tmp
+            - >-
+              lava-test-case os-release --result pass
+              --measurement $(sed -e '/VERSION_ID/!d' -e 's/.*=//' /tmp/osrel.tmp)
 {%- if excluded_tests %}
             - echo "# Disabled tests for KernelCI" > /tmp/excluded-tast-tests
 {%- for test in excluded_tests %}


### PR DESCRIPTION
This is the counterpart to #2497 for the new system.

Similarly, it implements the following to ensure Tast tests are (a bit) more reliable:
* implement proper shutdown at the end of Tast tests
* identify `self_repair` boot message as a failure, so we can more quickly spot (and fix) corrupt devices

Depends on #2496 