### PR TITLE
config: rt-tests: reduce the duration of the test

### DIFF
--- a/config/runtime/tests/rt-tests.jinja2
+++ b/config/runtime/tests/rt-tests.jinja2
@@ -13,7 +13,7 @@
         ARTIFACTORIAL_TOKEN: {{ artifactorial_token|default('') }}
         ARTIFACTORIAL_URL: {{ artifactorial_url|default('') }}
         AFFINTIY: {{ affinity|default('0-1') }}
-        DURATION: {{ duration|default('600s') }}
+        DURATION: {{ duration|default('540s') }}
         BACKGROUND_CMD: {{ background|default('hackbench') }}
       {% if tst_cmd == 'cyclicdeadline' %}
         INTERVAL: {{ interval|default('1000') }}


### PR DESCRIPTION
The timeout of the job is set to 10 minutes. We should run the test for less than that. Reduce the total duration of the test to 540 seconds. Leave 60 seconds for logging in, setting the environment and triggering the test runner script.

We wanted to have total time of this job to be 10 minutes and run the test for as much duration as possible. So reducing to 540 seconds or 9 minutes is okay.