### PR TITLE
docker: Workaround for broken LLVM signature (SHA1 deprecation)

### DIFF
--- a/config/docker/clang-21.jinja2
+++ b/config/docker/clang-21.jinja2
@@ -2,6 +2,11 @@
 
 {% block packages %}
 {{ super() }}
+# Temporary workaround for LLVM SHA1 deprecation in APT
+# TODO: Remove when LLVM repo switches to stronger hash algorithms
+RUN if [ -f /usr/share/apt/default-sequoia.config ]; then \
+    sed -i 's/\(sha1\.second_preimage_resistance =\).*/\1 9999-01-01/' /usr/share/apt/default-sequoia.config; \
+  fi
 RUN wget -q -O - https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /usr/share/keyrings/llvm-archive-keyring.gpg
 RUN echo 'deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/trixie/ llvm-toolchain-trixie-21 main' \
    >> /etc/apt/sources.list.d/clang.list


### PR DESCRIPTION
Ref: https://github.com/kernelci/kernelci-core/issues/3046
Ref: https://github.com/llvm/llvm-project/issues/153385