### PR TITLE
config: tast: Extract tast data directory at correct location

### DIFF
--- a/config/runtime/tests/tast.jinja2
+++ b/config/runtime/tests/tast.jinja2
@@ -35,6 +35,8 @@
               && cp remote_test_runner /usr/bin/remote_test_runner
               && mkdir -p /usr/libexec/tast/bundles/remote/
               && cp cros /usr/libexec/tast/bundles/remote/
+              && mkdir -p /usr/share/tast/data
+              && cp -r go.chromium.org /usr/share/tast/data
             - for i in $(seq 1 60); do ping -c 1 -w 1 $(lava-target-ip) && break || sleep 1; done
             - ping -c 1 -w 1 $(lava-target-ip) || lava-test-raise "cros-device-unreachable"
             - >-


### PR DESCRIPTION
The data directory has files which are required by some tests. Copy the go.chromium.org directory to /usr/share/tast/data location so that tast can find these files.

https://github.com/kernelci/kernelci-pipeline/pull/789 is a pre-requisite for this PR.