### PR TITLE
docker/pipeline: Add gcloud tools

### DIFF
--- a/config/docker/fragment/pipeline.jinja2
+++ b/config/docker/fragment/pipeline.jinja2
@@ -1,3 +1,6 @@
+USER root
+{% include 'fragment/gcloud.jinja2' %}
+USER kernelci
 ARG pipeline_url=https://github.com/kernelci/kernelci-pipeline.git
 ARG pipeline_rev=main
 RUN git clone --depth=1 $pipeline_url pipeline


### PR DESCRIPTION
Right now kubectl emit error in scheduler-k8s:
```
04/19/2024 12:27:47 AM UTC [ERROR] [Errno 2] No such file or directory: 'gke-gcloud-auth-plugin'
```
As gke auth plugin is missing.