### PR TITLE
feat(cli/event): Implement promisc flag

### DIFF
--- a/kernelci/cli/event.py
+++ b/kernelci/cli/event.py
@@ -27,13 +27,14 @@ def kci_event():
 
 @kci_event.command(secrets=True)
 @click.argument('channel')
+@click.option('--promisc', help="Subscribe to all users", is_flag=True)
 @Args.config
 @Args.api
 @catch_error
-def subscribe(config, api, channel, secrets):
+def subscribe(config, api, channel, secrets, promisc):
     """Subscribe to a Pub/Sub channel"""
     api = get_api(config, api, secrets)
-    sub_id = api.subscribe(channel)
+    sub_id = api.subscribe(channel, promisc)
     click.echo(sub_id)
 
 


### PR DESCRIPTION
We have API promisc flag for pub/sub events, and it is useful to have it available in cli too, to listen for all events on api instance.