### PR TITLE
config: core: rootfs-configs: add `curl` to bookworm-ltp

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -337,6 +337,7 @@ rootfs_configs:
       - arm64
       - armhf
     extra_packages:
+      - curl
       - dosfstools
       - gdb-minimal
       - libnuma-dev


### PR DESCRIPTION
As we're enabling code coverage in LTP test jobs, we need a way to upload the coverage data from LAVA. The simplest way is to just use `curl` to POST the artifacts to KernelCI storage, so let's add this tool to the rootfs used for LTP jobs.