### PR TITLE
Enable running discoverable devices probe kselftest

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -204,6 +204,7 @@ rootfs_configs:
       - publicsuffix
       - python3-minimal
       - python3-unittest2
+      - python3-yaml
       - socat
       - tappy
       - tcpdump

--- a/config/rootfs/debos/scripts/bookworm-kselftest.sh
+++ b/config/rootfs/debos/scripts/bookworm-kselftest.sh
@@ -17,6 +17,10 @@ mkdir /usr/share/alsa
 curl -L -o /tmp/alsa-ucm-conf.tar.gz https://github.com/alsa-project/alsa-ucm-conf/archive/refs/heads/master.tar.gz
 tar xvzf /tmp/alsa-ucm-conf.tar.gz -C /usr/share/alsa --strip-components=1 --wildcards "*/ucm" "*/ucm2"
 
+mkdir /opt/platform-test-parameters
+curl -L -o /tmp/platform-test-parameters.tar.gz https://github.com/kernelci/platform-test-parameters/archive/refs/heads/main.tar.gz
+tar xvzf /tmp/platform-test-parameters.tar.gz -C /opt/platform-test-parameters --strip-components=1 --wildcards "*/kselftest"
+
 ########################################################################
 # Cleanup: remove files and packages we don't want in the images       #
 ########################################################################


### PR DESCRIPTION
Do the setup needed to be able to run the discoverable devices probe kselftest in KernelCI. This involves adding a missing dependency to the kselftest rootfs, deploying additional files used by the test, and exposing a newly introduced parameter to allow passing parameters to kselftests.

This depends on https://github.com/Linaro/test-definitions/pull/511.