### PR TITLE
rootfs: trixie: build kselftest images for riscv64

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -26,6 +26,7 @@ rootfs_configs:
       - i386
       - mips64el
       - mipsel
+      - riscv64
     extra_packages:
       - isc-dhcp-client
     extra_packages_remove: &extra_packages_remove_trixie
@@ -305,6 +306,7 @@ rootfs_configs:
       - amd64
       - arm64
       - armhf
+      - riscv64
     extra_packages:
       - alsa-utils
       - arping


### PR DESCRIPTION
Add riscv64 to the trixie and trixie-kselftest arch lists so KernelCI publishes images for riscv64 NFS / ramdisk kselftest jobs.  The existing extra_packages list works as-is the renamed *t64 packages Provide the old names.  Local debos build verified.

Reported-by: Anirudh Srinivasan <asrinivasan@oss.tenstorrent.com>