### PR TITLE
fault-injection: update fault injection parameters

### DIFF
--- a/config/runtime/tests/fault-injection.jinja2
+++ b/config/runtime/tests/fault-injection.jinja2
@@ -23,8 +23,9 @@
                 echo "Iteration $i: {{ test_name }}"
                 FAILCMD_TYPE={{ fail_type|default('failslab') }} \
                   /usr/local/bin/failcmd \
-                  --probability={{ probability|default(100) }} \
-                  --times={{ times|default(100) }} \
+                  --interval={{ interval|default(1) }} \
+                  --probability={{ probability|default(range(1, 101)|random) }} \
+                  --times={{ times|default(-1) }} \
                   --verbose=2 \
                   "{{ test_command }}"
                 sleep {{ sleep_time|default(10) }}


### PR DESCRIPTION
fault-injection: update fault injection parameters

Set the default probability for fault-injection tests to a random
value between 1 and 100. This ensures each job run uses a different
probability value. Set times default to -1 for unlimited failures and
add interval to limit how often failures are injected. interval=1 allows
every eligible allocation to fail.