### PR TITLE
config/runtime/base/python.jinja2: update `BaseJob._submit`

### DIFF
--- a/config/runtime/base/python.jinja2
+++ b/config/runtime/base/python.jinja2
@@ -114,7 +114,6 @@ class BaseJob:
             'state': 'done',
         })
         self._api.node.update(self._node)
-        return self._node
 
     def run(self):
         if self._node.get('debug') and 'dry_run' in self._node['debug']:


### PR DESCRIPTION
Update `_submit` method in `BaseJob` and drop its returned value as it's not being used anywhere.