### PR TITLE
config: dmesg.sh: Ignore missing handler errors in baseline tests

### DIFF
--- a/config/docker/cros-baseline.jinja2
+++ b/config/docker/cros-baseline.jinja2
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 {{ super() }}
 
 ADD https://raw.githubusercontent.com/kernelci/kernelci-core/\
-kernelci.org/\
+main/\
 config/rootfs/debos/overlays/baseline/opt/kernelci/dmesg.sh \
 /home/cros/dmesg.sh
 

--- a/config/rootfs/debos/overlays/baseline/opt/kernelci/dmesg.sh
+++ b/config/rootfs/debos/overlays/baseline/opt/kernelci/dmesg.sh
@@ -12,6 +12,11 @@ fi
 
 for level in crit alert emerg; do
     dmesg --level=$level --notime -x -k > dmesg.$level
+    if grep -q "No irq handler for vector" dmesg.$level; then
+        echo "Ignoring:"
+        grep "No irq handler for vector" dmesg.$level
+        sed '/No irq handler for vector/d' dmesg.$level > dmesg.$level
+    fi
     if [ -s "dmesg.$level" ]; then
         res=fail
         ret=1


### PR DESCRIPTION
Ignore "No irq handler for vector" errors in baseline tests [1]. These errors are harmless. But because of these errors the baseline test gets marked as failed which makes results dirty. It would have been better to ignore these errors as known errors on the dashboard. But as we don't have the functionality at this time. We have decided to ignore these during the test until we have the functionality.

[1] https://kcidb.kernelci.org/d/test/test?orgId=1&var-datasource=default&var-build_architecture=x86_64&var-build_config_name=cros:%2F%2Fchromeos-6.6%2Fx86_64%2Fchromeos-amd-stoneyridge.flavour.config&var-id=maestro:67455b8c3be6da94b19fde34&from=now-100y&to=now&timezone=browser&var-origin=$__all&var-test_path=&var-issue_presence=$__all Close https://github.com/kernelci/kernelci-project/issues/496
Signed-off-by: Muhammad Usama Anjum <musamaanjum@collabora.com>