### PR TITLE
rootfs-configs.yaml: Increase image size for igt

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -157,6 +157,10 @@ rootfs_configs:
 #    linux_fw_version: d526e044bddaa2c2ad855c7296147e49be0ab03c
     script: "scripts/debian-igt.sh"
     test_overlay: "overlays/igt"
+    imagesize: 4GB
+    debos_memory: 8G
+    debos_scratchsize: 16G
+
 
   bookworm-kselftest:
     rootfs_type: debos

--- a/config/rootfs/debos/scripts/debian-igt.sh
+++ b/config/rootfs/debos/scripts/debian-igt.sh
@@ -29,6 +29,7 @@ BUILD_DEPS="\
     pkg-config \
     python3 \
     python3-requests \
+    python3-docutils \
     xutils-dev \
 "
 


### PR DESCRIPTION
During armhf build we noticed disk space issues.
https://github.com/kernelci/kernelci-core/actions/runs/9280775475/job/25535588226
```
2024-05-29T05:35:03.8358631Z 2024/05/29 05:35:01 a630_sqe.fw | cat: write error: No space left on device
```