### PR TITLE
Enable job priority setting for LAVA jobs

### DIFF
--- a/config/runtime/base/lava.jinja2
+++ b/config/runtime/base/lava.jinja2
@@ -21,7 +21,7 @@ device_type: {{ platform_config.name }}
 
 visibility: public
 
-priority: 10
+priority: {{ priority | default('10') }}
 
 {% if platform_config.context %}
 context:{% for key, value in platform_config.context | items %}

--- a/kernelci/config/job.py
+++ b/kernelci/config/job.py
@@ -8,19 +8,20 @@
 from .base import YAMLConfigObject
 
 
-class Job(YAMLConfigObject):
+class Job(YAMLConfigObject):  # pylint: disable=too-many-instance-attributes
     """Pipeline job definition"""
 
     yaml_tag = '!Job'
 
     # pylint: disable=too-many-arguments
     def __init__(self, name, template, kind="node", image=None, params=None, rules=None,
-                 kcidb_test_suite=None):
+                 kcidb_test_suite=None, priority=None):
         self._name = name
         self._template = template
         self._kind = kind
         self._image = image
         self._kcidb_test_suite = kcidb_test_suite
+        self._priority = priority
         self._params = self.format_params(params.copy(), params) if params else {}
         self._rules = rules
 
@@ -38,6 +39,11 @@ class Job(YAMLConfigObject):
     def kind(self):
         """Job node kind"""
         return self._kind
+
+    @property
+    def priority(self):
+        """Job priority"""
+        return self._priority
 
     @property
     def image(self):
@@ -62,7 +68,8 @@ class Job(YAMLConfigObject):
     @classmethod
     def _get_yaml_attributes(cls):
         attrs = super()._get_yaml_attributes()
-        attrs.update({'template', 'kind', 'image', 'params', 'rules', 'kcidb_test_suite'})
+        attrs.update({'template', 'kind', 'image', 'params', 'rules', 'kcidb_test_suite',
+                      'priority'})
         return attrs
 
 

--- a/tests/configs/jobs.yaml
+++ b/tests/configs/jobs.yaml
@@ -8,6 +8,7 @@ jobs:
       config: x86_64_defconfig
     rules:
     kcidb_test_suite:
+    priority:
 
   kunit: &kunit-job
     template: 'kunit.jinja2'
@@ -16,6 +17,7 @@ jobs:
     params: {}
     rules:
     kcidb_test_suite: kunit
+    priority:
 
   kunit-x86_64:
     <<: *kunit-job
@@ -24,6 +26,7 @@ jobs:
       arch: x86_64
     rules:
     kcidb_test_suite: kunit
+    priority:
 
   kver:
     template: 'kver.jinja2'
@@ -32,3 +35,4 @@ jobs:
     params: {}
     rules:
     kcidb_test_suite: kernelci_kver
+    priority:


### PR DESCRIPTION
Closes https://github.com/kernelci/kernelci-pipeline/issues/513

- Support `priority` field for job definitions
- Add method to calculate job priority from job definition priority and priority min and max values from lab configurations
