### PR TITLE
git.kernel.org started to throttle github runners

### DIFF
--- a/config/docker/base/host-tools.jinja2
+++ b/config/docker/base/host-tools.jinja2
@@ -75,12 +75,14 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     libssl-dev \
     libelf-dev \
     libdw-dev \
+    libbpf-dev \
     lz4 \
     lzop \
     make \
     python3 \
     python3-dev \
     python3-pip \
+    pkg-config \
     rdfind \
     rsync \
     swig \
@@ -92,16 +94,16 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 # Install dtschema for dtbs_check
 RUN pip3 install dtschema --break-system-packages
 
-# Clone and build pahole v1.28
-RUN git clone https://git.kernel.org/pub/scm/devel/pahole/pahole.git && \
-    cd pahole && \
-    git checkout v1.28 && \
+# Download and build pahole v1.28
+RUN wget -c https://web.git.kernel.org/pub/scm/devel/pahole/pahole.git/snapshot/pahole-1.29.tar.gz && \
+    tar -xzf pahole-1.29.tar.gz && \
+    cd pahole-1.29 && \
     mkdir build && cd build && \
-    cmake .. && \
+    cmake .. -DLIBBPF_EMBEDDED=OFF && \
     make && \
     make install && \
     echo "/usr/local/lib" > /etc/ld.so.conf.d/dwarves.conf && \
     ldconfig && \
-    cd ../.. && rm -rf pahole
+    cd ../.. && rm -rf pahole-1.29
 
 {% endblock %}


### PR DESCRIPTION
We need to download pahole, and use release tarball, otherwise staging builds are failing.