### PR TITLE
Get chromeos version for `tast` tests

### DIFF
--- a/kernelci/api/models.py
+++ b/kernelci/api/models.py
@@ -566,6 +566,10 @@ class TestData(BaseModel):
         description="Kernel image type (zimage, bzimage...)",
         default=None
     )
+    misc: Optional[dict] = Field(
+        description="Miscellaneous fields (e.g. chromeos version for tast tests)",
+        default=None
+    )
 
 
 class Test(Node):

--- a/kernelci/runtime/lava.py
+++ b/kernelci/runtime/lava.py
@@ -140,6 +140,17 @@ class Callback:
         result = kernelmsg and kernelmsg['result'] == 'pass'
         return 'pass' if result else 'fail'
 
+    def _get_os_release_measurement(self):
+        for suite_name, suite_results in self._data['results'].items():
+            if suite_name != '0_tast':
+                continue
+            tests = yaml.safe_load(suite_results)
+            tests_map = {test['name']: test for test in tests}
+            os_release = tests_map.get('os-release')
+            if os_release:
+                return os_release.get('measurement')
+        return None
+
     @classmethod
     def _get_suite_results(cls, tests):
         suite_results = {}
@@ -195,6 +206,9 @@ class Callback:
             elif isinstance(value, str):
                 node['result'] = value
                 node['kind'] = 'test'
+                if node['name'] == 'os-release':
+                    node['data'] = {"misc": {}}
+                    node['data']['misc']['measurement'] = self._get_os_release_measurement()
             hierarchy.append(item)
         return hierarchy
 


### PR DESCRIPTION
Add a method to get `measurement`(chromeos version) field for `os-release` test case from LAVA callback data.
Store the information into `node.data.misc` field of test node.