### PR TITLE
add(blktests-nvme-ddp*): Add rudimentary version of new, unique test

### DIFF
--- a/config/runtime/boot/grubhd0.jinja2
+++ b/config/runtime/boot/grubhd0.jinja2
@@ -1,0 +1,35 @@
+- deploy:
+    kernel:
+      url: '{{ node.artifacts.kernel }}'
+      image_arg: -kernel {kernel} -serial stdio --append "console=ttyS1,115200"
+      type: {{ node.data.kernel_type }}
+    os: oe
+    to: tftp
+
+
+- boot:
+    method: grub
+    commands:
+      - linux (hd0,gpt2)/boot/vmlinuz-6.1.0-30-amd64 root=UUID=02bb21d5-cf3b-4d38-8bea-082496adbf5a ro console=tty0 console=ttyS1,115200
+      - initrd (hd0,gpt2)/boot/initrd.img-6.1.0-30-amd64
+      - boot
+    prompts:
+      - 'root@supermicro-as-2015hr-tnr-cbg-0'
+      - 'doug@supermicro-as-2015hr-tnr-cbg-0'
+    auto_login:
+      login_prompt: 'login:'
+      username: doug
+      password_prompt: 'Password:'
+      password: DougIsHero
+      login_commands:
+        - sudo su
+    failure_retry: 3
+    timeout:
+      minutes: 20
+    timeouts:
+      bootloader-commands:
+        minutes: 3
+      auto-login-action:
+        minutes: 6
+      login-action:
+        minutes: 2

--- a/config/runtime/tests/blktests-ddp.jinja2
+++ b/config/runtime/tests/blktests-ddp.jinja2
@@ -1,0 +1,27 @@
+- test:
+    docker:
+        image: debian
+    timeout:
+      minutes: 20
+    wait:
+      device: true
+    results:
+      location: /home/cros/lava
+    definitions:
+      - from: inline
+        name: blktests
+        path: inline/blktests.yaml
+        repository:
+          metadata:
+            format: Lava-Test Test Definition 1.0
+            name: cros-tast
+          run:
+            steps:
+              - apt-get update
+              - apt-get install -y sshpass
+              - sshpass -p 'DougIsHero' ssh -o StrictHostKeyChecking=no doug@$(lava-target-ip) "cd nvidia-blktest && mkdir -p mnt && sudo ./orchestrator.py orchestrator.yml {{ node.id }} {{ api_config.name }} {{ rootfs }}"
+              - lava-test-case nvme_056_tcp_ddp --shell sshpass -p 'DougIsHero' ssh -o StrictHostKeyChecking=no doug@$(lava-target-ip) "grep 'pass' nvidia-blktest/nvme_056_tcp_ddp.test"
+              - sshpass -p 'DougIsHero' ssh -o StrictHostKeyChecking=no doug@$(lava-target-ip) "sync && sudo systemctl poweroff"
+              - sleep 10
+
+


### PR DESCRIPTION
This is very early version of blktests, more specifically test nvme/056, which tests nvme-tcp DDP offload on mlx network cards. It involves setting up hypervisor, 2xQEMU, PCI passthrough, and custom hardware.
This is very first version, jsut to make it works, but then a lot of improvements will follow up.