### PR TITLE
Enable code coverage support for kselftests

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -278,6 +278,7 @@ rootfs_configs:
       - bc
       - bpftool
       - ca-certificates
+      - curl
       - ethtool
       - iperf3
       - iproute2

--- a/config/runtime/tests/kselftest-platform-parameters.jinja2
+++ b/config/runtime/tests/kselftest-platform-parameters.jinja2
@@ -26,7 +26,9 @@
           - tar xf main.tar.gz -C /opt/
       name: platform-test-parameters-fetch
       path: inline/platform-test-parameters-fetch.yaml
-
+{% if "coverage" in node.data.config_full %}
+{% include "util/gcov-reset.jinja2" %}
+{% endif %}
     - repository: https://github.com/kernelci/test-definitions.git
       from: git
       revision: kernelci.org
@@ -39,3 +41,6 @@
         TST_CASENAME: '{{ tests }}'
         SKIP_INSTALL: True
         ENV: '{{ env }}'
+{% if "coverage" in node.data.config_full %}
+{% include "util/gcov-upload.jinja2" %}
+{% endif %}

--- a/config/runtime/tests/kselftest.jinja2
+++ b/config/runtime/tests/kselftest.jinja2
@@ -13,7 +13,9 @@
           - systemctl stop systemd-timesyncd || true
       name: timesync-off
       path: inline/timesync-off.yaml
-
+{% if "coverage" in node.data.config_full %}
+{% include "util/gcov-reset.jinja2" %}
+{% endif %}
     - repository: https://github.com/kernelci/test-definitions.git
       from: git
       revision: kernelci.org
@@ -26,3 +28,6 @@
         TST_CASENAME: '{{ tests }}'
         SKIP_INSTALL: True
         ENV: '{{ env }}'
+{% if "coverage" in node.data.config_full %}
+{% include "util/gcov-upload.jinja2" %}
+{% endif %}


### PR DESCRIPTION
This PR allows `kselftest` jobs to retrieve, pack and upload coverage data when support is enabled in the kernel. It contains the following changes:
* add `curl` to the `bookworm-kselftest` rootfs (needed for uploading the artifacts)
* conditionally add the relevant template fragments to the `kselftest*` job templates to pack & upload coverage data