### PR TITLE
build-configs.yaml: Prevent deferred probe timeout errors

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -350,6 +350,7 @@ fragments:
       - 'CONFIG_SND_SOC_MT8195_MT6359=m'
       - 'CONFIG_DRM_MEDIATEK_DP=m'
       - 'CONFIG_SND_SOC_SOF_MT8195=m'
+      - 'CONFIG_USB_RTL8152=y' # Allows kernel ip-config. Prevents deferred probe timeout errors.
       - 'CONFIG_EXTRA_FIRMWARE="
       mediatek/mt8173/vpu_d.bin
       mediatek/mt8173/vpu_p.bin


### PR DESCRIPTION
Jobs submitted from LAVA always pass an ip= parameter to the kernel (eg on depthcharge see [1]).

Chromebooks wired to the network using a servo board rely on the RTL8152 driver in order to have a working network interface.

Since the RTL8152 driver is currently enabled as a module in the arm64 defconfig, it is only available once the ramdisk loads the modules. However, due to the ip= parameter, the kernel tries to do IP auto configuration before the ramdisk has loaded, but since there are no network interfaces available, it waits for 12 seconds, in order to wait for some potential slow interfaces to get up [2], before carrying on with the boot process. Meanwhile, when 10 seconds elapse between the registering of two consecutive drivers, the deferred probe timer times out, which can result on some drivers probing with unmet dependencies and cause all sort of malfunctions of devices.

The end result is that not only are all arm64 chromebooks wasting 12 seconds on every boot, but the MediaTek-based Chromebooks are also booting to a broken state with "deferred probe pending" error messages being printed and causing tests to fail sometimes, introducing noise in the test results.

With the ChromeOS config, this issue doesn't happen since CONFIG_IP_PNP is disabled so the ip= parameter is ignored.

Enable the USB_RTL8152 driver as builtin to prevent the aforementioned issues.

[1] https://github.com/Linaro/lava/blob/e6db819ca9ff477885caac3b1603a2037a2a2331/etc/dispatcher-config/device-types/base-depthcharge.jinja2#L42
[2] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=964ad81cbd933e5fa310faeec1e923c14651284b