### PR TITLE
config: build_board: Include data directory in tast archive

### DIFF
--- a/config/rootfs/chromiumos/scripts/build_board.sh
+++ b/config/rootfs/chromiumos/scripts/build_board.sh
@@ -126,6 +126,7 @@ source "${SCRIPTPATH}/fixes/postbuild-${BRANCH}.sh"
 echo "Packing Tast files"
 sudo tar -cf "${DATA_DIR}/${BOARD}/tast.tar" -C ./chroot/usr/bin/ remote_test_runner tast
 sudo tar -uf "${DATA_DIR}/${BOARD}/tast.tar" -C ./chroot/usr/libexec/tast/bundles/remote/ cros
+sudo tar -uf "${DATA_DIR}/${BOARD}/tast.tar" -C ./chroot/usr/share/tast/data go.chromium.org
 sudo gzip -9 "${DATA_DIR}/${BOARD}/tast.tar"
 sudo mv "${DATA_DIR}/${BOARD}/tast.tar.gz" "${DATA_DIR}/${BOARD}/tast.tgz"
 


### PR DESCRIPTION
Tests can register ancillary data files that will be copied to the DUT and made available while the test is running.
- Small non-binary data files are present in data/ subdirectory.
- Larger data files are stored over the inernet to avoid permanently bloating the test repository.

The tast archive (tast.tgz) doesn't have the small data files. Copy all of the data files to this archive. There is a specific path for these data files inside /usr/share/tast/data/go.chromium.org. Copy go.chromium.org directory into the archive, so that the same directory can be placed at correct path in lava tast container.

I've got errors for storage.HealthInfo test where 13 data files are missing:
  2024-08-16T19:18:03.352903Z [19:18:03.352] Error at entity.go:34: Required data file seq_read missing
  2024-08-16T19:18:03.352931Z [19:18:03.352] Error at entity.go:34: Required data file seq_write missing
  2024-08-16T19:18:03.352982Z [19:18:03.352] Error at entity.go:34: Required data file tbw_probe missing

Instead of copying only these 13 files, I've decided to copy the entire data directory as it'll help us in solving similar issues for other test failures which we don't know yet at this time. Also it is under 7 MB which isn't much considering the size of tast archive which is already over 40-50 MB.

Signed-off-by: Muhammad Usama Anjum <usama.anjum@collabora.com>