### PR TITLE
config/iPXE: increase timeouts

### DIFF
--- a/config/runtime/boot/ipxe.jinja2
+++ b/config/runtime/boot/ipxe.jinja2
@@ -41,7 +41,7 @@
       minutes: 20
     timeouts:
       bootloader-commands:
-        minutes: 3
+        minutes: 5
       auto-login-action:
         minutes: 6
       login-action:


### PR DESCRIPTION
Based on observation, for example: https://lava.ciplatform.org/scheduler/job/1311593 3 minutes is not enough for bootloader.