### PR TITLE
config: update production instance URL

### DIFF
--- a/config/core/api-configs.yaml
+++ b/config/core/api-configs.yaml
@@ -4,7 +4,7 @@ api:
     url: http://172.17.0.1:8001
 
   production:
-    url: https://kernelci-api.westus3.cloudapp.azure.com
+    url: https://api.kernelci.org/
 
   staging:
     url: https://staging.kernelci.org:9000


### PR DESCRIPTION
Update maestro production API URL to `https://api.kernelci.org`. The former URL is an alias of the new URL and it's still working fine but this looks like more readable and standard URL.
The new URL is also being used in other places such as KCIDB submissions and documentation.