### PR TITLE
feature(k8s-runtime): Make api key configurable

### DIFF
--- a/config/runtime/base/kubernetes.jinja2
+++ b/config/runtime/base/kubernetes.jinja2
@@ -55,7 +55,7 @@ spec:
           valueFrom:
             secretKeyRef:
               # FIXME: convert to template parameter
-              name: {{ "kci-api-jwt-early-access" }}
+              name: {{ k8s_api_key }}
               key: token
 
         - name: KCI_STORAGE_CREDENTIALS

--- a/kernelci/runtime/kubernetes.py
+++ b/kernelci/runtime/kubernetes.py
@@ -8,6 +8,7 @@
 import random
 import re
 import string
+import os
 
 import kubernetes
 from . import Runtime
@@ -36,6 +37,11 @@ class Kubernetes(Runtime):
         safe_name = re.sub(r'[\:/_+=]', '-', job_name).lower()
         rand_sx = ''.join(random.sample(self.JOB_NAME_CHARACTERS, 8))
         k8s_job_name = '-'.join([safe_name[:(62 - len(rand_sx))], rand_sx])
+        instance = os.getenv('KCI_INSTANCE', 'prod')
+        if instance == 'prod':
+            params['k8s_api_key'] = 'kci-api-jwt-early-access'
+        else:
+            params['k8s_api_key'] = 'kci-api-jwt-staging'
         params['k8s_job_name'] = k8s_job_name
         return template.render(params)
 


### PR DESCRIPTION
Right now API key in k8s compiling nodes are hardcoded in template, and on staging we are live-patching kubernetes template. We can make it configurable, similar as we did job name in k8s job names.