### PR TITLE
.github: bump GitHub Actions to latest releases

### DIFF
--- a/.github/workflows/docker_images.yml
+++ b/.github/workflows/docker_images.yml
@@ -65,7 +65,7 @@ jobs:
     environment: deploydocker
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           repository: ${{ env.USER_GIT_OWNER }}/kernelci-core
           ref: ${{ env.USER_GIT_BRANCH }}
@@ -79,7 +79,7 @@ jobs:
           python3 -m pip install -r requirements-dev.txt --break-system-packages
           sudo cp -R config /etc/kernelci/
       - name: Cache apt packages
-        uses: awalsh128/cache-apt-pkgs-action@2c09a5e66da6c8016428a2172bd76e5e4f14bb17  # v1.5.4
+        uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9  # v1.6.3
         with:
           packages: python3-pip git docker.io python3-docker
           version: 1.0
@@ -91,7 +91,7 @@ jobs:
         run: |
           echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
       - name: Log in to the Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -148,21 +148,21 @@ jobs:
     environment: deploydocker
     steps:
       - name: Checkout kernelci-core
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           repository: ${{ env.USER_GIT_OWNER }}/kernelci-core
           ref: ${{ env.USER_GIT_BRANCH }}
           fetch-depth: 0
           path: kernelci-core
       - name: Checkout kernelci-pipeline
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           repository: ${{ env.USER_GIT_OWNER }}/kernelci-pipeline
           ref: ${{ env.USER_GIT_BRANCH }}
           fetch-depth: 0
           path: kernelci-pipeline
       - name: Checkout kernelci-api
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           repository: ${{ env.USER_GIT_OWNER }}/kernelci-api
           ref: ${{ env.USER_GIT_BRANCH }}
@@ -175,7 +175,7 @@ jobs:
           python3 -m pip install -r requirements-dev.txt --break-system-packages
           sudo cp -R config /etc/kernelci/
       - name: Cache apt packages
-        uses: awalsh128/cache-apt-pkgs-action@2c09a5e66da6c8016428a2172bd76e5e4f14bb17  # v1.5.4
+        uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9  # v1.6.3
         with:
           packages: python3-pip git docker.io python3-docker
           version: 1.0
@@ -187,7 +187,7 @@ jobs:
         run: |
           echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
       - name: Log in to the Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4.6.0
         with:
           registry: ghcr.io
           username: kernelci

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Check out source code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: '3.10'
           cache: 'pip'
@@ -37,10 +37,10 @@ jobs:
     name: Lint
     steps:
       - name: Check out source code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: "3.10"
           cache: 'pip'

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -26,7 +26,7 @@ jobs:
         needs: discord-notify-start
         steps:
             - name: Checkout code
-              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
               with:
                 repository: kernelci/kernelci-core
                 ref: main
@@ -46,7 +46,7 @@ jobs:
         needs: discord-notify-start
         steps:
             - name: Checkout code
-              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
               with:
                 repository: kernelci/kernelci-pipeline
                 ref: main
@@ -71,7 +71,7 @@ jobs:
         needs: discord-notify-start
         steps:
             - name: Checkout code
-              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
               with:
                 repository: kernelci/kernelci-api
                 ref: main
@@ -103,12 +103,12 @@ jobs:
         needs: call-docker-build
         steps:
             - name: Checkout code
-              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
               with:
                 repository: kernelci/kernelci-deploy
                 ref: main
             - name: Set up kubectl
-              uses: azure/k8s-set-context@ae59a723ba9abe7a9655538854a025448dbab4aa  # v4
+              uses: azure/k8s-set-context@8698eba2499e9012f0d5085f8798077cce4bc526  # v5.0.1
               with:
                 method: kubeconfig
                 kubeconfig: ${{ secrets.KUBECONFIG }}

--- a/.github/workflows/rootfs.yml
+++ b/.github/workflows/rootfs.yml
@@ -48,14 +48,14 @@ jobs:
       version: ${{ steps.select.outputs.version }}
     steps:
       - name: Check out requested KernelCI revision
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           repository: ${{ inputs.GIT_REPO }}
           ref: ${{ inputs.GIT_BRANCH }}
           fetch-depth: 1
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: "3.11"
           cache: pip
@@ -100,14 +100,14 @@ jobs:
       matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
     steps:
       - name: Check out requested KernelCI revision
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           repository: ${{ inputs.GIT_REPO }}
           ref: ${{ inputs.GIT_BRANCH }}
           fetch-depth: 1
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: "3.11"
           cache: pip

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -15,7 +15,7 @@ jobs:
         environment: deploydocker
         steps:
             - name: Checkout
-              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
               with:
                   repository: 'kernelci/kernelci-deploy'
                   ref: 'main'


### PR DESCRIPTION
Update pinned action revisions to the current upstream releases:

  actions/checkout                  v4     -> v7.0.1
  actions/setup-python              v5     -> v7.0.0
  awalsh128/cache-apt-pkgs-action   v1.5.4 -> v1.6.3
  docker/login-action               v2.2.0 -> v4.6.0
  azure/k8s-set-context             v4     -> v5.0.1

Ilshidur/action-discord and appleboy/scp-action are already pinned to their latest releases and are left unchanged.

The docker/login-action pin had no version comment, so add one to match the rest of the entries.

All of these majors moved to the Node 24 runtime, which needs the Actions runner v2.327.1 or later.