### PR TITLE
build-configs.yaml: Add fragment with Collabora lab specific configs

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -351,6 +351,7 @@ fragments:
       - 'CONFIG_DRM_MEDIATEK_DP=m'
       - 'CONFIG_SND_SOC_SOF_MT8195=m'
       - 'CONFIG_USB_RTL8152=y' # Allows kernel ip-config. Prevents deferred probe timeout errors.
+      - 'CONFIG_USB_USBNET=y' # Needed for ASIX AX88772B ethernet adapter used at Collabora's lab. Builtin to allow kernel ip-config, and prevent deferred probe timeout errors.
       - 'CONFIG_EXTRA_FIRMWARE="
       mediatek/mt8173/vpu_d.bin
       mediatek/mt8173/vpu_p.bin
@@ -610,6 +611,7 @@ fragments:
       - 'CONFIG_USB_ETH=y'
       - 'CONFIG_USB_GADGET=y'
       - 'CONFIG_USB_RTL8152=y'
+      - 'CONFIG_USB_USBNET=y' # Needed for ASIX AX88772B ethernet adapter used at Collabora's lab. Builtin to allow kernel ip-config, and prevent deferred probe timeout errors.
       - 'CONFIG_USB_VIDEO_CLASS=m'
       - 'CONFIG_WILCO_EC_DEBUGFS=m'
       - 'CONFIG_WILCO_EC_EVENTS=m'


### PR DESCRIPTION
Some devices in Collabora's lab are connected to the wired network using an ASIX AX88772B ethernet adapter. The kernel config for it needs to be enabled in order for tests that require working network to succeed. Furthermore it needs to be builtin for the same reason as commit ed888aa7f200 ("build-configs.yaml: Prevent deferred probe timeout errors").

Since this is specific to the hardware used at the Collabora lab, add a new config fragment for it.

@laura-nao Talking to you I got the impression the ASIX adapter is something standalone and specific to Collabora's setup. Can you confirm that? The alternative would be that the ASIX adapter is present in a newer revision of the servo board, in which case I'd consider it a generic setup, and include this config in the `arm64-chromebook` fragment instead.

Example runs:
* mt8186-corsola-steelix-sku131072 running baseline-nfs with the ChromeOS config, which doesn't include this config. It times out while waiting for a network interface to come up: https://lava.collabora.dev/scheduler/job/13560437
* With this config enabled it works: https://lava.collabora.dev/scheduler/job/13589287