### PR TITLE
kernelci.runtime.lava: fix setting failed job metadata

### DIFF
--- a/kernelci/runtime/lava.py
+++ b/kernelci/runtime/lava.py
@@ -102,8 +102,8 @@ class Callback:
         lava_yaml = self._data['results']['lava']
         lava = yaml.safe_load(lava_yaml)
         stages = {stage['name']: stage for stage in lava}
-        job_meta = stages['job']['metadata']
-        return job_meta.get('error_type'), job_meta.get('error_msg')
+        job_meta = stages.get('job', {}).get('metadata')
+        return job_meta
 
     @classmethod
     def _get_login_case(cls, tests):
@@ -168,9 +168,12 @@ class Callback:
         """Convert the plain results dictionary to a hierarchy for the API"""
         job_result = job_node['result']
         if job_result == "fail":
-            error_code, error_msg = self._get_job_failure_metadata()
-            job_node['data']['error_code'] = error_code
-            job_node['data']['error_msg'] = error_msg
+            job_meta = self._get_job_failure_metadata()
+            if job_meta:
+                job_node['data']['error_code'] = job_meta.get('error_type')
+                job_node['data']['error_msg'] = job_meta.get('error_msg')
+            else:
+                print(f"Job failure metadata not found for node: {job_node['id']}")
 
         return {
             'node': {


### PR DESCRIPTION
Fixes https://github.com/kernelci/kernelci-core/issues/2522

It seems like not all the failed lava jobs has
failure metadata available.
Fix the below error observed on staging for some
failed jobs:
```
29/04/2024 11:38:45 Traceback (most recent call last):
29/04/2024 11:38:45   File "/usr/local/lib/python3.11/threading.py", line 1045, in _bootstrap_inner
29/04/2024 11:38:45     self.run()
29/04/2024 11:38:45   File "/usr/local/lib/python3.11/threading.py", line 982, in run
29/04/2024 11:38:45     self._target(*self._args, **self._kwargs)
29/04/2024 11:38:45   File "/home/kernelci/pipeline/lava_callback.py", line 93, in async_job_submit
29/04/2024 11:38:45     hierarchy = job_callback.get_hierarchy(results, job_node)
29/04/2024 11:38:45                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
29/04/2024 11:38:45   File "/usr/local/lib/python3.11/site-packages/kernelci/runtime/lava.py", line 178, in get_hierarchy
29/04/2024 11:38:45     error_code, error_msg = self._get_job_failure_metadata()
29/04/2024 11:38:45                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
29/04/2024 11:38:45   File "/usr/local/lib/python3.11/site-packages/kernelci/runtime/lava.py", line 105, in _get_job_failure_metadata
29/04/2024 11:38:45     job_meta = stages['job']['metadata']
29/04/2024 11:38:45                ~~~~~~^^^^^^^
29/04/2024 11:38:45 KeyError: 'job'
```

Fixes: 3a2e6473 ("kernelci.runtime.lava: set failed job metadata")