### PR TITLE
workflows: Grant "pawiecz" permission to build rootfs

### DIFF
--- a/.github/workflows/rootfs.yml
+++ b/.github/workflows/rootfs.yml
@@ -29,7 +29,7 @@ env:
 jobs:
   rootfs-build:
     # only selected people can trigger this job
-    if: contains('["nuclearcat","JenySadadia","a-wai","broonie","laura-nao"]', github.actor)
+    if: contains('["nuclearcat","JenySadadia","a-wai","broonie","laura-nao","pawiecz"]', github.actor)
     runs-on: ubuntu-22.04
     environment: deploysecrets
     steps:


### PR DESCRIPTION
Reason for this request is verification of https://github.com/kernelci/kernelci-core/pull/2577 + https://github.com/kernelci/kernelci-pipeline/pull/642

Initial attempt resulted in [skipped workflow](https://github.com/kernelci/kernelci-core/actions/runs/9794201636)