### PR TITLE
config: docker: Add riscv64 support

### DIFF
--- a/config/docker/qemu.jinja2
+++ b/config/docker/qemu.jinja2
@@ -17,6 +17,7 @@ RUN apt-get update && \
         qemu-system-mips \
         qemu-system-misc \
         qemu-system-ppc \
+        qemu-system-riscv64 \
         qemu-system-s390x \
         qemu-system-sparc \
         qemu-system-x86 \


### PR DESCRIPTION
Needed to help the test jobs from https://github.com/kernelci/kernelci-pipeline/pull/1413/