### PR TITLE
kernelci: kbuild: manage coverage "source" artifacts

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -387,6 +387,13 @@ fragments:
       "'
 
 
+  coverage:
+    path: "kernel/configs/coverage.config"
+    configs:
+      - 'CONFIG_DEBUG_FS=y'
+      - 'CONFIG_GCOV_KERNEL=y'
+      - 'CONFIG_GCOV_PROFILE_ALL=y'
+
   crypto:
     path: "kernel/configs/crypto.config"
     configs:


### PR DESCRIPTION
As we plan on adding code coverage capabilities, we need to ensure `kbuild` nodes can extract and upload the required data:
- full source code *as configured for the build* (including symlinks)
- gcov data files (`*.gcno`)

This relies on a new `coverage` config fragment in order to enable code coverage.