### PR TITLE
fix(runtime/lava): Present rendered job template if loading it fails

### DIFF
--- a/kernelci/runtime/lava.py
+++ b/kernelci/runtime/lava.py
@@ -300,7 +300,14 @@ class LAVA(Runtime):
             return None
 
         # yaml round-trip to process e.g. multi-line commands
-        return yaml.dump(yaml.load(rendered, Loader=yaml.CLoader))
+        try:
+            loaded = yaml.load(rendered, Loader=yaml.CLoader)
+        except yaml.scanner.ScannerError as exc:
+            print(f"Error loading rendered job template as YAML: {exc}," +
+                  f"{rendered}")
+            return None
+
+        return yaml.dump(loaded)
 
     def submit(self, job_path):
         with open(job_path, 'r', encoding='utf-8') as job_file:


### PR DESCRIPTION
```
while scanning a plain scalar
  in "<unicode string>", line 121, column 23
found a tab character that violates indentation
  in "<unicode string>", line 122, column 1
```

Not being able to reproduce this error locally provide more information from the running pipeline.