### PR TITLE
(pyproject.toml) Fix pip install

### DIFF
--- a/config/docker/fragment/kernelci.jinja2
+++ b/config/docker/fragment/kernelci.jinja2
@@ -13,6 +13,8 @@ RUN git clone --depth=1 $core_url /tmp/kernelci-core
 WORKDIR /tmp/kernelci-core
 RUN git fetch origin $core_rev
 RUN git checkout FETCH_HEAD
+RUN python3 -m pip install --upgrade pip
+RUN pip3 install --upgrade setuptools wheel --break-system-packages
 RUN python3 -m pip install .[dev] --break-system-packages
 RUN cp -R config /etc/kernelci/
 WORKDIR /root


### PR DESCRIPTION
We need to fix staging failure.

```
  Building wheel for bson (setup.py): started
  Building wheel for bson (setup.py): finished with status 'error'
  error: subprocess-exited-with-error

  × python setup.py bdist_wheel did not run successfully.
  │ exit code: 1
  ╰─> [6 lines of output]
      usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
         or: setup.py --help [cmd1 cmd2 ...]
         or: setup.py --help-commands
         or: setup.py cmd --help

      error: invalid command 'bdist_wheel'
      [end of output]
```