### PR TITLE
CHROMEOS config: lava: chromeos: cros-boot: retry boot actions

### DIFF
--- a/config/lava/chromeos/cros-boot.jinja2
+++ b/config/lava/chromeos/cros-boot.jinja2
@@ -44,7 +44,12 @@ actions:
 - boot:
     namespace: modules
     timeout:
-      minutes: 5
+      minutes: 10
+    timeouts:
+      bootloader-commands:
+        minutes: 3
+      auto-login-action:
+        minutes: 2
     failure_retry: 3
     method: depthcharge
     commands: nfs
@@ -112,7 +117,12 @@ actions:
 - boot:
     namespace: chromeos
     timeout:
-      minutes: 5
+      minutes: 10
+    timeouts:
+      bootloader-commands:
+        minutes: 3
+      auto-login-action:
+        minutes: 2
     failure_retry: 3
     method: depthcharge
     commands: emmc

--- a/config/lava/chromeos/cros-boot.jinja2
+++ b/config/lava/chromeos/cros-boot.jinja2
@@ -45,6 +45,7 @@ actions:
     namespace: modules
     timeout:
       minutes: 5
+    failure_retry: 3
     method: depthcharge
     commands: nfs
     prompts:
@@ -112,6 +113,7 @@ actions:
     namespace: chromeos
     timeout:
       minutes: 5
+    failure_retry: 3
     method: depthcharge
     commands: emmc
     extra_kernel_args: cros_secure cros_debug root=PARTUUID=566f7961-6765-7220-746f-20756e697665 rootwait ro


### PR DESCRIPTION
There are numerous cases where LAVA either fails to recognize the login (and/or shell) prompt, leading to a job failure even if everything actually goes well.

Allowing `boot` actions to be retried is an effective way to work around those issues and reduce our waste of resources time.