### PR TITLE
pull_labs: use correct kselftest artifact key

### DIFF
--- a/config/runtime/base/pull_labs.jinja2
+++ b/config/runtime/base/pull_labs.jinja2
@@ -9,8 +9,8 @@
 {%- if node.artifacts.modules %},
     "modules": "{{ node.artifacts.modules }}"
 {%- endif %}
-{%- if node.artifacts.kselftest %},
-    "kselftest": "{{ node.artifacts.kselftest }}"
+{%- if node.artifacts.kselftest_tar_xz or node.artifacts.kselftest_tar_gz %},
+    "kselftest": "{{ node.artifacts.kselftest_tar_xz | default(node.artifacts.kselftest_tar_gz, true) }}"
 {%- endif %}
 {%- if nfsroot is defined and nfsroot %},
     "rootfs": "{{ nfsroot }}/full.rootfs.tar.xz"


### PR DESCRIPTION
Kbuild publishes the tarball as kselftest_tar_xz (or kselftest_tar_gz); node.artifacts.kselftest never exists, so the URL was being dropped from every pull_labs job definition. Match the lookup used by the other kselftest templates. Output JSON key stays "kselftest".