### PR TITLE
base/lava.jinja2: Add instance_callback retrieved from environment

### DIFF
--- a/config/runtime/base/lava.jinja2
+++ b/config/runtime/base/lava.jinja2
@@ -48,9 +48,7 @@ notify:
     {%- if notify.callback.token %}
     token: {{ notify.callback.token }}
     {%- endif %}
-    {%- if notify.callback.url %}
-    url: {{ notify.callback.url }}/node/{{ node.id }}
-    {%- else %}{{ kci_raise("Callback URL not provided") }}{%- endif %}
+    url: {{ instance_callback }}/node/{{ node.id }}
   criteria:
     status: finished
 {% endif %}


### PR DESCRIPTION
Right now we define callback URL for LAVA labs in config, which doesn't make sense, as this URL is pipeline instance specific, and complicates deployment of staging vs production instances. It is better to define callback URL as environment variable, for now.