### PR TITLE
Add fault injection template

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -117,6 +117,15 @@ rootfs_configs:
     script: "scripts/bookworm-cros-ec-tests.sh"
     test_overlay: ""
 
+  bookworm-fault-injection:
+    rootfs_type: debos
+    debian_release: bookworm
+    arch_list:
+      - amd64
+      - arm64
+      - armhf
+    script: "scripts/bookworm-fault-injection.sh"
+
   bookworm-gst-fluster:
     rootfs_type: debos
     debian_release: bookworm

--- a/config/rootfs/debos/scripts/bookworm-fault-injection.sh
+++ b/config/rootfs/debos/scripts/bookworm-fault-injection.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -ex
+
+PACKAGES_INSTALL="\
+      ca-certificates \
+      wget \
+"
+
+apt-get install --no-install-recommends -y ${PACKAGES_INSTALL}
+
+# Fetch and install failcmd
+wget https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/plain/tools/testing/fault-injection/failcmd.sh -O /usr/local/bin/failcmd
+chmod +x /usr/local/bin/failcmd
+
+# Basic validation
+if [ ! -x /usr/local/bin/failcmd ]; then
+    echo "failcmd installation failed" >&2
+    exit 1
+fi
+
+apt-get remove --purge -y ${PACKAGES_INSTALL}
+apt-get autoremove --purge -y
+apt-get clean

--- a/config/runtime/tests/fault-injection.jinja2
+++ b/config/runtime/tests/fault-injection.jinja2
@@ -1,0 +1,32 @@
+- test:
+    timeout:
+      minutes: {{ job_timeout|default(20) }}
+    definitions:
+    - from: inline
+      name: "fault-injection-{{ test_name }}"
+      path: inline/fault-injection.yaml
+      repository:
+        metadata:
+          format: Lava-Test Test Definition 1.0
+          name: fault-injection
+          description: |
+             Fault injection: {{ test_name }}
+             Type: {{ fail_type|default('failslab') }} | Iterations: {{ iterations|default(5) }}
+          os:
+          - debian
+          scope:
+          - functional
+        run:
+          steps:
+            - |
+              for i in $(seq 1 {{ iterations|default(5) }}); do
+                echo "Iteration $i: {{ test_name }}"
+                FAILCMD_TYPE={{ fail_type|default('failslab') }} \
+                  /usr/local/bin/failcmd \
+                  --probability={{ probability|default(100) }} \
+                  --times={{ times|default(100) }} \
+                  --interval={{ interval|default(100) }} \
+                  --verbose=2 \
+                  "{{ test_command }}"
+                sleep {{ sleep_time|default(10) }}
+              done


### PR DESCRIPTION
Add a basic fault injection test template which will be currently used to add a suspend/resume test.