### PR TITLE
config: add qcs6490-rb3gen2 device type

### DIFF
--- a/config/runtime/boot/fastboot.jinja2
+++ b/config/runtime/boot/fastboot.jinja2
@@ -1,0 +1,39 @@
+- deploy:
+    images:
+      image:
+        url: '{{ node.artifacts.kernel }}'
+      dtb:
+        url: '{{ node.artifacts.dtb }}'
+      ramdisk:
+        url: 'http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230703.0/{{ brarch }}/rootfs.cpio.gz'
+        compression: gz
+        format: cpio.newc
+        overlays:
+          lava: true
+    postprocess:
+      docker:
+        image: ghcr.io/mwasilew/docker-mkbootimage:master
+        steps:
+        - mkbootimg --header_version 2 --kernel Image --dtb qcs6490-rb3gen2.dtb --cmdline "earlycon clk_ignore_unused pd_ignore_unused audit=0" --ramdisk rootfs.cpio.gz --output boot.img
+    to: downloads
+
+- deploy:
+    images:
+      boot:
+        url: 'downloads://boot.img'
+    timeout:
+      minutes: 2
+    to: download
+
+- boot:
+    prompts:
+    - '/ #'
+    failure_retry: 3
+    timeout:
+      minutes: 10
+    timeouts:
+      bootloader-commands:
+        minutes: 3
+      auto-login-action:
+        minutes: 2
+    method: fastboot


### PR DESCRIPTION
qcs6490-rb3gen2 corresponds to gen 2 of Qualcomm robotics kit. This device type is pre-configured to use "fastboot boot" as boot method.