### PR TITLE
Fix: host pahole locally

### DIFF
--- a/config/docker/base/host-tools.jinja2
+++ b/config/docker/base/host-tools.jinja2
@@ -100,7 +100,7 @@ RUN pip3 install dtschema --break-system-packages
 RUN pip3 install gcovr --break-system-packages
 
 # Download and build pahole v1.28
-RUN wget -c https://web.git.kernel.org/pub/scm/devel/pahole/pahole.git/snapshot/pahole-1.29.tar.gz && \
+RUN wget -c https://storage.kernelci.org/pahole-1.29.tar.gz && \
     tar -xzf pahole-1.29.tar.gz && \
     cd pahole-1.29 && \
     mkdir build && cd build && \


### PR DESCRIPTION
We are retrieving pahole archive from external server on each staging run, and seems that host either doesnt like that, or unreliable. We should host it locally, especially as it is fixed version.

Example of error:
```
Step 28/62 : RUN wget -c https://web.git.kernel.org/pub/scm/devel/pahole/pahole.git/snapshot/pahole-1.29.tar.gz &&     tar -xzf pahole-1.29.tar.gz &&     cd pahole-1.29 &&     mkdir build && cd build &&     cmake .. -DLIBBPF_EMBEDDED=OFF &&     make &&     make install &&     echo "/usr/local/lib" > /etc/ld.so.conf.d/dwarves.conf &&     ldconfig &&     cd ../.. && rm -rf pahole-1.29

 ---> Running in 1427ce2ed752
--2025-08-26 08:05:49--  https://web.git.kernel.org/pub/scm/devel/pahole/pahole.git/snapshot/pahole-1.29.tar.gz

Resolving web.git.kernel.org (web.git.kernel.org)...
151.101.202.133, 2a04:4e42:2f::645
Connecting to web.git.kernel.org (web.git.kernel.org)|151.101.202.133|:443...
connected.

HTTP request sent, awaiting response...
503 Service Unavailable
2025-08-26 08:05:50 ERROR 503: Service Unavailable.
```