### PR TITLE
rootfs: Add IP utilities to LTP rootfs

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -376,8 +376,10 @@ rootfs_configs:
       - curl
       - dosfstools
       - gdb-minimal
+      - iproute2
       - jq
       - libnuma-dev
+      - net-tools
       - ntfs-3g
       - python3
     script: "scripts/bookworm-ltp.sh"


### PR DESCRIPTION
Some of the tests can use some network configuration utilities, add them
to the rootfs.

Signed-off-by: Mark Brown <broonie@kernel.org>
