### PR TITLE
docker: bump tuxmake to 1.44.0

### DIFF
--- a/config/docker/fragment/kernelci.jinja2
+++ b/config/docker/fragment/kernelci.jinja2
@@ -19,7 +19,7 @@ WORKDIR /root
 RUN rm -rf /tmp/kernelci-core
 
 # Install tuxmake kernel build tool
-RUN pip3 install --break-system-packages --no-cache-dir tuxmake==1.38.0
+RUN pip3 install --break-system-packages --no-cache-dir tuxmake==1.44.0
 
 # Set up kernelci user
 RUN useradd kernelci -u 1000 -d /home/kernelci -s /bin/bash


### PR DESCRIPTION
Update the pinned tuxmake version in the kernelci docker fragment from 1.38.0 to 1.44.0.

Notable changes for the builders:

- reproducer.sh is now written to the output directory, so it is picked up and uploaded along with the other build artifacts
- metadata.json is written early, so it survives a hard kill
- the compiler version is logged at the start of build.log
- arm was renamed to armhf and armv5 to armel; the old names are kept as aliases and armhf.ini is unchanged from the old arm.ini, so the arch=arm jobs are unaffected
- gcc-16, korg-gcc-16 and korg-clang-23 toolchains were added