### PR TITLE
config: runtime: base: lava: extend timeout for coverage-enabled jobs

### DIFF
--- a/config/runtime/base/lava.jinja2
+++ b/config/runtime/base/lava.jinja2
@@ -36,7 +36,7 @@ context:
 {% endif %}
 
 {%- if "coverage" in node.data.config_full -%}
-{%-   set coverage_timeout = 20 -%}
+{%-   set coverage_timeout = 30 -%}
 {%- else -%}
 {%-   set coverage_timeout = 0 -%}
 {%- endif -%}


### PR DESCRIPTION
When test coverage is enabled, we need to prepare the test run and pack the coverage artifacts once the tests are complete. This takes a significant amount of time, leading some jobs to time out during this packing operation. Increase the timeout value for such jobs by another 10 minutes in order to prevent such failures from happening