### PR TITLE
build-configs.yaml: Add lab-setup fragment

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -449,6 +449,25 @@ fragments:
       - 'CONFIG_NET_IPGRE=m'
       - 'CONFIG_NET_IPGRE_DEMUX=m'
 
+  lab-setup:
+    path: "kernel/configs/lab-setup.config"
+    configs:
+      - 'CONFIG_NFS_FS=y'
+      - 'CONFIG_NFS_V2=y'
+      - 'CONFIG_NFS_V3=y'
+      - 'CONFIG_NFS_V3_ACL=y'
+      - 'CONFIG_NFS_V4=y'
+      # Disable kernel IP config to avoid needing builtin network support,
+      # prevent long boot delays and deferred probe timeout errors. Rely on
+      # ramdisk to do the IP config.
+      - 'CONFIG_IP_PNP=n'
+      # Network adapters
+      - 'CONFIG_USB_ETH=m'
+      - 'CONFIG_USB_GADGET=m'
+      - 'CONFIG_USB_RTL8152=m'
+      - 'CONFIG_USB_USBNET=m'
+      - 'CONFIG_USB_NET_AX8817X=m'
+
   preempt_rt:
     path: "kernel/configs/preempt_rt.config"
     configs:


### PR DESCRIPTION
I'm still seeing long boot delays on mt8186-steelix: https://lava.collabora.dev/scheduler/job/13696724 . Upon closer inspection I see `CONFIG_USB_USBNET` is `=y`, but `CONFIG_USB_NET_AX8817X` is `=m`, even though it's supposed to be builtin by default. So I'm enabling it explicitly here, which should hopefully fix the issue. Since I was adding one more config for the ethernet adapters it seemed a good moment to do the move to a separate lab-setup fragment. Fixes #2540.

---

Add a new fragment to contain configurations required for the lab setup which, at least for now, consists of builtin network and NFS support.

These configs come from the arm64-chromebook and x86-board fragments, but aren't removed from those fragments for now in order to not impact legacy KernelCI.

An extra config, CONFIG_USB_NET_AX8817X, is also added which is needed for an ethernet adapter.

