### PR TITLE
config: runtime: increase test timeout when coverage is enabled

### DIFF
--- a/config/runtime/base/lava.jinja2
+++ b/config/runtime/base/lava.jinja2
@@ -36,15 +36,16 @@ context:
 {% endif %}
 
 {%- if "coverage" in node.data.config_full -%}
-{%-   set coverage_timeout = 10 -%}
+{%-   set coverage_timeout = 20 -%}
 {%- else -%}
 {%-   set coverage_timeout = 0 -%}
 {%- endif -%}
 {%- if job_timeout and (job_timeout > 15) -%}
-{%-   set full_timeout = job_timeout + 15 + coverage_timeout -%}
+{%-   set test_timeout = job_timeout + coverage_timeout -%}
 {%- else -%}
-{%-   set full_timeout = 30 + coverage_timeout -%}
+{%-   set test_timeout = 15 + coverage_timeout -%}
 {%- endif -%}
+{%- set full_timeout = 15 + test_timeout -%}
 
 timeouts:
   action:

--- a/config/runtime/tests/kselftest-platform-parameters.jinja2
+++ b/config/runtime/tests/kselftest-platform-parameters.jinja2
@@ -1,6 +1,6 @@
 - test:
     timeout:
-      minutes: {{ job_timeout }}
+      minutes: {{ test_timeout }}
     definitions:
     - from: inline
       repository:

--- a/config/runtime/tests/kselftest.jinja2
+++ b/config/runtime/tests/kselftest.jinja2
@@ -1,6 +1,6 @@
 - test:
     timeout:
-      minutes: {{ job_timeout }}
+      minutes: {{ test_timeout }}
     definitions:
     - from: inline
       repository:

--- a/config/runtime/tests/ltp.jinja2
+++ b/config/runtime/tests/ltp.jinja2
@@ -1,7 +1,7 @@
 - test:
     name: {{ node.name }}
     timeout:
-      minutes: {{ job_timeout|default(15) }}
+      minutes: {{ test_timeout|default(15) }}
     definitions:
 {% if "coverage" in node.data.config_full %}
 {% include "util/gcov-reset.jinja2" %}

--- a/config/runtime/tests/tast-debian.jinja2
+++ b/config/runtime/tests/tast-debian.jinja2
@@ -34,7 +34,7 @@
 
 - test:
     timeout:
-      minutes: {{ job_timeout|default('30') }}
+      minutes: {{ test_timeout|default('30') }}
     docker:
       image: kernelci/cros-tast
       wait:

--- a/config/runtime/tests/tast.jinja2
+++ b/config/runtime/tests/tast.jinja2
@@ -3,7 +3,7 @@
 - test:
     namespace: chromeos
     timeout:
-      minutes: {{ job_timeout|default('30') }}
+      minutes: {{ test_timeout|default('30') }}
     docker:
       image: kernelci/cros-tast
       wait:


### PR DESCRIPTION
We have a longer global timeout on coverage-enabled runs, as we need to leave enough time for packing and uploading the coverage data. However, this doesn't affect the job/test timeout, leading to many jobs timing out during coverage artifacts packing.

Fix this by adding a new `test_timeout` variable, calculated from `job_timeout` when it's present, and used in place of the latter in test templates.