### PR TITLE
fix(build): add shallow clone options to git helper functions

### DIFF
--- a/kernelci/build.py
+++ b/kernelci/build.py
@@ -138,16 +138,22 @@ def clone_git(url, path, branch, shallow=True):
     *shallow* shallow (depth=1) git clone
     """
     if not os.path.exists(path):
-        shell_cmd(f"git clone {url} {path}")
+        clone_opts = ""
+        if shallow:
+            clone_opts = "--depth=1 --single-branch --no-tags"
+        shell_cmd(f"git clone {clone_opts} {url} {path}")
+    depth_opt = ""
+    if shallow:
+        depth_opt = "--depth=1"
     shell_cmd(
         """
 set -e
 cd {path}
 git reset --hard
 git clean -fd
-git fetch origin
+git fetch {depth_opt} origin
 git checkout --detach origin/{branch}
-""".format(path=path, branch=branch)
+""".format(path=path, branch=branch, depth_opt=depth_opt)
     )
 
 


### PR DESCRIPTION
Fixes #2894

Unify shallow clone options in git helper functions to reduce network traffic in CI by adding depth=1 and other optimized flags to git clone operations.

Could not run the suite locally: . Fork CI needs a maintainer approval to run, so this branch has no test signal yet.

---
This change was prepared with AI assistance under human direction and review.