### PR TITLE
scheduler.py: If event have jobfilter, inject it to the job data

### DIFF
--- a/kernelci/runtime/__init__.py
+++ b/kernelci/runtime/__init__.py
@@ -40,6 +40,10 @@ class Job:
         """Node data for this job"""
         return self._node
 
+    @node.setter
+    def node(self, key, value):
+        self._node[key] = value
+
     @property
     def config(self):
         """Configuration for this job loaded from YAML"""

--- a/kernelci/scheduler.py
+++ b/kernelci/scheduler.py
@@ -56,6 +56,10 @@ class Scheduler:
                 runtimes = self._runtimes_by_type.get(runtime_type)
                 runtime = random.sample(runtimes, 1)[0] if runtimes else None
             job = self._jobs.get(config.job)
+            # if event have jobfilter, add/replace it to the job
+            if event.get('jobfilter'):
+                print(f"event jobfilter: {event['jobfilter']}")
+                job.node('jobfilter', event['jobfilter'])
             if not all((job, runtime)):
                 continue
             platforms = config.platforms or [runtime.config.lab_type]


### PR DESCRIPTION
When someone generate artificial event with jobfilter, this is likely maintainer trying to repeat job. Threat this accordingly, and inject job filter to job node, so we will run only tests maintainer wants.