### PR TITLE
Enable KVM unit tests

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -322,6 +322,19 @@ rootfs_configs:
       - xz-utils
     script: "scripts/bookworm-kselftest.sh"
 
+  bookworm-kvm-unit-tests:
+    rootfs_type: debos
+    debian_release: bookworm
+    arch_list:
+      - amd64
+      - arm64
+    extra_packages:
+      - python3-minimal
+      - python3-unittest2
+      - python3-yaml
+      - qemu-system
+    script: "scripts/bookworm-kvm-unit-tests.sh"
+
   bookworm-libcamera:
     rootfs_type: debos
     debian_release: bookworm

--- a/config/rootfs/debos/scripts/bookworm-kvm-unit-tests.sh
+++ b/config/rootfs/debos/scripts/bookworm-kvm-unit-tests.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Important: This script is run under QEMU
+
+set -e
+
+RELEASE=v2025-06-05
+
+BUILD_DEPS="\
+      gcc \
+      git \
+      ca-certificates \
+      libc6-dev \
+      make \
+"
+
+apt-get install --no-install-recommends -y ${BUILD_DEPS}
+
+# test-definitions is going to go looking for /opt/kvm-unit-tests
+# so build there
+mkdir -p /opt
+cd /opt
+git clone https://gitlab.com/kvm-unit-tests/kvm-unit-tests
+cd /opt/kvm-unit-tests
+git reset --hard ${RELEASE}
+./configure
+make
+
+# Cleanup: remove files and packages we don't want in the images
+rm -rf ./.git
+apt-get remove --purge -y ${BUILD_DEPS}
+apt-get remove --purge -y libgtest-dev
+apt-get autoremove --purge -y
+apt-get clean

--- a/config/runtime/tests/kvm-unit-tests.jinja2
+++ b/config/runtime/tests/kvm-unit-tests.jinja2
@@ -1,0 +1,23 @@
+- test:
+    timeout:
+      minutes: {{ job_timeout }}
+    definitions:
+    - from: inline
+      repository:
+        metadata:
+          format: Lava-Test Test Definition 1.0
+          name: timesync-off
+          description: Disable systemd time sync services
+        run:
+          steps:
+          - systemctl stop systemd-timesyncd || true
+      name: timesync-off
+      path: inline/timesync-off.yaml
+
+    - repository: https://github.com/kernelci/test-definitions.git
+      from: git
+      revision: kernelci.org
+      path: automated/linux/kvm-unit-tests/kvm-unit-tests.yaml
+      name: '{{ node.name }}'
+      parameters:
+        SKIP_INSTALL: True


### PR DESCRIPTION
Add a rootfs and job template fragment for the KVM unit tests.

- rootfs: Build rootfs with kvm-unit-tests installed
- runtime: Add template fragment for kvm-unit-tests
