### PR TITLE
config: runtime: tests: tast: drop useless "sync"

### DIFF
--- a/config/runtime/tests/tast.jinja2
+++ b/config/runtime/tests/tast.jinja2
@@ -52,13 +52,6 @@
 {%- for test in tests %}
               {{ test }}
 {%- endfor %}
-            - >-
-              ./ssh_retry.sh
-              -o StrictHostKeyChecking=no
-              -o UserKnownHostsFile=/dev/null
-              -i /home/cros/.ssh/id_rsa
-              root@$(lava-target-ip)
-              sync
             # Wait for DUT to shut down, or keep going if unreachable (e.g. crashed)
             - >-
               ./ssh_retry.sh


### PR DESCRIPTION
Calling `sync` after running Tast tests was a leftover from an old version, but it's been made useless as we now properly power off the device, with the kernel automatically performing this operation during shutdown.

This call failing caused wrong results to be reported, so let's drop it entirely.