### PR TITLE
feat(models): Add treeid field

### DIFF
--- a/kernelci/api/models.py
+++ b/kernelci/api/models.py
@@ -212,6 +212,9 @@ class Node(DatabaseModel):
     submitter: Optional[str] = Field(
         description="Token md5 hash to identify node origin(submitter token)"
     )
+    treeid: Optional[str] = Field(
+        description="Tree unique identifier"
+    )
     user_groups: List[str] = Field(
         default=[],
         description="User groups that are permitted to update node"


### PR DESCRIPTION
For easier tree tracking we introduce unique tree identified, treeid, which is sha256 hash of (treeurl + branch + time).