### PR TITLE
config: docker: Add gawk package to all build containers

### DIFF
--- a/config/docker/base/host-tools.jinja2
+++ b/config/docker/base/host-tools.jinja2
@@ -66,6 +66,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     dwarves \
     flex \
     g++ \
+    gawk \
     gcc \
     git \
     kmod \


### PR DESCRIPTION
The usage of gawk has recently appeared in the linux kernel. The build fails if it isn't found. Add the gawk package.