### PR TITLE
upd(bookworm-blktest.sh): Temporary change to custom repo

### DIFF
--- a/config/rootfs/debos/scripts/bookworm-blktest.sh
+++ b/config/rootfs/debos/scripts/bookworm-blktest.sh
@@ -36,10 +36,13 @@ rustup self uninstall -y
 ########################################################################
 # Build blktest                                                        #
 ########################################################################
-BLKTEST_URL=https://github.com/osandov/blktests.git
+# Change nuclearcat/blktests to kernelci/blktests to use the official
+# repo as soon as the fix-ynl-location branch is merged.
+BLKTEST_URL=https://github.com/nuclearcat/blktests.git
 mkdir -p /var/tests/blktest && cd /var/tests/blktest
 
-git clone --depth 1 $BLKTEST_URL .
+git clone $BLKTEST_URL .
+git checkout fix-ynl-location
 
 make
 make install

--- a/config/runtime/tests/blktests-ddp.jinja2
+++ b/config/runtime/tests/blktests-ddp.jinja2
@@ -19,9 +19,9 @@
             steps:
               - apt-get update
               - apt-get install -y sshpass
-              - sshpass -p 'DougIsHero' ssh -o StrictHostKeyChecking=no doug@$(lava-target-ip) "cd nvidia-blktest && mkdir -p mnt && sudo ./orchestrator.py orchestrator.yml {{ node.id }} {{ api_config.name }} {{ rootfs }}"
+              - sshpass -p 'DougIsHero' ssh -T -o StrictHostKeyChecking=no doug@$(lava-target-ip) "cd nvidia-blktest && mkdir -p mnt && sudo ./orchestrator.py orchestrator.yml {{ node.id }} {{ api_config.name }} {{ rootfs }}"
               - lava-test-case nvme_056_tcp_ddp --shell sshpass -p 'DougIsHero' ssh -o StrictHostKeyChecking=no doug@$(lava-target-ip) "grep 'pass' nvidia-blktest/nvme_056_tcp_ddp.test"
-              - sshpass -p 'DougIsHero' ssh -o StrictHostKeyChecking=no doug@$(lava-target-ip) "sync && sudo systemctl poweroff"
+              - sshpass -p 'DougIsHero' ssh -T -o StrictHostKeyChecking=no doug@$(lava-target-ip) "sync && sudo systemctl poweroff"
               - sleep 10
 
 


### PR DESCRIPTION
Recent changes in Linux kernel change path to tool used to manipulate parameters over netlink. As soon as PR merged to blktest, we need to change back.