### PR TITLE
fix(docker_images.yml): kernelci rootfs uses docker images with :kern…

### DIFF
--- a/.github/workflows/docker_images.yml
+++ b/.github/workflows/docker_images.yml
@@ -95,7 +95,8 @@ jobs:
                   'kernelci lava-callback',
                   'k8s kernelci',
                   'qemu',
-                  'buildroot',
+                  'buildroot kernelci',
+                  'debos kernelci',
                    ]
     # only selected people can trigger this job
     if: contains('["nuclearcat","JenySadadia","a-wai","broonie","laura-nao"]', github.actor)


### PR DESCRIPTION
…elci

We need to add tag kernelci, which also means kernelci tools inside.