### PR TITLE
rootfs:overlays:fluster Add verbose option for fluster parser

### DIFF
--- a/config/rootfs/debos/overlays/fluster/usr/bin/fluster_parser.py
+++ b/config/rootfs/debos/overlays/fluster/usr/bin/fluster_parser.py
@@ -67,10 +67,13 @@ def _load_results_file(filename):
     return ret
 
 
-def _run_fluster(test_suite=None, timeout=None, jobs=None, decoders=None, skips=None):
+def _run_fluster(test_suite=None, timeout=None, jobs=None, decoders=None, skips=None, verbose=False):
     cmd = ['python3', 'fluster.py', '-ne', 'run',
            '-f', 'junitxml', '-so', RESULTS_FILE]
 
+    if verbose:
+        cmd.extend(['-v'])
+        print(f'Running fluster tests with command: {cmd}')
     if test_suite:
         cmd.extend(['-ts', test_suite])
     if timeout:
@@ -96,7 +99,7 @@ def main(args):
         cmd = cmd.fromkeys(cmd, 'echo')
 
     # run fluster tests
-    _run_fluster(args.test_suite, args.timeout, args.jobs, args.decoders, args.skip_vectors)
+    _run_fluster(args.test_suite, args.timeout, args.jobs, args.decoders, args.skip_vectors, args.verbose)
 
     # load test results
     junitxml = _load_results_file(f'{FLUSTER_PATH}/{RESULTS_FILE}')
@@ -134,5 +137,6 @@ if __name__ == '__main__':
     parser.add_argument('-j', '--jobs')
     parser.add_argument('-d', '--decoders', nargs='+')
     parser.add_argument('-sv', '--skip-vectors', nargs='+')
+    parser.add_argument('-v', '--verbose', action="store_true")
     args = parser.parse_args()
     sys.exit(main(args))


### PR DESCRIPTION
This is a continuation of the PR https://github.com/kernelci/kernelci-core/pull/2609 accidentally closed by me.

This change adds `--verbose` option for fluster parser to make fluster more verbose to facilitate debug. When `--verbose` is provided, the `fluster_parser.py` script will forward it to fluster which will enable the verbosity of GStreamer.  The GStreamer verbosity facilitates the debug on regressions investigations.
The low verbosity level enabled by fluster adds few hundreds of lines on logs when this option is provided, without significant impact on the performance. Anyways, the verbosity option should be disabled by default on  `fluster_parser.py` and will not be used by kernel-ci pipeline by default. 
The intention is to enable users to add `--verbose` flag manually only when investigating a codec regression.