### PR TITLE
Keep LAVA infrastructure failures incomplete

### DIFF
--- a/kernelci/runtime/lava.py
+++ b/kernelci/runtime/lava.py
@@ -278,7 +278,12 @@ class Callback:
 
         child_nodes = self._get_results_hierarchy(results)
 
-        if job_result == "incomplete" and "baseline" in job_node["name"]:
+        error_code = job_node["data"].get("error_code")
+        if (
+            job_result == "incomplete"
+            and error_code != "Infrastructure"
+            and "baseline" in job_node["name"]
+        ):
             for child in child_nodes:
                 if (
                     child["node"]["name"] == "setup"

--- a/kernelci/scheduler.py
+++ b/kernelci/scheduler.py
@@ -41,8 +41,23 @@ class Scheduler:
             if sched_event_channel == channel:
                 sched_event = entry.event.copy()
                 sched_event.pop("channel")
-                if sched_event.items() <= event.items():
-                    yield entry
+                if not sched_event.items() <= event.items():
+                    continue
+                # Edge-triggered scheduling (kernelci-core#2912): when the API
+                # reports a node update together with its previous state/result,
+                # only act on the transition INTO the matched condition. This
+                # avoids re-creating identical child jobs every time the parent
+                # node is updated while staying in the same matching state (e.g.
+                # an artifact or timeout update on an already-`available` node).
+                # Falls back to level-triggered behaviour when no previous_*
+                # info is present (node creation, retry events or older API).
+                if event.get("op") == "updated" and "previous_state" in event:
+                    previous_event = dict(event)
+                    previous_event["state"] = event.get("previous_state")
+                    previous_event["result"] = event.get("previous_result")
+                    if sched_event.items() <= previous_event.items():
+                        continue
+                yield entry
 
     def get_schedule(self, event, channel="node"):
         """Get the (job, runtime, platform) configs for each job to run"""

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -15,8 +15,8 @@ import yaml
 
 import kernelci.config
 import kernelci.runtime
-from kernelci.runtime.pull_labs import compute_tuxrun_parameters
 import kernelci.runtime.lava
+from kernelci.runtime.pull_labs import compute_tuxrun_parameters
 
 
 class _FakeResponse:

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -10,9 +10,13 @@
 
 import types
 
+import pytest
+import yaml
+
 import kernelci.config
 import kernelci.runtime
 from kernelci.runtime.pull_labs import compute_tuxrun_parameters
+import kernelci.runtime.lava
 
 
 class _FakeResponse:
@@ -52,6 +56,87 @@ class _FakeSession:
             raise AssertionError("POST handler not set")
         self.calls.append((url, json))
         return self._post_handler(url, json)
+
+
+def _lava_callback(lava_results):
+    return kernelci.runtime.lava.Callback(
+        {
+            "status": kernelci.runtime.lava.Callback.INCOMPLETE,
+            "definition": yaml.safe_dump({"metadata": {}}),
+            "results": {"lava": yaml.safe_dump(lava_results)},
+        }
+    )
+
+
+def _lava_job_node():
+    return {
+        "id": "lava-job-node",
+        "name": "baseline",
+        "result": "incomplete",
+        "data": {},
+    }
+
+
+def test_lava_callback_early_infrastructure_failure_has_no_setup():
+    """Early infrastructure errors should not invent a setup test suite."""
+    callback = _lava_callback(
+        [
+            {
+                "name": "job",
+                "result": "fail",
+                "metadata": {
+                    "error_type": "Infrastructure",
+                    "error_msg": "Deployment failed before boot actions",
+                },
+            }
+        ]
+    )
+
+    results = callback.get_results()
+    hierarchy = callback.get_hierarchy(results, _lava_job_node())
+
+    assert results == {}
+    assert hierarchy["node"]["result"] == "incomplete"
+    assert hierarchy["node"]["data"]["error_code"] == "Infrastructure"
+    assert hierarchy["child_nodes"] == []
+
+
+@pytest.mark.parametrize(
+    ("lava_test", "setup_result"),
+    [
+        ({"name": "login-action", "result": "fail"}, {"login": "fail"}),
+        (
+            {"name": "kernel-messages", "result": "fail"},
+            {"kernelmsg": "fail"},
+        ),
+    ],
+)
+def test_lava_callback_infrastructure_setup_failures_stay_incomplete(
+    lava_test, setup_result
+):
+    """Infrastructure errors should remain incomplete even with setup failures."""
+    callback = _lava_callback(
+        [
+            {
+                "name": "job",
+                "result": "fail",
+                "metadata": {
+                    "error_type": "Infrastructure",
+                    "error_msg": "LAVA setup failed",
+                },
+            },
+            {"name": "1_setup", "result": "fail", "metadata": {}},
+            {**lava_test, "metadata": {}},
+        ]
+    )
+
+    results = callback.get_results()
+    hierarchy = callback.get_hierarchy(results, _lava_job_node())
+
+    assert results == {"setup": setup_result}
+    assert hierarchy["node"]["result"] == "incomplete"
+    assert hierarchy["node"]["data"]["error_code"] == "Infrastructure"
+    assert hierarchy["child_nodes"][0]["node"]["result"] == "fail"
 
 
 def test_runtimes_init():

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,173 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2026 Collabora Limited
+
+"""Unit tests for kernelci.scheduler edge-triggered matching (#2912)"""
+
+import types
+import unittest
+
+from kernelci.scheduler import Scheduler
+
+
+def _entry(event):
+    """Build a minimal scheduler entry exposing an ``event`` mapping."""
+    return types.SimpleNamespace(event=event)
+
+
+def _scheduler(entries):
+    """Build a Scheduler with a preset list of entries, bypassing __init__."""
+    sched = Scheduler.__new__(Scheduler)
+    sched._scheduler = entries
+    return sched
+
+
+class TestGetConfigsEdgeTrigger(unittest.TestCase):
+    """get_configs() should fire on the transition into a matched state,
+    not on every update that keeps the node in that state (#2912)."""
+
+    KBUILD_AVAILABLE = {
+        "channel": "node",
+        "kind": "kbuild",
+        "state": "available",
+        "name": "kbuild-gcc-14-arm",
+    }
+
+    def _matches(self, entries, event, channel="node"):
+        sched = _scheduler(entries)
+        return list(sched.get_configs(event, channel))
+
+    def test_created_event_matches(self):
+        """A creation event in the matched state fires (rising edge)."""
+        entry = _entry(self.KBUILD_AVAILABLE)
+        event = {
+            "op": "created",
+            "kind": "kbuild",
+            "state": "available",
+            "name": "kbuild-gcc-14-arm",
+        }
+        self.assertEqual(self._matches([entry], event), [entry])
+
+    def test_update_into_state_matches(self):
+        """An update transitioning INTO the matched state fires."""
+        entry = _entry(self.KBUILD_AVAILABLE)
+        event = {
+            "op": "updated",
+            "kind": "kbuild",
+            "state": "available",
+            "name": "kbuild-gcc-14-arm",
+            "previous_state": "running",
+            "previous_result": None,
+        }
+        self.assertEqual(self._matches([entry], event), [entry])
+
+    def test_update_keeping_state_does_not_match(self):
+        """An update that keeps the already-matched state does NOT fire.
+
+        This is the duplicate-job scenario from #2912: an artifact/timeout
+        update on a node that is already `available`.
+        """
+        entry = _entry(self.KBUILD_AVAILABLE)
+        event = {
+            "op": "updated",
+            "kind": "kbuild",
+            "state": "available",
+            "name": "kbuild-gcc-14-arm",
+            "previous_state": "available",
+            "previous_result": None,
+        }
+        self.assertEqual(self._matches([entry], event), [])
+
+    def test_update_without_previous_state_is_level_triggered(self):
+        """Older API events (no previous_*) fall back to level-triggered."""
+        entry = _entry(self.KBUILD_AVAILABLE)
+        event = {
+            "op": "updated",
+            "kind": "kbuild",
+            "state": "available",
+            "name": "kbuild-gcc-14-arm",
+        }
+        self.assertEqual(self._matches([entry], event), [entry])
+
+    def test_result_rising_edge(self):
+        """An entry matching state+result fires on the transition to done."""
+        entry = _entry(
+            {
+                "channel": "node",
+                "kind": "kbuild",
+                "state": "done",
+                "result": "pass",
+            }
+        )
+        rising = {
+            "op": "updated",
+            "kind": "kbuild",
+            "state": "done",
+            "result": "pass",
+            "previous_state": "available",
+            "previous_result": None,
+        }
+        self.assertEqual(self._matches([entry], rising), [entry])
+
+    def test_result_no_edge_when_already_done(self):
+        """No fire when the node was already done/pass and is updated again."""
+        entry = _entry(
+            {
+                "channel": "node",
+                "kind": "kbuild",
+                "state": "done",
+                "result": "pass",
+            }
+        )
+        no_edge = {
+            "op": "updated",
+            "kind": "kbuild",
+            "state": "done",
+            "result": "pass",
+            "previous_state": "done",
+            "previous_result": "pass",
+        }
+        self.assertEqual(self._matches([entry], no_edge), [])
+
+    def test_non_matching_event(self):
+        """An event that doesn't match the entry never fires."""
+        entry = _entry(self.KBUILD_AVAILABLE)
+        event = {
+            "op": "updated",
+            "kind": "kbuild",
+            "state": "running",
+            "name": "kbuild-gcc-14-arm",
+            "previous_state": "running",
+        }
+        self.assertEqual(self._matches([entry], event), [])
+
+    def test_channel_mismatch_skipped(self):
+        """Entries for another channel are skipped."""
+        entry = _entry(
+            {"channel": "retry", "kind": "kbuild", "state": "available"}
+        )
+        event = {"op": "created", "kind": "kbuild", "state": "available"}
+        self.assertEqual(self._matches([entry], event, channel="node"), [])
+
+    def test_retry_event_without_op_is_level_triggered(self):
+        """Retry events carry no ``op`` key and must always fire."""
+        entry = _entry(self.KBUILD_AVAILABLE)
+        # Synthesised retry event: parent node data with state forced
+        # to available, no "op"/"previous_state".
+        event = {
+            "kind": "kbuild",
+            "state": "available",
+            "name": "kbuild-gcc-14-arm",
+            "retry_counter": 1,
+        }
+        self.assertEqual(self._matches([entry], event), [entry])
+
+    def test_non_dict_event_returns_nothing(self):
+        """A non-dict event is handled gracefully."""
+        self.assertEqual(
+            self._matches([_entry(self.KBUILD_AVAILABLE)], None), []
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Do not convert baseline jobs with Infrastructure error metadata from incomplete to fail when setup/login/kernel-message stages fail early. This preserves the callback status so downstream KCIDB reporting can publish ERROR instead of FAIL.

Add regressions for early LAVA infrastructure failures with no setup results, login failures, and kernel-message failures.

This is a best-effort fix for the old discussion around issue #1087. I am not fully sure this is the correct final fix because that discussion happened a while ago and I do not remember all the details, so this should get maintainer review against the original failure modes.