### PR TITLE
config: qemu: set default parameter for boot jobs

### DIFF
--- a/config/runtime/boot/qemu.jinja2
+++ b/config/runtime/boot/qemu.jinja2
@@ -1,7 +1,7 @@
 - deploy:
     images:
       kernel:
-        image_arg: -kernel {kernel} -append "console=ttyS0,115200 root=/dev/ram0 debug
+        image_arg: -kernel {kernel} -append "console={{ platform_config.context.serial|default('ttyS0') }},115200 root=/dev/ram0 debug
           verbose console_msg_format=syslog earlycon"
         url: '{{ node.artifacts.kernel }}'
       ramdisk:


### PR DESCRIPTION
Set a default console, but we need to change console depending on arch. So for arm64, we should boot with ttyAMA0.