### PR TITLE
receive_event: Make it optionally semi-nonblocking

### DIFF
--- a/kernelci/api/helper.py
+++ b/kernelci/api/helper.py
@@ -64,9 +64,16 @@ class APIHelper:
             self._filters.pop(sub_id)
         self.api.unsubscribe(sub_id)
 
-    def receive_event_data(self, sub_id):
-        """Receive CloudEvent from Pub/Sub and return its data payload"""
-        return self.api.receive_event(sub_id).data
+    def receive_event_data(self, sub_id, block=True):
+        """Receive CloudEvent from Pub/Sub and return its data payload
+        If block is False, on receiving an "keep-alive" event,
+        such as "BEEP" ping, it will return None instead of the data.
+        Without this, it will block until an event is received.
+        """
+        event = self.api.receive_event(sub_id, block=block)
+        if event is None:
+            return None
+        return event.data
 
     def pop_event_data(self, list_name):
         """Receive CloudEvent from Redis list and return its data payload"""

--- a/kernelci/api/latest.py
+++ b/kernelci/api/latest.py
@@ -163,7 +163,7 @@ class LatestAPI(API):  # pylint: disable=too-many-public-methods
     def send_event(self, channel: str, data):
         self._post('/'.join(['publish', channel]), data)
 
-    def receive_event(self, sub_id: int):
+    def receive_event(self, sub_id: int, block: bool = True):
         path = '/'.join(['listen', str(sub_id)])
         while True:
             resp = self._get(path)
@@ -172,6 +172,10 @@ class LatestAPI(API):  # pylint: disable=too-many-public-methods
                 continue
             event = from_json(data)
             if event.data == 'BEEP':
+                if not block:
+                    # If block is False, return None
+                    # for semi-nonblocking operation
+                    return None
                 continue
             return event
 


### PR DESCRIPTION
Right now receive_event is blocking, and even on receiving keep alive it stay inside its own busy loop, which makes impossible to implement proper scheduling, watchdogs, health monitoring.
We make optional parameter, where on keep alive message, (sent each 45 sec by kernelci-api) it will return None. We keep backward compatible defaults, as lot of code is not expecting None in return.