### PR TITLE
Remove deprecation notice from config that are still used

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -1,7 +1,3 @@
-# This is LEGACY system config, do not send any new patches for this file.
-# More details:
-# https://lore.kernel.org/kernelci/5b603b8f-c9b2-4148-7212-dd69a3fdf506@collabora.com/T/#u
-
 trees:
 
   agross:


### PR DESCRIPTION
Unfortunately we are still using this config for kernel fragments configuration