### PR TITLE
config: runtime: boot: u-boot: use `nfsroot` if defined

### DIFF
--- a/config/runtime/boot/u-boot.jinja2
+++ b/config/runtime/boot/u-boot.jinja2
@@ -1,3 +1,7 @@
+{%- if boot_commands == 'nfs' and nfsroot is not defined %}
+{%-   set nfsroot = 'http://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20240221.0/' + debarch %}
+{%- endif %}
+
 - deploy:
     kernel:
       type: {{ node.data.kernel_type }}
@@ -11,10 +15,10 @@
 {%- endif %}
 {%- if boot_commands == 'nfs' %}
     nfsrootfs:
-      url: 'http://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20240221.0/{{ debarch }}/full.rootfs.tar.xz'
+      url: '{{ nfsroot }}/full.rootfs.tar.xz'
       compression: xz
     ramdisk:
-      url: 'http://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20240221.0/{{ debarch }}/initrd.cpio.gz'
+      url: '{{ nfsroot }}/initrd.cpio.gz'
       compression: gz
     os: debian
 {%- else %}


### PR DESCRIPTION
Device/job definitions can specify a NFS rootfs URL as the `nfsroot` param. However, this one is currently ignored when using the `u-boot` boot method. This patch ensures the `nfsroot` param is used when booting with an NFS rootfs, falling back to the default/hardcoded value only if this param is missing.

Needed for https://github.com/kernelci/kernelci-pipeline/pull/700