### PR TITLE
kernelci: runtime: lava: add method for retrieving device ID

### DIFF
--- a/kernelci/api/models.py
+++ b/kernelci/api/models.py
@@ -447,6 +447,9 @@ class TestData(BaseModel):
     platform: Optional[str] = Field(
         description="Test platform"
     )
+    device: Optional[str] = Field(
+        description="Test device"
+    )
     runtime: Optional[str] = Field(
         description="Runtime that runs the test"
     )
@@ -541,6 +544,9 @@ class RegressionData(BaseModel):
     )
     platform: Optional[str] = Field(
         description="Test platform"
+    )
+    device: Optional[str] = Field(
+        description="Test device"
     )
 
 

--- a/kernelci/runtime/lava.py
+++ b/kernelci/runtime/lava.py
@@ -77,6 +77,10 @@ class Callback:
         self._data = data
         self._meta = None
 
+    def get_data(self):
+        """Get the raw callback data"""
+        return self._data
+
     def get_device_id(self):
         """Get the ID of the tested device"""
         return self._data.get('actual_device_id')

--- a/kernelci/runtime/lava.py
+++ b/kernelci/runtime/lava.py
@@ -77,6 +77,10 @@ class Callback:
         self._data = data
         self._meta = None
 
+    def get_device_id(self):
+        """Get the ID of the tested device"""
+        return self._data.get('actual_device_id')
+
     def get_meta(self, key):
         """Get a metadata value from the job definition"""
         if self._meta is None:


### PR DESCRIPTION
It can be useful to know the exact device on which a job ran, without having to open the LAVA job page. Ensure this is possible by adding a new `get_device_id()` method to the `Callback` class.