### PR TITLE
rootfs: debos: ltp: Update kirk to v4.1.0

### DIFF
--- a/config/rootfs/debos/scripts/trixie-ltp.sh
+++ b/config/rootfs/debos/scripts/trixie-ltp.sh
@@ -8,7 +8,7 @@ LTP_URL="https://github.com/linux-test-project/ltp.git"
 LTP_SHA=20260130
 
 # Version of Kirk to install
-KIRK_VERSION=v2.3
+KIRK_VERSION=v4.1.0
 
 # Build-depends needed to build the test suites, they'll be removed later
 BUILD_DEPS="\


### PR DESCRIPTION
There have been quite a few releases of kirk since we last update,
including two major versions.  Let's update to pick up the new versions,
the majority of the changes that are relevant for us are performance,
robustness and bugfix ones.

Signed-off-by: Mark Brown <broonie@kernel.org>
