### PR TITLE
config: runtime: base: lava: improve timeout calculation

### DIFF
--- a/config/runtime/base/lava.jinja2
+++ b/config/runtime/base/lava.jinja2
@@ -35,6 +35,17 @@ context:
   {% endif %}
 {% endif %}
 
+{%- if "coverage" in node.data.config_full -%}
+{%-   set coverage_timeout = 10 -%}
+{%- else -%}
+{%-   set coverage_timeout = 0 -%}
+{%- endif -%}
+{%- if job_timeout and (job_timeout > 15) -%}
+{%-   set full_timeout = job_timeout + 15 + coverage_timeout -%}
+{%- else -%}
+{%-   set full_timeout = 30 + coverage_timeout -%}
+{%- endif -%}
+
 timeouts:
   action:
     minutes: 10
@@ -42,11 +53,7 @@ timeouts:
     power-off:
       seconds: 30
   job:
-{%- if job_timeout and (job_timeout > 30) %}
-    minutes: {{ job_timeout + 15 }}
-{%- else %}
-    minutes: 30
-{%- endif %}
+    minutes: {{ full_timeout }}
   queue:
     days: 2
 


### PR DESCRIPTION
Currently, the full job timeout is set to 30 minutes by default, or `job_timeout + 15` if `job_timeout` is defined and exceeds 30 minutes. Those 15 minutes are meant to account for artifacts download and device boot time, but if the test is supposed to last 30 minutes (or almost), then the job might time out before the test is complete. Fix this by making *15* the minimum value for `job_timeout` (and keep falling back to the default 30 minutes otherwise).

Also add an additional 10 minutes to account for coverage data post-processing and upload (which usually takes 5-6 minutes) when coverage support is enabled.