### PR TITLE
(workflows): Add discord notifications for prod deploy

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -2,8 +2,22 @@ name: 'Production deploy'
 
 on:
     workflow_dispatch:
+      inputs:
+        message:
+          description: 'Reason for the production deploy'
+          required: true
+          default: 'Scheduled production deploy'
 
 jobs:
+    discord-notify-start:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Discord notification for start
+              env:
+                DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+              uses: Ilshidur/action-discord@master
+              with:
+                args: 'KernelCI production deploy started: ${{ inputs.message }} by ${{ github.actor }}'
     call-docker-build:
         uses: ./.github/workflows/docker_images.yml
         secrets: inherit
@@ -28,3 +42,9 @@ jobs:
               run: |
                 cd kubernetes
                 ./api-production-update.sh workflow
+            - name: Discord notification for end
+              env:
+                DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+              uses: Ilshidur/action-discord@master
+              with:
+                args: 'KernelCI production deploy completed.'


### PR DESCRIPTION
We need to be notified if someone triggered production deploy, when it started, by whom, why, and when it ended.