### PR TITLE
kbuild: Add option to not install modules

### DIFF
--- a/kernelci/kbuild.py
+++ b/kernelci/kbuild.py
@@ -139,6 +139,7 @@ class KBuild():
                 self._dtbs_check = params['dtbs_check']
             else:
                 self._dtbs_check = False
+            self._disable_modules = params.get('disable_modules', False)
             self._apijobname = jobname
             self._steps = []
             self._artifacts = []
@@ -192,6 +193,7 @@ class KBuild():
             )
             self._full_artifacts = jsonobj['full_artifacts']
             self._dtbs_check = jsonobj['dtbs_check']
+            self._disable_modules = jsonobj['disable_modules']
             return
         raise ValueError("No valid arguments provided")
 
@@ -286,8 +288,9 @@ class KBuild():
         if not self._dtbs_check:
             self._artifacts.append("build_kimage.log")
             self._artifacts.append("build_kimage_stderr.log")
-            self._artifacts.append("build_modules.log")
-            self._artifacts.append("build_modules_stderr.log")
+            if not self._disable_modules:
+                self._artifacts.append("build_modules.log")
+                self._artifacts.append("build_modules_stderr.log")
             self._artifacts.append("build_kselftest.log")
             self._artifacts.append("build_kselftest_stderr.log")
             self._artifacts.append("build_dtbs.log")
@@ -505,12 +508,14 @@ class KBuild():
             # We can check that if fragments have CONFIG_EXTRA_FIRMWARE
             self._fetch_firmware()
             self._build_kernel()
-            self._build_modules()
+            if not self._disable_modules:
+                self._build_modules()
             self._build_kselftest()
             # TODO: verify if OF_FLATTREE is set
             self._build_dtbs()
             self._package_kimage()
-            self._package_modules()
+            if not self._disable_modules:
+                self._package_modules()
             self._package_kselftest()
             # TODO: verify if OF_FLATTREE is set
             self._package_dtbs()


### PR DESCRIPTION
Some configuration doesn't build modules,
we should not attempt to build them.