### PR TITLE
config/core: rename `early-access` entries

### DIFF
--- a/config/core/api-configs.yaml
+++ b/config/core/api-configs.yaml
@@ -3,7 +3,7 @@ api:
   docker-host:
     url: http://172.17.0.1:8001
 
-  early-access:
+  production:
     url: https://kernelci-api.westus3.cloudapp.azure.com
 
   staging:

--- a/config/core/storage.yaml
+++ b/config/core/storage.yaml
@@ -1,9 +1,9 @@
 storage:
 
-  early-access-azure:
+  production-azure:
     storage_type: azure
     base_url: https://kciapistagingstorage1.file.core.windows.net/
-    share: early-access
+    share: production
     sas_public_token: "?sv=2022-11-02&ss=f&srt=sco&sp=r&se=2024-10-17T19:19:12Z&st=2023-10-17T11:19:12Z&spr=https&sig=sLmFlvZHXRrZsSGubsDUIvTiv%2BtzgDq6vALfkrtWnv8%3D"
 
   kernelci.org:


### PR DESCRIPTION
Rename configurations for `early-access` to `production`. Early access instance was setup for the initial release phase. It's been used as production now.