### PR TITLE
docker: use google-cloud-cli package names

### DIFF
--- a/config/docker/fragment/gcloud.jinja2
+++ b/config/docker/fragment/gcloud.jinja2
@@ -19,6 +19,6 @@ RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg \
     | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
 
 RUN apt-get update && apt-get install -y \
-    google-cloud-sdk \
-    google-cloud-sdk-gke-gcloud-auth-plugin \
+    google-cloud-cli \
+    google-cloud-cli-gke-gcloud-auth-plugin \
     kubectl


### PR DESCRIPTION
Google renamed the apt packages in the cloud-sdk repository:
`google-cloud-sdk` is now `google-cloud-cli` and
`google-cloud-sdk-gke-gcloud-auth-plugin` is now
`google-cloud-cli-gke-gcloud-auth-plugin`. The old names have been dropped
from the repo, so any image using the `gcloud` fragment fails to build:

```
Package google-cloud-sdk is not available, but is referred to by another package.
However the following packages replace it:
  google-cloud-cli
E: Package 'google-cloud-sdk' has no installation candidate
E: Package 'google-cloud-sdk-gke-gcloud-auth-plugin' has no installation candidate
```

This currently breaks the `kernelci pipeline` and `k8s kernelci` images, e.g.
https://github.com/kernelci/kernelci-core/actions/runs/33052125599

`kubectl` is unaffected and keeps its name.