### PR TITLE
fix(pipeline.jinja2): Add logspec to docker recipe

### DIFF
--- a/config/docker/fragment/pipeline.jinja2
+++ b/config/docker/fragment/pipeline.jinja2
@@ -4,6 +4,9 @@ USER root
 # KCIDB python for kcidb bridge service
 RUN python3 -m pip install git+https://github.com/kernelci/kcidb.git --break-system-packages
 
+# Install logspec
+RUN pip install git+https://github.com/kernelci/logspec.git
+
 USER kernelci
 ARG pipeline_url=https://github.com/kernelci/kernelci-pipeline.git
 ARG pipeline_rev=main


### PR DESCRIPTION
Docker recipe is required to build pipeline container, and this container is used in k8s deployment.
At moment kcidb bridge is broken due missing logspec, fixing that.