### PR TITLE
config: runtime: boot: add support for barebox bootloader

### DIFF
--- a/config/runtime/boot/barebox.jinja2
+++ b/config/runtime/boot/barebox.jinja2
@@ -1,0 +1,48 @@
+{%- if boot_commands == 'nfs' and nfsroot is not defined %}
+{%-   set nfsroot = 'http://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20250117.0/' + debarch %}
+{%- endif %}
+
+- deploy:
+    kernel:
+      type: {{ node.data.kernel_type }}
+      url: '{{ node.artifacts.kernel }}'
+    modules:
+      compression: xz
+      url: '{{ node.artifacts.modules }}'
+{%- if device_dtb %}
+    dtb:
+      url: '{{ node.artifacts.dtb }}'
+{%- endif %}
+{%- if boot_commands == 'nfs' %}
+    nfsrootfs:
+      url: '{{ nfsroot }}/full.rootfs.tar.xz'
+      compression: xz
+    ramdisk:
+      url: '{{ nfsroot }}/initrd.cpio.gz'
+      compression: gz
+    os: debian
+{%- else %}
+    ramdisk:
+      url: 'http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230703.0/{{ brarch }}/rootfs.cpio.gz'
+      compression: gz
+    os: oe
+{%- endif %}
+    timeout:
+      minutes: 10
+    to: tftp
+
+- boot:
+    method: barebox
+    commands: {{ boot_commands | default('ramdisk', true) }}
+    failure_retry: 3
+    prompts:
+    - '/ #'
+    timeout:
+      minutes: 20
+    timeouts:
+      bootloader-commands:
+        minutes: 3
+      auto-login-action:
+        minutes: 6
+      login-action:
+        minutes: 2


### PR DESCRIPTION
We are currently in the process of reviving the [Pengutronix LAVA lab](https://lava.pengutronix.de/) for use with the new KernelCI infrastsructure.

As a first step we need [Barebox](https://www.barebox.org/) bootloader support, since it is used by all boards in the Pengutronix lab.

This PR replaces #2600 by @pawiecz and includes the following suggestion by @a-wai https://github.com/kernelci/kernelci-core/pull/2600#issuecomment-2320699175:

> This doesn't take into account the case where `boot_commands == nfs`; I'd rather suggest to just copy the u-boot template and `s/u-boot/barebox/` there, as it seems they should be otherwise identical.

The barebox template is indeed a copy of the u-boot template with the method set to `barebox`.
