### PR TITLE
config: runtime: boot: u-boot: update the default nfsroot to 20250117.0

### DIFF
--- a/config/runtime/boot/u-boot.jinja2
+++ b/config/runtime/boot/u-boot.jinja2
@@ -1,5 +1,5 @@
 {%- if boot_commands == 'nfs' and nfsroot is not defined %}
-{%-   set nfsroot = 'http://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20240221.0/' + debarch %}
+{%-   set nfsroot = 'http://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20250117.0/' + debarch %}
 {%- endif %}
 
 - deploy:


### PR DESCRIPTION
While adding barebox bootloader support in https://github.com/kernelci/kernelci-core/pull/2782#discussion_r1930452334 it was discovered that the default nfsroot image in the u-boot template has not been updated in some time. Update to the current most recent version 20250117.0.

Thanks to @pawiecz for noticing this in https://github.com/kernelci/kernelci-core/pull/2782.