### PR TITLE
config: tast: Disable verbose mode while tast.tgz is untar

### DIFF
--- a/config/runtime/tests/tast.jinja2
+++ b/config/runtime/tests/tast.jinja2
@@ -31,7 +31,7 @@
             - >-
               lava-test-case tast-tarball --shell
               curl -s '{{ platform_config.params.tast_tarball }}'
-              \| tar xzvf -
+              \| tar xzf -
               && cp remote_test_runner /usr/bin/remote_test_runner
               && mkdir -p /usr/libexec/tast/bundles/remote/
               && cp cros /usr/libexec/tast/bundles/remote/


### PR DESCRIPTION
The data directory has been added to tast archive which when extracted generates 3 thousands log lines per execution. In total, there are 6 thousands log lines in every job. In the past, verbose option may be usefult to know which files got extracted. But now it creates too much noise.

In verbose mode:
https://lava.collabora.dev/scheduler/job/15997406

Without verbose mode::
https://lava.collabora.dev/scheduler/job/15998558