### PR TITLE
rootfs-configs.yaml: Add more filesystem utilities to LTP rootfs

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -507,16 +507,22 @@ rootfs_configs:
       - arm64
       - armhf
     extra_packages:
+      - btrfs-progs
       - ca-certificates
       - curl
       - dosfstools
+      - e2fsprogs
       - gdb-minimal
       - iproute2
       - jq
       - libnuma-dev
       - net-tools
+      - nfs-kernel-server
       - ntfs-3g
+      - parted
       - python3
+      - quota
+      - xfsprogs
     script: "scripts/trixie-ltp.sh"
     imagesize: 2GB
     debos_memory: 8G


### PR DESCRIPTION
Various LTP tests create filesystems of various kinds, primarily ext2 but
also others, and there's also usage of exportfs, parted and quotacheck. Add
these to our LTP root filesystem images so the relevant tests can run.

Signed-off-by: Mark Brown <broonie@kernel.org>
