### PR TITLE
kernelci: api: models: add new "process" node type

### DIFF
--- a/kernelci/api/models.py
+++ b/kernelci/api/models.py
@@ -627,6 +627,19 @@ class Job(Node):
     ]
 
 
+class Process(Node):
+    """API model for post-processing job nodes"""
+    class_kind: ClassVar[str] = 'process'
+    kind: Literal['process'] = Field(
+        default='process',
+        description='Type of the object',
+    )
+
+    OBJECT_ID_FIELDS = Node.OBJECT_ID_FIELDS + [
+        'data.regression',
+    ]
+
+
 class RegressionData(BaseModel):
     """Model for the data field of a Regression node"""
     fail_node: Optional[PyObjectId] = Field(


### PR DESCRIPTION
Post-processing jobs are currently nodes of the `job` kind, which only works as long as they're related to `checkout` or `kbuild` nodes. However, due to performance issues of the `coverage-report` jobs, we need to post-process each coverage-enabled test job individually.

This leads to scheduling issues, as we could enter an infinite loop where new post-processing jobs would be triggered whenever one of those transitions to the `done` state.

We must therefore create a new node kind for post-processing jobs in order to avoid those scheduler limitations.