### PR TITLE
feat(docker): Add env var with build information

### DIFF
--- a/config/docker/fragment/api.jinja2
+++ b/config/docker/fragment/api.jinja2
@@ -23,6 +23,8 @@ RUN python3 -m pip install '.[dev]' --break-system-packages
 WORKDIR /home/kernelci
 RUN rm -rf /tmp/kernelci-api
 
+ENV KCI_VER_API=$api_rev
+
 # Set up kernelci user
 #RUN useradd kernelci -u 1000 -d /home/kernelci -s /bin/bash
 #RUN mkdir -p /home/kernelci

--- a/config/docker/fragment/lava-callback.jinja2
+++ b/config/docker/fragment/lava-callback.jinja2
@@ -12,3 +12,5 @@ USER kernelci
 WORKDIR /home/kernelci/
 RUN mv /tmp/kernelci-pipeline/* /home/kernelci/
 RUN rm -rf /tmp/kernelci-pipeline
+
+ENV KCI_VER_LAVACB=$pipeline_rev

--- a/config/docker/fragment/pipeline.jinja2
+++ b/config/docker/fragment/pipeline.jinja2
@@ -11,3 +11,4 @@ RUN git clone --depth=1 $pipeline_url pipeline
 WORKDIR pipeline
 RUN git fetch origin $pipeline_rev
 RUN git checkout FETCH_HEAD
+ENV KCI_VER_PIPELINE=$pipeline_rev


### PR DESCRIPTION
Sometimes we need to determine which snapshot of code used in docker container. Easiest way is to provide environment variable.