### PR TITLE
config: core: add SCHED_CONFIG needed for cyclicdeadline rt-test

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -538,6 +538,7 @@ fragments:
     path: "kernel/configs/preempt_rt.config"
     configs:
       - 'CONFIG_EXPERT=y'
+      - 'CONFIG_SCHED_DEBUG=y'
       - 'CONFIG_PREEMPT_RT=y'
       - 'CONFIG_PREEMPT_RT_FULL=y' # <= v4.19
 


### PR DESCRIPTION
I've reproduced the failure locally. The cyclicdeadline requires sched_feature or sched/feature directory. Add these directories by including SCHED_DEBUG config in the kernel.