### PR TITLE
kernelci/build.py: fix `git_branch_tip`

### DIFF
--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -275,7 +275,7 @@ cd {path}
 git rev-parse {tree}/{branch}
 """.format(path=path, tree=tree, branch=branch)
     head_commit_id = shell_cmd(cmd)
-    if commit == head_commit_id:
+    if commit.strip() == head_commit_id.strip():
         return True
     return False
 


### PR DESCRIPTION
Fixes https://github.com/kernelci/kernelci-pipeline/issues/846

Bug: `tip_of_branch` is always set to `False`.
Fix the method by stripping subprocess command output to get the correct value for `tip_of_branch`.