### PR TITLE
rootfs/bookworm-gst-fluster: Rename H265 vc-hevc test suite

### DIFF
--- a/config/rootfs/debos/scripts/bookworm-gst-fluster.sh
+++ b/config/rootfs/debos/scripts/bookworm-gst-fluster.sh
@@ -197,7 +197,7 @@ download_fluster_testsuite ./test_suites/av1/AV1-TEST-VECTORS.json
 download_fluster_testsuite ./test_suites/av1/CHROMIUM-10bit-AV1-TEST-VECTORS.json
 download_fluster_testsuite ./test_suites/h264/JVT-AVC_V1.json
 download_fluster_testsuite ./test_suites/h264/JVT-FR-EXT.json
-download_fluster_testsuite ./test_suites/h265/JCT-VC-HEVC-V1.json
+download_fluster_testsuite ./test_suites/h265/JCT-VC-HEVC_V1.json
 download_fluster_testsuite ./test_suites/vp8/VP8-TEST-VECTORS.json
 download_fluster_testsuite ./test_suites/vp9/VP9-TEST-VECTORS.json
 


### PR DESCRIPTION
Test suite was renamed in the upstream repository: https://github.com/fluendo/fluster/commit/cc9fb13dbd2a43ac9f7ab2e40a43c0b64010318f