### PR TITLE
build-configs.yaml: Add missing GuC/DMC firmware for brya

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -983,6 +983,8 @@ fragments:
       amdgpu/stoney_uvd.bin
       amdgpu/stoney_vce.bin
       amdgpu/yellow_carp_vcn.bin
+      i915/adlp_dmc.bin
+      i915/adlp_guc_70.bin
       i915/glk_dmc_ver1_04.bin
       i915/kbl_dmc_ver1_04.bin
       rtl_nic/rtl8153a-4.fw


### PR DESCRIPTION
When testing the chromeos-6.6 kernel on Brya, a BUG in intel_context_init() occurs during boot if the GuC and DMC firmware are missing[1]. This results in a failed GT initialization, leaving engine->gt->vm NULL and causing a kernel crash. Add the required firmware files to prevent the issue.

[1] https://dashboard.kernelci.org/issue/maestro%3Aea171ee4639b31e59d833248e4d66a2664c02f83?iv=1&tf%7Cb=a&tf%7Cbt=a&tf%7Ct=f