### PR TITLE
config: runtime: util: gcov-upload: fix compression method

### DIFF
--- a/config/runtime/util/gcov-upload.jinja2
+++ b/config/runtime/util/gcov-upload.jinja2
@@ -17,13 +17,13 @@
           - test -d ${GCDA} || exit 0
           - TEMPDIR=$(mktemp -d)
           - UPLOAD_PATH="{{ node.name }}-{{ node.id }}"
-          - UPLOAD_NAME="gcov.tar.xz"
+          - UPLOAD_NAME="gcov.tar.gz"
           # Retrieve GCOV artifacts
           # Taken from https://www.kernel.org/doc/html/v6.12/dev-tools/gcov.html#appendix-b-gather-on-test-sh
           - find $GCDA -type d -exec mkdir -p $TEMPDIR/\{\} \;
           - find $GCDA -name '*.gcda' -exec sh -c 'cat < $0 > '$TEMPDIR'/$0' {} \;
           - find $GCDA -name '*.gcno' -exec sh -c 'cp -d $0 '$TEMPDIR'/$0' {} \;
-          - tar cJf ${UPLOAD_NAME} -C $TEMPDIR sys
+          - tar czf ${UPLOAD_NAME} -C $TEMPDIR sys
           - rm -rf $TEMPDIR
           # Use set +x so we can don't echo secret tokens in the logs
           - set +x


### PR DESCRIPTION
The LTP rootfs doesn't include `xz`, so we can't use that compression method. Revert to `gz` as those artifacts aren't that big anyway.