### PR TITLE
scheduler/lava: add priority-weighted queue depth limit

### DIFF
--- a/kernelci/config/runtime.py
+++ b/kernelci/config/runtime.py
@@ -96,6 +96,7 @@ class RuntimeLAVA(Runtime):
         notify=None,
         max_queue_depth=None,
         disable_queue_limit=None,
+        max_queue_depth_priority_factor=None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -113,6 +114,15 @@ class RuntimeLAVA(Runtime):
             max_queue_depth if max_queue_depth is not None else 50
         )
         self._disable_queue_limit = bool(disable_queue_limit)
+        # The per-device queue ceiling is scaled from 1x (lowest priority)
+        # up to this factor (highest priority), never beyond it.  A value of
+        # 1.0 disables priority weighting; values below 1.0 are clamped to 1.0
+        # since a high-priority job must never get a smaller allowance.
+        self._max_queue_depth_priority_factor = (
+            max(1.0, float(max_queue_depth_priority_factor))
+            if max_queue_depth_priority_factor is not None
+            else 2.0
+        )
 
     @property
     def url(self):
@@ -163,6 +173,18 @@ class RuntimeLAVA(Runtime):
         """
         return self._disable_queue_limit
 
+    @property
+    def max_queue_depth_priority_factor(self):
+        """Highest-priority multiplier applied to max_queue_depth.
+
+        The per-device queue ceiling scales linearly with job priority, from
+        1x at the lowest priority up to this factor at the highest priority.
+        High-priority jobs therefore get a larger but still bounded queue
+        allowance (the hard cap is max_queue_depth * online_devices * factor),
+        so devices stay protected from excessive load. Set to 1.0 to disable.
+        """
+        return self._max_queue_depth_priority_factor
+
     @classmethod
     def _get_yaml_attributes(cls):
         attrs = super()._get_yaml_attributes()
@@ -176,6 +198,7 @@ class RuntimeLAVA(Runtime):
                 "notify",
                 "max_queue_depth",
                 "disable_queue_limit",
+                "max_queue_depth_priority_factor",
             }
         )
         return attrs

--- a/kernelci/runtime/lava.py
+++ b/kernelci/runtime/lava.py
@@ -399,6 +399,28 @@ class LAVA(Runtime):
             priority = int((priority * prio_range / 100) + prio_min)
         return priority
 
+    def get_queue_priority_fraction(
+        self, tree_priority=None, job_priority=None
+    ):
+        """Return job priority normalized to 0.0..1.0 for queue weighting.
+
+        Mirrors the pipeline-submitted branch of :meth:`_get_priority`:
+        *tree_priority* is preferred when set, otherwise *job_priority* (the
+        job config priority) is used, both resolved through the same
+        high/medium/low mapping and defaulting to ``PRIORITY_LOW``.
+
+        The result is the base priority as a fraction of the 0-100 scale. This
+        fraction is invariant under the lab's configured priority bounds
+        (priority / priority_min / priority_max), because those only apply a
+        linear remapping, so weighting the queue by it keeps us within the
+        configured priority bounds.
+        """
+        if tree_priority is not None:
+            base = self._resolve_priority(tree_priority, self.PRIORITY_LOW)
+        else:
+            base = self._resolve_priority(job_priority, self.PRIORITY_LOW)
+        return max(0.0, min(1.0, base / 100.0))
+
     def get_params(self, job, api_config=None):
         params = super().get_params(job, api_config)
         params["notify"] = self.config.notify

--- a/tests/configs/runtimes.yaml
+++ b/tests/configs/runtimes.yaml
@@ -26,6 +26,7 @@ runtimes:
       days: 1
     max_queue_depth: 50
     disable_queue_limit: false
+    max_queue_depth_priority_factor: 2.0
     notify: {}
     filters:
       - blocklist:
@@ -50,6 +51,7 @@ runtimes:
       hours: 1
     max_queue_depth: 50
     disable_queue_limit: false
+    max_queue_depth_priority_factor: 2.0
     notify:
       callback:
         token: some-token-name


### PR DESCRIPTION
Add max_queue_depth_priority_factor config option and a get_queue_priority_fraction() helper so the queue ceiling can scale with job priority within configured priority bounds.