### PR TITLE
config: runtime: tests: fix branch name for Linaro's test-definitions

### DIFF
--- a/config/runtime/tests/kselftest-platform-parameters.jinja2
+++ b/config/runtime/tests/kselftest-platform-parameters.jinja2
@@ -31,7 +31,7 @@
 {% endif %}
     - repository: https://github.com/linaro/test-definitions.git
       from: git
-      revision: kernelci.org
+      revision: master
       path: automated/linux/kselftest/kselftest.yaml
       name: '{{ node.name }}'
       parameters:

--- a/config/runtime/tests/kselftest.jinja2
+++ b/config/runtime/tests/kselftest.jinja2
@@ -18,7 +18,7 @@
 {% endif %}
     - repository: https://github.com/linaro/test-definitions.git
       from: git
-      revision: kernelci.org
+      revision: master
       path: automated/linux/kselftest/kselftest.yaml
       name: '{{ node.name }}'
       parameters:

--- a/config/runtime/tests/kvm-unit-tests.jinja2
+++ b/config/runtime/tests/kvm-unit-tests.jinja2
@@ -16,7 +16,7 @@
 
     - repository: https://github.com/linaro/test-definitions.git
       from: git
-      revision: kernelci.org
+      revision: master
       path: automated/linux/kvm-unit-tests/kvm-unit-tests.yaml
       name: '{{ node.name }}'
       parameters:

--- a/config/runtime/tests/ltp.jinja2
+++ b/config/runtime/tests/ltp.jinja2
@@ -8,7 +8,7 @@
 {% endif %}
     - repository: https://github.com/linaro/test-definitions.git
       from: git
-      revision: kernelci.org
+      revision: master
       path: automated/linux/ltp/ltp.yaml
       name: {{ node.name }}
       parameters:

--- a/config/runtime/tests/rt-tests.jinja2
+++ b/config/runtime/tests/rt-tests.jinja2
@@ -6,7 +6,7 @@
     definitions:
     - repository: https://github.com/linaro/test-definitions.git
       from: git
-      revision: kernelci.org
+      revision: master
       path: automated/linux/{{ tst_group|default(tst_cmd) }}/{{ tst_cmd }}.yaml
       name: {{ node.name }}
       parameters:


### PR DESCRIPTION
The main branch there is `master`, not `kernelci.org`.