### PR TITLE
config: rt-tests: set default priority of rt-migrate test

### DIFF
--- a/config/runtime/tests/rt-tests.jinja2
+++ b/config/runtime/tests/rt-tests.jinja2
@@ -26,6 +26,8 @@
         THREADS: {{ threads|default('2') }}
       {% elif tst_cmd == 'pi-stress' %}
         MLOCKALL: {{ mlockall|default('true') }}
+      {% elif tst_cmd == 'rt-migrate-test' %}
+        PRIORITY: {{ priority|default('90') }}
       {% elif tst_cmd == 'signaltest' %}
         PRIORITY: {{ priority|default('98') }}
         THREADS: {{ threads|default('2') }}


### PR DESCRIPTION
The priority of 96 if passed to rt-migrate causes failure. The test isn't designed well to handle high priority of 96. The test takes this priority and adds the count of number of tasks which becomes greater than 99. The 99 is the highest priority level for SCHED_FIFO. Hence, the priority setting of the main thread fails, we get warning and later test failure:

  Warning, can't set priority of main thread!

Instead of fixing the test at this time, let's use priority of 90 instead of 96 such that the total priority of main thread remains below highest priority level. We can set any other lower priority than 90 here as well such as 51 which is set in the rt-migrate-test.sh by default.

Relates https://github.com/kernelci/kernelci-project/issues/439
Signed-off-by: Muhammad Usama Anjum <usama.anjum@collabora.com>