### PR TITLE
Fix osnoise and timerlat rt-tests

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -268,6 +268,7 @@ rootfs_configs:
       - libnuma1
       - procps
       - python3
+      - rtla
     script: "scripts/bookworm-rt.sh"
 
   bookworm-v4l2:

--- a/config/runtime/tests/rt-tests.jinja2
+++ b/config/runtime/tests/rt-tests.jinja2
@@ -4,18 +4,6 @@
       minutes: {{ job_timeout }}
 
     definitions:
-    - from: inline
-      repository:
-        metadata:
-          format: Lava-Test Test Definition 1.0
-          name: rt-tests-prereq
-          description: Pre-requisites for PREEMPT_RT
-        run:
-          steps:
-          - apt-get update && apt-get install -y procps rt-tests
-      name: rt-tests-prereq
-      path: inline/rt-tests-prereq.yaml
-
     - repository: https://github.com/kernelci/test-definitions.git
       from: git
       revision: kernelci.org


### PR DESCRIPTION
I've removed a step at execution time and added rtla package which is needed for execution.