### PR TITLE
Revert "kbuild: preserve tuxmake metadata as tuxmake_metadata.json"

### DIFF
--- a/kernelci/kbuild.py
+++ b/kernelci/kbuild.py
@@ -223,7 +223,6 @@ class KBuild:
             self._artifacts = []
             self._current_job = None
             self._config_full = ""
-            self._compiler_version = None
             self._srcdir = None
             self._firmware_dir = None
             self._af_dir = None
@@ -259,7 +258,6 @@ class KBuild:
             self._artifacts = jsonobj["artifacts"]
             self._current_job = jsonobj["current_job"]
             self._config_full = jsonobj["config_full"]
-            self._compiler_version = jsonobj["compiler_version"]
             self._srcdir = jsonobj["srcdir"]
             self._srctarball = jsonobj["srctarball"]
             self._firmware_dir = jsonobj["firmware_dir"]
@@ -1263,35 +1261,9 @@ trap 'case $stage in
         metadata["build"]["srcdir"] = self._srcdir
         metadata["build"]["config_full"] = self._config_full
         metadata["build"]["backend"] = self._backend
-        if self._compiler_version:
-            metadata["build"]["compiler_version"] = self._compiler_version
 
         with open(os.path.join(self._af_dir, "metadata.json"), "w") as f:
             json.dump(metadata, f, indent=4)
-
-    def _preserve_tuxmake_metadata(self):
-        """
-        Rename tuxmake's metadata.json to tuxmake_metadata.json so it
-        survives _write_metadata overwriting it, and keep the compiler
-        version it records for our own metadata and the node data
-        """
-        metadata_path = os.path.join(self._af_dir, "metadata.json")
-        if self._backend != "tuxmake" or not os.path.exists(metadata_path):
-            return
-        try:
-            with open(metadata_path) as f:
-                tux_meta = json.load(f)
-        except (OSError, json.JSONDecodeError):
-            return
-        if not isinstance(tux_meta, dict) or "tuxmake" not in tux_meta:
-            return
-        os.rename(
-            metadata_path,
-            os.path.join(self._af_dir, "tuxmake_metadata.json"),
-        )
-        version_full = tux_meta.get("compiler", {}).get("version_full")
-        if version_full:
-            self._compiler_version = version_full
 
     def serialize(self, filename):
         """Serialize class to json
@@ -1332,7 +1304,6 @@ trap 'case $stage in
                         )
                         self._artifacts.append(file)
         # Update manifest/metadata
-        self._preserve_tuxmake_metadata()
         self._write_metadata()
         print("Artifacts verified")
 
@@ -1717,8 +1688,6 @@ trap 'case $stage in
         results["node"]["data"] = node["data"]
         results["node"]["data"]["arch"] = self._arch
         results["node"]["data"]["compiler"] = self._compiler
-        if self._compiler_version:
-            results["node"]["data"]["compiler_version"] = self._compiler_version
         # As we are late to change data formats, we need to keep
         # defconfig as string, not list, so we use + to separate
         # multiple defconfigs

--- a/tests/test_kbuild.py
+++ b/tests/test_kbuild.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 """Tests for kernelci.kbuild build script generation and metadata"""
 
-import json
 import os
 import sys
 import types
@@ -20,7 +19,6 @@ def _kbuild(tmp_path, compiler="clang-21", arch="x86_64"):
     kbuild._fragments = []
     kbuild._fragment_files = []
     kbuild._config_full = ""
-    kbuild._compiler_version = None
     kbuild._backend = "tuxmake"
     kbuild._dtbs_check = True
     kbuild._steps = []
@@ -82,60 +80,6 @@ class TestCompilerVersionProbe:
         kbuild = _kbuild(tmp_path, compiler="gcc-14")
         kbuild._build_with_tuxmake()
         assert not any("--version" in s for s in kbuild._steps)
-
-
-class TestPreserveTuxmakeMetadata:
-    def test_preserves_tuxmake_metadata(self, tmp_path):
-        kbuild = _kbuild(tmp_path)
-        af_dir = tmp_path / "artifacts"
-        tux_meta = {
-            "tuxmake": {"version": "1.40.0"},
-            "compiler": {
-                "name": "clang",
-                "version": "21.1.8",
-                "version_full": "Debian clang version 21.1.8",
-            },
-        }
-        (af_dir / "metadata.json").write_text(json.dumps(tux_meta))
-        kbuild._preserve_tuxmake_metadata()
-        kbuild._write_metadata()
-        preserved = json.loads((af_dir / "tuxmake_metadata.json").read_text())
-        assert preserved == tux_meta
-        own = json.loads((af_dir / "metadata.json").read_text())
-        assert own["build"]["backend"] == "tuxmake"
-        assert own["build"]["compiler_version"] == "Debian clang version 21.1.8"
-        assert kbuild._compiler_version == "Debian clang version 21.1.8"
-
-    def test_ignores_own_metadata(self, tmp_path):
-        kbuild = _kbuild(tmp_path)
-        af_dir = tmp_path / "artifacts"
-        own_meta = {"build": {"backend": "tuxmake"}}
-        (af_dir / "metadata.json").write_text(json.dumps(own_meta))
-        kbuild._preserve_tuxmake_metadata()
-        kbuild._write_metadata()
-        assert not (af_dir / "tuxmake_metadata.json").exists()
-        own = json.loads((af_dir / "metadata.json").read_text())
-        assert "compiler_version" not in own["build"]
-
-    def test_handles_invalid_json(self, tmp_path):
-        kbuild = _kbuild(tmp_path)
-        af_dir = tmp_path / "artifacts"
-        (af_dir / "metadata.json").write_text("not json {")
-        kbuild._preserve_tuxmake_metadata()
-        kbuild._write_metadata()
-        assert not (af_dir / "tuxmake_metadata.json").exists()
-        own = json.loads((af_dir / "metadata.json").read_text())
-        assert own["build"]["arch"] == "x86_64"
-
-    def test_no_existing_metadata(self, tmp_path):
-        kbuild = _kbuild(tmp_path)
-        af_dir = tmp_path / "artifacts"
-        kbuild._preserve_tuxmake_metadata()
-        kbuild._write_metadata()
-        assert not (af_dir / "tuxmake_metadata.json").exists()
-        own = json.loads((af_dir / "metadata.json").read_text())
-        assert own["build"]["compiler"] == "clang-21"
-        assert "compiler_version" not in own["build"]
 
 
 class FakeStorage:


### PR DESCRIPTION
This reverts commit 6ad0e70a86a2ac5bd3ba39a4ad8f90750a6867c1.

tuxmake now logs the compiler version at the start of build.log, so the exact compiler that produced a build is visible without kbuild carrying compiler.version_full over from tuxmake's metadata into build.compiler_version and the node data.

This also drops the rename of tuxmake's metadata.json to tuxmake_metadata.json, so _write_metadata overwrites it again.