### PR TITLE
config: Introduce rootfs_ref

### DIFF
--- a/config/runtime/boot/barebox.jinja2
+++ b/config/runtime/boot/barebox.jinja2
@@ -1,7 +1,3 @@
-{%- if boot_commands == 'nfs' and nfsroot is not defined %}
-{%-   set nfsroot = 'http://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20250117.0/' + debarch %}
-{%- endif %}
-
 - deploy:
     kernel:
       type: {{ node.data.kernel_type }}
@@ -23,7 +19,7 @@
     os: debian
 {%- else %}
     ramdisk:
-      url: 'http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230703.0/{{ brarch }}/rootfs.cpio.gz'
+      url: '{{ ramdisk }}'
       compression: gz
     os: oe
 {%- endif %}

--- a/config/runtime/boot/depthcharge.jinja2
+++ b/config/runtime/boot/depthcharge.jinja2
@@ -34,7 +34,7 @@
 {%- else %}
     ramdisk:
       compression: gz
-      url: 'http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230623.0/{{ brarch }}/rootfs.cpio.gz'
+      url: '{{ ramdisk }}'
 {%- endif %}
     os: oe
     timeout:

--- a/config/runtime/boot/fastboot.jinja2
+++ b/config/runtime/boot/fastboot.jinja2
@@ -8,7 +8,7 @@
         {% if boot_commands == "ramdisk" %}
         url: '{{ ramdiskroot }}/rootfs.cpio.gz'
         {% else %}
-        url: 'http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230703.0/{{ brarch }}/rootfs.cpio.gz'
+        url: '{{ ramdisk }}'
         {% endif %}
         compression: gz
         format: cpio.newc

--- a/config/runtime/boot/grub.jinja2
+++ b/config/runtime/boot/grub.jinja2
@@ -13,7 +13,7 @@
     os: debian
 {%- else %}
     ramdisk:
-      url: 'http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230703.0/{{ brarch }}/rootfs.cpio.gz'
+      url: '{{ ramdisk }}'
       compression: gz
     os: oe
 {%- endif %}

--- a/config/runtime/boot/ipxe.jinja2
+++ b/config/runtime/boot/ipxe.jinja2
@@ -1,7 +1,3 @@
-{%- if boot_commands == 'nfs' and nfsroot is not defined %}
-{%-   set nfsroot = 'http://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20250117.0/' + debarch %}
-{%- endif %}
-
 - deploy:
     kernel:
       type: {{ node.data.kernel_type }}
@@ -23,7 +19,7 @@
     os: debian
 {%- else %}
     ramdisk:
-      url: 'http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230703.0/{{ brarch }}/rootfs.cpio.gz'
+      url: '{{ ramdisk }}'
       compression: gz
     os: oe
 {%- endif %}

--- a/config/runtime/boot/qemu.jinja2
+++ b/config/runtime/boot/qemu.jinja2
@@ -7,7 +7,7 @@
         url: '{{ node.artifacts.kernel }}'
       ramdisk:
         image_arg: -initrd {ramdisk}
-        url: 'http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230421.0/{{ brarch }}/rootfs.cpio.gz'
+        url: '{{ ramdisk }}'
 {%- if device_dtb %}
       dtb:
         url: '{{ node.artifacts.dtb }}'

--- a/config/runtime/boot/u-boot.jinja2
+++ b/config/runtime/boot/u-boot.jinja2
@@ -1,7 +1,3 @@
-{%- if boot_commands == 'nfs' and nfsroot is not defined %}
-{%-   set nfsroot = 'http://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20250117.0/' + debarch %}
-{%- endif %}
-
 - deploy:
     kernel:
       type: {{ node.data.kernel_type }}
@@ -23,7 +19,7 @@
     os: debian
 {%- else %}
     ramdisk:
-      url: 'http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230703.0/{{ brarch }}/rootfs.cpio.gz'
+      url: '{{ ramdisk }}'
       compression: gz
     os: oe
 {%- endif %}

--- a/kernelci/cli/job.py
+++ b/kernelci/cli/job.py
@@ -115,6 +115,11 @@ def generate(node_id, *,  # pylint: disable=too-many-arguments, too-many-locals
         raise click.ClickException(
             f"Invalid job parameters: {exc}"
         ) from exc
+    # Resolve rootfs_ref before format_params so {brarch}/{debarch}
+    # placeholders in injected URLs get resolved
+    kernelci.config.resolve_rootfs_params(
+        params, configs.get('rootfs', {})
+    )
     # Process potential f-strings in `params` with configured job params
     # and platform attributes
     kernel_revision = job_node['data']['kernel_revision']['version']

--- a/kernelci/config/__init__.py
+++ b/kernelci/config/__init__.py
@@ -176,7 +176,43 @@ def load_data(data):
     ]:
         mod = importlib.import_module(module)
         config.update(mod.from_yaml(data, filters))
+    # Pass through rootfs definitions for rootfs_ref resolution
+    if 'rootfs' in data:
+        config['rootfs'] = data['rootfs']
     return config
+
+
+def resolve_rootfs_params(params, rootfs_defs):
+    """Resolve rootfs_ref in params to actual URL parameters.
+
+    If *params* contains a 'rootfs_ref' key, look it up in *rootfs_defs*
+    and merge the resulting URL parameters (e.g. nfsroot, ramdisk) into
+    *params*.  The rootfs_ref key is removed.  Existing keys in *params*
+    are not overwritten, so job-level overrides still work.
+
+    This must be called **before** format_params() so that injected URLs
+    containing {brarch}/{debarch} placeholders are resolved in the same
+    pass.
+
+    *params* is the job parameter dictionary (modified in place)
+    *rootfs_defs* is the 'rootfs' section from the YAML config
+    """
+    rootfs_ref = params.pop('rootfs_ref', None)
+    if not rootfs_ref:
+        return
+    if not rootfs_defs:
+        raise ValueError(
+            f"rootfs_ref '{rootfs_ref}' used but no rootfs "
+            f"definitions found in config"
+        )
+    if rootfs_ref not in rootfs_defs:
+        raise ValueError(
+            f"rootfs_ref '{rootfs_ref}' not found in "
+            f"rootfs config"
+        )
+    for key, value in rootfs_defs[rootfs_ref].items():
+        if key not in params:
+            params[key] = value
 
 
 def load(config_paths):


### PR DESCRIPTION
At current moment we have rootfs scattered across configs, and even hardcoded inside kernelci-core.
We need to arrange that properly, similar to legacy system (even better), where we have single section with all rootfs kinds (templated), which can be referenced in other sections such as rootfs_ref parameter.