### PR TITLE
Translate retry counter

### DIFF
--- a/kernelci/api/models.py
+++ b/kernelci/api/models.py
@@ -269,7 +269,7 @@ class Node(DatabaseModel):
         description="Flag to indicate if the node was processed by KCIDB-Bridge",
         default=False
     )
-    retry_counter: int = Field(
+    retry_counter: StrictInt = Field(
         default=0,
         description="Number of times the job has retried"
     )


### PR DESCRIPTION
Closes https://github.com/kernelci/kernelci-api/issues/626

In order to query nodes matching `retry_counter` field, translate query parameter value to integer since
all the query parameters are strings by default. For DB query, we need to change its data type to integer.