### PR TITLE
build-configs-android.yaml: Add android16-6.6-lts branch

### DIFF
--- a/config/core/build-configs-android.yaml
+++ b/config/core/build-configs-android.yaml
@@ -210,3 +210,10 @@ build_configs:
     variants:
       <<: *android_variants
       <<: *clang_android_variants
+
+  android15-6.6-lts:
+    tree: android
+    branch: 'android15-6.6-lts'
+    variants:
+      <<: *android_variants
+      <<: *clang_android_variants


### PR DESCRIPTION
As requested by Todd Kjos add the Android 16 v6.6-lts branch to the
coverage.

Signed-off-by: Mark Brown <broonie@kernel.org>
