### PR TITLE
debian-igt.sh: checkout specific IGT commit

### DIFF
--- a/config/rootfs/debos/scripts/debian-igt.sh
+++ b/config/rootfs/debos/scripts/debian-igt.sh
@@ -61,11 +61,13 @@ ninja -C build install
 ########################################################################
 
 IGT_URL=https://gitlab.freedesktop.org/drm/igt-gpu-tools.git
+IGT_VERSION=e7e14eff66bc42329903ee579f019094cf1fdfce
 
 mkdir -p /tmp/tests/igt-gpu-tools && cd /tmp/tests/igt-gpu-tools
 git clone --depth=1 $IGT_URL .
+git checkout "$IGT_VERSION"
 
-echo '    {"name": "igt-gpu-tools", "git_url": "'$IGT_URL'", "git_commit": ' \"`git rev-parse HEAD`\" '}' >> $BUILDFILE
+echo '    {"name": "igt-gpu-tools", "git_url": "'$IGT_URL'", "git_commit": "'$IGT_VERSION'"}' >> $BUILDFILE
 
 mkdir build
 meson -Dprefix=/usr/ build


### PR DESCRIPTION
Set IGT_VERSION to a fixed commit and checkout that version. This ensures reproducibility, so developers can track which IGT version issues were seen in, and uprev after testing.