### PR TITLE
(pyproject.toml) Fix pip install (pyyaml upgrade)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "pydantic==2.9.2",
   "pyelftools==0.29",
   "pytest==7.4.0",
-  "pyyaml==6.0",
+  "pyyaml==6.0.2",
   "requests==2.32.2",
   "scp==0.14.5",
   "toml==0.10.2",


### PR DESCRIPTION
Fixes:
```
Collecting pyyaml==6.0 (from kernelci==1.1)
  Using cached PyYAML-6.0.tar.gz (124 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error

  × Getting requirements to build wheel did not run successfully.
```