### PR TITLE
config: rt-tests: fix default timeout value in minutes

### DIFF
--- a/config/runtime/tests/rt-tests.jinja2
+++ b/config/runtime/tests/rt-tests.jinja2
@@ -1,7 +1,7 @@
 - test:
     name: {{ node.name }}
     timeout:
-      minutes: {{ job_timeout|default('600s') }}
+      minutes: {{ job_timeout|default('10') }}
 
     definitions:
     - repository: https://github.com/kernelci/test-definitions.git


### PR DESCRIPTION
Fixes: 0888c9cc0ec8 ("config: rt-tests: Add default timeout and duration values")