### PR TITLE
config/storage: Fix legacy option

### DIFF
--- a/config/core/storage.yaml
+++ b/config/core/storage.yaml
@@ -17,3 +17,10 @@ storage:
     host: staging.kernelci.org
     base_url: http://storage.staging.kernelci.org/
     api_url: https://api.staging.kernelci.org
+
+# Required by legacy
+  staging.kernelci.org:
+    storage_type: backend
+    host: staging.kernelci.org
+    base_url: http://storage.staging.kernelci.org/
+    api_url: https://api.staging.kernelci.org


### PR DESCRIPTION
Legacy require storage.kernelci.org, so 200bfa86296c023959f059568dc3c070b7069de7 breaks legacy setup for staging. Adding back option