### PR TITLE
Make dependabot happy for jinja2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
   "click==8.1.3",
   "cloudevents==1.9.0",
   "docker==7.1.0",
-  "jinja2==3.1.5",
+  "jinja2==3.1.6",
   "kubernetes==26.1.0",
   "paramiko==3.4.0",
   "pydantic==2.9.2",

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ bson==0.5.10
 click==8.1.3
 cloudevents==1.9.0
 docker==7.1.0
-jinja2==3.1.5
+jinja2==3.1.6
 kubernetes==26.1.0
 paramiko==3.4.0
 pydantic==2.9.2


### PR DESCRIPTION
Dependabot reports about security issue in old jinja2. Not like it is too relevant to us, we dont have externally supplied data in this templates, but better to upgrade.