### PR TITLE
feat(docker/cros-tast): Add package to cros-tast image

### DIFF
--- a/config/docker/cros-tast.jinja2
+++ b/config/docker/cros-tast.jinja2
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     inetutils-ping \
     python3 \
     python3-pkg-resources \
+    python3-junitparser \
     ssh \
     wget
 
@@ -30,6 +31,10 @@ ADD https://raw.githubusercontent.com/kernelci/kernelci-core/\
 kernelci.org/\
 config/docker/data/ssh_retry.sh \
 /home/cros/ssh_retry.sh
+
+ADD https://github.com/kernelci/kernelci-core/raw/main/config/\
+rootfs/debos/overlays/fluster/usr/bin/fluster_parser.py \
+/home/cros/fluster_parser.py
 
 # Needed by LAVA to install the overlay
 USER root

--- a/config/runtime/tests/fluster-chromeos.jinja2
+++ b/config/runtime/tests/fluster-chromeos.jinja2
@@ -45,7 +45,6 @@
             cat /etc/os-release > /tmp/osrel.tmp
             - cat /tmp/osrel.tmp
             - lava-test-set stop setup
-            - wget https://github.com/kernelci/kernelci-core/raw/main/config/rootfs/debos/overlays/fluster/usr/bin/fluster_parser.py
             - >-
               scp
               -o StrictHostKeyChecking=no
@@ -74,5 +73,4 @@
               -i /home/cros/.ssh/id_rsa
               root@$(lava-target-ip)
               poweroff && sleep 30 || true
-            - apt install -y python3-junitparser
             - python3 ./fluster_parser.py --results


### PR DESCRIPTION
Right now we are installing python3-junitparser by apt, it is better to pre-build it with docker image.