### PR TITLE
config: docker: net kselftest suite required openssl library

### DIFF
--- a/config/docker/fragment/kselftest.jinja2
+++ b/config/docker/fragment/kselftest.jinja2
@@ -23,5 +23,6 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
    libubsan1{{ pkgarch }} \
    liburing-dev{{ pkgarch }} \
    libpopt-dev{{ pkgarch }} \
+   libssl-dev{{ pkgarch }} \
    patch \
    pkg-config


### PR DESCRIPTION
This library is missing and hence build errors are encountered while building kselftests specifically net suite. Hence add this library.