### PR TITLE
build-configs: add iwlwifi-so-a0-gf-a0-89.ucode

### DIFF
--- a/config/core/build-configs.yaml
+++ b/config/core/build-configs.yaml
@@ -1016,6 +1016,7 @@ fragments:
       rtw88/rtw8822c_wow_fw.bin
       rtw89/rtw8852a_fw.bin
       iwlwifi-so-a0-gf-a0-86.ucode
+      iwlwifi-so-a0-gf-a0-89.ucode
       iwlwifi-so-a0-gf-a0.pnvm
       iwlwifi-QuZ-a0-hr-b0-77.ucode
       iwlwifi-7265D-29.ucode


### PR DESCRIPTION
Include iwlwifi-so-a0-gf-a0-89.ucode to fix missing firmware error for intel chromebooks.

iwlwifi 0000:00:14.3: Detected crf-id 0x400410, cnv-id 0x80400 wfpm id 0x80000020
iwlwifi 0000:00:14.3: PCI dev 51f0/0094, rev=0x370, rfid=0x2010d000
iwlwifi 0000:00:14.3: Detected Intel(R) Wi-Fi 6E AX211 160MHz
iwlwifi 0000:00:14.3: Direct firmware load for iwlwifi-so-a0-gf-a0-89.ucode failed with error -2
iwlwifi 0000:00:14.3: no suitable firmware found!
iwlwifi 0000:00:14.3: iwlwifi-so-a0-gf-a0-89 is required
iwlwifi 0000:00:14.3: check git://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git