### PR TITLE
feat(helper.py): Add promisc to subscribe_filters

### DIFF
--- a/kernelci/api/helper.py
+++ b/kernelci/api/helper.py
@@ -51,9 +51,10 @@ class APIHelper:
         """API object"""
         return self._api
 
-    def subscribe_filters(self, filters=None, channel='node'):
+    def subscribe_filters(self, filters=None, channel='node',
+                          promiscuous=False):
         """Subscribe to a channel with some added filters"""
-        sub_id = self.api.subscribe(channel)
+        sub_id = self.api.subscribe(channel, promiscuous)
         self._filters[sub_id] = filters
         return sub_id
 


### PR DESCRIPTION
Add support of promisc flag to subscribe_filters
helper function. Will be used in kcidb-bridge, to
listen for all users events.