### PR TITLE
roofs: deqp-runner: use rm -rf for rust cleanup

### DIFF
--- a/config/rootfs/debos/scripts/bookworm-deqp-runner.sh
+++ b/config/rootfs/debos/scripts/bookworm-deqp-runner.sh
@@ -59,9 +59,9 @@ pip3 install --break-system-packages \
 # Cleanup pip cache
 rm -rf /root/.cache/pip
 
-# Cleanup cargo cache
-rm -rf /root/.cargo/registry
-rustup self uninstall -y
+# Cleanup rust
+rm -rf /root/.cargo
+rm -rf /root/.rustup
 
 apt-get remove --purge -y ${BUILD_DEPS}
 apt-get autoremove --purge -y


### PR DESCRIPTION
Use rm -rf for rust cleanup instead of rustup uninstal to avoid the below error for armhf builds,

error: could not remove 'rustup_home' directory: '/root/.rustup': Value too large for defined data type (os error 75)