### PR TITLE
roofs: ltp: Use a fixed release of LTP when building it's rootfs

### DIFF
--- a/config/rootfs/debos/scripts/bookworm-ltp.sh
+++ b/config/rootfs/debos/scripts/bookworm-ltp.sh
@@ -4,6 +4,9 @@
 
 set -e
 
+LTP_URL="https://github.com/linux-test-project/ltp.git"
+LTP_SHA=20250530
+
 # Version of Kirk to install
 KIRK_VERSION=v1.5
 
@@ -35,13 +38,10 @@ mkdir -p ${BUILD_DIR} && cd ${BUILD_DIR}
 
 git config --global http.sslverify false
 
-LTP_URL="https://github.com/linux-test-project/ltp.git"
-LTP_SHA=$(git ls-remote ${LTP_URL} | head -n 1 | cut -f 1)
-
 echo '    {"name": "ltp-tests", "git_url": "'$LTP_URL'", "git_commit": "'$LTP_SHA'" }' >> $BUILDFILE
 echo '  ]}' >> $BUILDFILE
 
-git clone -b master ${LTP_URL}
+git clone -b ${LTP_SHA} ${LTP_URL}
 cd ltp
 
 # See https://github.com/kernelci/kernelci-core/issues/948


### PR DESCRIPTION
Currently we build LTP using whatever the current commit on the master
branch is. This means that any development on the rootfs could change the
set of LTP tests we're running and that we will be running just some random
snapshot of LTP, not an actual release, so could end up carrying bugs that
wouldn't make it into a release. Fix the version of LTP at the recently
released 20250530 version.

Signed-off-by: Mark Brown <broonie@kernel.org>
