### PR TITLE
rootfs-configs.yaml: Add Python3 to the LTP rootfs

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -352,6 +352,7 @@ rootfs_configs:
       - gdb-minimal
       - libnuma-dev
       - ntfs-3g
+      - python3
     script: "scripts/bookworm-ltp.sh"
     imagesize: 2GB
     debos_memory: 8G


### PR DESCRIPTION
Kirk needs Python3, install it into the LTP images so we can make use of
it.

Signed-off-by: Mark Brown <broonie@kernel.org>
