### PR TITLE
chore: Update actions/setup-python to v5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@master
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -68,7 +68,7 @@ jobs:
 
       - if: env.CHANGED_FILES
         name: Set up Python
-        uses: actions/setup-python@master
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 


### PR DESCRIPTION
Action "setup-python@master" has not been updated for 5 years and is still using a deprecated version of "cache" action. Updating it to "v5" will allow successful runs of this CI stage.

Fixes: #2861