### PR TITLE
kernelci.api: enable `promisc` flag for subscription

### DIFF
--- a/kernelci/api/__init__.py
+++ b/kernelci/api/__init__.py
@@ -360,7 +360,7 @@ class API(abc.ABC, Base):
     # -------
 
     @abc.abstractmethod
-    def subscribe(self, channel: str) -> int:
+    def subscribe(self, channel: str, promisc: Optional[bool] = None) -> int:
         """Subscribe to a pub/sub channel
 
         Subscribe to the given `channel` and get the subscription id.

--- a/kernelci/api/latest.py
+++ b/kernelci/api/latest.py
@@ -122,8 +122,9 @@ class LatestAPI(API):  # pylint: disable=too-many-public-methods
         def update(self, node: dict) -> dict:
             return self._put('/'.join(['node', node['id']]), node).json()
 
-    def subscribe(self, channel: str) -> int:
-        resp = self._post(f'subscribe/{channel}')
+    def subscribe(self, channel: str, promisc: Optional[bool] = None) -> int:
+        params = {'promisc': promisc} if promisc else None
+        resp = self._post(f'subscribe/{channel}', params=params)
         return resp.json()['id']
 
     def unsubscribe(self, sub_id: int):


### PR DESCRIPTION
Update `API.Node.subscribe` method to provide `promisc` field while calling API `subscribe/` endpoint.