### PR TITLE
kernelci.config.job: add attribute 'kcidb_test_suite'

### DIFF
--- a/kernelci/config/job.py
+++ b/kernelci/config/job.py
@@ -14,11 +14,13 @@ class Job(YAMLConfigObject):
     yaml_tag = '!Job'
 
     # pylint: disable=too-many-arguments
-    def __init__(self, name, template, kind="node", image=None, params=None, rules=None):
+    def __init__(self, name, template, kind="node", image=None, params=None, rules=None,
+                 kcidb_test_suite=None):
         self._name = name
         self._template = template
         self._kind = kind
         self._image = image
+        self._kcidb_test_suite = kcidb_test_suite
         self._params = self.format_params(params.copy(), params) if params else {}
         self._rules = rules
 
@@ -52,10 +54,15 @@ class Job(YAMLConfigObject):
         """Kernel requirements (tree, branch, version...)"""
         return self._rules
 
+    @property
+    def kcidb_test_suite(self):
+        """Mapping of KernelCI test to KCIDB test suite"""
+        return self._kcidb_test_suite
+
     @classmethod
     def _get_yaml_attributes(cls):
         attrs = super()._get_yaml_attributes()
-        attrs.update({'template', 'kind', 'image', 'params', 'rules'})
+        attrs.update({'template', 'kind', 'image', 'params', 'rules', 'kcidb_test_suite'})
         return attrs
 
 

--- a/tests/configs/jobs.yaml
+++ b/tests/configs/jobs.yaml
@@ -7,6 +7,7 @@ jobs:
     params:
       config: x86_64_defconfig
     rules:
+    kcidb_test_suite:
 
   kunit: &kunit-job
     template: 'kunit.jinja2'
@@ -14,6 +15,7 @@ jobs:
     image: 'gcc-10:x86-kunit-kernelci'
     params: {}
     rules:
+    kcidb_test_suite: kunit
 
   kunit-x86_64:
     <<: *kunit-job
@@ -21,6 +23,7 @@ jobs:
     params:
       arch: x86_64
     rules:
+    kcidb_test_suite: kunit
 
   kver:
     template: 'kver.jinja2'
@@ -28,3 +31,4 @@ jobs:
     image: 'kernelci'
     params: {}
     rules:
+    kcidb_test_suite: kernelci_kver


### PR DESCRIPTION
Every KernelCI test job will have mapping to KCIDB test suite name to unify the test names with other CI systems.
Add `kcidb_test_suite` attribute to job configurations that will store the mapped KCIDB test suite name.