### PR TITLE
Introduce `Job` model and re-structure test hierarchy

### DIFF
--- a/config/runtime/tests/tast.jinja2
+++ b/config/runtime/tests/tast.jinja2
@@ -12,7 +12,7 @@
       location: /home/cros/lava
     definitions:
     - from: inline
-      name: tast
+      name: setup
       path: inline/cros-tast.yaml
       repository:
         metadata:
@@ -41,6 +41,16 @@
             - >-
               lava-test-case os-release --result pass
               --measurement $(sed -e '/VERSION_ID/!d' -e 's/.*=//' /tmp/osrel.tmp)
+    - from: inline
+      name: tast
+      path: inline/cros-tast.yaml
+      repository:
+        metadata:
+          format: Lava-Test Test Definition 1.0
+          name: cros-tast
+        run:
+          steps:
+            - cd /home/cros
 {%- if excluded_tests %}
             - echo "# Disabled tests for KernelCI" > /tmp/excluded-tast-tests
 {%- for test in excluded_tests %}

--- a/kernelci/api/helper.py
+++ b/kernelci/api/helper.py
@@ -299,8 +299,8 @@ class APIHelper:
             print(f"Not creating node due to job rules for {job_config.name}")
             return None
         # Test-specific fields inherited from parent node (kbuild or
-        # test) if available
-        if job_config.kind == 'test':
+        # job) if available
+        if job_config.kind == 'job':
             job_node['data']['kernel_type'] = input_node['data'].get('kernel_type')
             job_node['data']['arch'] = input_node['data'].get('arch')
             job_node['data']['defconfig'] = input_node['data'].get('defconfig')

--- a/kernelci/api/models.py
+++ b/kernelci/api/models.py
@@ -503,6 +503,23 @@ class Test(Node):
     ]
 
 
+class Job(Node):
+    """API model for job (test suite) nodes"""
+    class_kind: ClassVar[str] = 'job'
+    kind: str = Field(
+        default='job',
+        description='Type of the object',
+        const=True
+    )
+    data: TestData = Field(
+        description="Test suite details"
+    )
+
+    _OBJECT_ID_FIELDS = Node._OBJECT_ID_FIELDS + [
+        'data.regression',
+    ]
+
+
 class RegressionData(BaseModel):
     """Model for the data field of a Regression node"""
     fail_node: Optional[PyObjectId] = Field(

--- a/kernelci/runtime/__init__.py
+++ b/kernelci/runtime/__init__.py
@@ -237,3 +237,36 @@ def get_all_runtimes(runtime_configs, opts):
             for opt in ('user', 'runtime_token')
         )
         yield config_name, get_runtime(config, user, token)
+
+
+def evaluate_test_suite_result(child_nodes):
+    """ Evaluate test suite result
+    Argument: List of child nodes with the below format:
+    [
+        {
+            "node": {
+                "name": <node-name>,
+                "result":<node-result>
+            },
+            "child_nodes": []
+        },
+        ...
+    ]
+
+    If all child nodes pass, the suite will be marked 'pass'
+    If one of the child node fails, the suite will be marked `fail`
+    If all child nodes skipped, the suite will be marked 'skip'
+    If atleast one of the child passes and other are skipped, the suite
+    will be marked as `pass`
+    If atleast one of the child skipped and other are unknown, the
+    suite will be marked as `skip`
+    """
+    result = None
+    result_list = [child['node']['result'] for child in child_nodes]
+    if 'fail' in result_list:
+        result = 'fail'
+    elif all(result == 'pass' for result in result_list) or 'pass' in result_list:
+        result = 'pass'
+    elif all(result == 'skip' for result in result_list) or 'skip' in result_list:
+        result = 'skip'
+    return result

--- a/kernelci/runtime/lava.py
+++ b/kernelci/runtime/lava.py
@@ -155,8 +155,10 @@ class Callback:
         for suite_name, suite_results in self._data['results'].items():
             tests = yaml.safe_load(suite_results)
             if suite_name == 'lava':
-                results['login'] = self._get_login_case(tests)
-                results['kernelmsg'] = self._get_kernelmsg_case(tests)
+                results['setup'] = {
+                    'login': self._get_login_case(tests),
+                    'kernelmsg': self._get_kernelmsg_case(tests)
+                }
             else:
                 suite_name = suite_name.partition("_")[2]
                 results[suite_name] = self._get_suite_results(tests)
@@ -182,8 +184,10 @@ class Callback:
             if isinstance(value, dict):
                 item['child_nodes'] = self._get_results_hierarchy(value)
                 node['result'] = self._get_stage_result(node['name'])
+                node['kind'] = 'job'
             elif isinstance(value, str):
                 node['result'] = value
+                node['kind'] = 'test'
             hierarchy.append(item)
         return hierarchy
 


### PR DESCRIPTION
- Introduce `Job` model for job/test suite nodes
- Introduce `setup` test suite for pre-check runs for `tast` test
- Tweaked LAVA callback data parsing to re-structure test hierarchy
- Calculate job node results based on child test nodes