### PR TITLE
build-configs.yaml: Disable media tree

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -1266,25 +1266,25 @@ build_configs:
           x86_64:
             base_defconfig: 'x86_64_defconfig'
 
-  media:
-    tree: media
-    branch: 'master'
-    variants:
-      gcc-10:
-        build_environment: gcc-10
-        fragments: [virtualvideo]
-        architectures:
-          i386: *i386_arch
-          x86_64: *x86_64_arch
-          arm: *arm_arch
-          arm64:
-            <<: *arm64_arch
-            extra_configs:
-              - 'allnoconfig'
-              - 'defconfig+CONFIG_CPU_BIG_ENDIAN=y'
-              - 'defconfig+arm64-chromebook+kselftest'
-              - 'defconfig+arm64-chromebook+videodec'
-            fragments: [arm64-chromebook, videodec]
+#  media:
+#    tree: media
+#    branch: 'master'
+#    variants:
+#      gcc-10:
+#        build_environment: gcc-10
+#        fragments: [virtualvideo]
+#        architectures:
+#          i386: *i386_arch
+#          x86_64: *x86_64_arch
+#          arm: *arm_arch
+#          arm64:
+#            <<: *arm64_arch
+#            extra_configs:
+#              - 'allnoconfig'
+#              - 'defconfig+CONFIG_CPU_BIG_ENDIAN=y'
+#              - 'defconfig+arm64-chromebook+kselftest'
+#              - 'defconfig+arm64-chromebook+videodec'
+#            fragments: [arm64-chromebook, videodec]
 
   mediatek-for-next:
     tree: mediatek


### PR DESCRIPTION
media tree is broken for several month and seems nobody is going to repair it, so disabling for now as it is breaking jenkins jobs:
```
+ kci_build update_repo --build-config=media --kdir=/data/workspace/bot.kernelci.org/build-trigger/workspace/kernel-build-trigger__2/configs/media --mirror=/data/workspace/bot.kernelci.org/build-trigger/workspace/kernel-build-trigger__2/linux.git
Cloning into '/data/workspace/bot.kernelci.org/build-trigger/workspace/kernel-build-trigger__2/configs/media'...

warning: remote HEAD refers to nonexistent ref, unable to checkout
fatal: couldn't find remote ref HEAD
```