### PR TITLE
kernelci.api.helper: fix `submit_results`

### DIFF
--- a/kernelci/api/helper.py
+++ b/kernelci/api/helper.py
@@ -394,6 +394,7 @@ class APIHelper:
         root_node = root.copy()
         root_node['result'] = results['node']['result']
         root_node['artifacts'].update(results['node']['artifacts'])
+        root_node['data'].update(results['node'].get('data', {}))
         root_results = {
             'node': root_node,
             'child_nodes': results['child_nodes'],


### PR DESCRIPTION
Enable sending `data` dictionary fields from root node while submitting hierarchy of results.