### PR TITLE
config: docker: Bump Python version for base template

### DIFF
--- a/config/docker/base/python.jinja2
+++ b/config/docker/base/python.jinja2
@@ -4,7 +4,7 @@
  # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
 -#}
 
-FROM mirror.gcr.io/python:3.11
+FROM mirror.gcr.io/python:3.12
 
 MAINTAINER "KernelCI TSC" <kernelci-tsc@groups.io>
 


### PR DESCRIPTION
This upgrade is inteded to make use of [recent changes](https://docs.python.org/3.12/library/tempfile.html#tempfile.NamedTemporaryFile) in handling temporary files (in "tempfile" module).

Depends on: https://github.com/kernelci/kernelci-pipeline/pull/1229