### PR TITLE
docker: uprev logspec to 15d893c

### DIFF
--- a/config/docker/fragment/pipeline.jinja2
+++ b/config/docker/fragment/pipeline.jinja2
@@ -6,7 +6,7 @@ RUN python3 -m pip install git+https://github.com/kernelci/kcidb.git --break-sys
 
 # Install logspec
 ARG logspec_url=https://github.com/kernelci/logspec.git
-ARG logspec_rev=370c994c940011e35cd7eb6ff173c451a5de2cd1
+ARG logspec_rev=15d893c47dee1d02b00714672edb59d0e144ad17
 RUN python3 -m pip install "git+${logspec_url}@${logspec_rev}" --break-system-packages
 ENV KCI_VER_LOGSPEC=$logspec_rev
 


### PR DESCRIPTION
Pulls in kernelci/logspec#29 ("kbuild: preserve generic error excerpts"), merged as 15d893c.

Generic kbuild failures were producing issues with an empty `log_excerpt`, so the mailed report had nothing between the "Log excerpt" markers:

```
---
 in arch/x86/include/generated/asm/cpufeaturemasks.h (/tmp/kci/linux/arch/x86/Makefile:269) [logspec:kbuild,kbuild.other]
---

Log excerpt:
=====================================================

=====================================================
```

(https://lore.kernel.org/all/178711194407.380.4108589457572337694@kernelci.org/, dashboard: https://d.kernelci.org/i/maestro:e019eff33641f280144d13719cbbf59eb379327c)

`KbuildGenericError` now keeps the full diagnostic line when the failed target appears within it, and falls back to the make failure itself when there is no preceding diagnostic. Verified with this revision installed against kernelci-pipeline `logspec_api.py`:

```
excerpt: 00:13:13 make[5]: *** [/tmp/kci/linux/arch/x86/Makefile:269: arch/x86/include/generated/asm/cpufeaturemasks.h] Error 1
excerpt: 04:41:43 cp: cannot create regular file '/tmp/kci/artifacts/build/kselftest/arm64/signal/fake_sigreturn_bad_magic': File exists
```

`370c994..15d893c` is that one commit plus its merge, so the uprev carries no other parser changes.

The headless comment line in the same report is a pipeline-side issue, fixed separately in kernelci/kernelci-pipeline#1584.