### PR TITLE
rootfs: trixie-ltp: put kirk on PATH

### DIFF
--- a/config/rootfs/debos/scripts/trixie-ltp.sh
+++ b/config/rootfs/debos/scripts/trixie-ltp.sh
@@ -82,6 +82,11 @@ cd /opt/kirk
 git reset --hard $KIRK_VERSION
 rm -rf ./.git
 
+# test-definitions' ltp.sh resolves the runner as a bare "kirk" through
+# PATH, so make it reachable without every caller having to know where
+# kirk is installed.
+ln -sf /opt/kirk/kirk /usr/bin/kirk
+
 ########################################################################
 # Cleanup: remove files and packages we don't want in the images       #
 ########################################################################


### PR DESCRIPTION
Since the recent test-definitions change, ltp default runner changed as a bare kirk through PATH. And looks only in the LTP install dir. So lets add a symlink just to catch these cases.