### PR TITLE
kernelci: cli: docker: use gcc-12 instead of gcc-10

### DIFF
--- a/kernelci/cli/docker.py
+++ b/kernelci/cli/docker.py
@@ -41,7 +41,7 @@ def kci_docker():
 
     The image and fragment names are positional arguments.  For example:
 
-        kci docker build gcc-10 --arch=x86 kernelci kselftest
+        kci docker build gcc-12 --arch=x86 kernelci kselftest
 
         kci docker generate kernelci
     """


### PR DESCRIPTION
GCC-10 was dropped with the refactor, so just update cli to output working command.