### PR TITLE
Docker: remove docker intermediate images after build

### DIFF
--- a/kernelci/docker.py
+++ b/kernelci/docker.py
@@ -89,7 +89,7 @@ class Docker:
         try:
             _, build_log = client.images.build(
                 fileobj=dockerfile_obj, tag=name, buildargs=buildargs,
-                nocache=nocache
+                nocache=nocache, rm=True, forcerm=True
             )
             build_err = None
         except docker.errors.BuildError as exc:


### PR DESCRIPTION
Building Docker images using the kci tool results in dangling intermediate images, which can lead to unnecessary disk space usage over time and leave the system in a dirty state

This PR updates the build process to properly clean up intermediate images after the build is complete, preventing the accumulation of dangling images.