### PR TITLE
add h26forge test

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -105,6 +105,36 @@ rootfs_configs:
     imagesize: 2GB
     debos_memory: 8G
 
+  bookworm-gst-h26forge:
+    rootfs_type: debos
+    debian_release: bookworm
+    arch_list:
+      - amd64
+      - arm64
+      - armhf
+    extra_packages_remove:
+      - bash
+      - e2fslibs
+      - e2fsprogs
+      - klibc-utils
+      - libext2fs2
+      - libgnutls30
+      - libklibc
+      - libncursesw6
+      - libp11-kit0
+      - libunistring2
+      - sensible-utils
+    extra_packages:
+      - ca-certificates
+      - python3-requests
+      - python3-yaml
+      - unzip
+      - wget
+    script: "scripts/bookworm-gst-h26forge.sh"
+    imagesize: 4GB
+    debos_memory: 8G
+    debos_scratchsize: 16G
+
   bookworm-igt:
     rootfs_type: debos
     debian_release: bookworm

--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -131,6 +131,7 @@ rootfs_configs:
       - unzip
       - wget
     script: "scripts/bookworm-gst-h26forge.sh"
+    test_overlay: "overlays/h26forge"
     imagesize: 4GB
     debos_memory: 8G
     debos_scratchsize: 16G

--- a/config/rootfs/debos/overlays/h26forge/usr/bin/h26forge-parser.sh
+++ b/config/rootfs/debos/overlays/h26forge/usr/bin/h26forge-parser.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+#
+# Copyright (C) 2025 Collabora Limited
+# Author: Benjamin Gaignard <benjamin.gaignard@collabora.com>
+#
+# This module is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+set -e
+
+if [ "$KERNELCI_LAVA" = "y" ]; then
+    alias test-result='lava-test-case'
+    alias test-exception='lava-test-raise'
+else
+    alias test-result='echo'
+    alias test-exception='echo'
+fi
+
+if ! command -v gst-inspect-1.0 >/dev/null; then
+	echo "gst-inspect-1.0 not found. Please install it to proceed."
+	test-result h26forge-debian --result skip
+	exit 0
+fi
+
+# Check if v4l2slh264dec element exist
+if command -v gst-inspect-1.0 --exists v4l2slh264dec>/dev/null; then
+	echo "v4l2slh264dec element is missing. Skipping the test"
+	test-result h26forge-debian --result skip
+	exit 0
+fi
+
+if [ ! -d /opt/h26forge/test_videos/ ]; then
+	echo "bitstreams test directory missing. Skipping the test"
+	test-result h26forge-debian --result skip
+	exit 0
+fi
+
+cd /opt/h26forge/test_videos/
+
+for i in $(seq -f "%04g" 0 99); do
+	if command -v gst-launch-1.0 filesrc location=video$i.264.mp4 ! parsebin ! v4l2slh264dec ! fakesink>/dev/null; then
+		test-result h26forge-debian --result fail
+		exit 1
+	fi
+done
+
+test-result h26forge-debian --result pass
+
+exit 0

--- a/config/rootfs/debos/scripts/bookworm-gst-h26forge.sh
+++ b/config/rootfs/debos/scripts/bookworm-gst-h26forge.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+set -e
+
+BUILD_DEPS="\
+	  g++ \
+	  flex \
+	  bison \
+	  ninja-build \
+	  git \
+	  python3-pip \
+	  pkg-config \
+	  openssl \
+	  ca-certificates \
+	  jq \
+	  wget \
+	  unzip \
+	  software-properties-common \
+	  libclang-dev
+"
+
+GST_DEPS="\
+	  libglib2.0-dev \
+	  libgudev-1.0-dev
+"
+
+export DEBIAN_FRONTEND=noninteractive
+
+# Install dependencies
+echo 'deb http://deb.debian.org/debian bookworm-backports main' >>/etc/apt/sources.list
+apt-get update
+apt-get install --no-install-recommends -y ${BUILD_DEPS} ${GST_DEPS} curl
+apt-mark manual python3 libpython3-stdlib python3 libglib2.0-0 libgudev-1.0
+apt-get remove -y libgstreamer1.0-0
+
+# Get latest meson from pip
+pip3 install meson --break-system-packages
+
+# Get latest stable rustc and cargo
+curl https://sh.rustup.rs -sSf | sh -s -- -y
+# add cargo path
+. "$HOME/.cargo/env"
+
+H26FORGE_URL=https://github.com/h26forge/h26forge.git
+H26FORGE=target/release/h26forge
+output_dir="test_videos"
+tool_args="--mp4 --mp4-rand-size --safestart"
+generation_args="--small --ignore-edge-intra-pred --ignore-ipcm --config config/default.json"
+
+# Configure git
+git config --global user.email "bot@kernelci.org"
+git config --global user.name "KernelCI Bot"
+
+GSTREAMER_URL=https://gitlab.freedesktop.org/gstreamer/gstreamer.git
+
+mkdir -p /var/tests/gstreamer && cd /var/tests/gstreamer
+
+git clone --depth 1 $GSTREAMER_URL .
+
+meson setup build \
+	--prefix=/usr \
+	--wrap-mode=nofallback \
+	-Dauto_features=disabled \
+	-Dbad=enabled \
+	-Dbase=enabled \
+	-Dgood=enabled \
+	-Dugly=disabled \
+	-Dgst-plugins-bad:ivfparse=enabled \
+	-Dgst-plugins-bad:debugutils=enabled \
+	-Dgst-plugins-bad:v4l2codecs=enabled \
+	-Dgst-plugins-bad:videoparsers=enabled \
+	-Dgst-plugins-base:app=enabled \
+	-Dgst-plugins-base:playback=enabled \
+	-Dgst-plugins-base:tools=enabled \
+	-Dgst-plugins-base:typefind=enabled \
+	-Dgst-plugins-base:videoconvertscale=enabled \
+	-Dgst-plugins-good:matroska=enabled \
+	-Dgst-plugins-good:v4l2=enabled \
+	-Dtools=enabled \
+	-Ddevtools=disabled \
+	-Dges=disabled \
+	-Dlibav=disabled \
+	-Drtsp_server=disabled
+
+ninja -C build
+ninja -C build install
+
+mkdir -p /opt/h26forge && cd /opt/h26forge
+
+git clone --depth 1 $H26FORGE_URL .
+
+cargo update -vv
+cargo build --release
+
+if [ ! -f $H26FORGE ]; then
+	echo "h26forge not found"
+	exit 1
+fi
+
+mkdir -p $output_dir
+for i in $(seq -f "%04g" 0 99); do
+  $H26FORGE $tool_args generate $generation_args -o $output_dir/video$i.264
+  gst-launch-1.0 filesrc location=$output_dir/video$i.264.mp4 ! parsebin ! fakesink
+done
+
+########################################################################
+# Cleanup: remove files and packages we don't want in the images       #
+########################################################################
+rm -rf /var/tests
+
+apt-get remove --purge -y ${BUILD_DEPS}
+apt-get autoremove --purge -y
+apt-get clean

--- a/config/runtime/tests/h26forge-debian.jinja2
+++ b/config/runtime/tests/h26forge-debian.jinja2
@@ -1,0 +1,23 @@
+{# This test verifies if h26forge generate bitstream
+ # do not make h264 stateless decoder crash basic functionality:
+-#}
+- test:
+    timeout:
+      minutes: {{ job_timeout|default('15') }}
+    definitions:
+    - repository:
+        metadata:
+          format: Lava-Test Test Definition 1.0
+          name: {{ node.name }}
+          description: "h26forge test plan"
+          os:
+          - debian
+          scope:
+          - functional
+        run:
+          steps:
+          - KERNELCI_LAVA=y /usr/bin/h26forge-parser.sh
+
+      from: inline
+      name: {{ node.name }}
+      path: inline/{{ node.name }}.yaml


### PR DESCRIPTION
Create a rootfs with rustc compiler to compile
and run h26forge.
h26forge will generate h264 test files to be parsed with Gstreamer h264parse element.