### PR TITLE
build-configs-android.yaml: Block gki_defconfig builds

### DIFF
--- a/config/core/build-configs-android.yaml
+++ b/config/core/build-configs-android.yaml
@@ -28,6 +28,10 @@ android_variants: &android_variants
 #            - 'multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y'
 
         arm64: &arm64_arch
+          filters:
+            - blocklist:
+                defconfig:
+                  - 'gki_defconfig'
           extra_configs:
             - 'allmodconfig'
             - 'allnoconfig'


### PR DESCRIPTION
Disable the gki_defconfig builds at the request off Todd Kjos, it is a
focus of their internal testing and pahole causes issues with KernelCI
so makes noise.

Signed-off-by: Mark Brown <broonie@kernel.org>
