### PR TITLE
rootfs/bookworm-gst-fluster: Rework error handling for missing test suites

### DIFF
--- a/config/rootfs/debos/scripts/bookworm-gst-fluster.sh
+++ b/config/rootfs/debos/scripts/bookworm-gst-fluster.sh
@@ -129,15 +129,20 @@ extract_vector_from_archive() {
 }
 
 download_fluster_testsuite() {
-	json_file=$(readlink -e "${1}")
+	local fluster_testsuite="${1}"
 
-	[ -z "${json_file}" ] && {
+	[ -z "${fluster_testsuite}" ] && {
 		echo "No JSON test suite file provided"
 		exit 1
 	}
 
+	# disable set -e (immediate exit) to allow error handling after readlink failure
+	set +e
+	json_file=$(readlink -e "${fluster_testsuite}")
+	set -e
+
 	if [ ! -f "${json_file}" ]; then
-		echo "${json_file} file not found!"
+		echo "${fluster_testsuite} file not found!"
 		exit 1
 	fi
 


### PR DESCRIPTION
This patch changes missing test suite error handling to:
- fail (with message) if no test suite was passed to downloader function
- allow readlink to fail and then handle its error with debugging message