### PR TITLE
config: handle ValueError exception properly

### DIFF
--- a/kernelci/config/base.py
+++ b/kernelci/config/base.py
@@ -73,7 +73,8 @@ def _format_dict_strings(param, fmap):
     if isinstance(param, str):
         try:
             param = param.format_map(fmap)
-        except KeyError:
+        except (KeyError, ValueError) as e:
+            print(f"Format string error in param '{param}': {e}")
             return param  # Don't do anything but keep python happy
     elif isinstance(param, dict):
         for key in param:


### PR DESCRIPTION
Bug in pipeline:
  Exception in thread Thread-2 (_run_scheduler):
  Traceback (most recent call last):
    File "/usr/local/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
      self.run()
    File "/usr/local/lib/python3.12/threading.py", line 1012, in run
      self._target(*self._args, **self._kwargs)
    File "/home/kernelci/pipeline/./src/scheduler.py", line 448, in _run_scheduler
      self._run_job(job, runtime, platform, input_node, retry_counter)
    File "/home/kernelci/pipeline/./src/scheduler.py", line 226, in _run_job
      params = job.platform_config.format_params(params, extra_args)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/local/lib/python3.12/site-packages/kernelci/config/base.py", line 168, in format_params
      return _format_dict_strings(param, args)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/local/lib/python3.12/site-packages/kernelci/config/base.py", line 80, in _format_dict_strings
      param[key] = _format_dict_strings(param[key], fmap)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/local/lib/python3.12/site-packages/kernelci/config/base.py", line 80, in _format_dict_strings
      param[key] = _format_dict_strings(param[key], fmap)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/local/lib/python3.12/site-packages/kernelci/config/base.py", line 80, in _format_dict_strings
      param[key] = _format_dict_strings(param[key], fmap)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    [Previous line repeated 1 more time]
    File "/usr/local/lib/python3.12/site-packages/kernelci/config/base.py", line 75, in _format_dict_strings
      param = param.format_map(fmap)
              ^^^^^^^^^^^^^^^^^^^^^^
  ValueError: Format string contains positional fields