### PR TITLE
rootfs: Update kvm-unit-tests to v2025-07-31

### DIFF
--- a/config/rootfs/debos/scripts/trixie-kvm-unit-tests.sh
+++ b/config/rootfs/debos/scripts/trixie-kvm-unit-tests.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-RELEASE=v2025-06-05
+RELEASE=v2025-07-31
 
 BUILD_DEPS="\
       gcc \


### PR DESCRIPTION
This is the most recent release they've done, with mainly x86
improvements plus support for using kvmtool instead of qemu.

Signed-off-by: Mark Brown <broonie@kerenel.org>
