### PR TITLE
docker: drop cdbs from host-tools build deps

### DIFF
--- a/config/docker/base/host-tools.jinja2
+++ b/config/docker/base/host-tools.jinja2
@@ -15,7 +15,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-transport-https \
     build-essential \
     ca-certificates \
-    cdbs \
     devscripts \
     equivs \
     fakeroot


### PR DESCRIPTION
Drop it. trixie images are unaffected since cdbs was never used there either.