### PR TITLE
build-configs.yaml: Update fault injection configs

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -478,6 +478,11 @@ fragments:
       - 'CONFIG_FAIL_MMC_REQUEST=y'
       - 'CONFIG_FUNCTION_ERROR_INJECTION=y'
       - 'CONFIG_FAIL_FUNCTION=y'
+      - 'CONFIG_BLK_DEV_NULL_BLK_FAULT_INJECTION=y'
+      - 'CONFIG_BLK_DEV=y'
+      - 'CONFIG_BLK_DEV_NULL_BLK=m'
+      - 'CONFIG_SCSI_DEBUG=m'
+      - 'CONFIG_BLK_DEV_UBLK=y'
 
   ima:
     path: "kernel/configs/ima.config"


### PR DESCRIPTION
Update fault injection configs to include support for null_blk fault injection. blktests can be used to run fault injection tests on raw block devices with the null_blk driver.