### PR TITLE
fix(helper.py): Handle better exception in kbuild

### DIFF
--- a/kernelci/api/helper.py
+++ b/kernelci/api/helper.py
@@ -453,7 +453,17 @@ class APIHelper:
                 'krev': f"{kernel_revision['version']}.{kernel_revision['patchlevel']}"
             }
             extra_args.update(job_config.params)
-            job_node['data'] = platform.format_params(job_node['data'], extra_args)
+            try:
+                job_node['data'] = platform.format_params(job_node['data'], extra_args)
+            except KeyError as error:
+                print(f"KeyError dyring creating job node: {error}")
+                return None
+            except ValueError as error:
+                print(f"ValueError during creating job node: {error}")
+                return None
+            except Exception as error:
+                print(f"Exception Error during creating job node: {error}")
+                return None
         try:
             return self._api.node.add(job_node)
         except requests.exceptions.HTTPError as error:


### PR DESCRIPTION
Observed error with pod crash:
```
11/27/2024 10:24:52 PM UTC [ERROR] Traceback (most recent call last):
  File "/home/kernelci/pipeline/src/base.py", line 69, in run
    status = self._run(context)
             ^^^^^^^^^^^^^^^^^^
  File "/home/kernelci/pipeline/./src/scheduler.py", line 296, in _run
    self._run_job(job, runtime, platform, input_node)
  File "/home/kernelci/pipeline/./src/scheduler.py", line 80, in _run_job
    node = self._api_helper.create_job_node(job_config, input_node,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/kernelci/api/helper.py", line 456, in create_job_node
    job_node['data'] = platform.format_params(job_node['data'], extra_args)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/kernelci/config/base.py", line 167, in format_params
    return _format_dict_strings(param, args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/kernelci/config/base.py", line 79, in _format_dict_strings
    param[key] = _format_dict_strings(param[key], fmap)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/kernelci/config/base.py", line 79, in _format_dict_strings
    param[key] = _format_dict_strings(param[key], fmap)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/kernelci/config/base.py", line 74, in _format_dict_strings
    param = param.format_map(fmap)
            ^^^^^^^^^^^^^^^^^^^^^^
ValueError: unmatched '{' in format spec
```
We can handle it without crash.