### PR TITLE
fix(docker/k8s): Fix image naming

### DIFF
--- a/config/runtime/base/kubernetes.jinja2
+++ b/config/runtime/base/kubernetes.jinja2
@@ -32,7 +32,7 @@ spec:
 
       containers:
       - name: kernelci
-        image: ghcr.io/{{ runtime_image }}
+        image: {{ runtime_image }}
         imagePullPolicy: Always
 
         volumeMounts:

--- a/kernelci/config/job.py
+++ b/kernelci/config/job.py
@@ -50,6 +50,11 @@ class Job(YAMLConfigObject):  # pylint: disable=too-many-instance-attributes
         """Runtime environment image name"""
         return self._image
 
+    @image.setter
+    def image(self, value):
+        """Set the runtime environment image name"""
+        self._image = value
+
     @property
     def params(self):
         """Arbitrary parameters passed to the template"""

--- a/kernelci/runtime/__init__.py
+++ b/kernelci/runtime/__init__.py
@@ -147,6 +147,7 @@ class Runtime(abc.ABC):
                 if not device_dtb:
                     print(f"dtb file {job.platform_config.dtb} not found!")
                     return None
+
         params = {
             'api_config': api_config or {},
             'storage_config': job.storage_config or {},


### PR DESCRIPTION
We had previously hack with hardcoding ghcr.io.
Now we make it more flexible, so people can set their own image url, and our staging instance automatically add staging- prefix in appropriate place.