### PR TITLE
tast-v4l2-decoder: Include test vectors on Docker image to avoid download on runtime

### DIFF
--- a/config/docker/cros-tast.jinja2
+++ b/config/docker/cros-tast.jinja2
@@ -42,4 +42,36 @@ RUN chmod +x /home/cros/tast_parser.py /home/cros/ssh_retry.sh
 
 # Create symlink to /usr/local/bin for tast gs:// downloads
 RUN ln -s /home/cros/trunk/chromite/bin/gsutil /usr/local/bin/
+
+RUN apt install -y jq
+USER cros
+WORKDIR /home/cros
+
+RUN git clone "https://chromium.googlesource.com/chromiumos/platform/tast-tests" && \
+cd tast-tests && git checkout release-R130-16033.B && cd .. && \
+mv tast-tests/src/go.chromium.org/tast-tests/cros/local/bundles/cros/video/data/test_vectors . && \
+rm -rf tast-tests
+
+RUN (find test_vectors -name '*.external' | xargs -P 4 -I '#' bash -c '\
+url=`jq -r .url #`;\
+filename=#;\
+dest=${filename%.external};\
+echo "Downloading $dest";\
+gsutil -q cp "$url" "$dest"; \
+echo "Finished $(basename "$dest")";\
+')
+
+RUN tar -czf "/home/cros/test_vectors.tar.gz" \
+./test_vectors/av1 \
+./test_vectors/h264 \
+./test_vectors/hevc \
+./test_vectors/vp8
+
+RUN tar -czf "/home/cros/test_vectors-vp9.tar.gz" \
+./test_vectors/vp9
+
+RUN rm -rf test_vectors
+
+USER root
+
 {%- endblock %}

--- a/config/runtime/tests/tast-debian.jinja2
+++ b/config/runtime/tests/tast-debian.jinja2
@@ -76,6 +76,16 @@
               cat /etc/os-release > /tmp/osrel.tmp
             - cat /tmp/osrel.tmp
             - sudo -u cros --login ssh-keyscan -t rsa $(lava-target-ip) > ~/.ssh/known_hosts
+{%- if 'v4l2' in tests|join(' ') %}
+            - sudo -u cros --login scp test_vectors.tar.gz root@$(lava-target-ip):/usr || true
+            - sudo -u cros --login ssh root@$(lava-target-ip) tar -xzf /usr/test_vectors.tar.gz -C
+              /usr/local/share/tast/data/go.chromium.org/tast-tests/cros/local/bundles/cros/video/data/ || true
+{%- endif %}
+{%- if 'vp9' in tests|join(' ') %}
+            - sudo -u cros --login scp test_vectors-vp9.tar.gz root@$(lava-target-ip):/usr || true
+            - sudo -u cros --login ssh root@$(lava-target-ip) tar -xzf /usr/test_vectors-vp9.tar.gz -C
+            /usr/local/share/tast/data/go.chromium.org/tast-tests/cros/local/bundles/cros/video/data/ || true
+{%- endif %}
             - >-
               lava-test-case tast-tarball --shell
               curl -s '{{ platform_config.params.tast_tarball }}'

--- a/config/runtime/tests/tast.jinja2
+++ b/config/runtime/tests/tast.jinja2
@@ -50,6 +50,17 @@
             - >-
               lava-test-case os-release --result pass
               --measurement $(sed -e '/VERSION_ID/!d' -e 's/.*=//' /tmp/osrel.tmp)
+            - sudo -u cros --login ssh-keyscan -t rsa $(lava-target-ip) > ~/.ssh/known_hosts
+{%- if 'v4l2' in tests|join(' ') %}
+            - sudo -u cros --login scp test_vectors.tar.gz root@$(lava-target-ip):/usr || true
+            - sudo -u cros --login ssh root@$(lava-target-ip) tar -xzf /usr/test_vectors.tar.gz -C
+              /usr/local/share/tast/data/go.chromium.org/tast-tests/cros/local/bundles/cros/video/data/ || true
+{%- endif %}
+{%- if 'vp9' in tests|join(' ') %}
+            - sudo -u cros --login scp test_vectors-vp9.tar.gz root@$(lava-target-ip):/usr || true
+            - sudo -u cros --login ssh root@$(lava-target-ip) tar -xzf /usr/test_vectors-vp9.tar.gz -C
+            /usr/local/share/tast/data/go.chromium.org/tast-tests/cros/local/bundles/cros/video/data/ || true
+{%- endif %}
             - lava-test-set stop setup
             - >-
               ./tast_parser.py --run


### PR DESCRIPTION
This commit includes the test vectors in the `cros-tast` image to avoid download of these artifacts on every test, reducing the test time and the network usage. Some additional notes:

- This aims to include the test vectors on tests targetting both Debian and ChromeOS.
- The test vectors are split in 2 files: `test_vectors.tar.gz` and `test_vectors-vp9.tar.gz`. The rationale behind this is that the test vectors targetting vp9 requires 11.1 GB of storage, while all the other test vectors for other codecs requires 349M.
- For this change to take effect, `kernelci/cros-tast` will need to be rebuilt. However, `||true` statements on the end of the `scp` and `ssh` commands on the jinja templates were placed to not break the tests while the `kernelci/cros-tast` image is not updated.

Examples of lava job testing:
- https://lava.collabora.dev/scheduler/job/17112682
- https://lava.collabora.dev/scheduler/job/17112944