### PR TITLE
rootfs: overlays: wifi: Add iwlwifi.conf

### DIFF
--- a/config/rootfs/debos/overlays/wifi/etc/modprobe.d/iwlwifi.conf
+++ b/config/rootfs/debos/overlays/wifi/etc/modprobe.d/iwlwifi.conf
@@ -1,0 +1,2 @@
+# iwlwifi require iwlmvm (module.dep does not contain the dep with chromeos kernel)
+softdep iwlwifi pre: iwlmvm


### PR DESCRIPTION
Add a modprobe.d configuration to ensure iwlmvm is loaded automatically before iwlwifi.