### PR TITLE
kernelci: api: helper: don't crash when adding artifacts to node

### DIFF
--- a/kernelci/api/helper.py
+++ b/kernelci/api/helper.py
@@ -559,6 +559,8 @@ class APIHelper:
         root_node = root.copy()
         root_node['result'] = results['node']['result']
         root_node['state'] = results['node'].get('state', 'done')
+        if root_node.get('artifacts') is None:
+            root_node['artifacts'] = {}
         root_node['artifacts'].update(results['node']['artifacts'])
         root_node['data'].update(results['node'].get('data', {}))
         root_node['processed_by_kcidb_bridge'] = False


### PR DESCRIPTION
Nodes are created with `'artifacts': null`, meaning calling `update()` could lead to an uncaught exception, and therefore a crash. Avoid this situation by ensuring this field is a dict before calling `update()`.