### PR TITLE
kernelci.api: remove timeout error metadata

### DIFF
--- a/kernelci/api/helper.py
+++ b/kernelci/api/helper.py
@@ -512,6 +512,12 @@ class APIHelper:
         root_node['result'] = results['node']['result']
         root_node['artifacts'].update(results['node']['artifacts'])
         root_node['data'].update(results['node'].get('data', {}))
+        if root_node['result'] != 'incomplete':
+            data = root_node.get('data', {})
+            if data.get('error_code') == 'node_timeout':
+                root_node['data']['error_code'] = None
+                root_node['data']['error_msg'] = None
+
         root_results = {
             'node': root_node,
             'child_nodes': results['child_nodes'],

--- a/kernelci/api/latest.py
+++ b/kernelci/api/latest.py
@@ -120,6 +120,11 @@ class LatestAPI(API):  # pylint: disable=too-many-public-methods
             return self._post('node', node).json()
 
         def update(self, node: dict) -> dict:
+            if node['result'] != 'incomplete':
+                data = node.get('data', {})
+                if data.get('error_code') == 'node_timeout':
+                    node['data']['error_code'] = None
+                    node['data']['error_msg'] = None
             return self._put('/'.join(['node', node['id']]), node).json()
 
     def subscribe(self, channel: str) -> int:


### PR DESCRIPTION
In some cases, when a k8s or lava job is stuck for a longer time than an allowed timeout, the result is set to `incomplete` with timeout error metadata.
However, these jobs manage to be completed after a period of time and set node result and data accordingly.
Remove timeout error metadata for such cases.
Update helper function for single node update and submitting hierarchy accordingly.