### PR TITLE
CHROMEOS config: lava: cros-tast: fail early for unreachable devices

### DIFF
--- a/config/lava/chromeos/cros-tast.jinja2
+++ b/config/lava/chromeos/cros-tast.jinja2
@@ -26,7 +26,8 @@
               && cp remote_test_runner /usr/bin/remote_test_runner
               && mkdir -p /usr/libexec/tast/bundles/remote/
               && cp cros /usr/libexec/tast/bundles/remote/
-            - while ! ping -c 1 -w 1 $(lava-target-ip); do sleep 1; done
+            - for i in $(seq 1 60); do ping -c 1 -w 1 $(lava-target-ip) && break || sleep 1; done
+            - ping -c 1 -w 1 $(lava-target-ip) || lava-test-raise "cros-device-unreachable"
             - >-
               lava-test-case os-release --shell
               ./ssh_retry.sh


### PR DESCRIPTION
Currently, we try to ping the DUT indefinitely, leading to the job to timeout after 30 mins. This is way too long and impacts other users, so we should limit the number of retries and raise an error if the device is unreachable.

This change ensures the job fails after 2 mins (60 iterations, 1s for `ping` + 1s for `sleep` per iteration).

Cherry-pick of #2515 for the legacy system.