### PR TITLE
fix(workflows/docker_images.yml): Add missing buildroot

### DIFF
--- a/.github/workflows/docker_images.yml
+++ b/.github/workflows/docker_images.yml
@@ -95,6 +95,7 @@ jobs:
                   'kernelci lava-callback',
                   'k8s kernelci',
                   'qemu',
+                  'buildroot',
                    ]
     # only selected people can trigger this job
     if: contains('["nuclearcat","JenySadadia","a-wai","broonie","laura-nao"]', github.actor)


### PR DESCRIPTION
buildroot package was not added to list of images that should be built with all docker images.