### PR TITLE
Enable job retry

### DIFF
--- a/kernelci/api/helper.py
+++ b/kernelci/api/helper.py
@@ -441,7 +441,7 @@ class APIHelper:
         return False
 
     def create_job_node(self, job_config, input_node,
-                        runtime=None, platform=None):
+                        runtime=None, platform=None, retry_counter=0):
         """Create a new job node based on input and configuration"""
         jobfilter = input_node.get('jobfilter')
         platform_filter = input_node.get('platform_filter')
@@ -459,6 +459,7 @@ class APIHelper:
             'data': {
                 'kernel_revision': input_node['data']['kernel_revision'],
             },
+            'retry_counter': retry_counter,
         }
         if jobfilter:
             job_node['jobfilter'] = jobfilter

--- a/kernelci/api/models.py
+++ b/kernelci/api/models.py
@@ -269,6 +269,10 @@ class Node(DatabaseModel):
         description="Flag to indicate if the node was processed by KCIDB-Bridge",
         default=False
     )
+    retry_counter: int = Field(
+        default=0,
+        description="Number of times the job has retried"
+    )
 
     OBJECT_ID_FIELDS: ClassVar[list] = ['parent']
     TIMESTAMP_FIELDS: ClassVar[list] = ['created', 'updated', 'timeout', 'holdoff']


### PR DESCRIPTION
- Add a field to `Node` model to keep track of a number of job retries
- Enable setting `retry_counter` while creating a job node