### PR TITLE
docker: build pahole in Release mode

### DIFF
--- a/config/docker/base/host-tools.jinja2
+++ b/config/docker/base/host-tools.jinja2
@@ -100,12 +100,18 @@ RUN CFLAGS="-DPyString_FromString=PyUnicode_FromString \
             -DPyInt_AsLong=PyLong_AsLong" \
     pip3 install dtschema --break-system-packages
 
-# Download and build pahole v1.28
+# Download and build pahole v1.29
+#
+# Build in Release mode: pahole's CMakeLists defaults to Debug, which adds
+# -Werror (and -O0).  glibc 2.43 in forky makes strchr()/bsearch() and
+# friends preserve the constness of their argument, so pahole's assignments
+# of their results to non-const pointers now trip -Wdiscarded-qualifiers and
+# fail the build.  Release drops -Werror and builds with -O2.
 RUN wget -c https://storage.kernelci.org/pahole-1.29.tar.gz && \
     tar -xzf pahole-1.29.tar.gz && \
     cd pahole-1.29 && \
     mkdir build && cd build && \
-    cmake .. -DLIBBPF_EMBEDDED=OFF && \
+    cmake .. -DCMAKE_BUILD_TYPE=Release -DLIBBPF_EMBEDDED=OFF && \
     make && \
     make install && \
     echo "/usr/local/lib" > /etc/ld.so.conf.d/dwarves.conf && \


### PR DESCRIPTION
pahole's CMakeLists defaults CMAKE_BUILD_TYPE to Debug when it is not set, and CMAKE_C_FLAGS_DEBUG is "-Wall -Werror -ggdb -O0".  The build here never set a build type, so pahole has been compiled unoptimised with -Werror armed.

glibc 2.43 in forky makes strchr(), bsearch() and friends preserve the constness of their argument, so pahole's assignments of their results to non-const pointers now warn, and -Werror turns that into a build failure on the gcc-15 images:

```
  /pahole-1.29/btf_encoder.c:1856:16: error: assignment discards
  'const' qualifier from pointer target type
  [-Werror=discarded-qualifiers]
   1856 |         target = bsearch(&key, base, cnt, sizeof(key),
                            btf_func_cmp);
```

Even i tried, this is not fixed by moving to a newer pahole: v1.31 fails the same way. Still we will upgrade pahole later.