### PR TITLE
config/v4l2-decoder-conformance: Replace dots in LAVA test set/case names

### DIFF
--- a/config/rootfs/debos/overlays/fluster/usr/bin/fluster_parser.py
+++ b/config/rootfs/debos/overlays/fluster/usr/bin/fluster_parser.py
@@ -110,13 +110,15 @@ def main(args):
         cmd['case'], 'validate-fluster-results', '--result', 'pass'])
 
     # parse test results
+    # avoid using dots in set/case names as they are used to represent test hierarchy in KCIDB
     for test_suite in junitxml:
         decoder = next(test_suite.properties()).value
+        set_name = f'{test_suite.name}-{decoder}'.replace('.', '-')
         subprocess.check_call([
-            cmd['set'], 'start', f'{test_suite.name}-{decoder}'])
+            cmd['set'], 'start', set_name])
 
         for res in map(_parse_vector_result, test_suite):
-            case_name, case_res = res
+            case_name, case_res = [x.replace('.', '-') for x in res]
             subprocess.check_call([
                 cmd['case'], f'{case_name}', '--result', f'{case_res}'])
 


### PR DESCRIPTION
Dots are used in KCIDB to denote test hierarchy; this can lead to misinterpretation when they're used in LAVA test sets and case names. Modify the fluster parser script to replace dots with dashes to prevent this issue.