### PR TITLE
config/docker: add libubsan to kselftest fragment

### DIFF
--- a/config/docker/fragment/kselftest.jinja2
+++ b/config/docker/fragment/kselftest.jinja2
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
    libhugetlbfs-dev{{ pkgarch }} \
    libmnl-dev{{ pkgarch }} \
    libnuma-dev{{ pkgarch }} \
+   libubsan1{{ pkgarch }} \
    liburing-dev{{ pkgarch }} \
    libpopt-dev{{ pkgarch }} \
    patch \


### PR DESCRIPTION
The libubsan is missing and is required for some kselftest suites such as openat2. The error is as following:

[error while loading shared libraries: libubsan.so.1: cannot open shared object file: No such file or directory](https://storage.kernelci.org/next/master/next-20240529/arm/multi_v7_defconfig/gcc-10/lab-broonie/kselftest-openat2-beaglebone-black.html)