### PR TITLE
docker: fix pylibfdt build with swig 4.5

### DIFF
--- a/config/docker/base/host-tools.jinja2
+++ b/config/docker/base/host-tools.jinja2
@@ -90,7 +90,15 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     zstd
 
 # Install dtschema for dtbs_check
-RUN pip3 install dtschema --break-system-packages
+# pylibfdt (a dtschema dependency) is built from source and pip's build
+# isolation fetches the latest swig from PyPI rather than using the
+# distro package.  swig 4.5 removed the Python 2 compatibility macros
+# which pylibfdt still uses in its typemaps, so define them on the
+# compiler command line until a pylibfdt release picks up the upstream
+# fix (dtc commit 5008d1d6a356).
+RUN CFLAGS="-DPyString_FromString=PyUnicode_FromString \
+            -DPyInt_AsLong=PyLong_AsLong" \
+    pip3 install dtschema --break-system-packages
 
 # Download and build pahole v1.28
 RUN wget -c https://storage.kernelci.org/pahole-1.29.tar.gz && \

--- a/config/docker/dt-validation.jinja2
+++ b/config/docker/dt-validation.jinja2
@@ -22,7 +22,15 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 RUN update-alternatives --install \
     /usr/bin/x86_64-linux-gnu-gcc x86_64-linux-gnu-gcc /usr/bin/gcc-14 500
 
-RUN pip3 install \
+# pylibfdt (a dt-schema dependency) is built from source and pip's build
+# isolation fetches the latest swig from PyPI rather than using the
+# distro package.  swig 4.5 removed the Python 2 compatibility macros
+# which pylibfdt still uses in its typemaps, so define them on the
+# compiler command line until a pylibfdt release picks up the upstream
+# fix (dtc commit 5008d1d6a356).
+RUN CFLAGS="-DPyString_FromString=PyUnicode_FromString \
+            -DPyInt_AsLong=PyLong_AsLong" \
+    pip3 install \
     git+https://github.com/devicetree-org/dt-schema.git@master
 
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Fix staging failure"
  `libfdt/libfdt_wrap.c:5555:20: error: implicit declaration of function 'PyInt_AsLong'; did you mean 'PyLong_AsLong'?`

Define the two macros on the compiler command line, using the same replacements as the upstream fix in dtc commit 5008d1d6a356.  They can be dropped once a pylibfdt release picks that fix up.