### PR TITLE
docker: initialise the rpm database in the container image

### DIFF
--- a/config/docker/fragment/kernelci.jinja2
+++ b/config/docker/fragment/kernelci.jinja2
@@ -23,8 +23,14 @@ RUN pip3 install --break-system-packages --no-cache-dir tuxmake==1.38.0
 
 # Set up kernelci user
 RUN useradd kernelci -u 1000 -d /home/kernelci -s /bin/bash
-RUN mkdir -p /home/kernelci
-RUN chown kernelci: /home/kernelci
+
+# Initialise the RPM database needed by tuxmake's *rpm-pkg targets.
+# /var/lib/rpm is not writable by the build user, so keep it in the
+# kernelci home directory. Images without rpm installed simply skip it.
+RUN mkdir -p /home/kernelci/rpm/db
+RUN rpmdb --initdb --dbpath /home/kernelci/rpm/db 2>/dev/null || true
+
+RUN chown -R kernelci: /home/kernelci
 USER kernelci
 ENV PATH=$PATH:/home/kernelci/.local/bin
 WORKDIR /home/kernelci

--- a/kernelci/kbuild.py
+++ b/kernelci/kbuild.py
@@ -867,16 +867,16 @@ trap 'case $stage in
         print(f"[_build_with_tuxmake] Command: {tuxmake_cmd}")
         print(f"[_build_with_tuxmake] Output directory: {self._af_dir}")
         # rpm defaults to /var/lib/rpm which a non-root build user cannot
-        # write to. Redirect _dbpath and _topdir into the workspace via
-        # ~/.rpmmacros so rpmdb and any rpmbuild invoked by tuxmake's
-        # *rpm-pkg targets share a writable location.
+        # write to. Point _dbpath at the database the container image
+        # initialised in the build user's home, and redirect _topdir into
+        # the workspace via ~/.rpmmacros so any rpmbuild invoked by
+        # tuxmake's *rpm-pkg targets writes somewhere writable.
         rpm_root = f"{self._workspace}/rpm"
-        self.addcmd(f"mkdir -p {rpm_root}/db {rpm_root}/build")
+        self.addcmd(f"mkdir -p {rpm_root}/build")
         self.addcmd(
-            f"printf '%%_dbpath {rpm_root}/db\\n"
+            "printf '%%_dbpath %%{getenv:HOME}/rpm/db\\n"
             f"%%_topdir {rpm_root}/build\\n' > $HOME/.rpmmacros"
         )
-        self.addcmd("rpmdb --initdb 2>/dev/null || true")
         try:
             from tuxmake.arch import Architecture
             from tuxmake.toolchain import Toolchain


### PR DESCRIPTION
The rpm database that tuxmake's *rpm-pkg targets need was created by 'rpmdb --initdb' at the start of every build. It does not change between builds, so create it once in the kernelci docker fragment instead.

/var/lib/rpm is not writable by the build user, so the database lives under the kernelci home directory and ~/.rpmmacros points _dbpath at it via %{getenv:HOME}. _topdir stays in the per-build workspace, since rpmbuild output is collected from there into the artifacts directory.

The initdb is tolerant of rpm being missing, as images built from base/python.jinja2 do not install it.