### PR TITLE
(fragment/kernelci.jinja2) Fix, add --break-system-packages to pip

### DIFF
--- a/.github/workflows/docker_images.yml
+++ b/.github/workflows/docker_images.yml
@@ -53,7 +53,7 @@ jobs:
           sudo apt-get install -y python3-pip git docker.io python3-docker
           pip3 install --upgrade pip
           cd kernelci-core
-          python3 -m pip install '.[dev]'
+          python3 -m pip install '.[dev]' --break-system-packages
           sudo cp -R config /etc/kernelci/
       - name: Dockerhub login by token
         run: |
@@ -142,7 +142,7 @@ jobs:
           sudo apt-get install -y python3-pip git docker.io python3-docker
           pip3 install --upgrade pip
           cd kernelci-core
-          python3 -m pip install '.[dev]'
+          python3 -m pip install '.[dev]' --break-system-packages
           sudo cp -R config /etc/kernelci/
       - name: Dockerhub login by token
         run: |

--- a/config/docker/fragment/kernelci.jinja2
+++ b/config/docker/fragment/kernelci.jinja2
@@ -13,7 +13,7 @@ RUN git clone --depth=1 $core_url /tmp/kernelci-core
 WORKDIR /tmp/kernelci-core
 RUN git fetch origin $core_rev
 RUN git checkout FETCH_HEAD
-RUN python3 -m pip install .[dev]
+RUN python3 -m pip install .[dev] --break-system-packages
 RUN cp -R config /etc/kernelci/
 WORKDIR /root
 RUN rm -rf /tmp/kernelci-core


### PR DESCRIPTION
Suddenly pip stopped to work for kernelci docker image builds on staging. Most likely reason is --break-system-packages, probably one of base images changed distro and this flag now mandatory.