### PR TITLE
lava: Support sharding for LTP

### DIFF
--- a/config/runtime/tests/ltp.jinja2
+++ b/config/runtime/tests/ltp.jinja2
@@ -10,5 +10,7 @@
       name: {{ node.name }}
       parameters:
         TST_CMDFILES: "{{ tst_cmdfiles|default('') }}"
+        SHARD_NUMBER: {{ shard_number|default(1) }}
+        SHARD_INDEX: {{ shard_index|default(1) }}
         SKIP_INSTALL: "{{ skip_install }}"
         SKIPFILE: {{ skipfile }}


### PR DESCRIPTION
Some of the LTP suites (especially the syscalls suite) are extremely
large and take a very long time to run, in order to make jobs more
managable the test-definitions integration for LTP supports sharding
the suites.  Add support for this to our template.

Signed-off-by: Mark Brown <broonie@kernel.org>
