### PR TITLE
config: runtime: tests: consistently indent test definitions

### DIFF
--- a/config/runtime/tests/blktests-ddp.jinja2
+++ b/config/runtime/tests/blktests-ddp.jinja2
@@ -8,21 +8,19 @@
     results:
       location: /home/cros/lava
     definitions:
-      - from: inline
-        name: blktests
-        path: inline/blktests.yaml
-        repository:
-          metadata:
-            format: Lava-Test Test Definition 1.0
-            name: cros-tast
-          run:
-            steps:
-              - apt-get update
-              - apt-get install -y sshpass
-              - sshpass -p 'DougIsHero' ssh -T -o StrictHostKeyChecking=no doug@$(lava-target-ip) "cd nvidia-blktest && mkdir -p mnt && sudo ./orchestrator.py orchestrator.yml {{ node.id }} {{ api_config.name }} {{ rootfs }}"
-              - lava-test-case ping_loopback --shell sshpass -p 'DougIsHero' ssh -o StrictHostKeyChecking=no doug@$(lava-target-ip) "ping -c 5 127.0.0.1"
-              - lava-test-case nvme_056_tcp_ddp --shell sshpass -p 'DougIsHero' ssh -o StrictHostKeyChecking=no doug@$(lava-target-ip) "grep 'pass' nvidia-blktest/nvme_056_tcp_ddp.test"
-              - sshpass -p 'DougIsHero' ssh -T -o StrictHostKeyChecking=no doug@$(lava-target-ip) "sync && sudo systemctl poweroff"
-              - sleep 10
-
-
+    - from: inline
+      name: blktests
+      path: inline/blktests.yaml
+      repository:
+        metadata:
+          format: Lava-Test Test Definition 1.0
+          name: cros-tast
+        run:
+          steps:
+            - apt-get update
+            - apt-get install -y sshpass
+            - sshpass -p 'DougIsHero' ssh -T -o StrictHostKeyChecking=no doug@$(lava-target-ip) "cd nvidia-blktest && mkdir -p mnt && sudo ./orchestrator.py orchestrator.yml {{ node.id }} {{ api_config.name }} {{ rootfs }}"
+            - lava-test-case ping_loopback --shell sshpass -p 'DougIsHero' ssh -o StrictHostKeyChecking=no doug@$(lava-target-ip) "ping -c 5 127.0.0.1"
+            - lava-test-case nvme_056_tcp_ddp --shell sshpass -p 'DougIsHero' ssh -o StrictHostKeyChecking=no doug@$(lava-target-ip) "grep 'pass' nvidia-blktest/nvme_056_tcp_ddp.test"
+            - sshpass -p 'DougIsHero' ssh -T -o StrictHostKeyChecking=no doug@$(lava-target-ip) "sync && sudo systemctl poweroff"
+            - sleep 10

--- a/config/runtime/tests/ltp.jinja2
+++ b/config/runtime/tests/ltp.jinja2
@@ -3,12 +3,12 @@
     timeout:
       minutes: {{ job_timeout|default(15) }}
     definitions:
-       - repository: https://github.com/kernelci/test-definitions
-         from: git
-         revision: kernelci.org
-         path: automated/linux/ltp/ltp.yaml
-         name: {{ node.name }}
-         parameters:
-            TST_CMDFILES: "{{ tst_cmdfiles|default('') }}"
-            SKIP_INSTALL: "{{ skip_install }}"
-            SKIPFILE: {{ skipfile }}
+    - repository: https://github.com/kernelci/test-definitions
+      from: git
+      revision: kernelci.org
+      path: automated/linux/ltp/ltp.yaml
+      name: {{ node.name }}
+      parameters:
+        TST_CMDFILES: "{{ tst_cmdfiles|default('') }}"
+        SKIP_INSTALL: "{{ skip_install }}"
+        SKIPFILE: {{ skipfile }}


### PR DESCRIPTION
At some point, we might want to provide "generic" test definitions to be included in specific tests. However, in order to do so, all test definitions entries must be consistently indented, which is mostly the case already. Howver, some test templates are a bit off in this regard, so fix this by re-indenting the "faulty" ones.