### PR TITLE
kernelci: runtime: lava: ensure result nodes are in "done" state

### DIFF
--- a/kernelci/runtime/lava.py
+++ b/kernelci/runtime/lava.py
@@ -192,7 +192,7 @@ class Callback:
     def _get_results_hierarchy(self, results):
         hierarchy = []
         for name, value in results.items():
-            node = {'name': name}
+            node = {'name': name, 'state': 'done'}
             child_nodes = []
             item = {'node': node, 'child_nodes': child_nodes}
             if isinstance(value, dict):


### PR DESCRIPTION
Nodes are created in `running` state by default. Recent changes to the API helper functions copy the `state` field from the node instead of setting it to `done` by default, meaning result nodes stay `running` until they time out.

Fix this by making those nodes `done` right from the beginning.