### PR TITLE
fix(yaml/jinja): Add IGB and grub nfs support

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -650,6 +650,7 @@ fragments:
       - 'CONFIG_I2C_HID_ACPI=m'
       - 'CONFIG_I2C_HID=m'
       - 'CONFIG_I2C_PIIX4=m'
+      - 'CONFIG_IGB=y'
       - 'CONFIG_IIO_CROS_EC_ACCEL_LEGACY=m'
       - 'CONFIG_IIO_CROS_EC_BARO=m'
       - 'CONFIG_IIO_CROS_EC_LIGHT_PROX=m'

--- a/config/runtime/boot/grub.jinja2
+++ b/config/runtime/boot/grub.jinja2
@@ -3,10 +3,20 @@
       url: '{{ node.artifacts.kernel }}'
       image_arg: -kernel {kernel} -serial stdio --append "console=ttyS0"
       type: {{ node.data.kernel_type }}
+{%- if boot_commands == 'nfs' %}
+    nfsrootfs:
+      url: '{{ nfsroot }}/full.rootfs.tar.xz'
+      compression: xz
     ramdisk:
-      url: 'http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230421.0/{{ brarch }}/rootfs.cpio.gz'
-      image_arg: -initrd {ramdisk}
+      url: '{{ nfsroot }}/initrd.cpio.gz'
       compression: gz
+    os: debian
+{%- else %}
+    ramdisk:
+      url: 'http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230703.0/{{ brarch }}/rootfs.cpio.gz'
+      compression: gz
+    os: oe
+{%- endif %}
 {%- if device_dtb %}
     dtb:
       url: '{{ node.artifacts.dtb }}'
@@ -18,7 +28,11 @@
 
 - boot:
     method: grub
+  {%- if boot_commands == 'nfs' %}
+    commands: nfs
+  {%- else %}
     commands: ramdisk
+  {%- endif %}
     failure_retry: 3
     prompts:
     - '/ #'


### PR DESCRIPTION
Board Aaeon UP squared 6000 with X6425RE needs IGB driver to have functioning networking.