### PR TITLE
Fix rules behaviour for missing params

### DIFF
--- a/kernelci/api/helper.py
+++ b/kernelci/api/helper.py
@@ -198,18 +198,18 @@ class APIHelper:
 
             for item in base[key]:
                 if item in deny:
-                    print(f"rules{key}: {key.capitalize()} {item} not allowed due {deny}")
+                    print(f"rules[{key}]: {key.capitalize()} {item} not allowed due !{deny}")
                     return False
                 if item in allow:
                     found = True
 
             if not found:
-                print(f"rules: {key.capitalize()} missing one of {allow}")
+                print(f"rules[{key}]: {key.capitalize()} missing one of {allow}")
                 return False
 
         else:
             if base[key] in deny or (len(allow) > 0 and base[key] not in allow):
-                print(f"rule[{key}]: {key.capitalize()} {base[key]} not allowed due {deny}")
+                print(f"rules[{key}]: {key.capitalize()} {base[key]} not allowed due !{deny}")
                 return False
 
         return True
@@ -290,20 +290,20 @@ class APIHelper:
                     break
                 match = self._match_combos(node, deny_combos)
                 if match:
-                    print(f"Tree/branch combination "
+                    print(f"rules[{key}]: Tree/branch combination "
                           f"{match['tree']}/{match['branch']} not allowed")
                     return False
 
                 # Get back to regular allow/deny list processing
                 if node[key] in deny:
-                    print(f"{key.capitalize()} {node[key]} not allowed due {deny}")
+                    print(f"rules[{key}]: {key.capitalize()} {node[key]} not allowed due !{deny}")
                     return False
                 if (len(allow) == 0 and len(allow_combos) > 0):
-                    print(f"{key.capitalize()} {node[key]} not allowed due"
+                    print(f"rules[{key}]: {key.capitalize()} {node[key]} not allowed due"
                           f" to tree/branch rules")
                     return False
                 if (len(allow) > 0 and node[key] not in allow):
-                    print(f"{key.capitalize()} {node[key]} not allowed due {allow}")
+                    print(f"rules[{key}]: {key.capitalize()} {node[key]} not allowed due {allow}")
                     return False
 
         return True
@@ -392,13 +392,13 @@ class APIHelper:
                 if (key.startswith('min') and
                     ((major < rule_major) or
                      (major == rule_major and minor < rule_minor))):
-                    print(f"rules: Version {major}.{minor} older than minimum version "
+                    print(f"rules[{key}]: Version {major}.{minor} older than minimum version "
                           f"({rule_major}.{rule_minor})")
                     return False
                 if (key.startswith('max') and
                     ((major > rule_major) or
                      (major == rule_major and minor > rule_minor))):
-                    print(f"rules: Version {major}.{minor} more recent than maximum version "
+                    print(f"rules[{key}]: Version {major}.{minor} newer than maximum version "
                           f"({rule_major}.{rule_minor})")
                     return False
 


### PR DESCRIPTION
By default, if a rule refers to a param that can be found neither in the
to-be-created node nor in any of its ancestors we assume the rule is
verified (as in, we don't block creating the node). This behaviour felt
safe enough until we encountered a rare corner case: `coverage-report`
nodes were created with a `kunit-x86_64` parent, although the former
should only happen on jobs run for a kernel built with the `coverage`
fragment.

This could happen because `kunit-x86_64` is created from a `checkout`
node, not a `kbuild` one, and therefore neither this job nor its parent
contain a `fragments` attribute.

The above showed we needed to be a bit stricter when checking rules. To
this end, the following behaviour is enforced for missing attributes:
- if the rule only contains a deny-list, the rule is verified and the
  node can be created (a non-existing attribute cannot have a forbidden
  value, precisely because it doesn't have a value at all)
- if an allow-list is present, then the attribute's value MUST be part
  of this list; as a consequence, we now require the attribute to exist,
  and deny the node creation if it doesn't

This PR also adds minor improvements to messages printed in the context
of rules verification in order to improve the consistency of said messages.

Fixes kernelci/kernelci-pipeline#1290