### PR TITLE
Add system-specific "arch" fields to account for differences

### DIFF
--- a/config/runtime/boot/depthcharge.jinja2
+++ b/config/runtime/boot/depthcharge.jinja2
@@ -34,7 +34,7 @@
 {%- else %}
     ramdisk:
       compression: gz
-      url: 'http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230623.0/{{ platform_config.arch }}/rootfs.cpio.gz'
+      url: 'http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230623.0/{{ platform_config.karch }}/rootfs.cpio.gz'
 {%- endif %}
     os: oe
     timeout:

--- a/config/runtime/boot/grub.jinja2
+++ b/config/runtime/boot/grub.jinja2
@@ -4,7 +4,7 @@
       image_arg: -kernel {kernel} -serial stdio --append "console=ttyS0"
       type: {{ node.data.kernel_type }}
     ramdisk:
-      url: 'http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230421.0/{{ platform_config.arch }}/rootfs.cpio.gz'
+      url: 'http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230421.0/{{ platform_config.karch }}/rootfs.cpio.gz'
       image_arg: -initrd {ramdisk}
       compression: gz
 {%- if device_dtb %}

--- a/config/runtime/boot/qemu.jinja2
+++ b/config/runtime/boot/qemu.jinja2
@@ -6,7 +6,7 @@
         url: '{{ node.artifacts.kernel }}'
       ramdisk:
         image_arg: -initrd {ramdisk}
-        url: 'http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230421.0/{{ platform_config.arch }}/rootfs.cpio.gz'
+        url: 'http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230421.0/{{ platform_config.karch }}/rootfs.cpio.gz'
 {%- if device_dtb %}
       dtb:
         url: '{{ node.artifacts.dtb }}'

--- a/config/runtime/boot/u-boot.jinja2
+++ b/config/runtime/boot/u-boot.jinja2
@@ -11,15 +11,15 @@
 {%- endif %}
 {%- if boot_commands == 'nfs' %}
     nfsrootfs:
-      url: 'http://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20240221.0/{{ platform_config.arch }}/full.rootfs.tar.xz'
+      url: 'http://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20240221.0/{{ platform_config.debarch }}/full.rootfs.tar.xz'
       compression: xz
     ramdisk:
-      url: 'http://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20240221.0/{{ platform_config.arch }}/initrd.cpio.gz'
+      url: 'http://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20240221.0/{{ platform_config.debarch }}/initrd.cpio.gz'
       compression: gz
     os: debian
 {%- else %}
     ramdisk:
-      url: 'http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230703.0/{{ platform_config.arch }}/rootfs.cpio.gz'
+      url: 'http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230703.0/{{ platform_config.debarch }}/rootfs.cpio.gz'
       compression: gz
     os: oe
 {%- endif %}

--- a/kernelci/config/base.py
+++ b/kernelci/config/base.py
@@ -13,6 +13,22 @@ import re
 import yaml
 
 
+CROS_ARCH = {
+    'arm': 'armel',
+}
+
+DEB_ARCH = {
+    'arm': 'armhf',
+    'riscv': 'riscv64',
+    'x86_64': 'amd64',
+}
+
+KERNEL_ARCH = {
+    'armel': 'arm',
+    'x86_64': 'x86',
+}
+
+
 def _format_dict_strings(param, fmap):
     """Format strings from a dict based on a format map
 
@@ -106,13 +122,18 @@ class YAMLConfigObject(yaml.YAMLObject):
     def format_params(self, param, fmap=None):
         """Format strings from a dict based on object attributes
 
-        Modify all the strings under a dict object, processing each on as an
+        Modify all the strings under a dict object, processing each one as an
         f-string using the object attributes combined with the optional 'fmap'
         parameter as format arguments.
         """
         args = self._get_format_map()
         if fmap:
             args.update(fmap)
+        arch = args.get('arch')
+        if arch:
+            args.update({'crosarch': CROS_ARCH.get(arch) or arch})
+            args.update({'debarch': DEB_ARCH.get(arch) or arch})
+            args.update({'karch': KERNEL_ARCH.get(arch) or arch})
         return _format_dict_strings(param, args)
 
 


### PR DESCRIPTION
This PR adds new, "virtual" (i.e. not used directly in config files), attributes for platform configuration in order to make it easier to account for differences in architecture strings used by the different systems (e.g. `x86` for Buildroot, `amd64` for Debian, `x86_64` for ChromeOS). More specifically, the following attributes are now available:
* `crosarch` for the ChromeOS-compatible architecture string
* `debarch` for the Debian version
* `karch` for the one used by the Linux kernel and Buildroot

The `boot` templates are modified to use those new properties instead of plain `arch`.

Closes #2500 