### PR TITLE
fix(kbuild): Add CC/HOST_CC variables for kselftest

### DIFF
--- a/config/docker/fragment/kselftest.jinja2
+++ b/config/docker/fragment/kselftest.jinja2
@@ -25,4 +25,5 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
    libpopt-dev{{ pkgarch }} \
    libssl-dev{{ pkgarch }} \
    patch \
-   pkg-config
+   pkg-config \
+   clang

--- a/kernelci/kbuild.py
+++ b/kernelci/kbuild.py
@@ -311,6 +311,8 @@ class KBuild():
         self.addcmd("export INSTALL_MOD_PATH=_modules_")
         self.addcmd("export INSTALL_MOD_STRIP=1")
         self.addcmd("export INSTALL_DTBS_PATH=_dtbs_")
+        self.addcmd("export CC=" + self._compiler)
+        self.addcmd("export HOSTCC=" + self._compiler)
         # if self._compiler start with clang- we need to set env vars
         if self._compiler.startswith("clang-"):
             # LLVM=1, can be suffix with version in future, like -14


### PR DESCRIPTION
kselftest (for example net) require correct CC/HOST_CC variable to compile some of the components.