### PR TITLE
build-configs.yaml: Add a fragment for fault injection

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -447,6 +447,31 @@ fragments:
   debug:
     path: "kernel/configs/debug.config"
 
+  fault-injection:
+    path: "kernel/configs/fault-injection.config"
+    configs:
+      - 'CONFIG_DEBUG_KERNEL=y'
+      - 'CONFIG_FAULT_INJECTION=y'
+      - 'CONFIG_FAILSLAB=y'
+      - 'CONFIG_FAIL_PAGE_ALLOC=y'
+      - 'CONFIG_FAULT_INJECTION_USERCOPY=y'
+      - 'CONFIG_BLOCK=y'
+      - 'CONFIG_FAIL_MAKE_REQUEST=y'
+      - 'CONFIG_FAIL_IO_TIMEOUT=y'
+      - 'CONFIG_FUTEX=y'
+      - 'CONFIG_FAIL_FUTEX=y'
+      - 'CONFIG_DEBUG_FS=y'
+      - 'CONFIG_FAULT_INJECTION_DEBUG_FS=y'
+      - 'CONFIG_FAIL_SKB_REALLOC=y'
+      - 'CONFIG_FAULT_INJECTION_CONFIGFS=y'
+      - 'CONFIG_STACKTRACE_SUPPORT=y'
+      - 'CONFIG_FRAME_POINTER=y'
+      - 'CONFIG_FAULT_INJECTION_STACKTRACE_FILTER=y'
+      - 'CONFIG_MMC=y'
+      - 'CONFIG_FAIL_MMC_REQUEST=y'
+      - 'CONFIG_FUNCTION_ERROR_INJECTION=y'
+      - 'CONFIG_FAIL_FUNCTION=y'
+
   ima:
     path: "kernel/configs/ima.config"
     configs:


### PR DESCRIPTION
We are working on adding a test based on fault injection into KernelCI, hence, add a fragment to enable fault injection specific configs