### PR TITLE
(kubernetes.jinja2) Introduce volume for firmware file caching

### DIFF
--- a/config/runtime/base/kubernetes.jinja2
+++ b/config/runtime/base/kubernetes.jinja2
@@ -24,6 +24,11 @@ spec:
       - name: compile-volume
         emptyDir: { }
 
+      - name: resource-cache
+        persistentVolumeClaim:
+          claimName: shared-data   # RWX PVC!
+          readOnly: true
+
       tolerations:
       - key: "kubernetes.azure.com/scalesetpriority"
         operator: "Equal"
@@ -40,6 +45,9 @@ spec:
           name: compile-volume
         - mountPath: "/dev/shm"
           name: dev-shm
+        - mountPath: "/data"
+          name: resource-cache
+          readOnly: true
 
         # FIXME: Request safe defaults to not overload node with
         # parallel pods


### PR DESCRIPTION
Related: https://github.com/kernelci/kernelci-core/issues/2883 We create volume, where cron job daily update linux-firmware archive. This volume PWX, mounted read-only on each kbuild container, so they can use this file.