### PR TITLE
host-tools.jinja2: Fix link from private repository to kernelci

### DIFF
--- a/config/docker/base/host-tools.jinja2
+++ b/config/docker/base/host-tools.jinja2
@@ -35,7 +35,7 @@ WORKDIR /root/patches
 #kernelci.org/\
 #config/docker/data/kmod_kci_bookworm.patch \
 #.
-ADD https://raw.githubusercontent.com/nuclearcat/kernelci-core/upgrade-bookworm-docker/config/docker/data/kmod_kci_bookworm.patch \
+ADD https://raw.githubusercontent.com/kernelci/kernelci-core/main/config/docker/data/kmod_kci_bookworm.patch \
 .
 
 RUN apt-get source kmod


### PR DESCRIPTION
As such links pose egg and chicken problem, we need first to place patch somewhere. Now after we get everything merged, we can use direct link.