### PR TITLE
(docker/lava-callback.jinja2) Update path to lava-callback requirements.txt

### DIFF
--- a/config/docker/fragment/lava-callback.jinja2
+++ b/config/docker/fragment/lava-callback.jinja2
@@ -7,7 +7,7 @@ RUN git fetch origin $pipeline_rev
 RUN git checkout FETCH_HEAD
 WORKDIR /home/kernelci/callback
 USER root
-RUN pip3 install -r /tmp/kernelci-pipeline/docker/lava-callback/requirements.txt
+RUN pip3 install -r /tmp/kernelci-pipeline/requirements-lava-callback.txt
 USER kernelci
 WORKDIR /home/kernelci/
 RUN mv /tmp/kernelci-pipeline/* /home/kernelci/


### PR DESCRIPTION
Path to requirements.txt is changed, reflect it in docker recipe