### PR TITLE
docker: install zstd in build images

### DIFF
--- a/config/docker/base/host-tools.jinja2
+++ b/config/docker/base/host-tools.jinja2
@@ -87,7 +87,8 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     u-boot-tools \
     uuid-dev \
     wget \
-    xz-utils
+    xz-utils \
+    zstd
 
 # Install dtschema for dtbs_check
 RUN pip3 install dtschema --break-system-packages


### PR DESCRIPTION
Install zstd alongside the other host tools so kernels with CONFIG_MODULE_COMPRESS_ZSTD can complete modules_install. The shared host-tools base is used by gcc and clang images, covering every architecture that enables zstd module compression.