### PR TITLE
config: runtime: base: add extra_kernel_args parameter to LAVA job template

### DIFF
--- a/config/runtime/base/lava.jinja2
+++ b/config/runtime/base/lava.jinja2
@@ -23,9 +23,16 @@ visibility: public
 
 priority: {{ priority | default('10') }}
 
-{% if platform_config.context %}
-context:{% for key, value in platform_config.context | items %}
-  {{ key }}: {{ value }}{% endfor %}
+{% if platform_config.context or extra_kernel_args %}
+context:
+  {% if platform_config.context %}
+    {% for key, value in platform_config.context.items() %}
+  {{ key }}: {{ value }}
+    {% endfor %}
+  {% endif %}
+  {% if extra_kernel_args %}
+  extra_kernel_args: {{ extra_kernel_args }}
+  {% endif %}
 {% endif %}
 
 timeouts:


### PR DESCRIPTION
Update context with extra_kernel_args when defined in the job parameters.