### PR TITLE
rootfs: Increase the image size for kvm-unit-tests

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -325,6 +325,7 @@ rootfs_configs:
   bookworm-kvm-unit-tests:
     rootfs_type: debos
     debian_release: bookworm
+    imagesize: 2GB
     arch_list:
       - amd64
       - arm64


### PR DESCRIPTION
We are not able to build the arm64 version with the default due to space
issues.

Signed-off-by: Mark Brown <broonie@kernel.org>
