### PR TITLE
runtime: raise TemplateRuntimeError from kci_raise

### DIFF
--- a/kernelci/legacy/lava/__init__.py
+++ b/kernelci/legacy/lava/__init__.py
@@ -12,6 +12,7 @@ import os
 import sys
 
 from jinja2 import Environment, FileSystemLoader
+from jinja2.exceptions import TemplateRuntimeError
 
 
 def add_kci_raise(jinja2_env):
@@ -23,7 +24,7 @@ def add_kci_raise(jinja2_env):
     """
 
     def template_exception(msg):
-        raise Exception(msg)
+        raise TemplateRuntimeError(msg)
 
     jinja2_env.globals["kci_raise"] = template_exception
 

--- a/kernelci/runtime/__init__.py
+++ b/kernelci/runtime/__init__.py
@@ -13,6 +13,7 @@ import os
 import requests
 import yaml
 from jinja2 import ChoiceLoader, Environment, FileSystemLoader
+from jinja2.exceptions import TemplateRuntimeError
 
 from kernelci.config.base import get_system_arch
 
@@ -136,7 +137,7 @@ class Runtime(abc.ABC):
 
         def kci_raise(msg):
             """Raise an exception"""
-            raise Exception(msg)
+            raise TemplateRuntimeError(msg)
 
         def kci_yaml_dump(data):
             """Dump data to YAML"""

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -14,11 +14,30 @@ from pathlib import Path
 import pytest
 import yaml
 from jinja2 import Environment, FileSystemLoader
+from jinja2.exceptions import TemplateRuntimeError
 
 import kernelci.config
+import kernelci.legacy.lava
 import kernelci.runtime
 import kernelci.runtime.lava
 from kernelci.runtime.pull_labs import compute_tuxrun_parameters
+
+
+def test_kci_raise_uses_jinja_runtime_error():
+    """The runtime helper raises a template-specific exception."""
+    kci_raise = kernelci.runtime.Runtime._get_jinja2_functions()["kci_raise"]
+
+    with pytest.raises(TemplateRuntimeError, match="invalid parameters"):
+        kci_raise("invalid parameters")
+
+
+def test_legacy_kci_raise_uses_jinja_runtime_error():
+    """The legacy LAVA helper raises a template-specific exception."""
+    environment = Environment()
+    kernelci.legacy.lava.add_kci_raise(environment)
+
+    with pytest.raises(TemplateRuntimeError, match="invalid parameters"):
+        environment.globals["kci_raise"]("invalid parameters")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #1797.

The `kci_raise` Jinja helper currently raises a generic `Exception`, which loses the template-specific error type expected by Jinja callers.

This changes both the current runtime helper and the legacy LAVA helper to raise `jinja2.TemplateRuntimeError`. Focused regression tests cover both registrations.

Tests:

* `pytest tests/test_runtime.py -q` — 18 passed
* `pre-commit run --files kernelci/runtime/__init__.py kernelci/legacy/lava/__init__.py tests/test_runtime.py` — passed
* `pytest tests -q` — 139 passed, 7 unrelated Windows-only failures (`os.getuid`, POSIX path expectations, and slash handling)
* `git diff --check`
