### PR TITLE
config: core: rootfs-configs: add `ca-certificates` to bookworm-ltp

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -346,6 +346,7 @@ rootfs_configs:
       - arm64
       - armhf
     extra_packages:
+      - ca-certificates
       - curl
       - dosfstools
       - gdb-minimal


### PR DESCRIPTION
This package is needed for using `curl` on SSL/TLS connections, but it is only a `Recommends`, so it must be explicitly listed as a wanted package.