### PR TITLE
rootfs: debos: fix dangling /init symlink

### DIFF
--- a/config/rootfs/debos/rootfs.yaml
+++ b/config/rootfs/debos/rootfs.yaml
@@ -128,7 +128,7 @@ actions:
   - action: run
     description: Set symbolic link to init
     chroot: true
-    command: ln -s /usr/bin/systemd /init
+    command: ln -s /usr/lib/systemd/systemd /init
 
   - action: run
     description: Clean installed package files


### PR DESCRIPTION
/init pointed at /usr/bin/systemd, which has never existed on Debian (systemd is at /usr/lib/systemd/systemd; /sbin/init is the working symlink).  LAVA's apply-overlay-ramdisk repacks the cpio so the bug is invisible there, but booting the published rootfs.cpio.gz as a raw initramfs (tuxrun, plain qemu -initrd) panics in mount_root_generic. Point /init at the real systemd binary.