### PR TITLE
Add watchdog reset test template and enable watchdog configs

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -223,6 +223,7 @@ fragments:
       - 'CONFIG_QCOM_RMTFS_MEM=y'
       - 'CONFIG_QCOM_SOCINFO=y'
       - 'CONFIG_QCOM_SYSMON=y'
+      - 'CONFIG_QCOM_WDT=m'
       - 'CONFIG_QRTR_SMD=y'
       - 'CONFIG_QRTR=y'
       - 'CONFIG_RMNET=y'
@@ -332,6 +333,7 @@ fragments:
       - 'CONFIG_SND_SOC_SOF_TOPLEVEL=y'
       - 'CONFIG_SPI_GPIO=y'
       - 'CONFIG_SPI_MTK_NOR=y'
+      - 'CONFIG_MEDIATEK_WATCHDOG=m'
       - 'CONFIG_MTK_THERMAL=y'
       - 'CONFIG_MTK_SOC_THERMAL=m'
       - 'CONFIG_MTK_LVTS_THERMAL=m'
@@ -354,6 +356,7 @@ fragments:
       - 'CONFIG_SND_SOC_SOF_MT8195=m'
       - 'CONFIG_USB_RTL8152=y' # Allows kernel ip-config. Prevents deferred probe timeout errors.
       - 'CONFIG_USB_USBNET=y' # Needed for ASIX AX88772B ethernet adapter used at Collabora's lab. Builtin to allow kernel ip-config, and prevent deferred probe timeout errors.
+      - 'CONFIG_WATCHDOG_SYSFS=y'
       - 'CONFIG_EXTRA_FIRMWARE="
       mediatek/mt8173/vpu_d.bin
       mediatek/mt8173/vpu_p.bin
@@ -668,6 +671,7 @@ fragments:
       - 'CONFIG_SND_SOC_SOF_PCI=m'
       - 'CONFIG_SND_SOC_SOF_TOPLEVEL=y'
       - 'CONFIG_SND_SOC=m'
+      - 'CONFIG_SP5100_TCO=m'
       - 'CONFIG_SPI_PXA2XX=y'
       - 'CONFIG_SPI=y'
       - 'CONFIG_TCG_TIS_I2C_CR50=y'
@@ -689,6 +693,7 @@ fragments:
       - 'CONFIG_USB_VIDEO_CLASS=m'
       - 'CONFIG_VIDEO_OV2740=m'
       - 'CONFIG_VIDEO_OV5675=m'
+      - 'CONFIG_WATCHDOG_SYSFS=y'
       - 'CONFIG_WILCO_EC_DEBUGFS=m'
       - 'CONFIG_WILCO_EC_EVENTS=m'
       - 'CONFIG_WILCO_EC_TELEMETRY=m'

--- a/config/runtime/tests/watchdog-reset.jinja2
+++ b/config/runtime/tests/watchdog-reset.jinja2
@@ -1,0 +1,24 @@
+{# This test verifies the watchdog reset functionality.
+ # It opens the watchdog device and waits for the timeout to expire, triggering a device reset.
+ # If the reset occurs as expected, a bootloader string should be matched.
+ # If the command returns successfully without a reset, the prompt string will be matched instead.
+ # This test assumes no other watchdog service is running on the system.
+-#}
+- test:
+    timeout:
+      minutes: 5
+    interactive:
+    - name: wdt-reset
+      prompts: ['/ #']
+      script:
+      - name: wdt-get-timeout
+        command: "wdt_timeout=$(cat /sys/class/watchdog/{{ wdt_dev|default('watchdog0') }}/timeout)"
+        wait_for_prompt: true
+        failures:
+        - message: "can't open '/sys/class/watchdog/watchdog\\d+/timeout': No such file or directory"
+          exception: JobError
+      - name: wdt-trigger-reset
+        command: "sleep $((wdt_timeout + 5)) > /dev/watchdog"
+        wait_for_prompt: false
+        successes:
+        - message: {{ bl_message }}


### PR DESCRIPTION
Add template for watchdog reset test. Enable the required watchdog configs to run the test on x86_64 and arm64 Chromebooks.