### PR TITLE
Fix buildroot rootfs naming for riscv64 arch

### DIFF
--- a/kernelci/config/base.py
+++ b/kernelci/config/base.py
@@ -16,6 +16,7 @@ import yaml
 BUILDROOT_ARCH = {
     'arm': 'armel',
     'x86_64': 'x86',
+    'riscv64': 'riscv',
 }
 
 CROS_ARCH = {


### PR DESCRIPTION
This PR fixes arch naming for riscv64 platform arch for buildroot rootfs.

Steps to reproduce the bug:
`kernelci-pipeline/config/platforms.yaml`:
```
...

platforms:

  qemu:
    base_name: qemu
    arch: riscv64
    boot_method: qemu
    mach: qemu
    context:
      arch: riscv64
      cpu: rv64
      guestfs_interface: virt

...
```

When a test job is on this platform the rootfs url would be similar to the the following:
`http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230421.0/riscv64/rootfs.cpio.gz`
when instead the correct url is:
`http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230421.0/riscv/rootfs.cpio.gz`