### PR TITLE
rootfs-configs.yaml: Add psmisc to the kselftest rootfs for mm

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -295,6 +295,7 @@ rootfs_configs:
       - perl
       - perl-modules-5.36
       - procps
+      - psmisc
       - publicsuffix
       - python3-minimal
       - python3-unittest2


### PR DESCRIPTION
The mm selftests use killall from one of the scripts, hanging if it's
not available.  Add psmisc so it's available.

Signed-off-by: Mark Brown <broonie@kernel.org>
