### PR TITLE
config: rt-tests: fix MLOCKALL getting set to True

### DIFF
--- a/config/runtime/tests/rt-tests.jinja2
+++ b/config/runtime/tests/rt-tests.jinja2
@@ -25,7 +25,7 @@
         PRIORITY: {{ priority|default('98') }}
         THREADS: {{ threads|default('2') }}
       {% elif tst_cmd == 'pi-stress' %}
-        MLOCKALL: {{ mlockall|default('true') }}
+        MLOCKALL: {{ mlockall|default('"true"') }}
       {% elif tst_cmd == 'rt-migrate-test' %}
         PRIORITY: {{ priority|default('90') }}
       {% elif tst_cmd == 'signaltest' %}


### PR DESCRIPTION
When MLOCKALL is set to 'true', the lava job has MLOCKALL becomes true [1] which in turn translates to "True" while job execution [2]. It causes error as the test expects true instead of True.

  ./pi-stress.sh -D 60s -m True -r false -w hackbench
  ./pi-stress.sh: 37: True: not found

Fix it by using double quotes instead.

[1] https://lava.collabora.dev/scheduler/job/15562666/definition#defline43
[2] https://lava.collabora.dev/scheduler/job/15562666#L220