### PR TITLE
config: runtime: allow to retry boot actions

### DIFF
--- a/config/runtime/boot/depthcharge.jinja2
+++ b/config/runtime/boot/depthcharge.jinja2
@@ -46,6 +46,7 @@
     namespace: {{ boot_namespace }}
 {%- endif %}
     method: depthcharge
+    failure_retry: 3
     prompts:
     - '/ #'
     timeout:

--- a/config/runtime/boot/depthcharge.jinja2
+++ b/config/runtime/boot/depthcharge.jinja2
@@ -50,4 +50,9 @@
     prompts:
     - '/ #'
     timeout:
-      minutes: 5
+      minutes: 10
+    timeouts:
+      bootloader-commands:
+        minutes: 3
+      auto-login-action:
+        minutes: 2

--- a/config/runtime/boot/grub.jinja2
+++ b/config/runtime/boot/grub.jinja2
@@ -22,3 +22,10 @@
     failure_retry: 3
     prompts:
     - '/ #'
+    timeout:
+      minutes: 10
+    timeouts:
+      bootloader-commands:
+        minutes: 3
+      auto-login-action:
+        minutes: 2

--- a/config/runtime/boot/grub.jinja2
+++ b/config/runtime/boot/grub.jinja2
@@ -19,5 +19,6 @@
 - boot:
     method: grub
     commands: ramdisk
+    failure_retry: 3
     prompts:
     - '/ #'

--- a/config/runtime/boot/qemu.jinja2
+++ b/config/runtime/boot/qemu.jinja2
@@ -27,4 +27,9 @@
     prompts:
       - '/ #'
     timeout:
-      minutes: 5
+      minutes: 10
+    timeouts:
+      bootloader-commands:
+        minutes: 3
+      auto-login-action:
+        minutes: 2

--- a/config/runtime/boot/qemu.jinja2
+++ b/config/runtime/boot/qemu.jinja2
@@ -23,6 +23,7 @@
       image: kernelci/qemu
     media: tmpfs
     method: qemu
+    failure_retry: 3
     prompts:
       - '/ #'
     timeout:

--- a/config/runtime/boot/u-boot.jinja2
+++ b/config/runtime/boot/u-boot.jinja2
@@ -30,6 +30,7 @@
 - boot:
     method: u-boot
     commands: {{ boot_commands | default('ramdisk', true) }}
+    failure_retry: 3
     prompts:
     - '/ #'
     timeout:

--- a/config/runtime/boot/u-boot.jinja2
+++ b/config/runtime/boot/u-boot.jinja2
@@ -34,4 +34,9 @@
     prompts:
     - '/ #'
     timeout:
-      minutes: 5
+      minutes: 10
+    timeouts:
+      bootloader-commands:
+        minutes: 3
+      auto-login-action:
+        minutes: 2

--- a/config/runtime/chromeos/base.jinja2
+++ b/config/runtime/chromeos/base.jinja2
@@ -42,6 +42,7 @@
     namespace: chromeos
     timeout:
       minutes: 5
+    failure_retry: 3
     method: depthcharge
     commands: emmc
     extra_kernel_args: cros_secure cros_debug root=PARTUUID=566f7961-6765-7220-746f-20756e697665 rootwait ro

--- a/config/runtime/chromeos/base.jinja2
+++ b/config/runtime/chromeos/base.jinja2
@@ -41,7 +41,12 @@
 - boot:
     namespace: chromeos
     timeout:
-      minutes: 5
+      minutes: 10
+    timeouts:
+      bootloader-commands:
+        minutes: 3
+      auto-login-action:
+        minutes: 2
     failure_retry: 3
     method: depthcharge
     commands: emmc


### PR DESCRIPTION
There are numerous cases where LAVA either fails to recognize the login (and/or shell) prompt, leading to a job failure even if everything actually goes well.

Allowing `boot` actions to be retried is an effective way to work around those issues and reduce our waste our resources time.