### PR TITLE
kernelci: kbuild: transition to `available` state when complete

### DIFF
--- a/kernelci/api/helper.py
+++ b/kernelci/api/helper.py
@@ -551,9 +551,12 @@ class APIHelper:
         root_node = merge(root_from_db, root)
         root_node = root.copy()
         root_node['result'] = results['node']['result']
+        root_node['state'] = results['node'].get('state', 'done')
         root_node['artifacts'].update(results['node']['artifacts'])
         root_node['data'].update(results['node'].get('data', {}))
         root_node['processed_by_kcidb_bridge'] = False
+        if 'holdoff' in results['node']:
+            root_node['holdoff'] = results['node']['holdoff']
         if root_node['result'] != 'incomplete':
             data = root_node.get('data', {})
             if data.get('error_code') == 'node_timeout':
@@ -577,7 +580,6 @@ class APIHelper:
                 'runtime': root['data'].get('runtime'),
             },
             'group': root['name'],
-            'state': 'done',
             'processed_by_kcidb_bridge': False,
         }
         data = self._prepare_results(root_results, parent, base)

--- a/kernelci/kbuild.py
+++ b/kernelci/kbuild.py
@@ -24,6 +24,7 @@ Available kbuild parameters:
 - kselftest: false - do not build kselftest
 """
 
+from datetime import datetime, timedelta
 import os
 import sys
 import re
@@ -1058,12 +1059,18 @@ class KBuild():
                     kselftest_result = 'pass'
                     break
 
+        if job_result == 'pass':
+            job_state = 'available'
+        else:
+            job_state = 'done'
+
         results = {
             'node': {
                 'name': self._apijobname,
                 'result': job_result,
-                'state': 'done',
+                'state': job_state,
                 'artifacts': af_uri,
+                'holdoff': str(datetime.utcnow() + timedelta(minutes=10)),
             },
             'child_nodes': []
         }


### PR DESCRIPTION
Currently, `kbuild` nodes transition to state `done` as soon as they complete, even though they often have many child nodes running afterwards. This is confusing as `checkout` nodes first transition to `available` state, then `closing` (waiting for child nodes to complete) and only transition to `done` once all child nodes have completed.

This behaviour should be applied to `kbuild` nodes as well, both for consistency and to be able to easily schedule post-processing jobs (e.g. by triggering those on the `state: done` event).

Also add a `holdoff` value (10 minutes, identical to `checkout` nodes) so the corresponding service properly handles state transitions for those nodes.

Fixes  #2875

Depends on https://github.com/kernelci/kernelci-pipeline/pull/1164