### PR TITLE
Bump `docker` from `6.1.2` to `7.1.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
   "bson==0.5.10",
   "click==8.1.3",
   "cloudevents==1.9.0",
-  "docker==6.1.2",
+  "docker==7.1.0",
   "jinja2==3.1.3",
   "kubernetes==26.1.0",
   "paramiko==3.4.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ azure-storage-file-share==12.13.0
 bson==0.5.10
 click==8.1.3
 cloudevents==1.9.0
-docker==6.1.2
+docker==7.1.0
 jinja2==3.1.3
 kubernetes==26.1.0
 paramiko==3.4.0


### PR DESCRIPTION
Fixes https://github.com/kernelci/kernelci-pipeline/issues/653

The latest version `7.1.0` has a fix applied to support `requests 2.32.2` version.
See the changelog:
https://docker-py.readthedocs.io/en/stable/change-log.html#id1