### PR TITLE
rootfs: trixie-ltp: build for riscv64

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -406,6 +406,7 @@ rootfs_configs:
       - amd64
       - arm64
       - armhf
+      - riscv64
     extra_packages:
       - btrfs-progs
       - ca-certificates


### PR DESCRIPTION
Add riscv64 to the arch_list so KernelCI publishes an LTP rootfs for riscv64 alongside amd64/arm64/armhf.