### PR TITLE
Add tast dut files

### DIFF
--- a/config/rootfs/chromiumos/scripts/build_board.sh
+++ b/config/rootfs/chromiumos/scripts/build_board.sh
@@ -116,9 +116,22 @@ sudo mkdir -p "${DATA_DIR}/${BOARD}"
 sudo cp "src/build/images/${BOARD}/latest/chromiumos_test_image.bin" "${DATA_DIR}/${BOARD}"
 
 echo "Packing Tast files"
+# Copy files for the Host (remote)
 sudo tar -cf "${DATA_DIR}/${BOARD}/tast.tar" -C ./chroot/usr/bin/ remote_test_runner tast
 sudo tar -uf "${DATA_DIR}/${BOARD}/tast.tar" -C ./chroot/usr/libexec/tast/bundles/remote/ cros
 sudo tar -uf "${DATA_DIR}/${BOARD}/tast.tar" -C ./chroot/usr/share/tast/data go.chromium.org
+# Copy files for the DUT (local)
+OUT_USR_DIR="./out/build/${BOARD}/usr"
+sudo tar -uf "${DATA_DIR}/${BOARD}/tast.tar" -C $OUT_USR_DIR/bin/ local_test_runner
+sudo tar -uf "${DATA_DIR}/${BOARD}/tast.tar" -C $OUT_USR_DIR/libexec/chrome-binary-tests \
+																															libtest_trace_processor.so \
+																															v4l2_stateless_decoder
+sudo tar -uf "${DATA_DIR}/${BOARD}/tast.tar" -C $OUT_USR_DIR/libexec/tast/bundles/ local/cros
+sudo tar -uf "${DATA_DIR}/${BOARD}/tast.tar" -C $OUT_USR_DIR/local/graphics validate
+sudo tar -uf "${DATA_DIR}/${BOARD}/tast.tar" -C $OUT_USR_DIR/local/bin v4l2_stateful_decoder
+sudo tar -uf "${DATA_DIR}/${BOARD}/tast.tar" -C ./src/platform/tast-tests/src/ \
+									go.chromium.org/tast-tests/cros/local/bundles/cros/video/data/test_vectors
+# Compress Tast files
 sudo gzip -9 "${DATA_DIR}/${BOARD}/tast.tar"
 sudo mv "${DATA_DIR}/${BOARD}/tast.tar.gz" "${DATA_DIR}/${BOARD}/tast.tgz"
 

--- a/config/rootfs/chromiumos/scripts/build_board.sh
+++ b/config/rootfs/chromiumos/scripts/build_board.sh
@@ -118,6 +118,7 @@ sudo cp "src/build/images/${BOARD}/latest/chromiumos_test_image.bin" "${DATA_DIR
 echo "Packing Tast files"
 sudo tar -cf "${DATA_DIR}/${BOARD}/tast.tar" -C ./chroot/usr/bin/ remote_test_runner tast
 sudo tar -uf "${DATA_DIR}/${BOARD}/tast.tar" -C ./chroot/usr/libexec/tast/bundles/remote/ cros
+sudo tar -uf "${DATA_DIR}/${BOARD}/tast.tar" -C ./chroot/usr/share/tast/data go.chromium.org
 sudo gzip -9 "${DATA_DIR}/${BOARD}/tast.tar"
 sudo mv "${DATA_DIR}/${BOARD}/tast.tar.gz" "${DATA_DIR}/${BOARD}/tast.tgz"
 


### PR DESCRIPTION
Tast-tests: Add files to be copied to DUT to the Tast tarball

Built on top of: https://github.com/kernelci/kernelci-core/pull/2663

This commit add files to the Tast tarball aiming to be dynamically copied to the DUT (local) when testing with non-chromeos (i.e. Debian) root filesytem. Specifically, add:

- `local_test_runner` - The local Tast agent
- `libtest_trace_processor.so` - The necessary library for v4l2 tests
- `v4l2_stateless_decoder` - The decoding application binary
- `cros` - Test bundle in binary format
- `validate` - Utility to compare bitstreams
- `test_vectors` containing the test vectors for the v4l2 tests