### PR TITLE
feat(kbuild.py): Download linux-firmware from kci infra

### DIFF
--- a/kernelci/kbuild.py
+++ b/kernelci/kbuild.py
@@ -414,8 +414,12 @@ class KBuild():
         TODO: Implement firmware commit id meta/settings
         '''
         self.startjob("fetch_firmware")
-        # self.addcmd(f"git clone {FW_GIT} --depth 1", False)
-        self.addcmdretry(f"git clone {FW_GIT} --depth 1", 10)
+        # self.addcmdretry(f"git clone {FW_GIT} --depth 1", 10)
+        # This file available https://storage.kernelci.org/linux-firmware.tar.gz
+        # we download it there for better reliability
+        self.addcmd("wget -c -t 10 --retry-on-host-error " +
+                    "https://storage.kernelci.org/linux-firmware.tar.gz -O linux-firmware.tar.gz")
+        self.addcmd("tar -xzf linux-firmware.tar.gz")
         self.addcmd("cd linux-firmware")
         self.addcmd("./copy-firmware.sh " + self._firmware_dir)
         self.addcmd("cd ..")


### PR DESCRIPTION
git.kernel.org sometimes unreachable or Azure k8s issue, so lets keep at least firmware locally on Azure storage.