### PR TITLE
CHROMEOS config: docker: data: tast_parser: report results then exit

### DIFF
--- a/config/docker/data/tast_parser.py
+++ b/config/docker/data/tast_parser.py
@@ -154,8 +154,6 @@ def parse_test_results():
             if "'/usr/local/bin/local_test_runner': No such file or directory" in stderr:
                 report_lava_critical("cros-partition-corrupt")
                 sys.exit(1)
-        report_lava_critical("Tast tests run failed")
-        sys.exit(1)
     json_file = os.path.join(RESULTS_DIR, RESULTS_FILE)
     with open(json_file, "r") as results_file:
         results = json.load(results_file)
@@ -167,6 +165,11 @@ def parse_test_results():
             measurements = parse_measurements(rc_data)
             test_data["measurements"] = measurements
         report_lava(test_data)
+    # If test run didn't finish, error out after reporting existing results
+    # so we don't lose data by exiting too early
+    if os.path.isfile(failed_file):
+        report_lava_critical("Tast tests run failed")
+        sys.exit(1)
 
 
 def main(tests):


### PR DESCRIPTION
In some cases (e.g. the DUT crashes while running one testcase), the Tast run might not finish but still yield important results, which we're losing if we error out before parsing them.

This change ensure we report existing results and only then error out in such cases.

Manually tested in LAVA: https://lava.collabora.dev/scheduler/job/13841947
As expected, the job fails ("Incomplete") but reports the results of tests which actually ran.