### PR TITLE
feat(runtime/lava.py): Add more LAVA submit error logging

### DIFF
--- a/kernelci/runtime/lava.py
+++ b/kernelci/runtime/lava.py
@@ -342,6 +342,8 @@ class LAVA(Runtime):
         resp = self._server.session.post(
             jobs_url, json=job_data, allow_redirects=False
         )
+        if resp.status_code >= 400:
+            print(f"Error submitting job: {resp.status_code}, {resp.text}")
         resp.raise_for_status()
         return resp.json()['job_ids'][0]
 


### PR DESCRIPTION
Sometimes LAVA doesn't like job, but HTTP error code not enough, to understand why. Let's log also response.