### PR TITLE
tests: Remove interval for fault injection testing

### DIFF
--- a/config/runtime/tests/fault-injection.jinja2
+++ b/config/runtime/tests/fault-injection.jinja2
@@ -25,7 +25,6 @@
                   /usr/local/bin/failcmd \
                   --probability={{ probability|default(100) }} \
                   --times={{ times|default(100) }} \
-                  --interval={{ interval|default(100) }} \
                   --verbose=2 \
                   "{{ test_command }}"
                 sleep {{ sleep_time|default(10) }}


### PR DESCRIPTION
Interval is making the probablity of fault occurrences less, hence remove it from the template.