### PR TITLE
Remove bson from dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ license = {text = "LGPL-2.1-or-later"}
 dependencies = [
   "azure-storage-blob==12.30.0",
   "azure-storage-file-share==12.25.0",
-  "bson==0.5.10",
   "click==8.3.1",
   "cloudevents==1.12.1",
   "docker==7.1.0",
@@ -26,6 +25,7 @@ dependencies = [
   "paramiko==5.0.0",
   "pydantic==2.13.4",
   "pyelftools==0.32",
+  "pymongo==4.17.0",
   "pytest==9.1.1",
   "pyyaml==6.0.3",
   "requests==2.34.2",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 azure-storage-blob==12.30.0
 azure-storage-file-share==12.25.0
-bson==0.5.10
 click==8.3.1
 cloudevents==1.12.1
 docker==7.1.0
@@ -9,6 +8,7 @@ kubernetes==36.0.3
 paramiko==5.0.0
 pydantic==2.13.4
 pyelftools==0.32
+pymongo==4.17.0
 pytest==9.1.1
 pyyaml==6.0.3
 requests==2.34.2


### PR DESCRIPTION
bson is not required in dependencies as pymongo already provide it. Also old bson breaks on new python.