### PR TITLE
tests: use linaro/test-definitions repository

### DIFF
--- a/config/runtime/tests/kselftest-platform-parameters.jinja2
+++ b/config/runtime/tests/kselftest-platform-parameters.jinja2
@@ -29,7 +29,7 @@
 {% if "coverage" in node.data.config_full %}
 {% include "util/gcov-reset.jinja2" %}
 {% endif %}
-    - repository: https://github.com/kernelci/test-definitions.git
+    - repository: https://github.com/linaro/test-definitions.git
       from: git
       revision: kernelci.org
       path: automated/linux/kselftest/kselftest.yaml

--- a/config/runtime/tests/kselftest.jinja2
+++ b/config/runtime/tests/kselftest.jinja2
@@ -16,7 +16,7 @@
 {% if "coverage" in node.data.config_full %}
 {% include "util/gcov-reset.jinja2" %}
 {% endif %}
-    - repository: https://github.com/kernelci/test-definitions.git
+    - repository: https://github.com/linaro/test-definitions.git
       from: git
       revision: kernelci.org
       path: automated/linux/kselftest/kselftest.yaml

--- a/config/runtime/tests/kvm-unit-tests.jinja2
+++ b/config/runtime/tests/kvm-unit-tests.jinja2
@@ -14,7 +14,7 @@
       name: timesync-off
       path: inline/timesync-off.yaml
 
-    - repository: https://github.com/kernelci/test-definitions.git
+    - repository: https://github.com/linaro/test-definitions.git
       from: git
       revision: kernelci.org
       path: automated/linux/kvm-unit-tests/kvm-unit-tests.yaml

--- a/config/runtime/tests/ltp.jinja2
+++ b/config/runtime/tests/ltp.jinja2
@@ -6,7 +6,7 @@
 {% if "coverage" in node.data.config_full %}
 {% include "util/gcov-reset.jinja2" %}
 {% endif %}
-    - repository: https://github.com/kernelci/test-definitions
+    - repository: https://github.com/linaro/test-definitions.git
       from: git
       revision: kernelci.org
       path: automated/linux/ltp/ltp.yaml

--- a/config/runtime/tests/rt-tests.jinja2
+++ b/config/runtime/tests/rt-tests.jinja2
@@ -4,7 +4,7 @@
       minutes: {{ job_timeout|default('10') }}
 
     definitions:
-    - repository: https://github.com/kernelci/test-definitions.git
+    - repository: https://github.com/linaro/test-definitions.git
       from: git
       revision: kernelci.org
       path: automated/linux/{{ tst_group|default(tst_cmd) }}/{{ tst_cmd }}.yaml


### PR DESCRIPTION
Switch from the kernelci/test-definitions mirror to the official linaro/test-definitions repository since kernelci/test-definitions is deprecated.