### PR TITLE
fix(bookworm-blktest.sh): It is better to use nvme_target_control.py from contrib

### DIFF
--- a/config/rootfs/debos/scripts/bookworm-blktest.sh
+++ b/config/rootfs/debos/scripts/bookworm-blktest.sh
@@ -42,6 +42,8 @@ git clone --depth 1 $BLKTEST_URL .
 
 make
 make install
+mkdir -p /usr/local/blktests/contrib
+cp -r contrib/* /usr/local/blktests/contrib
 
 ########################################################################
 # Cleanup: remove files and packages we don't want in the images       #


### PR DESCRIPTION
…from contrib

For proper blktest operation we need tool from contrib that is not installed by default.