### PR TITLE
config: runtime: tests: Add template kselftest-platform-parameters

### DIFF
--- a/config/runtime/tests/kselftest-platform-parameters.jinja2
+++ b/config/runtime/tests/kselftest-platform-parameters.jinja2
@@ -1,0 +1,41 @@
+- test:
+    timeout:
+      minutes: {{ job_timeout }}
+    definitions:
+    - from: inline
+      repository:
+        metadata:
+          format: Lava-Test Test Definition 1.0
+          name: timesync-off
+          description: Disable systemd time sync services
+        run:
+          steps:
+          - systemctl stop systemd-timesyncd || true
+      name: timesync-off
+      path: inline/timesync-off.yaml
+
+    - from: inline
+      repository:
+        metadata:
+          format: Lava-Test Test Definition 1.0
+          name: platform-test-parameters-fetch
+          description: Fetch platform-specific test parameters
+        run:
+          steps:
+          - wget https://github.com/kernelci/platform-test-parameters/archive/refs/heads/main.tar.gz
+          - tar xf main.tar.gz -C /opt/
+      name: platform-test-parameters-fetch
+      path: inline/platform-test-parameters-fetch.yaml
+
+    - repository: https://github.com/kernelci/test-definitions.git
+      from: git
+      revision: kernelci.org
+      path: automated/linux/kselftest/kselftest.yaml
+      name: '{{ node.name }}'
+      parameters:
+        TESTPROG_URL: '{{ node.artifacts.kselftest_tar_gz }}'
+        SKIPFILE: /dev/null
+        TST_CMDFILES: '{{ collections }}'
+        TST_CASENAME: '{{ tests }}'
+        SKIP_INSTALL: True
+        ENV: '{{ env }}'


### PR DESCRIPTION
This introduces a new template which is a copy of the kselftest template with the difference that an archive of the 'platform-test-parameters' repository is downloaded before running the kselftest. This provides the test with the most up-to-date version of the platform-specific details that some of them require.