### PR TITLE
config/rootfs: dmesg.sh: Change exit code for dmesg test script

### DIFF
--- a/config/rootfs/debos/overlays/baseline/opt/kernelci/dmesg.sh
+++ b/config/rootfs/debos/overlays/baseline/opt/kernelci/dmesg.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+ret=0
+
 if [ "$KERNELCI_LAVA" = "y" ]; then
     alias test-result='lava-test-case'
 else
@@ -10,7 +12,12 @@ fi
 
 for level in crit alert emerg; do
     dmesg --level=$level --notime -x -k > dmesg.$level
-    test -s dmesg.$level && res=fail || res=pass
+    if [ -s "dmesg.$level" ]; then
+        res=fail
+        ret=1
+    else
+        res=pass
+    fi
     count=$(cat dmesg.$level | wc -l)
     cat dmesg.$level
     test-result \
@@ -20,4 +27,4 @@ for level in crit alert emerg; do
         --units lines
 done
 
-exit 0
+exit $ret


### PR DESCRIPTION
Update the exit code for the dmesg test script to return 1 in the event of one or more test cases failing. This ensures that when the test is executed in LAVA, the overall pass/fail status of the dmesg test suite reflects the outcome of the individual test cases (i.e. status should be fail if any test cases fail).