### PR TITLE
config: docker: Install uuid-dev package

### DIFF
--- a/config/docker/base/host-tools.jinja2
+++ b/config/docker/base/host-tools.jinja2
@@ -88,6 +88,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     swig \
     tar \
     u-boot-tools \
+    uuid-dev \
     wget \
     xz-utils
 


### PR DESCRIPTION
Some headers in the kernel reference userspace headers provided by the uuid-dev package. Install it on all build containers.

Fixes: https://dashboard.kernelci.org/issue/maestro%3A6b8da43ff8bc6bf9d93cc9cf86c3c5b5c5ab20a2?iv=1