### PR TITLE
debian-igt.sh: update link to Gitlab server

### DIFF
--- a/config/rootfs/debos/scripts/debian-igt.sh
+++ b/config/rootfs/debos/scripts/debian-igt.sh
@@ -45,7 +45,7 @@ echo '{  "tests_suites": [' >> $BUILDFILE
 # Build libdrm
 ########################################################################
 
-DRM_URL=git://anongit.freedesktop.org/mesa/drm
+DRM_URL=https://gitlab.freedesktop.org/mesa/drm.git
 
 mkdir -p /tmp/tests/libdrm && cd /tmp/tests/libdrm
 git clone --depth=1 $DRM_URL .


### PR DESCRIPTION
The link for the upstream repository git://anongit.freedesktop.org/mesa/drm became obsolete with the move to Gitlab server in March 2024. Update the link from anongit to the Gitlab server.