### PR TITLE
config: build-configs: Add missing kernel configs for preempt-rt

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -542,6 +542,9 @@ fragments:
       - 'CONFIG_SCHED_DEBUG=y'
       - 'CONFIG_PREEMPT_RT=y'
       - 'CONFIG_PREEMPT_RT_FULL=y' # <= v4.19
+      - 'CONFIG_FTRACE=y'
+      - 'CONFIG_OSNOISE_TRACER=y'
+      - 'CONFIG_TIMERLAT_TRACER=y'
 
   rust:
     path: "kernel/configs/rust.config"


### PR DESCRIPTION
Add missing configurations needed to run rtla timerlat and osnoise tests.

Relates https://github.com/kernelci/kernelci-project/issues/439
Signed-off-by: Muhammad Usama Anjum <usama.anjum@collabora.com>