### PR TITLE
v4l2:fluster: Fix config/runtime/tests/fluster-chromeos.jinja2

### DIFF
--- a/config/runtime/tests/fluster-chromeos.jinja2
+++ b/config/runtime/tests/fluster-chromeos.jinja2
@@ -2,16 +2,16 @@
 
 {%- if testsuite %}
     {% set testsuite_arg = "-ts " + testsuite %}
-{%- endif -%}
-{%- if decoders -%}
-    {%- set decoders_arg = "-d " + decoders|join(" ") -%}
-{%- endif -%}
-{%- if videodec_timeout -%}
+{%- endif %}
+{%- if decoders %}
+    {%- set decoders_arg = "-d " + decoders|join(" ") %}
+{%- endif %}
+{%- if videodec_timeout %}
     {% set videodec_timeout_arg = "-t " + videodec_timeout|string %}
-{%- endif -%}
-{%- if videodec_parallel_jobs -%}
+{%- endif %}
+{%- if videodec_parallel_jobs %}
     {% set videodec_parallel_jobs_arg = "-j " + videodec_parallel_jobs|string %}
-{%- endif -%}
+{%- endif %}
 
 - test:
     namespace: chromeos

--- a/config/runtime/tests/fluster-chromeos.jinja2
+++ b/config/runtime/tests/fluster-chromeos.jinja2
@@ -43,8 +43,7 @@
               -o UserKnownHostsFile=/dev/null
               -i /home/cros/.ssh/id_rsa
               root@$(lava-target-ip)
-              python3 /usr/bin/fluster_parser.py {{ testsuite_arg }} {{ decoders_arg }} 
-                            {{ videodec_timeout_arg }} {{ videodec_parallel_jobs_arg }}
+              python3 /usr/bin/fluster_parser.py {{ testsuite_arg }} {{ decoders_arg }} {{ videodec_timeout_arg }} {{ videodec_parallel_jobs_arg }}
             - lava-test-set start get_results
             - mkdir -p /opt/fluster/
             - >-


### PR DESCRIPTION
Fix remaining right-stripping white space from the template and line breaking (details in the commit messages).