### PR TITLE
config: runtime: tests: rt-tests: Rename PRIORITY -> RT_PRIORITY

### DIFF
--- a/config/runtime/tests/rt-tests.jinja2
+++ b/config/runtime/tests/rt-tests.jinja2
@@ -22,13 +22,13 @@
       {% elif tst_cmd == 'cyclictest' %}
         HISTOGRAM: {{ histogram|default('') }}
         INTERVAL: {{ interval|default('1000') }}
-        PRIORITY: {{ priority|default('98') }}
+        RT_PRIORITY: {{ rt_priority|default('98') }}
         THREADS: {{ threads|default('2') }}
       {% elif tst_cmd == 'pi-stress' %}
         MLOCKALL: {{ mlockall|default('"true"') }}
       {% elif tst_cmd == 'rt-migrate-test' %}
-        PRIORITY: {{ priority|default('90') }}
+        RT_PRIORITY: {{ rt_priority|default('90') }}
       {% elif tst_cmd == 'signaltest' %}
-        PRIORITY: {{ priority|default('98') }}
+        RT_PRIORITY: {{ rt_priority|default('98') }}
         THREADS: {{ threads|default('2') }}
       {% endif %}


### PR DESCRIPTION
The cyclictest command is run a low task priority. From the output in the test I see
| / # /lava-22804428/bin/lava-test-runner /lava-22804428/0 | + export TESTRUN_ID=0_rt-tests-cyclictest
| + TESTRUN_ID=0_rt-tests-cyclictest
| + cd /lava-22804428/0/tests/0_rt-tests-cyclictest | ++ cat uuid
| + UUID=22804428_1.1.4.1
| + set +x
| <LAVA_SIGNAL_STARTRUN 0_rt-tests-cyclictest 22804428_1.1.4.1> | + cd ./automated/linux/cyclictest/
| + ./cyclictest.sh -D 540s -p 48 -i 1000 -t 2 -a 0 -h '' -w hackbench | Received signal: <STARTRUN> 0_rt-tests-cyclictest 22804428_1.1.4.1 | Starting test lava.0_rt-tests-cyclictest (22804428_1.1.4.1) | Skipping test definition patterns.
| # /dev/cpu_dma_latency set to 0us
| T: 0 (  437) P:48 I:1000 C: 540000 Min:      4 Act:    5 Avg:   18 Max:     217
| T: 1 (  438) P:48 I:1500 C: 360000 Min:      4 Act:    9 Avg:   17 Max:     340
| t0-min-latency pass 4 us
| t0-avg-latency pass 18.29 us
| t0-max-latency pass 217 us
| t1-min-latency pass 4 us
| t1-avg-latency pass 17.69 us
| t1-max-latency pass 340 us
| cyclictest pass

and the test definition has
|      name: rt-tests-cyclictest
|      parameters:
…
|        PRIORITY: 48
…
|     status: finished
| priority: 48
| timeouts:

I think that PRIORITY and priority arguments are getting confused and instead of the cylictest priority it is using the scheduling priority.

Rename PRIORITY to RT_PRIORITY