### PR TITLE
kbuild: log compiler version in tuxmake builds

### DIFF
--- a/kernelci/kbuild.py
+++ b/kernelci/kbuild.py
@@ -216,6 +216,7 @@ class KBuild:
             self._artifacts = []
             self._current_job = None
             self._config_full = ""
+            self._compiler_version = None
             self._srcdir = None
             self._firmware_dir = None
             self._af_dir = None
@@ -251,6 +252,7 @@ class KBuild:
             self._artifacts = jsonobj["artifacts"]
             self._current_job = jsonobj["current_job"]
             self._config_full = jsonobj["config_full"]
+            self._compiler_version = jsonobj["compiler_version"]
             self._srcdir = jsonobj["srcdir"]
             self._srctarball = jsonobj["srctarball"]
             self._firmware_dir = jsonobj["firmware_dir"]
@@ -1255,9 +1257,35 @@ trap 'case $stage in
         metadata["build"]["srcdir"] = self._srcdir
         metadata["build"]["config_full"] = self._config_full
         metadata["build"]["backend"] = self._backend
+        if self._compiler_version:
+            metadata["build"]["compiler_version"] = self._compiler_version
 
         with open(os.path.join(self._af_dir, "metadata.json"), "w") as f:
             json.dump(metadata, f, indent=4)
+
+    def _preserve_tuxmake_metadata(self):
+        """
+        Rename tuxmake's metadata.json to tuxmake_metadata.json so it
+        survives _write_metadata overwriting it, and keep the compiler
+        version it records for our own metadata and the node data
+        """
+        metadata_path = os.path.join(self._af_dir, "metadata.json")
+        if self._backend != "tuxmake" or not os.path.exists(metadata_path):
+            return
+        try:
+            with open(metadata_path) as f:
+                tux_meta = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            return
+        if not isinstance(tux_meta, dict) or "tuxmake" not in tux_meta:
+            return
+        os.rename(
+            metadata_path,
+            os.path.join(self._af_dir, "tuxmake_metadata.json"),
+        )
+        version_full = tux_meta.get("compiler", {}).get("version_full")
+        if version_full:
+            self._compiler_version = version_full
 
     def serialize(self, filename):
         """Serialize class to json
@@ -1298,6 +1326,7 @@ trap 'case $stage in
                         )
                         self._artifacts.append(file)
         # Update manifest/metadata
+        self._preserve_tuxmake_metadata()
         self._write_metadata()
         print("Artifacts verified")
 
@@ -1626,6 +1655,8 @@ trap 'case $stage in
         results["node"]["data"] = node["data"]
         results["node"]["data"]["arch"] = self._arch
         results["node"]["data"]["compiler"] = self._compiler
+        if self._compiler_version:
+            results["node"]["data"]["compiler_version"] = self._compiler_version
         # As we are late to change data formats, we need to keep
         # defconfig as string, not list, so we use + to separate
         # multiple defconfigs

--- a/kernelci/kbuild.py
+++ b/kernelci/kbuild.py
@@ -868,6 +868,19 @@ trap 'case $stage in
             f"%%_topdir {rpm_root}/build\\n' > $HOME/.rpmmacros"
         )
         self.addcmd("rpmdb --initdb 2>/dev/null || true")
+        try:
+            from tuxmake.arch import Architecture
+            from tuxmake.toolchain import Toolchain
+
+            compiler_bin = Toolchain(self._compiler).compiler(
+                Architecture(self._arch)
+            )
+        except Exception:
+            compiler_bin = (
+                "clang" if self._compiler.startswith("clang") else None
+            )
+        if compiler_bin:
+            self.addcmd(f"{compiler_bin} --version || true")
         self.addcmd("stage=1")  # stage 1 failure is build failure
         self.addcmd(tuxmake_cmd)
         self.addcmd("stage=2")

--- a/tests/test_kbuild.py
+++ b/tests/test_kbuild.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 """Tests for kernelci.kbuild build script generation and metadata"""
 
+import json
 import os
 import sys
 import types
@@ -19,6 +20,7 @@ def _kbuild(tmp_path, compiler="clang-21", arch="x86_64"):
     kbuild._fragments = []
     kbuild._fragment_files = []
     kbuild._config_full = ""
+    kbuild._compiler_version = None
     kbuild._backend = "tuxmake"
     kbuild._dtbs_check = True
     kbuild._steps = []
@@ -69,9 +71,7 @@ class TestCompilerVersionProbe:
         kbuild._build_with_tuxmake()
         assert "aarch64-linux-gnu-gcc --version || true" in kbuild._steps
 
-    def test_probe_clang_fallback_without_tuxmake(
-        self, tmp_path, monkeypatch
-    ):
+    def test_probe_clang_fallback_without_tuxmake(self, tmp_path, monkeypatch):
         monkeypatch.setitem(sys.modules, "tuxmake", None)
         kbuild = _kbuild(tmp_path, compiler="clang-21")
         kbuild._build_with_tuxmake()
@@ -82,3 +82,57 @@ class TestCompilerVersionProbe:
         kbuild = _kbuild(tmp_path, compiler="gcc-14")
         kbuild._build_with_tuxmake()
         assert not any("--version" in s for s in kbuild._steps)
+
+
+class TestPreserveTuxmakeMetadata:
+    def test_preserves_tuxmake_metadata(self, tmp_path):
+        kbuild = _kbuild(tmp_path)
+        af_dir = tmp_path / "artifacts"
+        tux_meta = {
+            "tuxmake": {"version": "1.40.0"},
+            "compiler": {
+                "name": "clang",
+                "version": "21.1.8",
+                "version_full": "Debian clang version 21.1.8",
+            },
+        }
+        (af_dir / "metadata.json").write_text(json.dumps(tux_meta))
+        kbuild._preserve_tuxmake_metadata()
+        kbuild._write_metadata()
+        preserved = json.loads((af_dir / "tuxmake_metadata.json").read_text())
+        assert preserved == tux_meta
+        own = json.loads((af_dir / "metadata.json").read_text())
+        assert own["build"]["backend"] == "tuxmake"
+        assert own["build"]["compiler_version"] == "Debian clang version 21.1.8"
+        assert kbuild._compiler_version == "Debian clang version 21.1.8"
+
+    def test_ignores_own_metadata(self, tmp_path):
+        kbuild = _kbuild(tmp_path)
+        af_dir = tmp_path / "artifacts"
+        own_meta = {"build": {"backend": "tuxmake"}}
+        (af_dir / "metadata.json").write_text(json.dumps(own_meta))
+        kbuild._preserve_tuxmake_metadata()
+        kbuild._write_metadata()
+        assert not (af_dir / "tuxmake_metadata.json").exists()
+        own = json.loads((af_dir / "metadata.json").read_text())
+        assert "compiler_version" not in own["build"]
+
+    def test_handles_invalid_json(self, tmp_path):
+        kbuild = _kbuild(tmp_path)
+        af_dir = tmp_path / "artifacts"
+        (af_dir / "metadata.json").write_text("not json {")
+        kbuild._preserve_tuxmake_metadata()
+        kbuild._write_metadata()
+        assert not (af_dir / "tuxmake_metadata.json").exists()
+        own = json.loads((af_dir / "metadata.json").read_text())
+        assert own["build"]["arch"] == "x86_64"
+
+    def test_no_existing_metadata(self, tmp_path):
+        kbuild = _kbuild(tmp_path)
+        af_dir = tmp_path / "artifacts"
+        kbuild._preserve_tuxmake_metadata()
+        kbuild._write_metadata()
+        assert not (af_dir / "tuxmake_metadata.json").exists()
+        own = json.loads((af_dir / "metadata.json").read_text())
+        assert own["build"]["compiler"] == "clang-21"
+        assert "compiler_version" not in own["build"]

--- a/tests/test_kbuild.py
+++ b/tests/test_kbuild.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+"""Tests for kernelci.kbuild build script generation and metadata"""
+
+import os
+import sys
+import types
+
+from kernelci.kbuild import KBuild
+
+
+def _kbuild(tmp_path, compiler="clang-21", arch="x86_64"):
+    kbuild = object.__new__(KBuild)
+    kbuild._af_dir = str(tmp_path / "artifacts")
+    kbuild._workspace = str(tmp_path)
+    kbuild._srcdir = str(tmp_path / "linux")
+    kbuild._arch = arch
+    kbuild._compiler = compiler
+    kbuild._defconfig = "defconfig"
+    kbuild._fragments = []
+    kbuild._fragment_files = []
+    kbuild._config_full = ""
+    kbuild._backend = "tuxmake"
+    kbuild._dtbs_check = True
+    kbuild._steps = []
+    kbuild._artifacts = []
+    kbuild._current_job = None
+    os.makedirs(kbuild._af_dir)
+    return kbuild
+
+
+def _fake_tuxmake(monkeypatch, compiler_bin):
+    fake_pkg = types.ModuleType("tuxmake")
+    fake_arch = types.ModuleType("tuxmake.arch")
+    fake_toolchain = types.ModuleType("tuxmake.toolchain")
+
+    class Architecture:
+        def __init__(self, name):
+            self.name = name
+
+    class Toolchain:
+        def __init__(self, name):
+            self.name = name
+
+        def compiler(self, arch):
+            return compiler_bin
+
+    fake_arch.Architecture = Architecture
+    fake_toolchain.Toolchain = Toolchain
+    monkeypatch.setitem(sys.modules, "tuxmake", fake_pkg)
+    monkeypatch.setitem(sys.modules, "tuxmake.arch", fake_arch)
+    monkeypatch.setitem(sys.modules, "tuxmake.toolchain", fake_toolchain)
+
+
+class TestCompilerVersionProbe:
+    def test_probe_before_build(self, tmp_path, monkeypatch):
+        _fake_tuxmake(monkeypatch, "clang")
+        kbuild = _kbuild(tmp_path)
+        kbuild._build_with_tuxmake()
+        steps = kbuild._steps
+        probe = steps.index("clang --version || true")
+        build = next(
+            i for i, s in enumerate(steps) if "tuxmake --runtime=null" in s
+        )
+        assert probe < build
+
+    def test_probe_uses_tuxmake_resolution(self, tmp_path, monkeypatch):
+        _fake_tuxmake(monkeypatch, "aarch64-linux-gnu-gcc")
+        kbuild = _kbuild(tmp_path, compiler="gcc-14", arch="arm64")
+        kbuild._build_with_tuxmake()
+        assert "aarch64-linux-gnu-gcc --version || true" in kbuild._steps
+
+    def test_probe_clang_fallback_without_tuxmake(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setitem(sys.modules, "tuxmake", None)
+        kbuild = _kbuild(tmp_path, compiler="clang-21")
+        kbuild._build_with_tuxmake()
+        assert "clang --version || true" in kbuild._steps
+
+    def test_no_probe_for_gcc_without_tuxmake(self, tmp_path, monkeypatch):
+        monkeypatch.setitem(sys.modules, "tuxmake", None)
+        kbuild = _kbuild(tmp_path, compiler="gcc-14")
+        kbuild._build_with_tuxmake()
+        assert not any("--version" in s for s in kbuild._steps)


### PR DESCRIPTION
When investigating a build failure it helps to know the exact
compiler version that produced it, but the build log never shows
one. The job parameters only carry the requested toolchain name
(e.g. clang-21), and with the null runtime tuxmake builds with
whatever compiler the build environment has installed, so the
requested name alone does not describe what actually ran.

Print the compiler's --version into build.log just before the
tuxmake invocation, so the version is visible even when the build
fails. The binary is resolved the same way tuxmake resolves it
(toolchain compiler plus tuxmake's arch-default CROSS_COMPILE)
rather than from the job's cross_compile parameter, because the two
can differ; arc jobs set arc-elf32- while tuxmake builds with
arc-linux-gnu-. Fall back to plain clang when tuxmake is not
importable.