### PR TITLE
fix(chromeos): Few small fixes to make cros-tast buildable

### DIFF
--- a/config/docker/cros-tast.jinja2
+++ b/config/docker/cros-tast.jinja2
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     git \
     inetutils-ping \
     python3 \
-    python-pkg-resources \
+    python3-pkg-resources \
     ssh \
     wget
 

--- a/config/docker/fragment/cros-lava.jinja2
+++ b/config/docker/fragment/cros-lava.jinja2
@@ -5,7 +5,7 @@ RUN \
   useradd cros -d /home/cros && \
   chown cros: -R /home/cros && \
   adduser cros sudo && \
-  echo 'PATH=/home/cros-tast/trunk/chromite/scripts:$PATH' >/home/cros-tast/.profile && \
+  echo 'PATH=/home/cros/trunk/chromite/scripts:$PATH' >/home/cros/.profile && \
   echo "cros ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 USER cros
 ENV HOME=/home/cros


### PR DESCRIPTION
Few small things missing, now cros-tast is buildable.
Fix package name for bookworm, and also change username in fragment (it was using old username cros-tast).