### PR TITLE
boot: fastboot: use xz kselftest archive for ramdisk boot

### DIFF
--- a/config/runtime/boot/fastboot.jinja2
+++ b/config/runtime/boot/fastboot.jinja2
@@ -30,10 +30,10 @@
             path: /
           {% if boot_commands == "ramdisk" %}
           kselftest:
-            compression: gz
+            compression: xz
             format: tar
             path: /opt/kselftests/mainline/
-            url: {{ node.artifacts.kselftest_tar_gz }}
+            url: {{ node.artifacts.kselftest_tar_xz }}
           {% endif %}
 {% set dtb = device_dtb.split('/')[-1] %}
 {% if boot_commands == "ramdisk" %}


### PR DESCRIPTION
When tuxmake is used as build backend the kselftest artifact name changed to kselftest.tar.xz instead of kselftest.tar.gz

Update the fastboot jinja2 runtime template to fetch and unpack the kselftest ramdisk artifact as xz instead of gz.