### PR TITLE
(rootfs-configs.yaml) Remove legacy remark

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -1,7 +1,3 @@
-# This is LEGACY system config, do not send any new patches for this file.
-# More details:
-# https://lore.kernel.org/kernelci/5b603b8f-c9b2-4148-7212-dd69a3fdf506@collabora.com/T/#u
-
 rootfs_configs:
   bookworm:
     rootfs_type: debos


### PR DESCRIPTION
This file is still used by new Maestro ecosystem and we use part of legacy code to generate rootfs. Removing confusing remark.