### PR TITLE
rootfs: strip: don't let apt cascade-purge the Python stack on trixie

### DIFF
--- a/config/rootfs/debos/scripts/strip.sh
+++ b/config/rootfs/debos/scripts/strip.sh
@@ -16,11 +16,15 @@ export DEBIAN_FRONTEND=noninteractive
 exec 3>&-
 exec 4>&-
 
-# Removing unused packages
+# Removing unused packages.
+# Use dpkg --purge --force-depends rather than apt-get remove --purge:
+# in Debian trixie, python3.13 and libpython3.13-stdlib Depend: tzdata,
+# so apt cascades the purge and drops the entire Python stack, which
+# breaks rootfses that need python3-tap / python3-yaml / asyncio etc.
 for PACKAGE in ${PACKAGES_TO_REMOVE}
 do
 	echo ${PACKAGE}
-	if ! apt-get remove --purge --yes "${PACKAGE}"
+	if ! dpkg --purge --force-depends "${PACKAGE}"
 	then
 		echo "WARNING: ${PACKAGE} isn't installed"
 	fi


### PR DESCRIPTION
In Debian trixie python3.13 and libpython3.13-stdlib Depends: tzdata, so the existing `apt-get remove --purge --yes tzdata` cascades and removes the whole Python stack (python3-tap, python3-yaml, asyncio stdlib...) from the crushed rootfs.cpio.gz.  trixie-kselftest is the visible casualty: parse-output.py fails with `No module named 'tap'`.

Use `dpkg --purge --force-depends` so only tzdata is removed.  Size saving is unchanged; dpkg-state warnings are cleared when crush.sh purges dpkg itself.