### PR TITLE
config: runtime: add ltp fault injection template

### DIFF
--- a/config/runtime/tests/ltp.jinja2
+++ b/config/runtime/tests/ltp.jinja2
@@ -19,6 +19,7 @@
         SKIPFILE: {{ skipfile }}
         RUNNER: /opt/kirk/kirk
         KIRK_WORKERS: {{ workers|default('1') }}
+        EXTRA_KIRK_ARGS: "{{ extra_kirk_args|default('') }}"
 {% if "coverage" in node.data.config_full %}
 {% include "util/gcov-upload.jinja2" %}
 {% endif %}


### PR DESCRIPTION
Add ltp-fault-injection.jinja2 based on ltp.jinja2 with fault injection arguments (-F 50) to kirk.