### PR TITLE
feat(models.py): Introduce processed_by_kcidb_bridge flag 

### DIFF
--- a/kernelci/api/models.py
+++ b/kernelci/api/models.py
@@ -262,6 +262,10 @@ class Node(DatabaseModel):
         default=[],
         description="User groups that are permitted to update node"
     )
+    processed_by_kcidb_bridge: bool = Field(
+        description="Flag to indicate if the node was processed by KCIDB-Bridge",
+        default=False
+    )
 
     OBJECT_ID_FIELDS: ClassVar[list] = ['parent']
     TIMESTAMP_FIELDS: ClassVar[list] = ['created', 'updated', 'timeout', 'holdoff']


### PR DESCRIPTION
To make kcidb data transmission more reliable introduce processed_by_kcidb_bridge flag, which indicates if node was processed by kcidb bridge service.