### PR TITLE
fix(kbuild): Do not build kselftest if not set in jobfilter

### DIFF
--- a/kernelci/kbuild.py
+++ b/kernelci/kbuild.py
@@ -156,6 +156,10 @@ class KBuild():
                 self._kfselftest = False
             else:
                 self._kfselftest = True
+            if node['jobfilter'] and self._kfselftest is True:
+                kselftest_name = node['name'] + "-kselftest"
+                if kselftest_name not in node['jobfilter']:
+                    self._kfselftest = False
             self._apijobname = jobname
             self._steps = []
             self._artifacts = []


### PR DESCRIPTION
To speed up bisection do not build kselftest if it is not set in jobfilter.