### PR TITLE
config: runtime: further refine timeouts for job with retries

### DIFF
--- a/config/runtime/boot/depthcharge.jinja2
+++ b/config/runtime/boot/depthcharge.jinja2
@@ -50,9 +50,11 @@
     prompts:
     - '/ #'
     timeout:
-      minutes: 10
+      minutes: 20
     timeouts:
       bootloader-commands:
         minutes: 3
       auto-login-action:
+        minutes: 6
+      login-action:
         minutes: 2

--- a/config/runtime/boot/grub.jinja2
+++ b/config/runtime/boot/grub.jinja2
@@ -23,9 +23,11 @@
     prompts:
     - '/ #'
     timeout:
-      minutes: 10
+      minutes: 20
     timeouts:
       bootloader-commands:
         minutes: 3
       auto-login-action:
+        minutes: 6
+      login-action:
         minutes: 2

--- a/config/runtime/boot/qemu.jinja2
+++ b/config/runtime/boot/qemu.jinja2
@@ -27,9 +27,11 @@
     prompts:
       - '/ #'
     timeout:
-      minutes: 10
+      minutes: 20
     timeouts:
       bootloader-commands:
         minutes: 3
       auto-login-action:
+        minutes: 6
+      login-action:
         minutes: 2

--- a/config/runtime/boot/u-boot.jinja2
+++ b/config/runtime/boot/u-boot.jinja2
@@ -38,9 +38,11 @@
     prompts:
     - '/ #'
     timeout:
-      minutes: 10
+      minutes: 20
     timeouts:
       bootloader-commands:
         minutes: 3
       auto-login-action:
+        minutes: 6
+      login-action:
         minutes: 2

--- a/config/runtime/chromeos/base.jinja2
+++ b/config/runtime/chromeos/base.jinja2
@@ -41,11 +41,13 @@
 - boot:
     namespace: chromeos
     timeout:
-      minutes: 10
+      minutes: 20
     timeouts:
       bootloader-commands:
         minutes: 3
       auto-login-action:
+        minutes: 6
+      login-action:
         minutes: 2
     failure_retry: 3
     method: depthcharge


### PR DESCRIPTION
The timeout for actions on jobs with failure retries needs to be adjusted to allow sufficient time for the retries. Set a short timeout for the login-action and extend the parent auto-login-action timeout accordingly. Also extend the main boot action timeout to accommodate 3 retries of the auto-login action.

- Current job example with the exception `No time left for remaining 1 retries. 2 retries out of 3 failed for depthcharge-retry`: https://lava.collabora.dev/scheduler/job/15129757
- Example job after further refining the individual action timeouts: https://lava.collabora.dev/scheduler/job/15614027

_Note_: this is a temporary measure to ensure all expected retries are executed. LAVA upstream is exploring better alternatives, including options to eliminate the need for users to manually manage individual timeouts - see e.g. https://gitlab.com/lava/lava/-/merge_requests/2596 and https://gitlab.com/lava/lava/-/merge_requests/2428