### PR TITLE
build-configs.yaml: Add MT6359_AUXADC config to arm64-chromebook

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -357,6 +357,7 @@ fragments:
       - 'CONFIG_USB_RTL8152=y' # Allows kernel ip-config. Prevents deferred probe timeout errors.
       - 'CONFIG_USB_USBNET=y' # Needed for ASIX AX88772B ethernet adapter used at Collabora's lab. Builtin to allow kernel ip-config, and prevent deferred probe timeout errors.
       - 'CONFIG_WATCHDOG_SYSFS=y'
+      - 'CONFIG_MEDIATEK_MT6359_AUXADC=m'
       - 'CONFIG_EXTRA_FIRMWARE="
       mediatek/mt8173/vpu_d.bin
       mediatek/mt8173/vpu_p.bin


### PR DESCRIPTION
Enable the CONFIG_MEDIATEK_MT6359_AUXADC config option (which provides the mt6359-auxadc driver) in the arm64-chromebook fragment. This makes the test case /soc/pwrap@10024000/pmic/adc in the DT kselftest pass on the mediatek chromebooks, which has been failing in linux-next since the addition of commit b0a4ce81f327 ("arm64: dts: mediatek: Add ADC node on MT6357, MT6358, MT6359 PMICs") in the kernel.