### PR TITLE
lava: Install the kselftest tarball using an overlay

### DIFF
--- a/config/runtime/boot/depthcharge.jinja2
+++ b/config/runtime/boot/depthcharge.jinja2
@@ -27,7 +27,16 @@
 {%- if boot_commands == 'nfs' and nfsroot %}
     nfsrootfs:
       compression: xz
+      format: tar
       url: '{{ nfsroot }}/full.rootfs.tar.xz'
+      {%- if node.artifacts.kselftest_tar_gz %}
+      overlays:
+        kselftest:
+          url: {{ node.artifacts.kselftest_tar_gz }}
+          compression: gz
+          format: tar
+          path: /opt/kselftest
+      {%- endif %}
     ramdisk:
       compression: gz
       url: '{{ nfsroot }}/initrd.cpio.gz'

--- a/config/runtime/boot/fastboot.jinja2
+++ b/config/runtime/boot/fastboot.jinja2
@@ -16,6 +16,14 @@
             format: tar
             path: /
 {% set dtb = device_dtb.split('/')[-1] %}
+          {%- if node.artifacts.kselftest_tar_gz %}
+          kselftest:
+            url: {{ node.artifacts.kselftest_tar_gz }}
+            compression: gz
+            format: tar
+            path: /opt/kselftest
+          {%- endif %}
+
     postprocess:
       docker:
         image: ghcr.io/mwasilew/docker-mkbootimage:master

--- a/config/runtime/boot/grub.jinja2
+++ b/config/runtime/boot/grub.jinja2
@@ -6,7 +6,16 @@
 {%- if boot_commands == 'nfs' %}
     nfsrootfs:
       url: '{{ nfsroot }}/full.rootfs.tar.xz'
+      format: tar
       compression: xz
+      {%- if node.artifacts.kselftest_tar_gz %}
+      overlays:
+        kselftest:
+          url: {{ node.artifacts.kselftest_tar_gz }}
+          compression: gz
+          format: tar
+          path: /opt/kselftest
+      {%- endif %}
     ramdisk:
       url: '{{ nfsroot }}/initrd.cpio.gz'
       compression: gz

--- a/config/runtime/boot/u-boot.jinja2
+++ b/config/runtime/boot/u-boot.jinja2
@@ -16,7 +16,16 @@
 {%- if boot_commands == 'nfs' %}
     nfsrootfs:
       url: '{{ nfsroot }}/full.rootfs.tar.xz'
+      format: tar
       compression: xz
+      {%- if node.artifacts.kselftest_tar_gz %}
+      overlays:
+        kselftest:
+          url: {{ node.artifacts.kselftest_tar_gz }}
+          compression: gz
+          format: tar
+          path: /opt/kselftest
+      {%- endif %}
     ramdisk:
       url: '{{ nfsroot }}/initrd.cpio.gz'
       compression: gz

--- a/config/runtime/tests/kselftest-platform-parameters.jinja2
+++ b/config/runtime/tests/kselftest-platform-parameters.jinja2
@@ -35,7 +35,7 @@
       path: automated/linux/kselftest/kselftest.yaml
       name: '{{ node.name }}'
       parameters:
-        TESTPROG_URL: '{{ node.artifacts.kselftest_tar_gz }}'
+        KSELFTEST_PATH: /opt/kselftest
         SKIPFILE: /dev/null
         TST_CMDFILES: '{{ collections }}'
         TST_CASENAME: '{{ tests }}'

--- a/config/runtime/tests/kselftest.jinja2
+++ b/config/runtime/tests/kselftest.jinja2
@@ -22,7 +22,7 @@
       path: automated/linux/kselftest/kselftest.yaml
       name: '{{ node.name }}'
       parameters:
-        TESTPROG_URL: '{{ node.artifacts.kselftest_tar_gz }}'
+        KSELFTEST_PATH: /opt/kselftest
         SKIPFILE: {{ skipfile if skipfile else '/dev/null' }}
         TST_CMDFILES: '{{ collections }}'
         TST_CASENAME: '{{ tests }}'


### PR DESCRIPTION
Currently the kselftest LAVA jobs that KernelCI generates have the test
job download the kselftest tarball onto the device.  This has a couple
of disadvantages:

 - Any caching that is configured for the LAVA worker will be bypassed,
   increasing network traffic both for the lab and for the KernelCI
   storage server.
 - The entire kselftest tarball has to be downloaded onto the test
   system, and if (as is usual) it is a NFS filesystem then an
   uncompressed copy written over the network to the LAVA worker.

The test-definitions integration for kselftest also supports running a
copy that is already installed in the filesystem, and LAVA supports
adding files onto the root filesystem via it's overlay mechanism, so we
can avoid the overheads of downloading directly to the device by having
LAVA apply the kselftest tarball to the root filesystem as an overlay
instead.

A commit was previously merged doing this for the legacy LAVA templates,
this updates the Maestro ones.

Signed-off-by: Mark Brown <broonie@kernel.org>
