### PR TITLE
kernelci.api.helper: get `is_hierarchy` from event data

### DIFF
--- a/kernelci/api/helper.py
+++ b/kernelci/api/helper.py
@@ -121,7 +121,7 @@ class APIHelper:
                 continue
             if all(self.pubsub_event_filter(sub_id, obj)
                    for obj in [node, event]):
-                return node
+                return node, event.get('is_hierarchy')
 
     def _find_container(self, field, node):
         """

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -207,7 +207,7 @@ def test_receive_event_node(get_api_config, mock_receive_event,
                 "op": "created"
             },
         )
-        resp = helper.receive_event_node(sub_id=sub_id)
+        resp, _ = helper.receive_event_node(sub_id=sub_id)
         assert resp.keys() == {
             'id',
             'artifacts',


### PR DESCRIPTION
Depends on https://github.com/kernelci/kernelci-api/pull/529

PubSub event data has a field called `is_hierarchy` to distinguish events of submission of hierarchy of results from a single node submission.
Return this field value from `APIHelper.receive_event_node` method along with node.