### PR TITLE
kernelci: update system-specific arch params in runtime.get_params()

### DIFF
--- a/config/runtime/boot/depthcharge.jinja2
+++ b/config/runtime/boot/depthcharge.jinja2
@@ -34,7 +34,7 @@
 {%- else %}
     ramdisk:
       compression: gz
-      url: 'http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230623.0/{{ platform_config.karch }}/rootfs.cpio.gz'
+      url: 'http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230623.0/{{ brarch }}/rootfs.cpio.gz'
 {%- endif %}
     os: oe
     timeout:

--- a/config/runtime/boot/grub.jinja2
+++ b/config/runtime/boot/grub.jinja2
@@ -4,7 +4,7 @@
       image_arg: -kernel {kernel} -serial stdio --append "console=ttyS0"
       type: {{ node.data.kernel_type }}
     ramdisk:
-      url: 'http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230421.0/{{ platform_config.karch }}/rootfs.cpio.gz'
+      url: 'http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230421.0/{{ brarch }}/rootfs.cpio.gz'
       image_arg: -initrd {ramdisk}
       compression: gz
 {%- if device_dtb %}

--- a/config/runtime/boot/qemu.jinja2
+++ b/config/runtime/boot/qemu.jinja2
@@ -6,7 +6,7 @@
         url: '{{ node.artifacts.kernel }}'
       ramdisk:
         image_arg: -initrd {ramdisk}
-        url: 'http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230421.0/{{ platform_config.karch }}/rootfs.cpio.gz'
+        url: 'http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230421.0/{{ brarch }}/rootfs.cpio.gz'
 {%- if device_dtb %}
       dtb:
         url: '{{ node.artifacts.dtb }}'

--- a/config/runtime/boot/u-boot.jinja2
+++ b/config/runtime/boot/u-boot.jinja2
@@ -11,15 +11,15 @@
 {%- endif %}
 {%- if boot_commands == 'nfs' %}
     nfsrootfs:
-      url: 'http://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20240221.0/{{ platform_config.debarch }}/full.rootfs.tar.xz'
+      url: 'http://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20240221.0/{{ debarch }}/full.rootfs.tar.xz'
       compression: xz
     ramdisk:
-      url: 'http://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20240221.0/{{ platform_config.debarch }}/initrd.cpio.gz'
+      url: 'http://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20240221.0/{{ debarch }}/initrd.cpio.gz'
       compression: gz
     os: debian
 {%- else %}
     ramdisk:
-      url: 'http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230703.0/{{ platform_config.debarch }}/rootfs.cpio.gz'
+      url: 'http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230703.0/{{ brarch }}/rootfs.cpio.gz'
       compression: gz
     os: oe
 {%- endif %}

--- a/kernelci/runtime/__init__.py
+++ b/kernelci/runtime/__init__.py
@@ -14,6 +14,8 @@ import yaml
 
 from jinja2 import Environment, FileSystemLoader
 
+from kernelci.config.base import get_system_arch
+
 
 class Job:
     """Pipeline job"""
@@ -159,6 +161,9 @@ class Runtime(abc.ABC):
         if device_dtb:
             params['device_dtb'] = device_dtb
         params.update(job.config.params)
+        arch = params.get('arch') or job.platform_config.arch
+        for system in ('brarch', 'crosarch', 'debarch', 'karch'):
+            params.update({system: get_system_arch(system, arch)})
         return params
 
     @classmethod


### PR DESCRIPTION
We currently allow using the `crosarch`, `debarch` & `karch` virtual
params in configuration files, but those should also be accessible from
job templates. This used to be possible with the initial implementation
as those were part of the `Platform` config object, but this was changed
as it caused negative side effects.

As the current implementation is more robust, stick to it but make it
available to other modules so we can make those params usable from
`Runtime` objects.