### PR TITLE
(docker) Use google container mirror to workaround pull limits

### DIFF
--- a/config/docker/base/debian.jinja2
+++ b/config/docker/base/debian.jinja2
@@ -6,7 +6,7 @@
  # Author: Alexandra Pereira <alexandra.pereira@collabora.com>
 -#}
 
-FROM debian:bookworm
+FROM mirror.gcr.io/debian:bookworm
 MAINTAINER "KernelCI TSC" <kernelci-tsc@groups.io>
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/config/docker/base/debos.jinja2
+++ b/config/docker/base/debos.jinja2
@@ -4,7 +4,7 @@
  # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
 -#}
 
-FROM godebos/debos
+FROM mirror.gcr.io/godebos/debos
 MAINTAINER "KernelCI TSC" <kernelci-tsc@groups.io>
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/config/docker/base/host-tools.jinja2
+++ b/config/docker/base/host-tools.jinja2
@@ -45,7 +45,7 @@ RUN mk-build-deps -ir \
     -t "apt-get -o Debug::pkgProblemResolver=yes -y --no-install-recommends"
 RUN debuild -b -uc -us
 
-FROM debian:bookworm
+FROM mirror.gcr.io/debian:bookworm
 MAINTAINER "KernelCI TSC" <kernelci-tsc@groups.io>
 ENV DEBIAN_FRONTEND=noninteractive
 {%- endblock %}

--- a/config/docker/base/python.jinja2
+++ b/config/docker/base/python.jinja2
@@ -4,7 +4,7 @@
  # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
 -#}
 
-FROM python:3.11
+FROM mirror.gcr.io/python:3.11
 
 MAINTAINER "KernelCI TSC" <kernelci-tsc@groups.io>
 


### PR DESCRIPTION
Docker Hub introducing severe pull limits, we need a workaround, such as using mirrors, to solve that.