### PR TITLE
build-configs.yaml: Drop removed firmware file for SOF on MT8195

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -368,7 +368,7 @@ fragments:
       mediatek/mt8192/scp.img
       mediatek/mt8195/scp.img
       mediatek/sof-tplg/sof-mt8186.tplg
-      mediatek/sof-tplg/sof-mt8195-mt6359-rt1019-rt5682-dts.tplg
+      mediatek/sof-tplg/sof-mt8195-mt6359-rt1019-rt5682.tplg
       mediatek/sof/sof-mt8186.ri
       mediatek/sof/sof-mt8195.ri
       mediatek/WIFI_MT7961_patch_mcu_1_2_hdr.bin


### PR DESCRIPTION
The firmware mediatek/sof-tplg/sof-mt8195-mt6359-rt1019-rt5682-dts.tplg has been removed upstream [1]. The plan seems to be to use another firmware for MT8195 Tomato, but a kernel change [2] needs to land before that can happen. In the mean time, consider audio functionality for MT8195-Tomato broken, and drop the file from the config so we can build again. Fixes
https://github.com/kernelci/kernelci-pipeline/issues/726.

[1] https://lore.kernel.org/all/20240719022132.30990-1-xiangzhi.tang@mediatek.com/
[2] https://lore.kernel.org/all/20240318183004.3976923-1-cujomalainey@chromium.org/#t