### PR TITLE
config: runtime: tests: ltp: enable support for code coverage

### DIFF
--- a/config/runtime/tests/ltp.jinja2
+++ b/config/runtime/tests/ltp.jinja2
@@ -3,12 +3,68 @@
     timeout:
       minutes: {{ job_timeout|default(15) }}
     definitions:
-       - repository: https://github.com/kernelci/test-definitions
-         from: git
-         revision: kernelci.org
-         path: automated/linux/ltp/ltp.yaml
-         name: {{ node.name }}
-         parameters:
-            TST_CMDFILES: "{{ tst_cmdfiles|default('') }}"
-            SKIP_INSTALL: "{{ skip_install }}"
-            SKIPFILE: {{ skipfile }}
+    - from: inline
+      repository:
+        metadata:
+          format: Lava-Test Test Definition 1.0
+          name: reset-gcov
+          description: Reset GCOV data
+        run:
+          steps:
+          - GCOV_RESET="/sys/kernel/debug/gcov/reset"
+          - if [ -f ${GCOV_RESET} ]; then echo 1 > ${GCOV_RESET}; fi
+      name: reset-gcov
+      path: inline/reset-gcov.yaml
+
+    - repository: https://github.com/kernelci/test-definitions
+      from: git
+      revision: kernelci.org
+      path: automated/linux/ltp/ltp.yaml
+      name: {{ node.name }}
+      parameters:
+        TST_CMDFILES: "{{ tst_cmdfiles|default('') }}"
+        SKIP_INSTALL: "{{ skip_install }}"
+        SKIPFILE: {{ skipfile }}
+
+    - from: inline
+      name: upload
+      path: inline/upload.yaml
+      repository:
+        metadata:
+          description: GCOV artifacts upload
+          format: Lava-Test Test Definition 1.0
+          name: upload
+          environment:
+            - lava-test-shell
+          os:
+          - debian
+        run:
+          steps:
+          - GCDA=/sys/kernel/debug/gcov
+          # Bail out if $GCDA doesn't exist (as GCOV is likely not enabled)
+          - test -d ${GCDA} || exit 0
+          - TEMPDIR=$(mktemp -d)
+          - UPLOAD_PATH="{{ node.name }}-{{ node.id }}"
+          - UPLOAD_NAME="gcov.tar.gz"
+          # Retrieve GCOV artifacts
+          # Taken from https://www.kernel.org/doc/html/v6.12/dev-tools/gcov.html#appendix-b-gather-on-test-sh
+          - find $GCDA -type d -exec mkdir -p $TEMPDIR/\{\} \;
+          - find $GCDA -name '*.gcda' -exec sh -c 'cat < $0 > '$TEMPDIR'/$0' {} \;
+          - find $GCDA -name '*.gcno' -exec sh -c 'cp -d $0 '$TEMPDIR'/$0' {} \;
+          - tar czf gcov.tar.gz -C $TEMPDIR sys
+          - rm -rf $TEMPDIR
+          # Use set +x so we can don't echo secret tokens in the logs
+          - set +x
+          - . /lava-${LAVA_JOB_ID}/secrets
+          # FIXME: this should actually be part of the rootfs
+          - apt-get -q update
+          - apt-get -q install -y curl
+          - >-
+            lava-test-case "artifact-upload:coverage-data:{{ storage_config.base_url }}/${UPLOAD_PATH}/${UPLOAD_NAME}"
+            --shell curl -X POST {{ storage_config.base_url }}/upload
+            -H "Authorization: Bearer ${UPLOAD_TOKEN}"
+            -F "file0=@${UPLOAD_NAME}"
+            -F "path=${UPLOAD_PATH}"
+
+secrets:
+  UPLOAD_TOKEN: {{ storage_config.name }}-token


### PR DESCRIPTION
When enabling code coverage support using in-kernel GCOV, we must first reset coverage "recording" right before starting the test, then ensure we pack and upload the resulting artifacts.

The latter is implemented by POSTing the artifact to the storage server, providing the artifact name and URL as a LAVA test result using the following format:

  `artifact-upload:<artifact name>:<artifact URL>`

This allows the pipeline to add the uploaded artifact(s) to the corresponding node so the information can be easily re-used at a later stage.

Depends on https://github.com/kernelci/kernelci-pipeline/pull/1141