### PR TITLE
(kbuild) Verify image existence only if build pass

### DIFF
--- a/kernelci/kbuild.py
+++ b/kernelci/kbuild.py
@@ -1182,7 +1182,7 @@ trap 'case $stage in
         # This is second line of defense against kernel build failure,
         # if 'kernel' is not in artifacts, we assume it is a failure
         # but keep in mind dtbs_check can be run without kernel
-        if 'kernel' not in af_uri and not self._dtbs_check:
+        if 'kernel' not in af_uri and not self._dtbs_check and job_result == 'pass':
             self.submit_failure("Kernel image not found in artifacts")
 
         if job_result == 'pass':


### PR DESCRIPTION
We should not submit_failure if already we detected failure by other means, because submit_failure doesnt add artifacts.