### PR TITLE
Revert "fix(workflows/docker_images): Extend list of built arch"

### DIFF
--- a/.github/workflows/docker_images.yml
+++ b/.github/workflows/docker_images.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kciarch: [ 'arc', 'arm', 'armv5', 'arm64', 'x86', 'mips', 'riscv64', 'i386', 'riscv' ]
+        kciarch: [ 'arc', 'arm', 'armv5', 'arm64', 'x86', 'mips', 'riscv64' ]
         kcicmd: [ 'clang-15 kselftest kernelci',
                   'clang-17 kselftest kernelci',
                   'gcc-12 kselftest kernelci'


### PR DESCRIPTION
Reverts kernelci/kernelci-core#2716
i386 handled by x86, and riscv by riscv64