### PR TITLE
kbuild: fix config make targets being merged as fragment data

### DIFF
--- a/kernelci/kbuild.py
+++ b/kernelci/kbuild.py
@@ -54,6 +54,10 @@ FW_GIT = "https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmwar
 LATEST_LTS_MAJOR = 6
 LATEST_LTS_MINOR = 12
 
+# Prefix marking a fragment entry as a kernel make target generating
+# config (e.g. 'make:kselftest-merge') rather than a config symbol.
+MAKE_FRAGMENT_PREFIX = "make:"
+
 DTBS_DISABLED = {
     "i386": True,
     "x86_64": True,
@@ -618,13 +622,44 @@ trap - ERR
         print(f"Using fragment {fragname} from inline configs")
         return self.extract_config(frag)
 
+    @staticmethod
+    def _split_fragment(content):
+        """Split fragment content into make targets and config symbols
+
+        A fragment entry prefixed with 'make:' names a kernel make target
+        generating config, such as 'make:kselftest-merge', rather than a
+        config symbol. Those entries must be kept out of the fragment file:
+        kconfig does not understand them and merges them as "unexpected
+        data", silently dropping the config the fragment is meant to add.
+
+        Returns:
+            tuple: (list of make targets, config symbol text)
+        """
+        make_targets = []
+        config_lines = []
+
+        for line in content.splitlines():
+            entry = line.strip()
+            if entry.startswith(MAKE_FRAGMENT_PREFIX):
+                target = entry[len(MAKE_FRAGMENT_PREFIX) :]
+                if target:
+                    make_targets.append(target)
+            else:
+                config_lines.append(line)
+
+        config = "\n".join(config_lines).strip()
+        if config:
+            config += "\n"
+        return make_targets, config
+
     def _parse_fragments(self, firmware=False):
         """Parse fragments kbuild config and create config fragments
 
         Returns:
-            list: List of fragment file paths
+            list: List of kconfig additions, each either a fragment file
+            path or a 'make:<target>' directive, in merge order
         """
-        fragment_files = []
+        kconfig_adds = []
 
         for idx, fragment in enumerate(self._fragments):
             content = ""
@@ -646,23 +681,34 @@ trap - ERR
                 )
                 continue
 
-            fragfile = os.path.join(self._fragments_dir, f"{idx}.config")
-            with open(fragfile, "w") as f:
-                f.write(content)
+            make_targets, config = self._split_fragment(content)
 
-            config_count = len(
-                [line for line in content.split("\n") if line.strip()]
-            )
-            print(
-                f"[_parse_fragments] Created {fragfile} ({config_count} configs)"
-            )
+            if config:
+                fragfile = os.path.join(self._fragments_dir, f"{idx}.config")
+                with open(fragfile, "w") as f:
+                    f.write(config)
 
-            fragment_files.append(fragfile)
+                config_count = len(
+                    [line for line in config.split("\n") if line.strip()]
+                )
+                print(
+                    f"[_parse_fragments] Created {fragfile} ({config_count} configs)"
+                )
 
-            # add fragment to artifacts but relative to artifacts dir
-            frag_rel = os.path.relpath(fragfile, self._af_dir)
+                kconfig_adds.append(fragfile)
+
+                # add fragment to artifacts but relative to artifacts dir
+                frag_rel = os.path.relpath(fragfile, self._af_dir)
+                self._artifacts.append(frag_rel)
+
+            for target in make_targets:
+                print(
+                    f"[_parse_fragments] Fragment {fragment_name} runs "
+                    f"make target {target}"
+                )
+                kconfig_adds.append(MAKE_FRAGMENT_PREFIX + target)
+
             self._config_full += "+" + fragment_name
-            self._artifacts.append(frag_rel)
 
         if firmware:
             content = 'CONFIG_EXTRA_FIRMWARE_DIR="' + self._firmware_dir + '"\n'
@@ -672,22 +718,23 @@ trap - ERR
             with open(fragfile, "w") as f:
                 f.write(content)
 
-            fragment_files.append(fragfile)
+            kconfig_adds.append(fragfile)
 
             # add fragment to artifacts but relative to artifacts dir
             frag_rel = os.path.relpath(fragfile, self._af_dir)
             self._artifacts.append(frag_rel)
 
         print(
-            f"[_parse_fragments] Created {len(fragment_files)} fragment files"
+            f"[_parse_fragments] Created {len(kconfig_adds)} kconfig additions"
         )
-        return fragment_files
+        return kconfig_adds
 
-    def _merge_frags(self, fragment_files):
+    def _merge_frags(self, kconfig_adds):
         """Merge config fragments to .config
 
         Args:
-            fragment_files: List of fragment file paths to merge
+            kconfig_adds: List of kconfig additions, as returned by
+            _parse_fragments()
         """
         self.startjob("config_defconfig")
         self.addcmd("cd " + self._srcdir)
@@ -715,10 +762,14 @@ trap - ERR
                 self._config_full = defconfigs + self._config_full
         # fragments
         self.startjob("config_fragments")
-        for fragfile in fragment_files:
-            self.addcmd(
-                f"./scripts/kconfig/merge_config.sh -m .config {fragfile}"
-            )
+        for entry in kconfig_adds:
+            if entry.startswith(MAKE_FRAGMENT_PREFIX):
+                print(
+                    f"[_merge_frags] WARNING: ignoring {entry}, the make "
+                    "backend does not run config make targets"
+                )
+                continue
+            self.addcmd(f"./scripts/kconfig/merge_config.sh -m .config {entry}")
         # TODO: olddefconfig should be optional/configurable
         # TODO: log all warnings/errors of olddefconfig to separate file
         self.addcmd("make olddefconfig")
@@ -729,12 +780,12 @@ trap - ERR
     def _generate_script(self):
         """Generate shell script for complete build"""
         print("Generating shell script")
-        self._fragment_files = self._parse_fragments(firmware=True)
+        self._kconfig_adds = self._parse_fragments(firmware=True)
 
         if self._backend == "tuxmake":
             self._build_with_tuxmake()
         else:
-            self._merge_frags(self._fragment_files)
+            self._merge_frags(self._kconfig_adds)
             self._build_with_make()
 
         self._write_metadata()
@@ -800,12 +851,12 @@ trap 'case $stage in
         """Build kernel using tuxmake with native fragment support"""
         print("[_build_with_tuxmake] Starting tuxmake build")
 
-        if not hasattr(self, "_fragment_files"):
-            print("[_build_with_tuxmake] ERROR: No fragment files available")
-            self._fragment_files = []
+        if not hasattr(self, "_kconfig_adds"):
+            print("[_build_with_tuxmake] ERROR: No kconfig additions available")
+            self._kconfig_adds = []
 
         print(
-            f"[_build_with_tuxmake] Using {len(self._fragment_files)} fragment files"
+            f"[_build_with_tuxmake] Using {len(self._kconfig_adds)} kconfig additions"
         )
 
         # Handle defconfigs - first goes to --kconfig, rest to --kconfig-add
@@ -931,17 +982,20 @@ trap 'case $stage in
         for extra in extra_defconfigs:
             parts.append(f"--kconfig-add={extra}")
             print(f"[_tuxmake_base] Adding extra defconfig: {extra}")
-        for fragfile in self._fragment_files:
-            if os.path.exists(fragfile):
-                parts.append(f"--kconfig-add={fragfile}")
+        for entry in self._kconfig_adds:
+            if entry.startswith(MAKE_FRAGMENT_PREFIX):
+                # tuxmake runs the make target during config preparation
+                parts.append(f"--kconfig-add={entry}")
+                print(f"[_tuxmake_base] Adding make target: {entry}")
+            elif os.path.exists(entry):
+                parts.append(f"--kconfig-add={entry}")
                 print(
                     "[_tuxmake_base] Adding fragment: "
-                    f"{os.path.basename(fragfile)}"
+                    f"{os.path.basename(entry)}"
                 )
             else:
                 print(
-                    "[_tuxmake_base] WARNING: Fragment file not found: "
-                    f"{fragfile}"
+                    f"[_tuxmake_base] WARNING: Fragment file not found: {entry}"
                 )
         return parts
 

--- a/kernelci/kbuild.py
+++ b/kernelci/kbuild.py
@@ -764,10 +764,10 @@ trap - ERR
         self.startjob("config_fragments")
         for entry in kconfig_adds:
             if entry.startswith(MAKE_FRAGMENT_PREFIX):
-                print(
-                    f"[_merge_frags] WARNING: ignoring {entry}, the make "
-                    "backend does not run config make targets"
-                )
+                # the target merges its own config into the .config built
+                # so far, so run it in place of a merge_config.sh call
+                target = entry[len(MAKE_FRAGMENT_PREFIX) :]
+                self.addcmd(f"make {target}")
                 continue
             self.addcmd(f"./scripts/kconfig/merge_config.sh -m .config {entry}")
         # TODO: olddefconfig should be optional/configurable

--- a/tests/test_kbuild.py
+++ b/tests/test_kbuild.py
@@ -137,6 +137,24 @@ class TestFragments:
 
         assert "--kconfig-add=make:kselftest-merge" in parts
 
+    def test_make_target_is_run_by_the_make_backend(self, tmp_path):
+        kbuild = _kbuild(tmp_path)
+        kbuild._backend = "make"
+        fragfile = os.path.join(kbuild._af_dir, "0.config")
+
+        kbuild._merge_frags(["make:kselftest-merge", fragfile])
+
+        steps = kbuild._steps
+        merge = steps.index("make kselftest-merge")
+        assert (
+            steps.index(
+                f"./scripts/kconfig/merge_config.sh -m .config {fragfile}"
+            )
+            > merge
+        )
+        # kselftest-merge needs a .config to merge into
+        assert steps.index("make defconfig") < merge
+
 
 class TestKselftestSuiteResults:
     def test_names_identify_build_results(self, tmp_path):

--- a/tests/test_kbuild.py
+++ b/tests/test_kbuild.py
@@ -18,7 +18,7 @@ def _kbuild(tmp_path, compiler="clang-21", arch="x86_64"):
     kbuild._compiler = compiler
     kbuild._defconfig = "defconfig"
     kbuild._fragments = []
-    kbuild._fragment_files = []
+    kbuild._kconfig_adds = []
     kbuild._config_full = ""
     kbuild._backend = "tuxmake"
     kbuild._dtbs_check = True
@@ -81,6 +81,61 @@ class TestCompilerVersionProbe:
         kbuild = _kbuild(tmp_path, compiler="gcc-14")
         kbuild._build_with_tuxmake()
         assert not any("--version" in s for s in kbuild._steps)
+
+
+class TestFragments:
+    @staticmethod
+    def _fragments(tmp_path, fragments, fragment_configs):
+        kbuild = _kbuild(tmp_path)
+        kbuild._fragments = fragments
+        kbuild._fragment_configs = fragment_configs
+        kbuild._fragments_dir = os.path.join(kbuild._af_dir, "fragments")
+        os.makedirs(kbuild._fragments_dir)
+        return kbuild
+
+    def test_make_target_is_not_written_to_a_fragment_file(self, tmp_path):
+        kbuild = self._fragments(
+            tmp_path,
+            ["kselftest"],
+            {"kselftest": {"configs": ["make:kselftest-merge"]}},
+        )
+
+        kconfig_adds = kbuild._parse_fragments()
+
+        # kconfig would merge the directive as "unexpected data"
+        assert kconfig_adds == ["make:kselftest-merge"]
+        assert os.listdir(kbuild._fragments_dir) == []
+        assert kbuild._artifacts == []
+        assert kbuild._config_full == "+kselftest"
+
+    def test_make_targets_are_split_from_config_symbols(self, tmp_path):
+        kbuild = self._fragments(
+            tmp_path,
+            ["kselftest"],
+            {
+                "kselftest": {
+                    "configs": [
+                        "make:kselftest-merge",
+                        "CONFIG_KUNIT=y",
+                    ]
+                }
+            },
+        )
+
+        kconfig_adds = kbuild._parse_fragments()
+
+        fragfile = os.path.join(kbuild._fragments_dir, "0.config")
+        assert kconfig_adds == [fragfile, "make:kselftest-merge"]
+        with open(fragfile) as f:
+            assert f.read() == "CONFIG_KUNIT=y\n"
+
+    def test_make_target_is_passed_to_tuxmake(self, tmp_path):
+        kbuild = _kbuild(tmp_path)
+        kbuild._kconfig_adds = ["make:kselftest-merge"]
+
+        parts = kbuild._tuxmake_base(kbuild._af_dir, "defconfig", [])
+
+        assert "--kconfig-add=make:kselftest-merge" in parts
 
 
 class TestKselftestSuiteResults:


### PR DESCRIPTION
The `kselftest` build fragment is a single entry, `make:kselftest-merge`
(kernelci-pipeline `config/fragments.yaml`), which tuxmake accepts as a magic
`--kconfig-add` value (kernelci/tuxmake#275, documented since kernelci/tuxmake#280).

`_parse_fragments()` writes every fragment entry into `fragments/N.config` and
passes that *file* to `--kconfig-add`, so the directive reaches kconfig as
fragment content and gets merged as unexpected data:

```
.config:5652:warning: unexpected data: make:kselftest-merge
```

No kselftest config has been merged since the fragment was switched over, on
either backend. The resulting kernels are missing everything
`tools/testing/selftests/*/config` asks for — `CONFIG_IOMMUFD`,
`CONFIG_FAULT_INJECTION`, `CONFIG_USER_NS`, `CONFIG_BPF_SYSCALL`,
`CONFIG_VETH`, ... — which wipes out whole suites rather than individual tests.

Observed effect in production: `kselftest-iommu` has **1 pass in 18376 runs**
all-time, and accounted for ~43k of the ~61k test-level failures in the
04-07 Sep window (70%), pushing the overall test failure rate from ~3.2% to
9.8%. Every subtest dies in fixture setup on a missing `/dev/iommu`:

```
# # iommufd.c:66:simple_close:Expected -1 (-1) != self->fd (-1)
```

with `# CONFIG_IOMMUFD is not set` in the build's `.config`, on hardware whose
IOMMU is otherwise fine (`DMAR: dmar0 ...`, `iommu: Default domain type: Translated`).

### Changes

1. **`kbuild: pass config make targets through to tuxmake`** — split `make:`
   directives out of fragment content and keep them as separate kconfig
   additions, ordered with the fragment files so merge order is preserved, then
   pass them to tuxmake verbatim. `_fragment_files` becomes `_kconfig_adds`
   since it no longer holds only files. The make backend skips them, unchanged,
   so this commit stands on its own.
2. **`kbuild: run config make targets in the make backend`** — emit
   `make <target>` in place of the `merge_config.sh` call. `kselftest-merge`
   merges into the `.config` built so far and runs its own `olddefconfig`, so it
   drops into the existing sequence.

### Result

```
tuxmake: --kconfig-add=.../0.config --kconfig-add=.../1.config \
         --kconfig-add=make:kselftest-merge --kconfig-add=.../3.config

make:    make x86_64_defconfig
         merge_config.sh -m .config .../0.config
         merge_config.sh -m .config .../1.config
         make kselftest-merge
         merge_config.sh -m .config .../3.config
         make olddefconfig
```

### Testing

`ruff check` and `ruff format` clean; `tests/test_kbuild.py` passes (13 tests,
4 new in `TestFragments`: directive not written to a fragment file, mixed
config/directive fragments split correctly, tuxmake passthrough, make-backend
ordering).

No kernelci-pipeline change is needed — `config/fragments.yaml` was already
correct; only the consumer was dropping the directive.

Draft: worth a build on staging to confirm `CONFIG_IOMMUFD` lands in
`x86_64_defconfig+lab-setup+x86-board+kselftest` before merging, and to check
that the now-effective `kselftest-merge` doesn't pull in config that upsets
other suites (it is all-or-nothing across every subsystem).
