### PR TITLE
build-configs.yaml: Enable Elan Touchpad driver found on x86 Intel Chromebooks

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -591,6 +591,7 @@ fragments:
       - 'CONFIG_MMC_SDHCI_PCI=y'
       - 'CONFIG_MMC_SDHCI=y'
       - 'CONFIG_MMC=y'
+      - 'CONFIG_MOUSE_ELAN_I2C=m'
       - 'CONFIG_MT7921E=m'
       - 'CONFIG_NFS_FS=y'
       - 'CONFIG_NFS_V2=y'


### PR DESCRIPTION
Enable the driver for the Elan Touchpad devices, found on some of the x86 Intel Chromebooks.

Should have been part of https://github.com/kernelci/kernelci-core/pull/2556 , but I forgot to add it.