### PR TITLE
fix(build-configs.yaml): Add CONFIG_CPUSETS_V1

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -165,6 +165,7 @@ fragments:
       - 'CONFIG_ROOT_NFS=y'
       - 'CONFIG_REGULATOR_DA9211=y'
       - 'CONFIG_ARM_MEDIATEK_CPUFREQ=y'
+      - 'CONFIG_CPUSETS_V1=y'
       - 'CONFIG_RTC_DRV_MT6397=y'
       # This is required for sc7180-trogdor-lazor-limozeen and it hasn't been
       # merged upstream yet.
@@ -615,6 +616,7 @@ fragments:
       - 'CONFIG_BT_HCIBTUSB_MTK=y'
       - 'CONFIG_BT_HCIBTUSB=m'
       - 'CONFIG_BT=m'
+      - 'CONFIG_CPUSETS_V1=y'
       - 'CONFIG_CHARGER_CROS_USBPD=m'
       - 'CONFIG_CHARGER_WILCO=m'
       - 'CONFIG_CHROME_PLATFORMS=y'


### PR DESCRIPTION
Due changes of 1abab1ba0775036bb67c6c57945c637be644c04f ChromeOS tests not passing anymore. Regression bisection pointed to this commit.