### PR TITLE
rootfs.yml: Add nfraprado to list as allowed to generate rootfs

### DIFF
--- a/.github/workflows/rootfs.yml
+++ b/.github/workflows/rootfs.yml
@@ -37,7 +37,7 @@ env:
 jobs:
   rootfs-build:
     # only selected people can trigger this job
-    if: contains('["nuclearcat","JenySadadia","a-wai","broonie","laura-nao","pawiecz","musamaanjum"]', github.actor)
+    if: contains('["nuclearcat","JenySadadia","a-wai","broonie","laura-nao","pawiecz","musamaanjum","nfraprado"]', github.actor)
     runs-on: ubuntu-22.04
     environment: deploysecrets
     steps:


### PR DESCRIPTION
nfraprado often does changes to tests that require rootfs update, so it will help to unblock him on this process.