### PR TITLE
config: chromeos: Select teo cpuidle governor for arm64 devices

### DIFF
--- a/config/runtime/chromeos/base.jinja2
+++ b/config/runtime/chromeos/base.jinja2
@@ -50,7 +50,11 @@
     failure_retry: 3
     method: depthcharge
     commands: emmc
+{% if debarch == 'arm64' %}
+    extra_kernel_args: cros_secure cros_debug cpuidle.governor=teo root=PARTUUID=566f7961-6765-7220-746f-20756e697665 rootwait ro
+{% else %}
     extra_kernel_args: cros_secure cros_debug root=PARTUUID=566f7961-6765-7220-746f-20756e697665 rootwait ro
+{% endif %}
     prompts:
       - 'localhost(.*)~(.*)#'
     failure_message: 'chromeos-boot-alert: self_repair'


### PR DESCRIPTION
ChromeOS uses teo by default on arm64 targets by specifying it in the command line arguments. Do the same in kernelci. Not only our cpuidle tast test will pass with it. But also we may have more similar behaviours like ChromeOS.