### PR TITLE
config: docker: base: host-tools: add gcovr

### DIFF
--- a/config/docker/base/host-tools.jinja2
+++ b/config/docker/base/host-tools.jinja2
@@ -95,6 +95,10 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 # Install dtschema for dtbs_check
 RUN pip3 install dtschema --break-system-packages
 
+# Install gcovr from pip as bookworm's version is too old
+# FIXME: revert to installing with apt after switching to trixie
+RUN pip3 install gcovr --break-system-packages
+
 # Download and build pahole v1.28
 RUN wget -c https://web.git.kernel.org/pub/scm/devel/pahole/pahole.git/snapshot/pahole-1.29.tar.gz && \
     tar -xzf pahole-1.29.tar.gz && \


### PR DESCRIPTION
`gcovr` is needed to post-process coverage data. However, the version available in Debian Bookworm is old and lacks features we need, such as generating `lcov`-compatible tracefiles. Install it using `pip` as a temporary workaround.