### PR TITLE
config: update Buildroot baseline to 2026.05

### DIFF
--- a/config/core/rootfs-configs.yaml
+++ b/config/core/rootfs-configs.yaml
@@ -2,7 +2,7 @@ rootfs_configs:
   buildroot-baseline:
     rootfs_type: buildroot
     git_url: https://github.com/kernelci/buildroot
-    git_branch: main
+    git_branch: kernelci/2026.05
     arch_list:
       - arc
       - arm64


### PR DESCRIPTION
The KernelCI Buildroot tree has been rebased onto Buildroot 2026.05.1 and its architecture fragments updated for the new release.

Point the baseline rootfs configuration at the kernelci/2026.05 branch so rootfs builds use the updated Buildroot tree while the existing main branch remains available during the transition.