### PR TITLE
config/core: rename staging entry

### DIFF
--- a/config/core/api-configs.yaml
+++ b/config/core/api-configs.yaml
@@ -6,5 +6,5 @@ api:
   early-access:
     url: https://kernelci-api.westus3.cloudapp.azure.com
 
-  staging.kernelci.org:
+  staging:
     url: https://staging.kernelci.org:9000

--- a/config/core/db-configs.yaml
+++ b/config/core/db-configs.yaml
@@ -12,6 +12,6 @@ db_configs:
     db_type: kernelci_backend
     url: http://localhost:5001/
 
-  staging.kernelci.org:
+  staging:
     db_type: kernelci_backend
     url: https://api.staging.kernelci.org/

--- a/config/core/storage.yaml
+++ b/config/core/storage.yaml
@@ -12,7 +12,7 @@ storage:
     base_url: http://storage.kernelci.org/
     api_url: https://api.kernelci.org
 
-  staging.kernelci.org:
+  staging:
     storage_type: backend
     host: staging.kernelci.org
     base_url: http://storage.staging.kernelci.org/


### PR DESCRIPTION
Update YAML configurations for staging instance.
Rename staging instance entries from `staging.kernelci.org` to `staging` to simplify TOML section names.
The the same convetion has been used here for similar reasons: https://github.com/kernelci/kernelci-pipeline/commit/1991f2cfd18fe0fde12c3a13c8738f381f483aa5