### PR TITLE
feat(rootfs-configs.yaml): prepare rootfs for netdev/kselftest

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -177,6 +177,7 @@ rootfs_configs:
       - alsa-utils
       - bc
       - ca-certificates
+      - iperf3
       - iproute2
       - iputils-ping
       - jdim
@@ -197,6 +198,7 @@ rootfs_configs:
       - liburing2
       - libxtables12
       - netbase
+      - netsniff-ng
       - openssl
       - perl
       - perl-modules-5.36

--- a/config/rootfs/debos/rootfs.yaml
+++ b/config/rootfs/debos/rootfs.yaml
@@ -66,7 +66,7 @@ actions:
   - action: run
     description: Install extra packages
     chroot: true
-    command: apt-get update && apt-get -y install --no-install-recommends {{ $extra_packages }}
+    command: DEBIAN_FRONTEND=noninteractive apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends {{ $extra_packages }}
 
 
   - action: run


### PR DESCRIPTION
As part of work to prepare kselftest rootfs we need to add packages required to run netdev related tests properly.