### PR TITLE
config: runtime: boot: use the same buildroot image for all

### DIFF
--- a/config/runtime/boot/grub.jinja2
+++ b/config/runtime/boot/grub.jinja2
@@ -4,7 +4,7 @@
       image_arg: -kernel {kernel} -serial stdio --append "console=ttyS0"
       type: {{ node.data.kernel_type }}
     ramdisk:
-      url: 'http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230421.0/{{ platform_config.arch }}/rootfs.cpio.gz'
+      url: 'http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230623.0/{{ platform_config.arch }}/rootfs.cpio.gz'
       image_arg: -initrd {ramdisk}
       compression: gz
 {%- if device_dtb %}

--- a/config/runtime/boot/qemu.jinja2
+++ b/config/runtime/boot/qemu.jinja2
@@ -6,7 +6,7 @@
         url: '{{ node.artifacts.kernel }}'
       ramdisk:
         image_arg: -initrd {ramdisk}
-        url: 'http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230421.0/{{ platform_config.arch }}/rootfs.cpio.gz'
+        url: 'http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230623.0/{{ platform_config.arch }}/rootfs.cpio.gz'
 {%- if device_dtb %}
       dtb:
         url: '{{ node.artifacts.dtb }}'


### PR DESCRIPTION
This is the image used  for the `depthcharge` boot method, and also the only one containing a `x86_64` subfolder (or rather, symlink). Changing this avoid job failures on the new system due to how we handle the `arch` parameter there.