### PR TITLE
fluster: Use /tmp as result directory and small fixes

### DIFF
--- a/config/rootfs/debos/overlays/fluster/usr/bin/fluster_parser.py
+++ b/config/rootfs/debos/overlays/fluster/usr/bin/fluster_parser.py
@@ -27,6 +27,7 @@ from junitparser import JUnitXml, Skipped
 
 FLUSTER_PATH = '/opt/fluster'
 RESULTS_FILE = 'results.xml'
+RESULTS_PATH = '/tmp'
 
 
 def _check(path, match):
@@ -69,7 +70,7 @@ def _load_results_file(filename):
 
 def _run_fluster(test_suite=None, timeout=None, jobs=None, decoders=None, skips=None, verbose=False):
     cmd = ['python3', 'fluster.py', '-ne', 'run',
-           '-f', 'junitxml', '-so', RESULTS_FILE]
+           '-f', 'junitxml', '-so', f'{FLUSTER_PATH}/{RESULTS_FILE}']
 
     if verbose:
         cmd.extend(['-v'])

--- a/config/runtime/tests/fluster-chromeos.jinja2
+++ b/config/runtime/tests/fluster-chromeos.jinja2
@@ -36,28 +36,36 @@
             - lava-test-set start setup
             - for i in $(seq 1 60); do ping -c 1 -w 1 $(lava-target-ip) && break || sleep 1; done
             - ping -c 1 -w 1 $(lava-target-ip) || lava-test-raise "cros-device-unreachable"
+            - >-
+            ./ssh_retry.sh
+            -o StrictHostKeyChecking=no
+            -o UserKnownHostsFile=/dev/null
+            -i /home/cros/.ssh/id_rsa
+            root@$(lava-target-ip)
+            cat /etc/os-release > /tmp/osrel.tmp
+            - cat /tmp/osrel.tmp
             - lava-test-set stop setup
+            - wget https://github.com/kernelci/kernelci-core/raw/main/config/rootfs/debos/overlays/fluster/usr/bin/fluster_parser.py
+            - >-
+              scp
+              -o StrictHostKeyChecking=no
+              -o UserKnownHostsFile=/dev/null
+              -i /home/cros/.ssh/id_rsa
+              ./fluster_parser.py root@$(lava-target-ip):/tmp
             - >-
               /home/cros/ssh_retry.sh
               -o StrictHostKeyChecking=no
               -o UserKnownHostsFile=/dev/null
               -i /home/cros/.ssh/id_rsa
               root@$(lava-target-ip)
-              python3 /usr/bin/fluster_parser.py {{ testsuite_arg }} {{ decoders_arg }} {{ videodec_timeout_arg }} {{ videodec_parallel_jobs_arg }}
+              python3 /tmp/fluster_parser.py --run {{ testsuite_arg }} {{ decoders_arg }} {{ videodec_timeout_arg }} {{ videodec_parallel_jobs_arg }}
             - lava-test-set start get_results
-            - mkdir -p /opt/fluster/
             - >-
               scp
               -o StrictHostKeyChecking=no
               -o UserKnownHostsFile=/dev/null
               -i /home/cros/.ssh/id_rsa
-              root@$(lava-target-ip):/opt/fluster/results.xml /opt/fluster/
-            - >-
-              scp
-              -o StrictHostKeyChecking=no
-              -o UserKnownHostsFile=/dev/null
-              -i /home/cros/.ssh/id_rsa
-              root@$(lava-target-ip):/usr/bin/fluster_parser.py /usr/bin/
+              root@$(lava-target-ip):/tmp/results.xml /tmp
             - lava-test-set stop get_results
             - >-
               /home/cros/ssh_retry.sh
@@ -66,4 +74,5 @@
               -i /home/cros/.ssh/id_rsa
               root@$(lava-target-ip)
               poweroff && sleep 30 || true
-            - python3 /usr/bin/fluster_parser.py --results
+            - apt install -y python3-junitparser
+            - python3 ./fluster_parser.py --results

--- a/config/runtime/tests/v4l2-decoder-conformance.jinja2
+++ b/config/runtime/tests/v4l2-decoder-conformance.jinja2
@@ -25,7 +25,8 @@
           - functional
         run:
           steps:
-          - python3 /usr/bin/fluster_parser.py {{ testsuite_arg }} {{ decoders_arg }} {{ videodec_timeout_arg }} {{ videodec_parallel_jobs_arg }}
+          - python3 /usr/bin/fluster_parser.py --run {{ testsuite_arg }} {{ decoders_arg }} {{ videodec_timeout_arg }} {{ videodec_parallel_jobs_arg }}
+          - python3 /usr/bin/fluster_parser.py --results
       from: inline
       name: {{ node.name }}
       path: inline/{{ node.name }}.yaml


### PR DESCRIPTION
This commit will:

- Replace the result directory from `/opt/fluster` to `/tmp`. Chromeos uses a read-only filesystem and the program is failing when writing on the previous directory.
- Uses `wget` to fetch the latest version of `fluster_parser.py` from the kernelci-core repo
- Execute `cat /etc/os-release > /tmp/osrel.tmp` in loop to wait the `ssh` host to be available.
- Add the `--run` flag on the `fluster_parser.py` execution to follow the current struct of the program in the repo. Execute the same script with the `--results` flag to collect the results.
- Install the dependency `python3-junitparser` to parse `fluster_parser.py` results.