### PR TITLE
fix(tast_parser): Fix if data is not iterable

### DIFF
--- a/config/docker/data/tast_parser.py
+++ b/config/docker/data/tast_parser.py
@@ -146,18 +146,25 @@ def parse_test_results():
     failed_file = os.path.join(RESULTS_DIR, FAILED_RUN_FILE)
     if os.path.isfile(failed_file):
         stderr_file = os.path.join(RESULTS_DIR, STDERR_FILE)
-        with open(stderr_file, "r") as f:
-            stderr = f.read()
-            print("### BEGIN STDERR DUMP ###")
-            print(stderr)
-            print("### END STDERR DUMP ###")
-            if "'/usr/local/bin/local_test_runner': No such file or directory" in stderr:
-                report_lava_critical("cros-partition-corrupt")
-                sys.exit(1)
+        if os.path.isfile(stderr_file):
+            with open(stderr_file, "r") as f:
+                stderr = f.read()
+                print("### BEGIN STDERR DUMP ###")
+                print(stderr)
+                print("### END STDERR DUMP ###")
+                if "'/usr/local/bin/local_test_runner': No such file or directory" in stderr:
+                    report_lava_critical("cros-partition-corrupt")
+                    sys.exit(1)
+        else:
+            report_lava_critical("Tast tests run failed, stderr not found")
+            sys.exit(1)
     json_file = os.path.join(RESULTS_DIR, RESULTS_FILE)
     if os.path.isfile(json_file):
         with open(json_file, "r") as results_file:
-            results = json.load(results_file)
+            try:
+                results = json.load(results_file)
+            except json.JSONDecodeError:
+                results = None
             if not results:
                 report_lava_critical("Tast tests run failed, no results")
                 sys.exit(1)

--- a/config/docker/data/tast_parser.py
+++ b/config/docker/data/tast_parser.py
@@ -158,6 +158,9 @@ def parse_test_results():
     if os.path.isfile(json_file):
         with open(json_file, "r") as results_file:
             results = json.load(results_file)
+            if not results:
+                report_lava_critical("Tast tests run failed, no results")
+                sys.exit(1)
         for test_data in parse_results(results):
             results_chart = os.path.join(test_data["outDir"], RESULTS_CHART_FILE)
             if os.path.isfile(results_chart):


### PR DESCRIPTION
Fix error:
/tast_parser.py --results\n### BEGIN STDERR DUMP ###\n### END STDERR DUMP ###\n Traceback (most recent call last):\nFile "/home/cros/./tast_parser.py", line 191, in <module>\nparse_test_results()\nFile "/home/cros/./tast_parser.py", line 161, in parse_test_results\nfor test_data in parse_results(results):\n File "/home/cros/./tast_parser.py", line 118, in parse_results\n for element in json_data:\nTypeError: \'NoneType\' object is not iterable