### PR TITLE
feat(storage/azure.py): Add content_type option for .gz files

### DIFF
--- a/kernelci/storage/azure.py
+++ b/kernelci/storage/azure.py
@@ -8,6 +8,7 @@
 from urllib.parse import urljoin
 import os
 from azure.storage.fileshare import ShareServiceClient
+from azure.storage.blob import ContentSettings
 from . import Storage
 
 
@@ -68,7 +69,11 @@ class StorageAzureFiles(Storage):
         for src, dst in file_paths:
             file_client = root.get_file_client(file_name=dst)
             with open(src, 'rb') as src_file:
-                file_client.upload_file(src_file)
+                c_type = 'application/octet-stream'
+                if src.endswith('.gz'):
+                    c_type = 'application/gzip'
+                c_settings = ContentSettings(content_type=c_type)
+                file_client.upload_file(src_file, content_settings=c_settings)
             urls[dst] = urljoin(
                 self.config.base_url,
                 '/'.join([self.config.share, dest_path, dst]),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ readme = "README.md"
 requires-python = ">=3.9"
 license = {text = "LGPL-2.1-or-later"}
 dependencies = [
+  "azure-storage-blob==12.23.1",
   "azure-storage-file-share==12.13.0",
   "bson==0.5.10",
   "click==8.1.3",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+azure-storage-blob==12.23.1
 azure-storage-file-share==12.13.0
 bson==0.5.10
 click==8.1.3


### PR DESCRIPTION
As requested by kcidb team, it will be easier to handle files if they have proper content-type set.