### PR TITLE
config: docker: data: add gcov-related scripts

### DIFF
--- a/config/docker/data/gcov_pack.sh
+++ b/config/docker/data/gcov_pack.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+FILE_NAME=$1
+
+set -x
+
+GCDA=/sys/kernel/debug/gcov
+
+# Act only if $GCDA does exist (as GCOV is definitely enabled)
+if [ -d ${GCDA} ]; then
+    TEMPDIR=$(mktemp -d)
+    # Retrieve GCOV artifacts
+    # Taken from https://www.kernel.org/doc/html/v6.12/dev-tools/gcov.html#appendix-b-gather-on-test-sh
+    find $GCDA -type d -exec mkdir -p $TEMPDIR/\{\} \;
+    find $GCDA -name '*.gcda' -exec sh -c 'cat < $0 > '$TEMPDIR'/$0' {} \;
+    find $GCDA -name '*.gcno' -exec sh -c 'cp -d $0 '$TEMPDIR'/$0' {} \;
+    tar czf "${FILE_NAME}" -C $TEMPDIR sys
+    rm -rf $TEMPDIR
+fi

--- a/config/docker/data/gcov_reset.sh
+++ b/config/docker/data/gcov_reset.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -x
+
+GCOV_RESET="/sys/kernel/debug/gcov/reset"
+if [ -f ${GCOV_RESET} ]; then
+    echo 1 > ${GCOV_RESET};
+fi


### PR DESCRIPTION
For coverage-enabled builds, we need to reset coverage data before executing the tests, and retrieve the coverage data after the tests have completed. As those are "complex" operations (i.e. more than just running a single command) we need to provide scripts we can then copy to the DUT and then execute through SSH.

Create those scripts so we can add them to Docker images in the future.