### PR TITLE
docker: add gcc-15 toolchain images on a forky base

### DIFF
--- a/.github/workflows/docker_images.yml
+++ b/.github/workflows/docker_images.yml
@@ -31,7 +31,8 @@ jobs:
         kciarch: [ 'arc', 'arm', 'armv5', 'arm64', 'x86', 'mips', 'riscv64',
                    'powerpc', 's390', 'loongarch' ]
         kcicmd: [ 'clang-21 kselftest kernelci',
-                  'gcc-14 kselftest kernelci'
+                  'gcc-14 kselftest kernelci',
+                  'gcc-15 kselftest kernelci'
                    ]
         exclude:
           # no clang-21 templates for these architectures (yet)
@@ -43,6 +44,21 @@ jobs:
             kcicmd: 'clang-21 kselftest kernelci'
           - kciarch: 'loongarch'
             kcicmd: 'clang-21 kselftest kernelci'
+          # gcc-15 (forky-based) is only rolled out on arm, x86 and arm64 for now
+          - kciarch: 'arc'
+            kcicmd: 'gcc-15 kselftest kernelci'
+          - kciarch: 'armv5'
+            kcicmd: 'gcc-15 kselftest kernelci'
+          - kciarch: 'mips'
+            kcicmd: 'gcc-15 kselftest kernelci'
+          - kciarch: 'riscv64'
+            kcicmd: 'gcc-15 kselftest kernelci'
+          - kciarch: 'powerpc'
+            kcicmd: 'gcc-15 kselftest kernelci'
+          - kciarch: 's390'
+            kcicmd: 'gcc-15 kselftest kernelci'
+          - kciarch: 'loongarch'
+            kcicmd: 'gcc-15 kselftest kernelci'
     # only selected people can trigger this job
     if: contains('["nuclearcat","JenySadadia","a-wai","broonie","laura-nao","bhcopeland"]', github.actor) && !inputs.SKIP_COMPILER_IMAGES
     runs-on: ubuntu-22.04

--- a/config/docker/base/debian.jinja2
+++ b/config/docker/base/debian.jinja2
@@ -6,7 +6,7 @@
  # Author: Alexandra Pereira <alexandra.pereira@collabora.com>
 -#}
 
-FROM mirror.gcr.io/debian:trixie
+FROM mirror.gcr.io/debian:{{ debian_release | default('trixie') }}
 MAINTAINER "KernelCI TSC" <kernelci-tsc@groups.io>
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/config/docker/base/host-tools.jinja2
+++ b/config/docker/base/host-tools.jinja2
@@ -5,9 +5,9 @@
 
 # Add retries and deb-src entries
 RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries && \
-    echo "deb-src http://deb.debian.org/debian trixie main non-free contrib" \
+    echo "deb-src http://deb.debian.org/debian {{ debian_release | default('trixie') }} main non-free contrib" \
         >> /etc/apt/sources.list && \
-    echo "deb-src http://deb.debian.org/debian-security/ trixie-security main contrib non-free" \
+    echo "deb-src http://deb.debian.org/debian-security/ {{ debian_release | default('trixie') }}-security main contrib non-free" \
         >> /etc/apt/sources.list
 
 # Prepare environment for building packages
@@ -41,7 +41,7 @@ RUN mk-build-deps -ir \
     -t "apt-get -o Debug::pkgProblemResolver=yes -y --no-install-recommends"
 RUN debuild -b -uc -us
 
-FROM mirror.gcr.io/debian:trixie
+FROM mirror.gcr.io/debian:{{ debian_release | default('trixie') }}
 MAINTAINER "KernelCI TSC" <kernelci-tsc@groups.io>
 ENV DEBIAN_FRONTEND=noninteractive
 {%- endblock %}

--- a/config/docker/gcc-15-arm.jinja2
+++ b/config/docker/gcc-15-arm.jinja2
@@ -1,0 +1,33 @@
+{%- set sub_arch = 'armhf' %}
+{%- set debian_release = 'forky' %}
+{%- extends 'base/host-tools.jinja2' %}
+
+{% block packages %}
+{{ super() }}
+RUN apt update && apt install --no-install-recommends -y \
+    gcc-15-arm-linux-gnueabihf \
+    gcc-15-plugin-dev-arm-linux-gnueabihf
+
+RUN update-alternatives \
+    --install /usr/bin/arm-linux-gnueabihf-gcc \
+              arm-linux-gnueabihf-gcc \
+              /usr/bin/arm-linux-gnueabihf-gcc-15 500 \
+    --slave /usr/bin/arm-linux-gnueabihf-gcc-ar \
+            arm-linux-gnueabihf-gcc-ar \
+            /usr/bin/arm-linux-gnueabihf-gcc-ar-15 \
+    --slave /usr/bin/arm-linux-gnueabihf-gcc-nm \
+            arm-linux-gnueabihf-gcc-nm \
+            /usr/bin/arm-linux-gnueabihf-gcc-nm-15 \
+    --slave /usr/bin/arm-linux-gnueabihf-gcc-ranlib \
+            arm-linux-gnueabihf-gcc-ranlib \
+            /usr/bin/arm-linux-gnueabihf-gcc-ranlib-15 \
+    --slave /usr/bin/arm-linux-gnueabihf-gcc-gcov \
+            arm-linux-gnueabihf-gcov \
+            /usr/bin/arm-linux-gnueabihf-gcov-15 \
+    --slave /usr/bin/arm-linux-gnueabihf-gcc-gcov-dump \
+            arm-linux-gnueabihf-gcov-dump \
+            /usr/bin/arm-linux-gnueabihf-gcov-dump-15 \
+    --slave /usr/bin/arm-linux-gnueabihf-gcc-gcov-tool \
+            arm-linux-gnueabihf-gcov-tool \
+            /usr/bin/arm-linux-gnueabihf-gcov-tool-15
+{%- endblock %}

--- a/config/docker/gcc-15-arm64.jinja2
+++ b/config/docker/gcc-15-arm64.jinja2
@@ -1,0 +1,58 @@
+{%- set sub_arch = 'arm64' %}
+{%- set debian_release = 'forky' %}
+{%- extends 'base/host-tools.jinja2' %}
+
+{% block packages %}
+{{ super() }}
+RUN apt update && apt install --no-install-recommends -y \
+    gcc-15-aarch64-linux-gnu \
+    gcc-15-plugin-dev-aarch64-linux-gnu \
+    gcc-15-arm-linux-gnueabihf \
+    gcc-15-plugin-dev-arm-linux-gnueabihf
+
+RUN update-alternatives \
+    --install /usr/bin/aarch64-linux-gnu-gcc \
+              aarch64-linux-gnu-gcc \
+              /usr/bin/aarch64-linux-gnu-gcc-15 500 \
+    --slave /usr/bin/aarch64-linux-gnu-gcc-ar \
+            aarch64-linux-gnu-ar \
+            /usr/bin/aarch64-linux-gnu-gcc-ar-15 \
+    --slave /usr/bin/aarch64-linux-gnu-gcc-nm \
+            aarch64-linux-gnu-nm \
+            /usr/bin/aarch64-linux-gnu-gcc-nm-15 \
+    --slave /usr/bin/aarch64-linux-gnu-gcc-ranlib \
+            aarch64-linux-gnu-ranlib \
+            /usr/bin/aarch64-linux-gnu-gcc-ranlib-15 \
+    --slave /usr/bin/aarch64-linux-gnu-gcc-gcov \
+            aarch64-linux-gnu-gcov \
+            /usr/bin/aarch64-linux-gnu-gcov-15 \
+    --slave /usr/bin/aarch64-linux-gnu-gcov-gcc-dump \
+            aarch64-linux-gnu-gcov-dump \
+            /usr/bin/aarch64-linux-gnu-gcov-dump-15 \
+    --slave /usr/bin/aarch64-linux-gnu-gcov-gcc-tool \
+            aarch64-linux-gnu-gcov-tool \
+            /usr/bin/aarch64-linux-gnu-gcov-tool-15
+
+RUN update-alternatives \
+    --install /usr/bin/arm-linux-gnueabihf-gcc \
+              arm-linux-gnueabihf-gcc \
+              /usr/bin/arm-linux-gnueabihf-gcc-15 500 \
+    --slave /usr/bin/arm-linux-gnueabihf-gcc-ar \
+            arm-linux-gnueabihf-gcc-ar \
+            /usr/bin/arm-linux-gnueabihf-gcc-ar-15 \
+    --slave /usr/bin/arm-linux-gnueabihf-gcc-nm \
+            arm-linux-gnueabihf-gcc-nm \
+            /usr/bin/arm-linux-gnueabihf-gcc-nm-15 \
+    --slave /usr/bin/arm-linux-gnueabihf-gcc-ranlib \
+            arm-linux-gnueabihf-gcc-ranlib \
+            /usr/bin/arm-linux-gnueabihf-gcc-ranlib-15 \
+    --slave /usr/bin/arm-linux-gnueabihf-gcc-gcov \
+            arm-linux-gnueabihf-gcov \
+            /usr/bin/arm-linux-gnueabihf-gcov-15 \
+    --slave /usr/bin/arm-linux-gnueabihf-gcc-gcov-dump \
+            arm-linux-gnueabihf-gcov-dump \
+            /usr/bin/arm-linux-gnueabihf-gcov-dump-15 \
+    --slave /usr/bin/arm-linux-gnueabihf-gcc-gcov-tool \
+            arm-linux-gnueabihf-gcov-tool \
+            /usr/bin/arm-linux-gnueabihf-gcov-tool-15
+{%- endblock %}

--- a/config/docker/gcc-15-x86.jinja2
+++ b/config/docker/gcc-15-x86.jinja2
@@ -1,0 +1,20 @@
+{%- set debian_release = 'forky' %}
+{%- extends 'base/host-tools.jinja2' %}
+
+{% block packages %}
+{{ super() }}
+RUN apt update && apt install --no-install-recommends -y \
+    gcc-15 \
+    gcc-15-plugin-dev
+
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-15 500
+
+# 32-bit support for host tools and kselftest
+RUN apt update && apt install --no-install-recommends -y \
+    gcc-multilib \
+    libc6-i386 \
+    libc6-dev-i386
+
+# GCC i386.h header fix for the Debian package
+RUN apt update && apt install --no-install-recommends -y curl patch
+{% endblock %}


### PR DESCRIPTION
gcc-15 is not packaged in Debian trixie, which the toolchain images build on. Add x86 and arm64 gcc-15 images based on forky, where gcc-15 is the default compiler.

Parameterise the Debian suite in the base templates with a default of trixie so all existing images are unchanged, and build the gcc-15 images for x86 and arm64 only.