### PR TITLE
docker: pin logspec revision in pipeline image

### DIFF
--- a/config/docker/fragment/pipeline.jinja2
+++ b/config/docker/fragment/pipeline.jinja2
@@ -5,7 +5,10 @@ USER root
 RUN python3 -m pip install git+https://github.com/kernelci/kcidb.git --break-system-packages
 
 # Install logspec
-RUN pip install git+https://github.com/kernelci/logspec.git
+ARG logspec_url=https://github.com/kernelci/logspec.git
+ARG logspec_rev=370c994c940011e35cd7eb6ff173c451a5de2cd1
+RUN python3 -m pip install "git+${logspec_url}@${logspec_rev}" --break-system-packages
+ENV KCI_VER_LOGSPEC=$logspec_rev
 
 USER kernelci
 ARG pipeline_url=https://github.com/kernelci/kernelci-pipeline.git


### PR DESCRIPTION
Install logspec through configurable URL and revision build arguments, defaulting to kernelci/logspec@370c994c. An explicit revision invalidates the Docker layer on upgrades and makes pipeline images reproducible.

Expose KCI_VER_LOGSPEC in the image so deployments can verify the installed source revision. This revision includes the bounded BUG-report fix from kernelci/logspec#24 and the DTC parser updates.