### PR TITLE
(kbuild) Fix missing cros:// defconfig

### DIFF
--- a/kernelci/kbuild.py
+++ b/kernelci/kbuild.py
@@ -576,6 +576,7 @@ class KBuild():
                     self._getcrosfragment(self._defconfig)
                 f.write(content)
             self.addcmd("make olddefconfig")
+            self._config_full = self._defconfig + self._config_full
         else:
             if isinstance(self._defconfig, str):
                 self.addcmd("make " + self._defconfig)


### PR DESCRIPTION
In configuration where cros:// config is defconfig, node will have incorrect entry for config_full, missing cross:// (defconfig) part.

Fixes: https://github.com/kernelci/kernelci-core/issues/2812