### PR TITLE
config/runtime: accept '~ #' shell prompt in LAVA boot templates

### DIFF
--- a/config/runtime/boot/barebox.jinja2
+++ b/config/runtime/boot/barebox.jinja2
@@ -36,6 +36,7 @@
     failure_retry: 3
     prompts:
     - '/ #'
+    - '~ #'
     timeout:
       minutes: 20
     timeouts:

--- a/config/runtime/boot/depthcharge.jinja2
+++ b/config/runtime/boot/depthcharge.jinja2
@@ -49,6 +49,7 @@
     failure_retry: 3
     prompts:
     - '/ #'
+    - '~ #'
     timeout:
       minutes: 20
     timeouts:

--- a/config/runtime/boot/efi.jinja2
+++ b/config/runtime/boot/efi.jinja2
@@ -82,6 +82,7 @@
 - boot:
     prompts:
     - '/ #'
+    - '~ #'
     failure_retry: 3
     timeout:
       minutes: 10

--- a/config/runtime/boot/fastboot.jinja2
+++ b/config/runtime/boot/fastboot.jinja2
@@ -79,6 +79,7 @@
 - boot:
     prompts:
     - '/ #'
+    - '~ #'
     failure_retry: 3
     timeout:
       minutes: 10

--- a/config/runtime/boot/grub.jinja2
+++ b/config/runtime/boot/grub.jinja2
@@ -39,6 +39,7 @@
     failure_retry: 3
     prompts:
     - '/ #'
+    - '~ #'
     timeout:
       minutes: 20
     timeouts:

--- a/config/runtime/boot/ipxe.jinja2
+++ b/config/runtime/boot/ipxe.jinja2
@@ -33,6 +33,7 @@
     failure_retry: 3
     prompts:
     - '/ #'
+    - '~ #'
     timeout:
       minutes: 20
     timeouts:

--- a/config/runtime/boot/qemu.jinja2
+++ b/config/runtime/boot/qemu.jinja2
@@ -27,6 +27,7 @@
     failure_retry: 3
     prompts:
       - '/ #'
+      - '~ #'
     timeout:
       minutes: 20
     timeouts:

--- a/config/runtime/boot/u-boot.jinja2
+++ b/config/runtime/boot/u-boot.jinja2
@@ -36,6 +36,7 @@
     failure_retry: 3
     prompts:
     - '/ #'
+    - '~ #'
     timeout:
       minutes: 20
     timeouts:

--- a/config/runtime/tests/watchdog-reset.jinja2
+++ b/config/runtime/tests/watchdog-reset.jinja2
@@ -9,7 +9,7 @@
       minutes: {{ job_timeout|default('5') }}
     interactive:
     - name: wdt-reset
-      prompts: ['/ #']
+      prompts: ['/ #', '~ #']
       script:
       - name: wdt-get-timeout
         command: "wdt_timeout=$(cat /sys/class/watchdog/{{ wdt_dev|default('watchdog0') }}/timeout)"


### PR DESCRIPTION
The new Buildroot-based baseline ramdisks ship BusyBox 1.38.0, whose lineedit get_homedir_or_NULL() now prefers $HOME over the passwd entry when expanding '\w' in the default PS1 ('\w \$ ').  The kernel hands init HOME=/, so with cwd '/' the prompt collapses to '~ #' instead of the '/ #' printed by older BusyBox, which only consulted getpwuid() (/root) and therefore never matched.

LAVA only knows about '/ #', so login-action times out and every baseline job on the new ramdisk fails, e.g.:

  login-action timed out after 117 seconds

Add '~ #' next to '/ #' in every boot template and in the watchdog-reset interactive test.  Prompts are regexes and '~' has no special meaning, so this stays compatible with the older ramdisks still in use.