### PR TITLE
config: runtime: tests: tast: enable code coverage support

### DIFF
--- a/config/runtime/tests/tast.jinja2
+++ b/config/runtime/tests/tast.jinja2
@@ -61,12 +61,42 @@
             - sudo -u cros --login ssh root@$(lava-target-ip) tar -xzf /usr/test_vectors-vp9.tar.gz -C
             /usr/local/share/tast/data/go.chromium.org/tast-tests/cros/local/bundles/cros/video/data/ || true
 {%- endif %}
+{% if "coverage" in node.data.config_full %}
+            - scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
+              -i /home/cros/.ssh/id_rsa /home/cros/gcov_* root@$(lava-target-ip):/usr/local/bin || true
+            - /home/cros/ssh_retry.sh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
+              -i /home/cros/.ssh/id_rsa root@$(lava-target-ip) /usr/local/bin/gcov_reset.sh || true
+            - lava-test-case gcov-scripts --result pass
+{% endif %}
             - lava-test-set stop setup
             - >-
               ./tast_parser.py --run
 {%- for test in tests %}
               {{ test }}
 {%- endfor %}
+              || true
+{% if "coverage" in node.data.config_full %}
+            - UPLOAD_PATH="{{ node.name }}-{{ node.id }}"
+            - UPLOAD_NAME="gcov.tar.gz"
+            # Pack and retrieve GCOV artifacts
+            - /home/cros/ssh_retry.sh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
+              -i /home/cros/.ssh/id_rsa root@$(lava-target-ip) /usr/local/bin/gcov_pack.sh
+              "/tmp/${UPLOAD_NAME}" || true
+            - scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
+              -i /home/cros/.ssh/id_rsa root@$(lava-target-ip):"/tmp/${UPLOAD_NAME}" . || true
+            # Use set +x so we can don't echo secret tokens in the logs
+            - set +x
+            - . /lava-${LAVA_JOB_ID}/secrets
+            - >-
+              lava-test-case "artifact-upload:coverage_data:{{ storage_config.base_url }}/${UPLOAD_PATH}/${UPLOAD_NAME}"
+              --shell curl -X POST {{ storage_config.base_url }}/upload
+              -H "Authorization: Bearer ${UPLOAD_TOKEN}"
+              -F "file0=@${UPLOAD_NAME}"
+              -F "path=${UPLOAD_PATH}"
+              || true
+            # Re-enable set -x for the final commands
+            - set -x
+{% endif %}
             # Wait for DUT to shut down, or keep going if unreachable (e.g. crashed)
             - >-
               /home/cros/ssh_retry.sh
@@ -76,3 +106,7 @@
               root@$(lava-target-ip)
               poweroff && sleep 30 || true
             - ./tast_parser.py --results
+{% if "coverage" in node.data.config_full %}
+secrets:
+  UPLOAD_TOKEN: {{ storage_config.name }}-token
+{% endif %}


### PR DESCRIPTION
Other tests for which we enabled code coverage support run directly on the DUT and are therefore easy to process using additional common test definitions. However, for Tast tests, we execute commands from a container and need to use SSH for executing commands on the DUT which actually runs ChromeOS.

For this reason, we can't re-use the existing gcov-related utility templates for Tast test and need to re-implement the whole logic separately:
* provide scripts for:
  * resetting coverage data before running the test
  * packing coverage data once the test is complete
* copy those scripts to the DUT using SCP and execute them when needed through SSH
* retrieve coverage data from DUT and upload it to storage

All those commands need to be fail-safe, hence the (ab)use of `|| true` so we end up proprely shutting down the DUT (not doing so leads to filesystem corruption, requiring the DUT to be reflashed).