### PR TITLE
config: pull_labs: output nfsroot as rootfs artifact

### DIFF
--- a/config/runtime/base/pull_labs.jinja2
+++ b/config/runtime/base/pull_labs.jinja2
@@ -13,7 +13,7 @@
     "kselftest": "{{ node.artifacts.kselftest }}"
 {%- endif %}
 {%- if nfsroot is defined and nfsroot %},
-    "nfsroot": "{{ nfsroot }}/full.rootfs.tar.xz"
+    "rootfs": "{{ nfsroot }}/full.rootfs.tar.xz"
 {%- endif %}
 {%- if ramdisk is defined and ramdisk %},
     "ramdisk": "{{ ramdisk }}"


### PR DESCRIPTION
Change the artifact key from nfsroot to rootfs so the correct URL appears with the /full.rootfs.tar.xz suffix.