### PR TITLE
kbuild: identify kselftest suite build results

### DIFF
--- a/kernelci/kbuild.py
+++ b/kernelci/kbuild.py
@@ -1044,7 +1044,10 @@ trap 'case $stage in
             # A TARGET may be a nested path (e.g. "net/mptcp"); it is "built"
             # if any installed file lives under it. Use "." in the node name
             # to keep path elements free of slashes.
-            name = suite.replace("/", ".")
+            # These nodes report whether each kselftest suite was built; they
+            # are not results from executing the suite.  Keep that distinction
+            # visible when dashboards display the leaf name without its path.
+            name = "build.kselftest." + suite.replace("/", ".")
             if kselftest_result == "skip":
                 result = "skip"
             elif kselftest_result == "fail":

--- a/tests/test_kbuild.py
+++ b/tests/test_kbuild.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 """Tests for kernelci.kbuild build script generation and metadata"""
 
+import json
 import os
 import sys
 import types
@@ -80,6 +81,33 @@ class TestCompilerVersionProbe:
         kbuild = _kbuild(tmp_path, compiler="gcc-14")
         kbuild._build_with_tuxmake()
         assert not any("--version" in s for s in kbuild._steps)
+
+
+class TestKselftestSuiteResults:
+    def test_names_identify_build_results(self, tmp_path):
+        kbuild = _kbuild(tmp_path)
+        af_dir = tmp_path / "artifacts"
+        (af_dir / "kselftest_targets.txt").write_text(
+            "accel net/mptcp\n", encoding="utf-8"
+        )
+        (af_dir / "kselftest_metadata.json").write_text(
+            json.dumps(
+                {
+                    "artifacts": {
+                        "kselftest": [
+                            "accel/test_accel",
+                            "net/mptcp/mptcp_connect",
+                        ]
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        assert kbuild._kselftest_suite_results("pass") == [
+            ("build.kselftest.accel", "pass"),
+            ("build.kselftest.net.mptcp", "pass"),
+        ]
 
 
 class FakeStorage:


### PR DESCRIPTION
Per-suite kselftest nodes report whether suite artifacts were built, not whether the tests were executed. Bare target names such as accel lose that context when dashboards display only the leaf node.

Prefix suite names with build.kselftest and continue replacing slashes with dots for nested targets. Add a focused test covering both ordinary and nested suite names.