### PR TITLE
fix(amd64-chromebook.fragment): Fix fragment due config rename in new kernels

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -195,6 +195,7 @@ fragments:
       - 'CONFIG_QCOM_WDT=y'
       - 'CONFIG_POWER_RESET_QCOM_PON=y'
       - 'CONFIG_USB_ONBOARD_HUB=y'
+      - 'CONFIG_USB_ONBOARD_DEV=y' # [PATCH v4 1/8] usb: misc: onboard_hub: rename to onboard_dev
       - 'CONFIG_BACKLIGHT_GPIO=y'
       - 'CONFIG_BLK_DEV_NVME=y'
       - 'CONFIG_CORESIGHT_SOURCE_ETM4X=m'


### PR DESCRIPTION

[PATCH v4 1/8] usb: misc: onboard_hub: rename to onboard_dev rename CONFIG_USB_ONBOARD_HUB to CONFIG_USB_ONBOARD_DEV