### PR TITLE
Add LAVA runtime job definition getter method

### DIFF
--- a/kernelci/runtime/lava.py
+++ b/kernelci/runtime/lava.py
@@ -86,7 +86,6 @@ class Callback:
     def __init__(self, data):
         """This class can be used to parse LAVA callback data"""
         self._data = data
-        self._meta = None
 
     def get_data(self):
         """Get the raw callback data"""
@@ -95,12 +94,14 @@ class Callback:
     def get_device_id(self):
         """Get the ID of the tested device"""
         return self._data.get('actual_device_id')
+    
+    def get_job_definition(self, key):
+        """Get the job definition"""
+        return yaml.safe_load(self._data.get('definition')).get(key)
 
     def get_meta(self, key):
         """Get a metadata value from the job definition"""
-        if self._meta is None:
-            self._meta = yaml.safe_load(self._data['definition'])['metadata']
-        return self._meta.get(key)
+        return self.get_job_definition('metadata').get(key)
 
     def get_job_status(self):
         """Get the job status"""


### PR DESCRIPTION
This PR adds a getter method for LAVA job definition in order to easily retrieve definitions of test jobs scheduled on LAVA runtimes. This could be used for example to get input artifacts such as rootfs or initram.