### PR TITLE
upd(various): Various updates for blktest enablement

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -43,6 +43,8 @@ rootfs_configs:
   bookworm-blktest:
     rootfs_type: debos
     debian_release: bookworm
+    imagesize: 2GB
+    debos_memory: 8G
     arch_list:
       - amd64
     extra_packages:
@@ -50,7 +52,36 @@ rootfs_configs:
       - ethtool
       - iproute2
       - python3-minimal
+      - python3-pip
+      - e2fsprogs
+      - xfsprogs
+      - f2fs-tools
+      - btrfs-progs
+      - nvme-cli
+      - nbd-client
+      - nbd-server
+      - dmsetup
+      - ethtool
+      - iproute2
+      - fio
+      - gawk
+      - e2fslibs
+      - e2fsprogs
+      - fonts-dejavu-core
+      - klibc-utils
+      - libext2fs2
+      - ncurses-bin
+      - bsdextrautils
     script: "scripts/bookworm-blktest.sh"
+    crush_image_options:
+      - filesystem
+      - compress_tool
+      - hostname_tool
+      - systemd
+      - misc_packages
+      - package_management
+      - misc_directories
+
 
   bookworm-cros-ec:
     rootfs_type: debos

--- a/config/rootfs/debos/scripts/bookworm-blktest.sh
+++ b/config/rootfs/debos/scripts/bookworm-blktest.sh
@@ -6,10 +6,13 @@ set -e
 
 # Build-depends needed to build the test suites, they'll be removed later
 BUILD_DEPS="\
-    fio \
     gcc \
     g++ \
-    make
+    make \
+    git \
+    ca-certificates \
+    libclang-dev \
+    curl
 "
 
 export DEBIAN_FRONTEND=noninteractive
@@ -20,6 +23,14 @@ apt-get install --no-install-recommends -y ${BUILD_DEPS}
 # Configure git
 git config --global user.email "bot@kernelci.org"
 git config --global user.name "KernelCI Bot"
+
+curl https://sh.rustup.rs -sSf | sh -s -- -y
+. "$HOME/.cargo/env" || true
+# Install dependencies for blktests
+cargo install --version=^0.1 rublk
+# cleanup cargo cache
+rm -rf /root/.cargo/registry
+rustup self uninstall -y
 
 ########################################################################
 # Build blktest                                                        #

--- a/config/rootfs/debos/scripts/create_initrd_ramdisk.sh
+++ b/config/rootfs/debos/scripts/create_initrd_ramdisk.sh
@@ -1,25 +1,5 @@
 #!/bin/bash
 
-patch -p1 << EOF
-diff --git a/usr/share/initramfs-tools/scripts/local.dist b/usr/share/initramfs-tools/scripts/local
-index 4ec926c..ca06c0b 100644
---- a/usr/share/initramfs-tools/scripts/local.dist
-+++ b/usr/share/initramfs-tools/scripts/local
-@@ -60,6 +60,12 @@ local_device_setup()
- 	local time_elapsed
- 	local count
- 
-+	expr match ${dev_id#/dev/} "ram" > /dev/null
-+	if [ $? = 0 ]; then
-+		echo "Ignoring ${dev_id}.  We're already in a ramdisk."
-+		return 1
-+	fi
-+
- 	wait_for_udev 10
- 
- 	# Load ubi with the correct MTD partition and return since fstype
-EOF
-
 patch -p1 << 'EOF'
 --- a/usr/share/initramfs-tools/scripts/nfs-premount/wait_ethernet	1970-01-01 02:00:00.000000000 +0200
 +++ b/usr/share/initramfs-tools/scripts/nfs-premount/wait_ethernet	2022-11-25 12:38:46.037498198 +0200


### PR DESCRIPTION
1)Remove in create_initrd_ramdisk.sh code with expr, as expr anyway missing in initramfs and this code
breaks local non-nfs boot.
2)Add various packages to satisky blktest requirements 3)Enable one of package install over rust/cargo
4)Disable removal of ncurses-bin as blktest require tools from it.