### PR TITLE
feat: Adapt to apt-key removal in Debian Trixie

### DIFF
--- a/config/docker/clang-12.jinja2
+++ b/config/docker/clang-12.jinja2
@@ -2,8 +2,8 @@
 
 {% block packages %}
 {{ super() }}
-RUN wget -q -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-RUN echo 'deb http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-12 main' \
+RUN wget -q -O - https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /usr/share/keyrings/llvm-archive-keyring.gpg
+RUN echo 'deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-12 main' \
    >> /etc/apt/sources.list.d/clang.list
 
 RUN apt-get update && apt-get install --no-install-recommends -y \

--- a/config/docker/clang-13.jinja2
+++ b/config/docker/clang-13.jinja2
@@ -2,8 +2,8 @@
 
 {% block packages %}
 {{ super() }}
-RUN wget -q -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-RUN echo 'deb http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-13 main' \
+RUN wget -q -O - https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /usr/share/keyrings/llvm-archive-keyring.gpg
+RUN echo 'deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-13 main' \
    >> /etc/apt/sources.list.d/clang.list
 
 RUN apt-get update && apt-get install --no-install-recommends -y \

--- a/config/docker/clang-14.jinja2
+++ b/config/docker/clang-14.jinja2
@@ -2,8 +2,8 @@
 
 {% block packages %}
 {{ super() }}
-RUN wget -q -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-RUN echo 'deb http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-14 main' \
+RUN wget -q -O - https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /usr/share/keyrings/llvm-archive-keyring.gpg
+RUN echo 'deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-14 main' \
    >> /etc/apt/sources.list.d/clang.list
 
 RUN apt-get update && apt-get install --no-install-recommends -y \

--- a/config/docker/clang-15.jinja2
+++ b/config/docker/clang-15.jinja2
@@ -2,8 +2,8 @@
 
 {% block packages %}
 {{ super() }}
-RUN wget -q -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-RUN echo 'deb http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-15 main' \
+RUN wget -q -O - https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /usr/share/keyrings/llvm-archive-keyring.gpg
+RUN echo 'deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-15 main' \
    >> /etc/apt/sources.list.d/clang.list
 
 RUN apt-get update && apt-get install --no-install-recommends -y \

--- a/config/docker/clang-16.jinja2
+++ b/config/docker/clang-16.jinja2
@@ -2,8 +2,8 @@
 
 {% block packages %}
 {{ super() }}
-RUN wget -q -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-RUN echo 'deb http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-16 main' \
+RUN wget -q -O - https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /usr/share/keyrings/llvm-archive-keyring.gpg
+RUN echo 'deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-16 main' \
    >> /etc/apt/sources.list.d/clang.list
 
 RUN apt-get update && apt-get install --no-install-recommends -y \

--- a/config/docker/clang-17.jinja2
+++ b/config/docker/clang-17.jinja2
@@ -2,8 +2,8 @@
 
 {% block packages %}
 {{ super() }}
-RUN wget -q -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-RUN echo 'deb http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-17 main' \
+RUN wget -q -O - https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /usr/share/keyrings/llvm-archive-keyring.gpg
+RUN echo 'deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-17 main' \
    >> /etc/apt/sources.list.d/clang.list
 
 RUN apt-get update && apt-get install --no-install-recommends -y \

--- a/config/docker/fragment/gcloud.jinja2
+++ b/config/docker/fragment/gcloud.jinja2
@@ -16,7 +16,7 @@ https://packages.cloud.google.com/apt cloud-sdk main" \
     | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
 
 RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg \
-    | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
+    | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
 
 RUN apt-get update && apt-get install -y \
     google-cloud-sdk \


### PR DESCRIPTION
Debian Trixie and later versions have removed apt-key, which is used to add GPG keys for APT repositories. This change updates the Dockerfile templates to use the new recommended way of handling GPG keys, which is to store them in /usr/share/keyrings and reference them from the sources.list file.

This change is necessary to ensure that the Docker images can be built on Debian Trixie and later.